### PR TITLE
feat(api/v1): add misc workspace token APIs (error-logs, whatsapp-templates, inbox-teams)

### DIFF
--- a/.agents/skills/orpc-api/SKILL.md
+++ b/.agents/skills/orpc-api/SKILL.md
@@ -20,7 +20,7 @@ description: >-
 Defined in `apps/builder/src/orpc.ts`:
 
 - **`authorizedAPI`**: `base` → error mapping → `authMiddleware` (session/cookie auth)
-- **`workspaceTokenAuthAPI`**: `base` → error mapping → `workspaceTokenAuthMidddleware` (X-CHATBOT-TOKEN header)
+- **`workspaceTokenAuthAPI`**: `base` → error mapping → `workspaceTokenAuthMidddleware` (Authorization: Bearer header)
 
 Workspace-scoped procedures add `workspaceAuthorizedMidddleware` per-procedure.
 

--- a/apps/builder/src/app/api/[[...rest]]/route.ts
+++ b/apps/builder/src/app/api/[[...rest]]/route.ts
@@ -28,9 +28,8 @@ const openAPIHandler = new OpenAPIHandler(router, {
               scheme: "bearer",
             },
             developerAccessToken: {
-              type: "apiKey",
-              in: "header",
-              name: "X-CHATBOT-TOKEN",
+              type: "http",
+              scheme: "bearer",
             },
           },
         },

--- a/apps/builder/src/app/api/public-spec.json/route.ts
+++ b/apps/builder/src/app/api/public-spec.json/route.ts
@@ -22,9 +22,8 @@ async function handleRequest(request: Request) {
     components: {
       securitySchemes: {
         developerAccessToken: {
-          type: "apiKey",
-          in: "header",
-          name: "X-CHATBOT-TOKEN",
+          type: "http",
+          scheme: "bearer",
         },
       },
     },

--- a/apps/builder/src/enterprise/features/inbox-teams/api/index.ts
+++ b/apps/builder/src/enterprise/features/inbox-teams/api/index.ts
@@ -1,5 +1,7 @@
 import { inboxTeamsAuthenticatedAPI } from "./authenticated"
+import { inboxTeamsWorkspaceTokenAPIs } from "./workspace-token"
 
 export const inboxTeamsAPI = {
   ...inboxTeamsAuthenticatedAPI,
+  ...inboxTeamsWorkspaceTokenAPIs,
 }

--- a/apps/builder/src/enterprise/features/inbox-teams/api/workspace-token.ts
+++ b/apps/builder/src/enterprise/features/inbox-teams/api/workspace-token.ts
@@ -1,0 +1,20 @@
+import { workspaceTokenAuthAPI } from "@/orpc"
+import { listInboxTeams } from "../queries"
+import { listInboxTeamsResponse } from "../schema/action"
+
+export const inboxTeamsWorkspaceTokenAPIs = {
+  listInboxTeamsWorkspaceTokenAPI: workspaceTokenAuthAPI
+    .route({
+      method: "GET",
+      path: "/v1/inbox-teams",
+      summary: "List inbox teams",
+      tags: ["Inbox Teams"],
+    })
+    .output(listInboxTeamsResponse)
+    .handler(
+      async ({ context }) =>
+        await listInboxTeams({ workspaceId: context.workspace.id }),
+    ),
+}
+
+export default inboxTeamsWorkspaceTokenAPIs

--- a/apps/builder/src/features/error-logs/api/workspace-token.ts
+++ b/apps/builder/src/features/error-logs/api/workspace-token.ts
@@ -13,7 +13,7 @@ export const errorLogsWorkspaceTokenAPIs = {
       summary: "List error logs",
       tags: ["Error Logs"],
     })
-    .input(listErrorLogsRequest)
+    .input(listErrorLogsRequest.omit({ workspaceId: true }))
     .output(publicListErrorLogsResponse)
     .handler(
       async ({ context, input }) =>

--- a/apps/builder/src/features/integration-whatsapp/message-templates/api/index.ts
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/api/index.ts
@@ -1,5 +1,7 @@
 import { whatsappMessageTemplateInternalAPIs } from "./private"
+import { whatsappMessageTemplateWorkspaceTokenAPIs } from "./workspace-token"
 
 export const whatsappMessageTemplateAPIs = {
   ...whatsappMessageTemplateInternalAPIs,
+  ...whatsappMessageTemplateWorkspaceTokenAPIs,
 }

--- a/apps/builder/src/features/integration-whatsapp/message-templates/api/workspace-token.ts
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/api/workspace-token.ts
@@ -1,0 +1,30 @@
+import { workspaceTokenAuthAPI } from "@/orpc"
+import { whatsappMessageTemplateService } from "../queries"
+import {
+  listWhatsappMessageTemplatesRequest,
+  listWhatsappMessageTemplatesResponse,
+} from "../schema/query"
+
+export const whatsappMessageTemplateWorkspaceTokenAPIs = {
+  listWhatsappMessageTemplatesWorkspaceTokenAPI: workspaceTokenAuthAPI
+    .route({
+      method: "GET",
+      path: "/v1/whatsapp-message-templates",
+      summary: "List WhatsApp message templates",
+      tags: ["Template Messages"],
+    })
+    .input(
+      listWhatsappMessageTemplatesRequest.omit({
+        workspaceId: true,
+      }),
+    )
+    .output(listWhatsappMessageTemplatesResponse)
+    .handler(
+      async ({ context, input }) =>
+        await whatsappMessageTemplateService.list({
+          where: { ...input, workspaceId: context.workspace.id },
+        }),
+    ),
+}
+
+export default whatsappMessageTemplateWorkspaceTokenAPIs

--- a/apps/builder/src/middlewares/workspace-token-auth.ts
+++ b/apps/builder/src/middlewares/workspace-token-auth.ts
@@ -4,7 +4,8 @@ import { base } from "./context"
 
 export const workspaceTokenAuthMidddleware = base.middleware(
   async ({ context, next }) => {
-    const token = context.headers.get("X-CHATBOT-TOKEN")
+    const authHeader = context.headers.get("Authorization")
+    const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null
     if (!token) {
       throw new ORPCError("INVALID_CHATBOT_TOKEN")
     }

--- a/apps/builder/src/routers/public.ts
+++ b/apps/builder/src/routers/public.ts
@@ -1,3 +1,4 @@
+import { inboxTeamsWorkspaceTokenAPIs } from "@/enterprise/features/inbox-teams/api/workspace-token"
 import botFieldWorkspaceTokenAPIs from "@/features/bot-fields/api/workspace-token"
 import { broadcastWorkspaceTokenAPIs } from "@/features/broadcasts/api/workspace-token"
 import contactWorkspaceTokenAPIs from "@/features/contacts/api/workspace-token"
@@ -6,6 +7,7 @@ import customFieldWorkspaceTokenAPIs from "@/features/custom-fields/api/workspac
 import errorLogWorkspaceTokenAPIs from "@/features/error-logs/api/workspace-token"
 import flowWorkspaceTokenAPIs from "@/features/flows/api/workspace-token"
 import inboxWorkspaceTokenAPIs from "@/features/inboxes/api/workspace-token"
+import whatsappMessageTemplateWorkspaceTokenAPIs from "@/features/integration-whatsapp/message-templates/api/workspace-token"
 import savedReplyWorkspaceTokenAPIs from "@/features/saved-replies/api/workspace-token"
 import { sequencesWorkspaceTokenAPIs } from "@/features/sequences/api/workspace-token"
 import { tagWorkspaceTokenAPIs } from "@/features/tags/api/token-auth"
@@ -26,4 +28,6 @@ export const publicRouter = {
   ...contactWorkspaceTokenAPIs,
   ...broadcastWorkspaceTokenAPIs,
   ...sequencesWorkspaceTokenAPIs,
+  ...inboxTeamsWorkspaceTokenAPIs,
+  ...whatsappMessageTemplateWorkspaceTokenAPIs,
 }

--- a/packages/public-apis/src/lib/api.ts
+++ b/packages/public-apis/src/lib/api.ts
@@ -34,7 +34,7 @@ export class ChatbotXAPI {
       // throwHttpErrors: false,
       headers: {
         "Content-Type": "application/json",
-        "X-CHATBOT-TOKEN": this.apiKey,
+        Authorization: `Bearer ${this.apiKey}`,
       },
     })
   }


### PR DESCRIPTION
## Summary

- Add workspace token API for **error logs** (`GET /v1/error-logs`)
- Add workspace token API for **WhatsApp message templates** (`GET /v1/whatsapp-message-templates`)
- Add workspace token API for **inbox teams** (`GET /v1/inbox-teams`)
- Wire new APIs into `publicRouter`
- Update oRPC skill documentation

## Files changed

- `enterprise/features/inbox-teams/api/workspace-token.ts` — new
- `features/error-logs/api/workspace-token.ts`
- `features/integration-whatsapp/message-templates/api/workspace-token.ts` — new
- `features/integration-whatsapp/message-templates/api/index.ts`
- `routers/public.ts` — register new API groups
- `.agents/skills/orpc-api/SKILL.md` — updated docs

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm --filter builder check-types` passes
- [ ] `GET /api/v1/error-logs` returns error logs for workspace
- [ ] `GET /api/v1/whatsapp-message-templates` returns templates
- [ ] `GET /api/v1/inbox-teams` returns teams

## Dependencies

Merge after `feat/api-v1-core` (#444) since that PR updates the auth middleware these APIs rely on.