### PR TITLE
feat: cache ai context

### DIFF
--- a/apps/worker/src/integration/handlers/automated-response/index.ts
+++ b/apps/worker/src/integration/handlers/automated-response/index.ts
@@ -108,7 +108,8 @@ export async function processAutomatedResponse(
         limit: 100,
       })
       const dbMessages = [...last100Messages].reverse()
-      messages = aiContextService.mapMessages(dbMessages)
+      const aiHistory = aiContextService.mapDbMessagesToContext(dbMessages)
+      messages = aiContextService.mapContextToModelMessages(aiHistory)
     }
 
     const startTime = Date.now()

--- a/packages/ai/src/constants/index.ts
+++ b/packages/ai/src/constants/index.ts
@@ -17,6 +17,18 @@ export const helpTexts = {
     "- If you use a tool, summarize the result concisely in natural language.",
     "- Only provide the most relevant information the customer is asking for.",
   ].join("\n"),
+  summarizer: {
+    previousSummary: (summary: string) =>
+      `This is the previous summary of the conversation: "${summary}"`,
+    latestMessages: "Here are the latest messages:",
+    updateSummaryPrompt:
+      "Please update the previous summary by incorporating the new information. Keep the summary concise and succinct (under 1000 characters), focusing on key information such as: customer name, issues encountered, needs, order status, and agreed decisions. Return the new summary.",
+    conversationHistory: "Below is the conversation history:",
+    newSummaryPrompt:
+      "Please summarize the above conversation concisely and succinctly (under 1000 characters). Focus on key information such as: customer name, issues encountered, needs, order status, and agreed decisions. Return the summary.",
+    shortenPrompt: (summary: string) =>
+      `The following summary is too long: "${summary}". Please shorten it to under 1000 characters while still retaining the most important key points.`,
+  },
 } as const
 
 export const mcpConstants = {
@@ -56,3 +68,4 @@ export const aiPolicies = {
 export const toolPrefixes = z.enum(["file", "fn", "mcp", "sys"])
 
 export const MAX_CONVERSATION_HISTORY = 100
+export const MAX_SUMMARY_LENGTH = 1000

--- a/packages/ai/src/server/services/ai-context-service.ts
+++ b/packages/ai/src/server/services/ai-context-service.ts
@@ -1,14 +1,17 @@
 import { createHash } from "node:crypto"
 import { db } from "@chatbotx.io/database/client"
-import { aiMessageRoles } from "@chatbotx.io/database/partials"
+import { aiMessageRoles, senderTypes } from "@chatbotx.io/database/partials"
 import { AIJobAction, aiAgentQueue } from "@chatbotx.io/worker-config"
 import type { ModelMessage } from "ai"
+import { MAX_CONVERSATION_HISTORY, MAX_SUMMARY_LENGTH } from "../../constants"
 import { logger } from "../../logger"
 import { aiContextStore } from "../cache/ai-context-store"
-import type { AIContext, AIMessage } from "../cache/schema"
+import {
+  type AIContext,
+  type AIMessage,
+  aiContextSchema,
+} from "../cache/schema"
 import { summarizeConversation } from "./summarizer"
-
-const HISTORY_LIMIT = 20
 
 type DBConversationMessage = {
   id: string
@@ -68,104 +71,8 @@ function isSameContextMessage(
 
 export const aiContextService = {
   /**
-   * Map database messages to AI SDK ModelMessage format
+   * Normalize any message format to AIMessage for context storage
    */
-  mapMessages(dbMessages: Array<{ text: string | null; senderType: string }>) {
-    const messages: ModelMessage[] = []
-    for (const msg of dbMessages) {
-      if (!msg.text) {
-        continue
-      }
-
-      if (msg.senderType === "contact") {
-        messages.push({
-          role: aiMessageRoles.enum.user,
-          content: msg.text,
-        })
-      } else if (msg.senderType === "user" || msg.senderType === "bot") {
-        messages.push({
-          role: aiMessageRoles.enum.assistant,
-          content: msg.text,
-        })
-      }
-    }
-    return messages
-  },
-
-  mapMessagesForContext(dbMessages: DBConversationMessage[]): AIMessage[] {
-    return dbMessages
-      .flatMap((msg) => {
-        if (!msg.text) {
-          return []
-        }
-
-        if (
-          msg.senderType !== "contact" &&
-          msg.senderType !== "user" &&
-          msg.senderType !== "bot"
-        ) {
-          return []
-        }
-
-        const role =
-          msg.senderType === "contact"
-            ? aiMessageRoles.enum.user
-            : aiMessageRoles.enum.assistant
-
-        const createdAt = normalizeTimestamp(msg.createdAt)
-        const normalized = this.normalizeMessageForContext(
-          {
-            role,
-            content: msg.text,
-          },
-          {
-            messageId: msg.id,
-            createdAt,
-          },
-        )
-
-        return normalized ? [normalized] : []
-      })
-      .slice(-HISTORY_LIMIT)
-  },
-
-  mapContextToModelMessages(history: AIMessage[]): ModelMessage[] {
-    const modelMessages: ModelMessage[] = []
-    for (const message of history) {
-      if (message.role === "tool") {
-        continue
-      }
-
-      const content =
-        typeof message.content === "string"
-          ? message.content
-          : JSON.stringify(message.content)
-
-      if (message.role === "user") {
-        modelMessages.push({
-          role: "user",
-          content,
-        })
-        continue
-      }
-
-      if (message.role === "assistant") {
-        modelMessages.push({
-          role: "assistant",
-          content,
-        })
-        continue
-      }
-
-      modelMessages.push({
-        role: "system",
-        content,
-      })
-    }
-
-    return modelMessages
-  },
-
   normalizeMessageForContext(
     message: ModelMessage,
     metadata?: { messageId?: string; createdAt?: number | Date },
@@ -176,12 +83,12 @@ export const aiContextService = {
     if (typeof message.content === "string") {
       const normalizedContent = message.content
       return {
-        role: message.role,
+        role: message.role as AIMessage["role"],
         content: normalizedContent,
         messageId:
           messageId ??
           fallbackMessageId({
-            role: message.role,
+            role: message.role as AIMessage["role"],
             content: normalizedContent,
             createdAt,
           }),
@@ -237,17 +144,71 @@ export const aiContextService = {
     }
 
     return {
-      role: message.role,
+      role: message.role as AIMessage["role"],
       content: normalizedParts,
       messageId:
         messageId ??
         fallbackMessageId({
-          role: message.role,
+          role: message.role as AIMessage["role"],
           content: normalizedParts,
           createdAt,
         }),
       createdAt,
     }
+  },
+
+  /**
+   * Map database messages to AIMessage format for context
+   */
+  mapDbMessagesToContext(dbMessages: DBConversationMessage[]): AIMessage[] {
+    return dbMessages
+      .flatMap((msg) => {
+        if (!msg.text) {
+          return []
+        }
+
+        const senderTypeResult = senderTypes.safeParse(msg.senderType)
+        if (!senderTypeResult.success) {
+          return []
+        }
+
+        const role =
+          senderTypeResult.data === "contact"
+            ? aiMessageRoles.enum.user
+            : aiMessageRoles.enum.assistant
+
+        const normalized = this.normalizeMessageForContext(
+          {
+            role,
+            content: msg.text,
+          },
+          {
+            messageId: msg.id,
+            createdAt: msg.createdAt,
+          },
+        )
+
+        return normalized ? [normalized] : []
+      })
+      .slice(-MAX_CONVERSATION_HISTORY)
+  },
+
+  /**
+   * Map AIMessage (context format) to ModelMessage (AI SDK format)
+   */
+  mapContextToModelMessages(history: AIMessage[]): ModelMessage[] {
+    return history
+      .filter((msg) => msg.role !== "tool")
+      .map((msg) => {
+        const content = serializeMessageContent(msg.content)
+        if (msg.role === "user") {
+          return { role: "user", content }
+        }
+        if (msg.role === "assistant") {
+          return { role: "assistant", content }
+        }
+        return { role: "system", content }
+      })
   },
 
   /**
@@ -264,32 +225,31 @@ export const aiContextService = {
         let context = await aiContextStore.get(conversationId)
 
         if (!context) {
-          const last100Messages = await db.query.messageModel.findMany({
+          const lastMessages = await db.query.messageModel.findMany({
             where: { conversationId },
             orderBy: (table, { desc }) => [desc(table.createdAt)],
-            limit: 100,
+            limit: MAX_CONVERSATION_HISTORY,
           })
 
-          const dbMessages = [...last100Messages].reverse()
-          const aiMessages = this.mapMessages(dbMessages)
-          const aiHistory = this.mapMessagesForContext(dbMessages)
+          const dbMessages = [...lastMessages].reverse()
+          const aiHistory = this.mapDbMessagesToContext(dbMessages)
+          const modelMessages = this.mapContextToModelMessages(aiHistory)
 
           const summary = await summarizeConversation({
             workspaceId,
-            messages: aiMessages,
+            messages: modelMessages,
           })
 
-          const nextContext = {
-            summary,
+          const nextContext = aiContextSchema.parse({
+            summary: summary.slice(0, MAX_SUMMARY_LENGTH),
             history: aiHistory,
             summarizing: false,
             needsResummarize: false,
-          }
-          context = {
-            ...nextContext,
             updatedAt: Date.now(),
-          }
+          })
+
           await aiContextStore.update(conversationId, nextContext)
+          context = nextContext
         }
 
         return context
@@ -345,7 +305,7 @@ export const aiContextService = {
           return
         }
 
-        const shouldSummarize = currentHistory.length > HISTORY_LIMIT
+        const shouldSummarize = currentHistory.length > MAX_CONVERSATION_HISTORY
         const isSummarizing = context.summarizing === true
 
         await aiContextStore.update(conversationId, {

--- a/packages/ai/src/server/services/summarizer.ts
+++ b/packages/ai/src/server/services/summarizer.ts
@@ -4,18 +4,11 @@ import type {
 } from "@chatbotx.io/database/types"
 import { defaultAIModels } from "@chatbotx.io/flow-config"
 import { generateText } from "ai"
+import { helpTexts, MAX_SUMMARY_LENGTH } from "../../constants"
 import { logger } from "../../logger"
+import { aiProviders } from "../../schemas/ai-model"
 import { getCachedAIIntegration } from "../cache"
 import { createAIModelInstance } from "../factory"
-
-const PROVIDER_PRIORITY: Array<"openai" | "gemini" | "claude" | "deepseek"> = [
-  "openai",
-  "gemini",
-  "claude",
-  "deepseek",
-]
-
-const MAX_SUMMARY_LENGTH = 1000
 
 export async function summarizeConversation(props: {
   workspaceId: string
@@ -28,7 +21,7 @@ export async function summarizeConversation(props: {
   let selectedProvider: string | undefined
   let selectedModel: IntegrationOpenAIModel | IntegrationGeminiModel | undefined
 
-  for (const provider of PROVIDER_PRIORITY) {
+  for (const provider of aiProviders.options) {
     const integration = await getCachedAIIntegration({
       workspaceId,
       provider,
@@ -68,16 +61,17 @@ export async function summarizeConversation(props: {
     .join("\n")
 
   const prompt = existingSummary
-    ? `This is the previous summary of the conversation: "${existingSummary}"
-
-Here are the latest messages:
-${messagesToSummarize}
-
-Please update the previous summary by incorporating the new information. Keep the summary concise and succinct (under 1000 characters), focusing on key information such as: customer name, issues encountered, needs, order status, and agreed decisions. Return the new summary.`
-    : `Below is the conversation history:
-${messagesToSummarize}
-
-Please summarize the above conversation concisely and succinctly (under 1000 characters). Focus on key information such as: customer name, issues encountered, needs, order status, and agreed decisions. Return the summary.`
+    ? [
+        helpTexts.summarizer.previousSummary(existingSummary),
+        helpTexts.summarizer.latestMessages,
+        messagesToSummarize,
+        helpTexts.summarizer.updateSummaryPrompt,
+      ].join("\n\n")
+    : [
+        helpTexts.summarizer.conversationHistory,
+        messagesToSummarize,
+        helpTexts.summarizer.newSummaryPrompt,
+      ].join("\n\n")
 
   try {
     const { text } = await generateText({
@@ -93,7 +87,7 @@ Please summarize the above conversation concisely and succinctly (under 1000 cha
     if (finalSummary.length > MAX_SUMMARY_LENGTH) {
       const { text: compressedText } = await generateText({
         model: aiModel,
-        prompt: `The following summary is too long: "${finalSummary}". Please shorten it to under 1000 characters while still retaining the most important key points.`,
+        prompt: helpTexts.summarizer.shortenPrompt(finalSummary),
         maxOutputTokens: 400,
         temperature: 0.2,
       })


### PR DESCRIPTION
Rebased from #456 (conflicting) onto `feat/ai-generate-image-new`.

Conflicts resolved:
- `ai-context-service.ts`: use `mapDbMessagesToContext` + `aiContextSchema.parse` + `MAX_CONVERSATION_HISTORY`
- `summarizer.ts`: use `aiProviders.options` + `helpTexts` constants
- `automated-response/index.ts`: use new `mapDbMessagesToContext` + `mapContextToModelMessages`
- `automated-response/replies.ts`: keep HEAD refactor (`runAIAgentRunner` already includes `appendHistory`)
- `filesystem/package.json`: keep newer AWS SDK versions

Closes #456