### PR TITLE
feat: update chat widget

### DIFF
--- a/apps/builder/public/chat-widget/plugin-toggle.svg
+++ b/apps/builder/public/chat-widget/plugin-toggle.svg
@@ -1,13 +1,3 @@
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="comments" class="svg-inline--fa fa-comments fa-w-18" role="img" viewBox="0 0 576 512" version="1.1" id="svg4" sodipodi:docname="comments-solid.svg" inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)">
-  <metadata id="metadata10">
-    <rdf:RDF>
-      <cc:Work rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs id="defs8"/>
-  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="1001" id="namedview6" showgrid="false" inkscape:zoom="1.6210938" inkscape:cx="288" inkscape:cy="256" inkscape:window-x="-9" inkscape:window-y="-9" inkscape:window-maximized="1" inkscape:current-layer="svg4"/>
-  <path fill="currentColor" d="M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z" id="path2" style="fill:#ffffff"/>
-<script xmlns=""/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" aria-hidden="true" focusable="false" role="img">
+  <path fill="currentColor" d="M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z"/>
+</svg>

--- a/apps/builder/public/chat-widget/plugin-toggle.svg
+++ b/apps/builder/public/chat-widget/plugin-toggle.svg
@@ -1,0 +1,13 @@
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="comments" class="svg-inline--fa fa-comments fa-w-18" role="img" viewBox="0 0 576 512" version="1.1" id="svg4" sodipodi:docname="comments-solid.svg" inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)">
+  <metadata id="metadata10">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs id="defs8"/>
+  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="1001" id="namedview6" showgrid="false" inkscape:zoom="1.6210938" inkscape:cx="288" inkscape:cy="256" inkscape:window-x="-9" inkscape:window-y="-9" inkscape:window-maximized="1" inkscape:current-layer="svg4"/>
+  <path fill="currentColor" d="M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z" id="path2" style="fill:#ffffff"/>
+<script xmlns=""/></svg>

--- a/apps/builder/public/chat-widget/plugin.css
+++ b/apps/builder/public/chat-widget/plugin.css
@@ -1,33 +1,38 @@
 /* ChatbotX Widget Styles */
 .ahc-btn {
   position: fixed;
-  right: 16px;
-  bottom: 16px;
+  right: 20px;
+  bottom: 20px;
   z-index: 9999;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
+  width: 60px;
+  height: 60px;
   cursor: pointer;
-  background-color: white;
-  border: 1px solid gray;
+  background-color: #333333;
+  border: none;
   border-radius: 50%;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  transition:
+    transform 0.2s ease,
+    opacity 0.2s ease;
 }
 
 .ahc-btn img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: center center;
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
 }
 
 .ahc-btn:hover {
-  opacity: 0.8;
+  opacity: 0.9;
+  transform: scale(1.05);
 }
 
 .ahc-btn:active {
-  opacity: 0.6;
+  opacity: 0.8;
+  transform: scale(0.97);
 }
 
 .ahc-btn:focus {
@@ -35,32 +40,50 @@
   outline-offset: 2px;
 }
 
-.ahc-btn:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
+.ahc-btn--open img {
+  opacity: 0.85;
 }
 
-.ahc-btn:disabled:hover,
-.ahc-btn:disabled:active {
-  opacity: 0.6;
-}
-
-.ahc-btn:disabled:focus {
-  outline: 2px solid #00000040;
-  outline-offset: 2px;
-}
-
-.ahc-iframe {
+/* Iframe container — hidden by default */
+.ahc-iframe-container {
   position: fixed;
-  right: 16px;
-  bottom: 16px;
-  z-index: 9999;
+  right: 20px;
+  bottom: 96px;
+  z-index: 9998;
+  visibility: hidden;
   width: 350px;
-  max-width: calc(100vw - 32px);
-  height: 500px;
-  max-height: calc(100vh - 32px);
+  max-width: calc(100vw - 40px);
+  height: 520px;
+  max-height: calc(100vh - 120px);
+  overflow: hidden;
+  pointer-events: none;
   background: white;
   border: none;
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  border-radius: 20px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  opacity: 0;
+  /* delay visibility so it hides only after slide-out finishes */
+  transform: translateY(20px);
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease,
+    visibility 0s linear 0.3s;
+}
+
+.ahc-iframe-container--open {
+  visibility: visible;
+  pointer-events: auto;
+  opacity: 1;
+  transform: translateY(0);
+  /* make visible immediately on open */
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease,
+    visibility 0s linear 0s;
+}
+
+.ahc-iframe-container iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
 }

--- a/apps/builder/public/chat-widget/plugin.css
+++ b/apps/builder/public/chat-widget/plugin.css
@@ -1,14 +1,23 @@
 /* ChatbotX Widget Styles */
+
+/* Layout tokens — kept in sync so bottom offset stays correct if sizes change */
+:root {
+  --ahc-btn-size: 60px;
+  --ahc-btn-bottom: 20px;
+  --ahc-btn-right: 20px;
+  --ahc-iframe-gap: 16px;
+}
+
 .ahc-btn {
   position: fixed;
-  right: 20px;
-  bottom: 20px;
+  right: var(--ahc-btn-right);
+  bottom: var(--ahc-btn-bottom);
   z-index: 9999;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 60px;
-  height: 60px;
+  width: var(--ahc-btn-size);
+  height: var(--ahc-btn-size);
   cursor: pointer;
   background-color: #333333;
   border: none;
@@ -40,15 +49,31 @@
   outline-offset: 2px;
 }
 
+.ahc-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.ahc-btn:disabled:hover,
+.ahc-btn:disabled:active {
+  opacity: 0.5;
+  transform: none;
+}
+
 .ahc-btn--open img {
   opacity: 0.85;
 }
 
 /* Iframe container — hidden by default */
+/* bottom = button height + gap + button bottom offset */
 .ahc-iframe-container {
   position: fixed;
-  right: 20px;
-  bottom: 96px;
+  right: var(--ahc-btn-right);
+  bottom: calc(
+    var(--ahc-btn-size) +
+    var(--ahc-btn-bottom) +
+    var(--ahc-iframe-gap)
+  );
   z-index: 9998;
   visibility: hidden;
   width: 350px;
@@ -86,4 +111,12 @@
   width: 100%;
   height: 100%;
   border: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ahc-btn,
+  .ahc-iframe-container,
+  .ahc-iframe-container--open {
+    transition: none;
+  }
 }

--- a/apps/builder/public/chat-widget/plugin.js
+++ b/apps/builder/public/chat-widget/plugin.js
@@ -19,7 +19,9 @@
         "/chat-widget/plugin.css",
         csmChatWidget.webchatUrl,
       ).toString()
-      loadStylesheet(cssUrl)
+      loadStylesheet(cssUrl).catch(() => {
+        // stylesheet load failure is non-fatal; widget renders without custom styles
+      })
 
       // Load icon
       const iconUrl = new URL(
@@ -51,7 +53,7 @@
       url.searchParams.set("domain", window.location.hostname)
 
       csmChatWidget.floatButton = `<button type="button" class="ahc-btn"><img src="${iconUrl}" alt="Chat"></button>`
-      csmChatWidget.floatHtml = `<div class="ahc-iframe-container"><iframe id="ahc-iframe" src="${url.toString()}" frameborder="0"></iframe></div>`
+      csmChatWidget.floatHtml = `<div class="ahc-iframe-container"><iframe id="ahc-iframe" src="${url.toString()}"></iframe></div>`
 
       appendHtml(document.body, csmChatWidget.floatButton)
       appendHtml(document.body, csmChatWidget.floatHtml)
@@ -59,7 +61,11 @@
       const btn = document.querySelector(".ahc-btn")
       const container = document.querySelector(".ahc-iframe-container")
 
-      if (btn && config.brandColor) {
+      if (!(btn && container)) {
+        return
+      }
+
+      if (config.brandColor) {
         btn.style.backgroundColor = config.brandColor
       }
 
@@ -68,7 +74,12 @@
         btn.classList.toggle("ahc-btn--open", isOpen)
       })
 
+      const iframeOrigin = new URL(csmChatWidget.webchatUrl).origin
+
       window.addEventListener("message", (event) => {
+        if (event.origin !== iframeOrigin) {
+          return
+        }
         if (event.data?.type === "ahc:hide") {
           container.classList.remove("ahc-iframe-container--open")
           btn.classList.remove("ahc-btn--open")

--- a/apps/builder/public/chat-widget/plugin.js
+++ b/apps/builder/public/chat-widget/plugin.js
@@ -23,7 +23,7 @@
 
       // Load icon
       const iconUrl = new URL(
-        "/brand/icon_black.svg",
+        "/chat-widget/plugin-toggle.svg",
         csmChatWidget.webchatUrl,
       ).toString()
 
@@ -50,11 +50,30 @@
 
       url.searchParams.set("domain", window.location.hostname)
 
-      csmChatWidget.floatButton = `<button type="button" class="ahc-btn"><img src="${iconUrl}"></button>`
-      csmChatWidget.floatHtml = `<div class="ahc-iframe"><iframe id="ahc-iframe" src="${url.toString()}" class="ahc-iframe"></iframe></div>`
+      csmChatWidget.floatButton = `<button type="button" class="ahc-btn"><img src="${iconUrl}" alt="Chat"></button>`
+      csmChatWidget.floatHtml = `<div class="ahc-iframe-container"><iframe id="ahc-iframe" src="${url.toString()}" frameborder="0"></iframe></div>`
 
       appendHtml(document.body, csmChatWidget.floatButton)
       appendHtml(document.body, csmChatWidget.floatHtml)
+
+      const btn = document.querySelector(".ahc-btn")
+      const container = document.querySelector(".ahc-iframe-container")
+
+      if (btn && config.brandColor) {
+        btn.style.backgroundColor = config.brandColor
+      }
+
+      btn.addEventListener("click", () => {
+        const isOpen = container.classList.toggle("ahc-iframe-container--open")
+        btn.classList.toggle("ahc-btn--open", isOpen)
+      })
+
+      window.addEventListener("message", (event) => {
+        if (event.data?.type === "ahc:hide") {
+          container.classList.remove("ahc-iframe-container--open")
+          btn.classList.remove("ahc-btn--open")
+        }
+      })
     },
   }
 
@@ -94,7 +113,7 @@
   }
 
   function loadStylesheet(href) {
-    new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       const link = document.createElement("link")
       link.rel = "stylesheet"
       link.href = href

--- a/apps/builder/src/features/integration-webchat/webchat-header.tsx
+++ b/apps/builder/src/features/integration-webchat/webchat-header.tsx
@@ -13,10 +13,8 @@ export const WebchatHeader = () => {
   // }
 
   const hideWebchatIframe = () => {
-    const iframe = document.getElementById("ahc-iframe")
-    if (iframe) {
-      iframe.style.display = "none"
-    }
+    // "*" is intentional — widget is embedded in unknown customer domains
+    window.parent.postMessage({ type: "ahc:hide" }, "*")
   }
 
   return (


### PR DESCRIPTION
## Summary

- Add toggle button to show/hide chat frame
- Implement smooth open/close animation for chat frame

## Fixes applied (post-review)

- **Null guard** — bail out early if `btn` or `container` can't be found in the DOM after insertion, preventing a crash on unexpected DOM states
- **postMessage origin validation** — `ahc:hide` messages are now validated against the iframe's origin; third-party scripts on the host page can no longer spoof a close event
- **SVG cleanup** — stripped all Inkscape editor metadata, sodipodi/DC/RDF namespaces, the empty `<script>` tag (CSP blocker), and the inline `style="fill:#ffffff"` that overrode `currentColor`; file is now ~80% smaller and CSP-safe
- **Deprecated `frameborder` removed** — CSS `border: none` already handles this
- **CSS custom properties** — button size, bottom offset, and right offset are now tokens (`--ahc-btn-size`, `--ahc-btn-bottom`, etc.) so the iframe container position stays correct if the button dimensions change
- **Restored `:disabled` button styles** — prevents broken UX if the button is ever disabled (e.g., while loading)
- **`prefers-reduced-motion`** — all widget transitions are disabled for users who opt out of motion
- **Unhandled promise rejection fixed** — `loadStylesheet` now has an explicit `.catch()` with a comment

## Test plan

- [ ] Toggle button opens and closes the iframe
- [ ] Clicking the X inside the webchat closes the iframe (postMessage flow)
- [ ] `brandColor` config applies correctly to button background
- [ ] Widget renders correctly when stylesheet load fails (graceful degradation)
- [ ] No console errors on pages that embed the widget
- [ ] Animations are suppressed under `prefers-reduced-motion: reduce`