### PR TITLE
fix(whatsapp): detect OAuth revoked tokens in error mapper

### DIFF
--- a/.claude/commands/commit-pr.md
+++ b/.claude/commands/commit-pr.md
@@ -1,0 +1,56 @@
+---
+description: Commit staged changes, push branch, and open a PR in one shot
+allowed-tools: Bash, Read
+---
+
+Run `/commit` flow then push and open PR. Follows `.agents/rules/git.md`.
+
+## Steps
+
+1. **Commit** — follow `.claude/commands/commit.md` end-to-end (analyze diff, stage specific files, conventional `<type>(<scope>): <subject>`, HEREDOC, no `--no-verify`, no attribution). Abort if nothing to commit.
+
+2. **Push** — parallel:
+   - `git rev-parse --abbrev-ref HEAD` to get branch
+   - `git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null` to check upstream
+   - If no upstream: `git push -u origin <branch>`; else `git push`
+   - Never force-push. Never push to `main`/`master` directly.
+
+3. **PR** — parallel:
+   - `git log main..HEAD --oneline` for commit list
+   - `git diff main...HEAD --stat` for scope
+   - `gh pr view --json url 2>/dev/null` to detect existing PR (skip create if present, return URL)
+
+4. **Draft PR body**:
+   - Title: same as commit subject (≤ 100 chars). Add `#<issue>` if `$ARGUMENTS` contains issue ref.
+   - Body sections: `## Summary` (1–3 bullets, why), `## Changes` (key files/modules), `## Test plan` (markdown checklist).
+
+5. **Create PR** against `main`:
+   ```bash
+   gh pr create --base main --title "<title>" --body "$(cat <<'EOF'
+   ## Summary
+   - ...
+
+   ## Changes
+   - ...
+
+   ## Test plan
+   - [ ] pnpm lint
+   - [ ] pnpm --filter <app> check-types
+   - [ ] manual verification
+   EOF
+   )"
+   ```
+
+6. Return PR URL.
+
+## Arguments
+
+$ARGUMENTS — optional issue ref / hint (e.g. `#414 flow token`). Used in PR title/body when present.
+
+## Guardrails
+
+- No `git add -A`/`.`, no `.env`, no secrets.
+- No `--no-verify`, no `--force`/`--force-with-lease` unless user explicitly asks.
+- No attribution footers.
+- If branch is `main`/`master`: abort and tell user to create feature branch first.
+- If `pnpm lint` or typecheck obviously broken in diff, warn before pushing (do not auto-run unless asked).

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,46 @@
+---
+description: Stage specific files and create a conventional commit following ChatbotX git rules
+allowed-tools: Bash, Read
+---
+
+Create a git commit for the current changes following the ChatbotX conventions in `.agents/rules/git.md`.
+
+## Steps
+
+1. Run in parallel:
+   - `git status` (never `-uall`)
+   - `git diff` (staged + unstaged)
+   - `git log -n 10 --oneline` for style reference
+
+2. Analyze the diff:
+   - Determine commit `type`: `feat`, `fix`, `bugfix`, `refactor`, `docs`, `style`, `test`, `chore`, `ci`, `perf`, `build`, `revert`
+   - Determine `scope` from touched package/app/feature when obvious (e.g. `builder`, `worker`, `whatsapp`, `database`)
+   - Draft subject: `<type>(<scope>): <subject>` — ≤ 100 chars, lowercase after `:`, no trailing period
+   - Add body only when the *why* is non-obvious
+
+3. Stage **specific files only** — never `git add -A` or `git add .`.
+   - Skip `.env*` and any file containing secrets. Warn if user explicitly requests them.
+
+4. Commit using a HEREDOC so formatting is preserved:
+   ```bash
+   git commit -m "$(cat <<'EOF'
+   <type>(<scope>): <subject>
+
+   <optional body>
+   EOF
+   )"
+   ```
+   - Do **not** pass `--no-verify`. Let `lefthook` commit-msg + pre-commit hooks run.
+   - If a hook fails, fix the underlying issue and create a **new** commit (do not `--amend`).
+
+5. Run `git status` after commit to confirm clean state.
+
+## Arguments
+
+$ARGUMENTS — optional. Treat as a hint about scope/intent (e.g. `flow token fallback`). Still derive type/scope from the diff.
+
+## Guardrails
+
+- No attribution / `Co-Authored-By` footers (disabled globally).
+- No pushing in this command — use `/pr` for that.
+- If nothing is staged and there are no changes, abort without creating an empty commit.

--- a/integrations/whatsapp/src/lib/error-mapper.ts
+++ b/integrations/whatsapp/src/lib/error-mapper.ts
@@ -184,6 +184,13 @@ function mapApiFields(fields: ChannelErrorSource): ChannelError {
 // === Revoked / invalidated access token detection ===
 // WA Cloud API signals revoked permission via GraphMethodException + code 100 + subcode 33
 // (system user / phone number disconnected, or permission revoked).
+// FB Graph signals revoked tokens via OAuthException + code 190 + specific subcodes:
+//   458 = app not installed / user not authenticated
+//   460 = password changed
+//   463 = access token expired
+//   467 = invalid access token
+const REVOKED_TOKEN_SUBCODES = new Set([458, 460, 463, 467])
+
 export function isRevokedTokenError(error: unknown): boolean {
   if (!(error instanceof WhatsappException)) {
     return false
@@ -191,11 +198,18 @@ export function isRevokedTokenError(error: unknown): boolean {
 
   const mappedError = mapToChannelError(error)
 
-  return (
+  const isGraphMethodRevoked =
     mappedError.type === "GraphMethodException" &&
     mappedError.code === 100 &&
     Number(mappedError.subCode) === 33
-  )
+
+  const isOAuthRevoked =
+    mappedError.category === ChannelErrorCategory.AUTH_FAILED &&
+    mappedError.code === 190 &&
+    mappedError.subCode !== null &&
+    REVOKED_TOKEN_SUBCODES.has(Number(mappedError.subCode))
+
+  return isGraphMethodRevoked || isOAuthRevoked
 }
 
 export function mapToChannelError(rawError: unknown): ChannelError {


### PR DESCRIPTION
## Summary
- WhatsApp disconnect flow only triggered on `GraphMethodException` (100/33), missing OAuth revocations that surface as `OAuthException` (190).
- Brings WhatsApp revocation detection in line with the Messenger integration so disconnect/reauth handling fires consistently.
- Also ships project-local Claude Code slash commands (`/commit`, `/commit-pr`) that codify ChatbotX git conventions.

## Changes
- `integrations/whatsapp/src/lib/error-mapper.ts`: extend `isRevokedTokenError` to also match `AUTH_FAILED` + code 190 + subcodes `{458, 460, 463, 467}` (app uninstalled, password changed, token expired, invalid token).
- `.claude/commands/commit.md`, `.claude/commands/commit-pr.md`: Claude Code slash commands.

## Test plan
- [ ] `pnpm lint`
- [ ] `pnpm --filter @chatbotx.io/integration-whatsapp check-types`
- [ ] Manual: simulate WhatsApp OAuthException 190/463 → channel marked disconnected.