### PR TITLE
fix(whatsapp): use /ref- prefix for inbox referral links

### DIFF
--- a/integrations/whatsapp/src/handlers/message/incomming-message.ts
+++ b/integrations/whatsapp/src/handlers/message/incomming-message.ts
@@ -48,11 +48,18 @@ export const receiveMessage: MessageHandlers<WhatsappAuthValue>["receiveMessage"
       firstName: data.name,
     }
     let postbackAction: string | null = null
+    let ref: string | null = null
 
     switch (data.message.type) {
-      case "text":
-        message.text = (data.message as ServerTextMessage).text.body
+      case "text": {
+        const body = (data.message as ServerTextMessage).text.body
+        if (body.startsWith("/ref-")) {
+          ref = body.slice(5)
+        } else {
+          message.text = body
+        }
         break
+      }
       case "audio": {
         const attached = (data.message as ServerAudioMessage).audio
         const mediaSpecs = await fetchMedia(ctx, whatsappClient, attached.id)
@@ -190,7 +197,7 @@ export const receiveMessage: MessageHandlers<WhatsappAuthValue>["receiveMessage"
       contact,
       postbackAction,
       quickReplyAction: null,
-      ref: null,
+      ref,
     }
   }
 

--- a/packages/business/src/inbox/utils.ts
+++ b/packages/business/src/inbox/utils.ts
@@ -28,7 +28,7 @@ export function buildInboxLink(
     whatsapp: {
       url: `https://wa.me/${inbox.integrationWhatsapp?.displayPhoneNumber ?? ""}`,
       refKey: "text",
-      refValue: refValue ? `/${refValue}` : undefined,
+      refValue: refValue ? `/ref-${refValue}` : undefined,
     },
     telegram: {
       url: `https://t.me/${inbox.name}`,


### PR DESCRIPTION
## Summary
- Align WhatsApp referral link generation and inbound parsing on a shared `/ref-` prefix so the receive handler can reliably extract `ref` from the message text body.
- Previously the link wrote `/<refValue>` while the handler hardcoded `ref: null`, so ref-triggered flows/drafts never fired on WhatsApp replies.

## Changes
- `packages/business/src/inbox/utils.ts`: build WhatsApp share link with `/ref-${refValue}` instead of `/${refValue}`.
- `integrations/whatsapp/src/handlers/message/incomming-message.ts`: detect `/ref-` prefix in incoming text, extract the ref, and propagate it on the returned message context.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter @chatbotx.io/integration-whatsapp check-types`
- [x] `pnpm --filter @chatbotx.io/business check-types`
- [x] Manual: open a WhatsApp inbox link with a ref param, send the prefilled message, verify ref-driven flow/draft triggers correctly