### PR TITLE
feat: migrate credentials to credential service

### DIFF
--- a/apps/builder/src/app/integrations/[...integration]/callback.ts
+++ b/apps/builder/src/app/integrations/[...integration]/callback.ts
@@ -1,4 +1,8 @@
-import { organizationService, workspaceService } from "@chatbotx.io/business"
+import {
+  organizationCredentialService,
+  organizationService,
+  workspaceService,
+} from "@chatbotx.io/business"
 import { db } from "@chatbotx.io/database/client"
 import type { IntegrationType } from "@chatbotx.io/database/partials"
 import {
@@ -52,7 +56,6 @@ export const handleCallback = async (
 
   // find organization from domain and current user
   const organization = await organizationService.findByDomain(url.hostname)
-  const organizationSettings = organization.settings
 
   const userId = await getCurrentUserId()
   if (!userId) {
@@ -74,12 +77,16 @@ export const handleCallback = async (
   let googleSheetsAuth: Oauth2AuthValue | null = null
   switch (integrationType) {
     case "zalo": {
-      if (!organizationSettings.zalo) {
+      const zaloCredential = await organizationCredentialService.findDecrypted({
+        organizationId: organization.id,
+        type: "zalo",
+      })
+      if (!zaloCredential) {
         return notFound()
       }
 
       await connectZaloHandler({
-        zaloSettings: organizationSettings.zalo,
+        zaloSettings: zaloCredential.config,
         workspaceId: workspace.id,
         req,
       })
@@ -88,7 +95,12 @@ export const handleCallback = async (
     }
 
     case "googleSheets": {
-      if (!organizationSettings.google) {
+      const googleCredential =
+        await organizationCredentialService.findDecrypted({
+          organizationId: organization.id,
+          type: "google",
+        })
+      if (!googleCredential) {
         return notFound()
       }
 
@@ -100,7 +112,7 @@ export const handleCallback = async (
 
       authResult = (await integrations.googleSheets.handleRequest?.({
         config: {
-          ...organizationSettings.google,
+          ...googleCredential.config,
           redirectUrl: callbackUrl,
         },
         req,

--- a/apps/builder/src/app/integrations/[...integration]/webhook.ts
+++ b/apps/builder/src/app/integrations/[...integration]/webhook.ts
@@ -1,8 +1,8 @@
-import { organizationService } from "@chatbotx.io/business"
 import {
-  type OrganizationSettings,
-  organizationSettingsSchema,
-} from "@chatbotx.io/database/partials"
+  organizationCredentialService,
+  organizationService,
+} from "@chatbotx.io/business"
+import { organizationCredentialTypes } from "@chatbotx.io/database/partials"
 import { integrationQueue } from "@chatbotx.io/worker-config"
 import type { NextRequest } from "next/server"
 import { findIntegrationTelegramByBotId } from "@/features/integration-telegram/queries"
@@ -22,9 +22,27 @@ export const handleWebhook = async (
   const domain = await getDomainFromHeader()
   const organization = await organizationService.findByDomain(domain)
 
-  // Verify organization settings
-  const orgSettings = organizationSettingsSchema.parse(organization?.settings)
-  if (!orgSettings?.[integrationType as keyof OrganizationSettings]) {
+  const credentialTypeResult =
+    organizationCredentialTypes.safeParse(integrationType)
+  if (!credentialTypeResult.success) {
+    logger.debug(
+      `Integration ${integrationType} is not a supported credential type`,
+    )
+    return new Response(
+      JSON.stringify({ message: "Integration is not configured" }),
+      {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      },
+    )
+  }
+
+  const credential = await organizationCredentialService.findDecrypted({
+    organizationId: organization.id,
+    type: credentialTypeResult.data,
+  })
+
+  if (!credential) {
     logger.debug(`Integration ${integrationType} is not configured`)
     return new Response(
       JSON.stringify({ message: "Integration is not configured" }),
@@ -51,24 +69,10 @@ export const handleWebhook = async (
     req.nextUrl,
   ).toString()
 
-  const settings = orgSettings[integration.name as keyof OrganizationSettings]
-
-  if (!settings) {
-    return new Response(
-      JSON.stringify({
-        message: `Integration ${integration.name} is not configured`,
-      }),
-      {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      },
-    )
-  }
-
   try {
     const result = await integration.handleRequest({
       config: {
-        ...settings,
+        ...credential.config,
         redirectUrl,
         stateParams: {
           workspaceId: req.nextUrl.searchParams.get("workspaceId") ?? "",


### PR DESCRIPTION
## Summary

- **Credential service migration**: `callback.ts` and `webhook.ts` now fetch integration credentials via `organizationCredentialService.findDecrypted()` instead of reading from `organization.settings` directly, aligning with the encrypted credential storage pattern.

## Changes
### `apps/builder/src/app/integrations/[...integration]/`
- `callback.ts`: replaced `organizationSettings.zalo` / `organizationSettings.google` reads with `organizationCredentialService.findDecrypted()`
- `webhook.ts`: replaced `organizationSettingsSchema.parse()` check with `organizationCredentialTypes.safeParse()` validation + `organizationCredentialService.findDecrypted()`, removing a now-redundant second settings guard

## Test plan
- [ ] Connect Zalo / Google Sheets integration via OAuth callback — flow completes without error
- [ ] Trigger a webhook for a configured integration — returns 200; trigger for an unconfigured type — returns 404
