### PR TITLE
fix: get-data-from-json step — states support, safe JSON parse, and proper return types

### DIFF
--- a/apps/builder/src/features/flows/react-flow/steps/get-data-from-json/viewer.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/get-data-from-json/viewer.tsx
@@ -1,17 +1,35 @@
 "use client"
 
+import type { GetDataFromJsonStepSchema } from "@chatbotx.io/flow-config"
+import { Card, CardContent } from "@chatbotx.io/ui/components/ui/card"
 import { CodeIcon } from "lucide-react"
 import { useTranslations } from "next-intl"
+import { BaseStateViewer } from "../../states/viewer"
 import { BaseStepViewer } from "../base/viewer"
 
-const GetDataFromJsonViewer = () => {
+const GetDataFromJsonViewer = ({
+  data,
+}: {
+  data: GetDataFromJsonStepSchema
+}) => {
   const t = useTranslations()
 
   return (
-    <BaseStepViewer
-      icon={CodeIcon}
-      title={t("flows.actions.getDataFromJson")}
-    />
+    <Card className="overflow-hidden p-0">
+      <CardContent className="p-0">
+        <div className="px-4 py-2">
+          <BaseStepViewer
+            icon={CodeIcon}
+            title={t("flows.actions.getDataFromJson")}
+          />
+        </div>
+        <div className="my-2 mr-3 flex flex-col gap-1">
+          {data.states.map((state) => (
+            <BaseStateViewer data={state} key={state.id} />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
   )
 }
 

--- a/apps/worker/src/integration/handlers/tool-handler.ts
+++ b/apps/worker/src/integration/handlers/tool-handler.ts
@@ -16,6 +16,7 @@ import { faker } from "@faker-js/faker"
 import { format } from "date-fns"
 import { getProperty } from "dot-prop"
 import type { ExecuteStepProps } from "./flow"
+import type { ExecuteStepResult } from "./step"
 
 export async function countCharacters({
   conversation,
@@ -215,7 +216,7 @@ export async function generateCode({
 export async function getDataFromJSON({
   conversation,
   step,
-}: ExecuteStepProps<GetDataFromJsonStepSchema>) {
+}: ExecuteStepProps<GetDataFromJsonStepSchema>): Promise<ExecuteStepResult> {
   const inputValue = await db.query.contactCustomFieldModel.findFirst({
     where: {
       contactId: conversation.contactId,
@@ -223,10 +224,16 @@ export async function getDataFromJSON({
     },
   })
   if (!inputValue) {
-    return
+    return { status: "error", result: undefined }
   }
 
-  const dataJSON = JSON.parse(inputValue.value)
+  let dataJSON: unknown
+  try {
+    dataJSON = JSON.parse(inputValue.value)
+  } catch {
+    return { status: "error", result: undefined }
+  }
+
   const mapping = step.mapping as {
     jsonPath: string
     outputFieldId: string
@@ -260,8 +267,9 @@ export async function getDataFromJSON({
       if (validCustomFieldIds.includes(data.outputFieldId)) {
         const value = getProperty(dataJSON, data.jsonPath)
 
-        if (value) {
-          const encodedValue = JSON.stringify(value)
+        if (value !== undefined && value !== null) {
+          const encodedValue =
+            typeof value === "string" ? value : JSON.stringify(value)
 
           // Get existing value
           const existing = await tx.query.contactCustomFieldModel.findFirst({
@@ -314,4 +322,6 @@ export async function getDataFromJSON({
       field.newValue,
     )
   }
+
+  return { status: "success", result: undefined }
 }

--- a/apps/worker/src/integration/handlers/tool-handler.ts
+++ b/apps/worker/src/integration/handlers/tool-handler.ts
@@ -36,6 +36,7 @@ export async function countCharacters({
     await db.query.contactCustomFieldModel.findFirst({
       where: {
         customFieldId: step.inputFieldId,
+        contactId: conversation.contactId,
       },
     })
   if (!targetContactCustomField) {
@@ -224,20 +225,25 @@ export async function getDataFromJSON({
     },
   })
   if (!inputValue) {
-    return { status: "error", result: undefined }
+    return {
+      status: "error",
+      errorMessage: "Input custom field not found",
+      result: null,
+    }
   }
 
   let dataJSON: unknown
   try {
     dataJSON = JSON.parse(inputValue.value)
   } catch {
-    return { status: "error", result: undefined }
+    return {
+      status: "error",
+      errorMessage: "Input custom field value is not valid JSON",
+      result: null,
+    }
   }
 
-  const mapping = step.mapping as {
-    jsonPath: string
-    outputFieldId: string
-  }[]
+  const mapping = step.mapping
 
   // Find valid custom fields
   const validCustomFields = await db.query.customFieldModel.findMany({
@@ -263,6 +269,18 @@ export async function getDataFromJSON({
       newValue: string
     }> = []
 
+    // Batch-fetch existing values to avoid N+1 queries
+    const existingFields = await tx.query.contactCustomFieldModel.findMany({
+      where: {
+        contactId: conversation.contactId,
+        customFieldId: { in: validCustomFieldIds },
+      },
+      columns: { customFieldId: true, value: true },
+    })
+    const existingMap = new Map(
+      existingFields.map((f) => [f.customFieldId, f.value]),
+    )
+
     for (const data of mapping) {
       if (validCustomFieldIds.includes(data.outputFieldId)) {
         const value = getProperty(dataJSON, data.jsonPath)
@@ -270,15 +288,7 @@ export async function getDataFromJSON({
         if (value !== undefined && value !== null) {
           const encodedValue =
             typeof value === "string" ? value : JSON.stringify(value)
-
-          // Get existing value
-          const existing = await tx.query.contactCustomFieldModel.findFirst({
-            where: {
-              contactId: conversation.contactId,
-              customFieldId: data.outputFieldId,
-            },
-            columns: { value: true },
-          })
+          const oldValue = existingMap.get(data.outputFieldId) ?? null
 
           await tx
             .insert(contactCustomFieldModel)
@@ -302,7 +312,7 @@ export async function getDataFromJSON({
             customFieldId: data.outputFieldId,
             customFieldName:
               customFieldMap.get(data.outputFieldId) || data.outputFieldId,
-            oldValue: existing?.value || null,
+            oldValue,
             newValue: encodedValue,
           })
         }
@@ -323,5 +333,5 @@ export async function getDataFromJSON({
     )
   }
 
-  return { status: "success", result: undefined }
+  return { status: "success", result: null }
 }

--- a/packages/flow-config/src/steps/get-data-from-json.ts
+++ b/packages/flow-config/src/steps/get-data-from-json.ts
@@ -1,5 +1,11 @@
 import { createId, zodBigintAsString } from "@chatbotx.io/utils"
 import { z } from "zod"
+import {
+  errorStateDefaultFn,
+  errorStateSchema,
+  successStateDefaultFn,
+  successStateSchema,
+} from "../states"
 import { stepTypes } from "./step-action"
 
 export const getDataFromJsonStepSchema = z.object({
@@ -12,6 +18,7 @@ export const getDataFromJsonStepSchema = z.object({
       outputFieldId: z.string().trim().min(1),
     }),
   ),
+  states: z.tuple([successStateSchema, errorStateSchema]),
 })
 export type GetDataFromJsonStepSchema = z.infer<
   typeof getDataFromJsonStepSchema
@@ -27,4 +34,5 @@ export const getDataFromJsonStepDefaultFn = (): GetDataFromJsonStepSchema => ({
       outputFieldId: "",
     },
   ],
+  states: [successStateDefaultFn(), errorStateDefaultFn()],
 })


### PR DESCRIPTION
## Summary

- Add success/error states to `GetDataFromJsonStep` — The step schema now includes a `states` tuple (success + error) consistent with other step types. The flow builder viewer renders these states inline below the step header.
- Fix unsafe `JSON.parse` — Previously, a malformed custom field value would throw an unhandled exception and crash the worker. It is now wrapped in `try/catch` and returns an error result gracefully.
- Fix value encoding for string fields — String values extracted from JSON were previously double-encoded via `JSON.stringify(value)`. Now primitive strings are stored as-is; only non-string values are serialized.
- Fix falsy-value check — The old `if (value)` guard skipped legitimate falsy values (`0`, `false`, `""`). Changed to `value !== undefined && value !== null`.
- Explicit `ExecuteStepResult` return types — `getDataFromJSON` and `stepAutoAssignConversation` now declare `Promise<ExecuteStepResult>` return types and return structured `{ status, result }` objects instead of bare `return` statements.

## Test plan

- [ ] Create a flow with a Get Data from JSON step; confirm success and error states appear in the canvas viewer.
- [ ] Set a contact custom field to a valid JSON string and run the step — confirm mapped fields are saved correctly.
- [ ] Set the custom field to an invalid JSON string — confirm the step exits with `status: "error"` without crashing the worker.
- [ ] Set a mapped JSON path that resolves to `0` or `false` — confirm the value is saved (not skipped).
- [ ] Set a mapped JSON path that resolves to a plain string — confirm it is stored without extra quotes.
- [ ] Trigger `stepAutoAssignConversation` with no assigned IDs or no available agents — confirm the step returns `status: "error"` cleanly.
