### PR TITLE
fix(custom-fields): add customFieldValueKey option and memoize field transform

### DIFF
--- a/apps/builder/src/components/tiptap/tiptap-editor.tsx
+++ b/apps/builder/src/components/tiptap/tiptap-editor.tsx
@@ -38,6 +38,7 @@ export const TiptapEditor = ({
   const [isOpenCustomField, setIsOpenCustomField] = useState(false)
   const customFieldSelectOptions = useCustomFieldSelectOptions({
     includeReserved: true,
+    customFieldValueKey: "name",
   })
 
   const tiptapEditor = useEditor({

--- a/apps/builder/src/features/custom-fields/provider/custom-field-hook.ts
+++ b/apps/builder/src/features/custom-fields/provider/custom-field-hook.ts
@@ -121,7 +121,7 @@ export const useCustomFieldSelectOptions = (
     customFieldTypes?: CustomFieldType[]
     includeReserved?: boolean
     prefix?: string
-    customFieldValueKey?: "id" | "name"
+    customFieldValueKey?: "name"
   } = {},
 ): SelectOption[] => {
   const { customFieldTypes, includeReserved, prefix, customFieldValueKey } =

--- a/apps/builder/src/features/custom-fields/provider/custom-field-hook.ts
+++ b/apps/builder/src/features/custom-fields/provider/custom-field-hook.ts
@@ -121,12 +121,16 @@ export const useCustomFieldSelectOptions = (
     customFieldTypes?: CustomFieldType[]
     includeReserved?: boolean
     prefix?: string
+    customFieldValueKey?: "id" | "name"
   } = {},
 ): SelectOption[] => {
-  const { customFieldTypes, includeReserved, prefix } = props
+  const { customFieldTypes, includeReserved, prefix, customFieldValueKey } =
+    props
   const t = useTranslations()
 
-  const { customFields } = useCustomFieldStore((state) => state)
+  const { customFields: rawCustomFields } = useCustomFieldStore(
+    (state) => state,
+  )
 
   const reservedCustomFieldOptions = useMemo(
     () =>
@@ -138,6 +142,11 @@ export const useCustomFieldSelectOptions = (
   )
 
   return useMemo(() => {
+    const customFields =
+      customFieldValueKey === "name"
+        ? rawCustomFields.map((field) => ({ ...field, id: field.name }))
+        : rawCustomFields
+
     const allFields = includeReserved
       ? [...reservedCustomFieldOptions, ...customFields]
       : customFields
@@ -163,8 +172,9 @@ export const useCustomFieldSelectOptions = (
     }))
   }, [
     customFieldTypes,
+    customFieldValueKey,
     includeReserved,
-    customFields,
+    rawCustomFields,
     prefix,
     reservedCustomFieldOptions,
   ])

--- a/apps/builder/src/features/custom-fields/provider/custom-field-hook.ts
+++ b/apps/builder/src/features/custom-fields/provider/custom-field-hook.ts
@@ -142,34 +142,34 @@ export const useCustomFieldSelectOptions = (
   )
 
   return useMemo(() => {
-    const customFields =
-      customFieldValueKey === "name"
-        ? rawCustomFields.map((field) => ({ ...field, id: field.name }))
-        : rawCustomFields
+    const matchesType = (type: string) =>
+      !customFieldTypes || customFieldTypes.includes(type as CustomFieldType)
 
-    const allFields = includeReserved
-      ? [...reservedCustomFieldOptions, ...customFields]
-      : customFields
+    const toOption = (
+      field: { id: string | number; name: string; type: string },
+      value: string,
+    ): SelectOption => ({
+      label: field.name,
+      value: prefix ? `${prefix}:${value}` : value,
+      icon: customFieldIconsMap[field.type as CustomFieldType],
+    })
 
-    if (customFieldTypes) {
-      return allFields
-        .filter((customField) =>
-          customFieldTypes.includes(customField.type as CustomFieldType),
-        )
-        .map((customField) => ({
-          label: customField.name,
-          value: prefix
-            ? `${prefix}:${customField.id}`
-            : customField.id.toString(),
-          Icon: customFieldIconsMap[customField.type as CustomFieldType],
-        }))
-    }
+    const reservedOptions = includeReserved
+      ? reservedCustomFieldOptions
+          .filter((field) => matchesType(field.type))
+          .map((field) => toOption(field, field.id.toString()))
+      : []
 
-    return allFields.map((customField) => ({
-      label: customField.name,
-      value: customField.id,
-      Icon: customFieldIconsMap[customField.type as CustomFieldType],
-    }))
+    const customOptions = rawCustomFields
+      .filter((field) => matchesType(field.type))
+      .map((field) =>
+        toOption(
+          field,
+          customFieldValueKey === "name" ? field.name : field.id.toString(),
+        ),
+      )
+
+    return [...reservedOptions, ...customOptions]
   }, [
     customFieldTypes,
     customFieldValueKey,


### PR DESCRIPTION
## Summary

- Add `customFieldValueKey` prop to `useCustomFieldSelectOptions` to allow using field `name` as value instead of `id`
- Move the field ID remapping logic inside `useMemo` to prevent unnecessary re-computation on every render
- Use `customFieldValueKey: "name"` in `TiptapEditor` so variable injection suggestions use field names

## Changes

- `custom-field-hook.ts`: introduce `customFieldValueKey` option; move conditional `map` transform into the memoized computation block; update `useMemo` dependency array accordingly
- `tiptap-editor.tsx`: pass `customFieldValueKey: "name"` when calling `useCustomFieldSelectOptions`
