### PR TITLE
fix: coerce min/max to number in generateCode step schema

### DIFF
--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -1578,7 +1578,8 @@
   "validation": {
     "maxSize": "File size exceeds maximum limit",
     "maxItemsReached": "Maximum {max} {feature} allowed per workspace",
-    "invalidApiKey": "Invalid API key"
+    "invalidApiKey": "Invalid API key",
+    "maxMustBeGreaterThanMin": "{maxField} must be greater than or equal to {minField}"
   },
   "webchat": {
     "description": "Let your customers get instant automated responses from your business directly from your website",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -1593,7 +1593,8 @@
   "validation": {
     "maxSize": "Kích thước tệp vượt quá giới hạn tối đa",
     "maxItemsReached": "Tối đa {max} {feature} cho mỗi workspace",
-    "invalidApiKey": "API key không hợp lệ"
+    "invalidApiKey": "API key không hợp lệ",
+    "maxMustBeGreaterThanMin": "{maxField} phải lớn hơn hoặc bằng {minField}"
   },
   "webchat": {
     "description": "Cho phép khách hàng của bạn nhận phản hồi tự động ngay lập tức từ doanh nghiệp của bạn trực tiếp từ trang web của bạn",

--- a/apps/builder/src/features/flows/react-flow/button-editor-dialog.tsx
+++ b/apps/builder/src/features/flows/react-flow/button-editor-dialog.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import {
+  type ButtonStepInput,
   type ButtonStepProps,
   type ButtonType,
   buttonStepSchema,
@@ -229,7 +230,7 @@ export function ButtonEditorDialog() {
   )
   const onChangeButtonData = useStepStore((state) => state.onChangeButtonData)
 
-  const form = useForm<ButtonStepProps>({
+  const form = useForm<ButtonStepInput, object, ButtonStepProps>({
     resolver: zodResolver(buttonStepSchema),
     defaultValues: {},
     mode: "onChange",
@@ -281,7 +282,7 @@ export function ButtonEditorDialog() {
     setOpenButtonEditorDialog(false)
     onChangeButtonData({
       path: buttonPath,
-      data: values,
+      data: values as unknown as ButtonStepProps,
     })
   }, [
     activeNode,

--- a/apps/builder/src/features/flows/react-flow/steps/generate-code/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/generate-code/editor.tsx
@@ -1,11 +1,12 @@
 "use client"
 
 import {
+  type GenerateCodeStepInput,
   type GenerateCodeStepSchema,
   GenerateCodeType,
   generateCodeStepSchema,
 } from "@chatbotx.io/flow-config"
-import { InputField } from "@chatbotx.io/ui/components/form/input-field"
+import { InputNumberField } from "@chatbotx.io/ui/components/form/input-number-field"
 import { SelectField } from "@chatbotx.io/ui/components/form/select-field"
 import { Button } from "@chatbotx.io/ui/components/ui/button"
 import {
@@ -22,8 +23,13 @@ import { Form } from "@chatbotx.io/ui/components/ui/form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { ShuffleIcon } from "lucide-react"
 import { useTranslations } from "next-intl"
-import { useState } from "react"
-import { useForm, useFormContext } from "react-hook-form"
+import { useCallback, useEffect, useState } from "react"
+import {
+  type Resolver,
+  useForm,
+  useFormContext,
+  useWatch,
+} from "react-hook-form"
 import { CustomFieldSelect } from "@/features/custom-fields/custom-field-select"
 import { BaseStepEditor } from "../base/editor"
 
@@ -42,19 +48,55 @@ const GenerateCodeDialog = ({ parentName }: { parentName: string }) => {
   const [open, setOpen] = useState(false)
   const { setValue, getValues } = useFormContext()
 
-  const form = useForm<GenerateCodeStepSchema>({
-    resolver: zodResolver(generateCodeStepSchema),
+  const resolver = useCallback<
+    Resolver<GenerateCodeStepInput, object, GenerateCodeStepSchema>
+  >(
+    async (values, context, options) => {
+      const zodResolve = zodResolver(generateCodeStepSchema) as Resolver<
+        GenerateCodeStepInput,
+        object,
+        GenerateCodeStepSchema
+      >
+      const result = await zodResolve(values, context, options)
+      if (Number(values.min) > Number(values.max)) {
+        result.errors.max = {
+          type: "manual",
+          message: t("validation.maxMustBeGreaterThanMin", {
+            maxField: t("fields.max.label"),
+            minField: t("fields.min.label"),
+          }),
+        }
+      }
+      return result
+    },
+    [t],
+  )
+
+  const form = useForm<GenerateCodeStepInput, object, GenerateCodeStepSchema>({
+    resolver,
     defaultValues: {
       ...getValues(parentName),
     },
     mode: "onChange",
   })
 
+  const min = useWatch({
+    control: form.control,
+    name: "min",
+  })
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-trigger max validation when min changes
+  useEffect(() => {
+    form.trigger("max")
+  }, [min, form])
+
+  useEffect(() => {
+    if (open) {
+      form.reset(getValues(parentName))
+    }
+  }, [open, form, getValues, parentName])
+
   const onSubmit = (data: GenerateCodeStepSchema) => {
-    setValue(`${parentName}.type`, data.type)
-    setValue(`${parentName}.min`, data.min)
-    setValue(`${parentName}.max`, data.max)
-    setValue(`${parentName}.outputFieldId`, data.outputFieldId)
+    setValue(parentName, data)
     setOpen(false)
   }
 
@@ -67,7 +109,7 @@ const GenerateCodeDialog = ({ parentName }: { parentName: string }) => {
           </Button>
         </div>
       </DialogTrigger>
-      <DialogContent className={"max-h-screen overflow-y-scroll lg:max-w-5xl"}>
+      <DialogContent className="max-h-screen overflow-y-scroll lg:max-w-5xl">
         <DialogHeader>
           <DialogTitle>{t("flows.actions.generateCode")}</DialogTitle>
           <DialogDescription />
@@ -98,9 +140,17 @@ const GenerateCodeDialog = ({ parentName }: { parentName: string }) => {
               required
             />
 
-            <InputField label={t("fields.min.label")} name="min" required />
+            <InputNumberField
+              label={t("fields.min.label")}
+              name="min"
+              required
+            />
 
-            <InputField label={t("fields.max.label")} name="max" required />
+            <InputNumberField
+              label={t("fields.max.label")}
+              name="max"
+              required
+            />
 
             <CustomFieldSelect
               allowCreate={true}

--- a/apps/builder/src/features/flows/react-flow/steps/generate-code/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/generate-code/editor.tsx
@@ -52,13 +52,13 @@ const GenerateCodeDialog = ({ parentName }: { parentName: string }) => {
     Resolver<GenerateCodeStepInput, object, GenerateCodeStepSchema>
   >(
     async (values, context, options) => {
-      const zodResolve = zodResolver(generateCodeStepSchema) as Resolver<
+      const base = zodResolver(generateCodeStepSchema) as Resolver<
         GenerateCodeStepInput,
         object,
         GenerateCodeStepSchema
       >
-      const result = await zodResolve(values, context, options)
-      if (Number(values.min) > Number(values.max)) {
+      const result = await base(values, context, options)
+      if (result.errors.max?.type === "custom") {
         result.errors.max = {
           type: "manual",
           message: t("validation.maxMustBeGreaterThanMin", {

--- a/packages/flow-config/src/steps/button.ts
+++ b/packages/flow-config/src/steps/button.ts
@@ -67,6 +67,7 @@ export const buttonStepSchema = z
     ]),
   )
 export type ButtonStepProps = z.infer<typeof buttonStepSchema>
+export type ButtonStepInput = z.input<typeof buttonStepSchema>
 
 export const buttonStepDefaultFn = (
   props?: Pick<ButtonStepProps, "label">,

--- a/packages/flow-config/src/steps/generate-code.ts
+++ b/packages/flow-config/src/steps/generate-code.ts
@@ -8,18 +8,23 @@ export const GenerateCodeType = {
   ALPHANUMERIC_LENGTH: "ALPHANUMERIC_LENGTH",
 } as const
 
-export const generateCodeStepSchema = z.object({
-  id: zodBigintAsString(),
-  stepType: z.literal(stepTypes.enum.generateCode),
-  type: z.enum(GenerateCodeType),
-  min: z.coerce
-    .number()
-    .int()
-    .min(0)
-    .max(Number.MAX_SAFE_INTEGER - 1),
-  max: z.coerce.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
-  outputFieldId: z.string().trim().min(1),
-})
+export const generateCodeStepSchema = z
+  .object({
+    id: zodBigintAsString(),
+    stepType: z.literal(stepTypes.enum.generateCode),
+    type: z.enum(GenerateCodeType),
+    min: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .max(Number.MAX_SAFE_INTEGER - 1),
+    max: z.coerce.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+    outputFieldId: z.string().trim().min(1),
+  })
+  .refine((data) => data.min <= data.max, {
+    message: "Max must be greater than or equal to Min",
+    path: ["max"],
+  })
 export type GenerateCodeStepSchema = z.infer<typeof generateCodeStepSchema>
 export type GenerateCodeStepInput = z.input<typeof generateCodeStepSchema>
 

--- a/packages/flow-config/src/steps/generate-code.ts
+++ b/packages/flow-config/src/steps/generate-code.ts
@@ -8,24 +8,20 @@ export const GenerateCodeType = {
   ALPHANUMERIC_LENGTH: "ALPHANUMERIC_LENGTH",
 } as const
 
-export const generateCodeStepSchema = z
-  .object({
-    id: zodBigintAsString(),
-    stepType: z.literal(stepTypes.enum.generateCode),
-    type: z.enum(GenerateCodeType),
-    min: z
-      .number()
-      .int()
-      .min(0)
-      .max(Number.MAX_SAFE_INTEGER - 1),
-    max: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
-    outputFieldId: z.string().trim().min(1),
-  })
-  .refine((data) => data.min <= data.max, {
-    message: "Max must be larger than Min",
-    path: ["max"],
-  })
+export const generateCodeStepSchema = z.object({
+  id: zodBigintAsString(),
+  stepType: z.literal(stepTypes.enum.generateCode),
+  type: z.enum(GenerateCodeType),
+  min: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .max(Number.MAX_SAFE_INTEGER - 1),
+  max: z.coerce.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  outputFieldId: z.string().trim().min(1),
+})
 export type GenerateCodeStepSchema = z.infer<typeof generateCodeStepSchema>
+export type GenerateCodeStepInput = z.input<typeof generateCodeStepSchema>
 
 export const generateCodeStepDefaultFn = (): GenerateCodeStepSchema => ({
   id: createId(),

--- a/packages/ui/src/components/ui/input-number.tsx
+++ b/packages/ui/src/components/ui/input-number.tsx
@@ -115,7 +115,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
     }
 
     return (
-      <div className="flex items-center">
+      <div className="flex items-center w-full">
         <NumericFormat
           value={value}
           onValueChange={handleChange}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5761,116 +5761,99 @@ packages:
   '@react-email/body@0.3.0':
     resolution: {integrity: sha512-uGo0BOOzjbMUo3lu+BIDWayvn5o6Xyfmnlla5VGf05n8gHMvO1ll7U4FtzWe3hxMLwt53pmc4iE0M+B5slG+Ug==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/button@0.2.1':
     resolution: {integrity: sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/code-block@0.2.1':
     resolution: {integrity: sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/code-inline@0.0.6':
     resolution: {integrity: sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/column@0.0.14':
     resolution: {integrity: sha512-f+W+Bk2AjNO77zynE33rHuQhyqVICx4RYtGX9NKsGUg0wWjdGP0qAuIkhx9Rnmk4/hFMo1fUrtYNqca9fwJdHg==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/components@1.0.12':
     resolution: {integrity: sha512-tH18JhPDWgE+3jnYkzyB6ZrZdfNnEsFe4PwmuXmlOw4NGIysP8wPY5aXZg++pTG9qUabXg1nzX/FGHGkObH8xQ==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/container@0.0.16':
     resolution: {integrity: sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/font@0.0.10':
     resolution: {integrity: sha512-0urVSgCmQIfx5r7Xc586miBnQUVnGp3OTYUm8m5pwtQRdTRO5XrTtEfNJ3JhYhSOruV0nD8fd+dXtKXobum6tA==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/head@0.0.13':
     resolution: {integrity: sha512-AJg6le/08Gz4tm+6MtKXqtNNyKHzmooOCdmtqmWxD7FxoAdU1eVcizhtQ0gcnVaY6ethEyE/hnEzQxt1zu5Kog==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/heading@0.0.16':
     resolution: {integrity: sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/hr@0.0.12':
     resolution: {integrity: sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/html@0.0.12':
     resolution: {integrity: sha512-KTShZesan+UsreU7PDUV90afrZwU5TLwYlALuCSU0OT+/U8lULNNbAUekg+tGwCnOfIKYtpDPKkAMRdYlqUznw==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/img@0.0.12':
     resolution: {integrity: sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/link@0.0.13':
     resolution: {integrity: sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/markdown@0.0.18':
     resolution: {integrity: sha512-gSuYK5fsMbGk87jDebqQ6fa2fKcWlkf2Dkva8kMONqLgGCq8/0d+ZQYMEJsdidIeBo3kmsnHZPrwdFB4HgjUXg==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/preview-server@5.2.10':
     resolution: {integrity: sha512-cYi21KF+Z/HGXT8RpkQMNFFubBafxyoB9Hn/wrslfDNtdoews2MdsDo6XXKkZvDTRG9SxQN3HGk4v4aoQZc20g==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@react-email/preview@0.0.14':
     resolution: {integrity: sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
@@ -5891,21 +5874,18 @@ packages:
   '@react-email/row@0.0.13':
     resolution: {integrity: sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/section@0.0.17':
     resolution: {integrity: sha512-qNl65ye3W0Rd5udhdORzTV9ezjb+GFqQQSae03NDzXtmJq6sqVXNWNiVolAjvJNypim+zGXmv6J9TcV5aNtE/w==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/tailwind@2.0.7':
     resolution: {integrity: sha512-kGw80weVFXikcnCXbigTGXGWQ0MRCSYNCudcdkWxebkWYd0FG6/NPoN3V1p/u68/4+NxZwYPVi2fhnp0x23HdA==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       '@react-email/body': '>=0'
       '@react-email/button': '>=0'
@@ -5944,7 +5924,6 @@ packages:
   '@react-email/text@0.1.6':
     resolution: {integrity: sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw==}
     engines: {node: '>=20.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
@@ -6401,7 +6380,6 @@ packages:
   '@smithy/util-retry@4.3.6':
     resolution: {integrity: sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==}
     engines: {node: '>=18.0.0'}
-    deprecated: '@smithy/util-retry v4.3.6 contains a bug in Adaptive Retry, see https://github.com/smithy-lang/smithy-typescript/issues/1993. Upgrade to 4.3.7+'
 
   '@smithy/util-stream@4.5.25':
     resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
@@ -8617,7 +8595,6 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@13.0.6:
@@ -8844,7 +8821,6 @@ packages:
 
   intersection-observer@0.12.2:
     resolution: {integrity: sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==}
-    deprecated: The Intersection Observer polyfill is no longer needed and can safely be removed. Intersection Observer has been Baseline since 2019.
 
   intl-messageformat@11.2.3:
     resolution: {integrity: sha512-kZthTU+3WLcoWoRg5j6LOkN1TeUBtmkX0OIwSAbcHVIfQAEbGVdmANM8u6GL3eUDOqLwheYoXMUshAh1UdeXlQ==}
@@ -9731,7 +9707,6 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
 
   node-ensure@0.0.0:
     resolution: {integrity: sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==}
@@ -11448,7 +11423,6 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuniq@1.3.20:
@@ -11590,7 +11564,6 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
-    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -16465,14 +16438,14 @@ snapshots:
       msw: 2.14.6(@types/node@24.12.2)(typescript@5.9.3)
       vite: 7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/mocker@3.2.4(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.3(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.14.6(@types/node@24.12.4)(typescript@5.9.3)
-      vite: 7.3.3(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -21592,7 +21565,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.3(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4


### PR DESCRIPTION
## Summary

- Add `z.coerce` to `min` and `max` fields in `generateCodeStepSchema` so that string values (e.g., from form inputs) are automatically coerced to numbers before validation, preventing schema rejection on valid numeric inputs.

## Test plan

- [ ] Open a flow with a Generate Code step
- [ ] Set `min` and `max` values via the UI form — ensure they save and validate correctly
- [ ] Confirm no regression when values are already numbers
