### PR TITLE
fix(email): sync from address via triggerValueChange instead of useEffect

### DIFF
--- a/apps/builder/src/features/flows/react-flow/steps/email/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/email/editor.tsx
@@ -18,7 +18,7 @@ import {
 } from "@chatbotx.io/ui/components/ui/sortable"
 import { MoveVerticalIcon, PlusIcon, XIcon } from "lucide-react"
 import { useTranslations } from "next-intl"
-import { useCallback, useEffect, useRef } from "react"
+import { useCallback, useRef } from "react"
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form"
 import { TiptapEditorField } from "@/components/tiptap/tiptap-editor-field"
 import {
@@ -44,14 +44,6 @@ export default function EmailStepEditor(props: EmailStepEditorProps) {
   const integrationSmtpId = useWatch({
     name: `${parentName}.integrationSmtpId`,
   })
-  // Always sync `from` when the inbox changes so the form value stays consistent
-  // with the editor remount triggered by the `key` prop above.
-  useEffect(() => {
-    setValue(
-      `${parentName}.from`,
-      smtpFromAddressMapRef.current[integrationSmtpId] ?? "",
-    )
-  }, [integrationSmtpId, setValue, parentName])
 
   const { fields, append, move, remove } = useFieldArray({
     control,
@@ -71,6 +63,12 @@ export default function EmailStepEditor(props: EmailStepEditorProps) {
         label={t("fields.smtpChannel.label")}
         name={`${parentName}.integrationSmtpId`}
         options={smtpInboxOptions}
+        triggerValueChange={(value) => {
+          setValue(
+            `${parentName}.from`,
+            smtpFromAddressMapRef.current[value ?? ""] ?? "",
+          )
+        }}
       />
 
       <TiptapEditorField


### PR DESCRIPTION
## Summary
  - Removes a `useEffect` that eagerly overwrote the `from` field on every `integrationSmtpId` change, causing it to be cleared on re-render
  - Replaces it with a `triggerValueChange` callback on the SMTP selector so `from` only updates when the user explicitly picks a different inbox                   
  
  ## Changes
  - `apps/builder/src/features/flows/react-flow/steps/email/editor.tsx` — drop `useEffect` import, add `triggerValueChange` prop to SMTP channel selector
  
  ## Test plan
  - [ ] Select an SMTP inbox in an email step — `from` address populates correctly
  - [ ] Change the SMTP inbox — `from` updates to match the new inbox
  - [ ] `from` field is not cleared unexpectedly on re-render
  - [ ] `pnpm lint`
  - [ ] `pnpm --filter builder check-types`
