### PR TITLE
fix(channels): centralize duplicate connection detection across all integrations

### DIFF
--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -313,7 +313,16 @@
     }
   },
   "channels": {
-    "title": "Channels"
+    "title": "Channels",
+    "duplicated": {
+      "generic": "This account is already connected to another workspace.",
+      "instagram": "This Instagram account is already connected to another workspace.",
+      "messenger": "This Facebook Page is already connected to another workspace.",
+      "telegram": "This Telegram bot is already connected to another workspace.",
+      "tiktok": "This TikTok account is already connected to another workspace.",
+      "whatsapp": "This WhatsApp number is already connected to another workspace.",
+      "zalo": "This Zalo OA is already connected to another workspace."
+    }
   },
   "workspaces": {
     "list": {
@@ -2003,8 +2012,7 @@
   },
   "zalo": {
     "title": "Zalo OA",
-    "refreshPermissions": "Refresh permissions",
-    "duplicated": "This Zalo OA account has already been connected to another workspace."
+    "refreshPermissions": "Refresh permissions"
   },
   "telegram": {
     "description": "This integration lets you create Telegram bots.",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -314,7 +314,16 @@
     }
   },
   "channels": {
-    "title": "Kênh"
+    "title": "Kênh",
+    "duplicated": {
+      "generic": "Tài khoản này đã được kết nối với một workspace khác.",
+      "instagram": "Tài khoản Instagram này đã được kết nối với một workspace khác.",
+      "messenger": "Trang Facebook này đã được kết nối với một workspace khác.",
+      "telegram": "Bot Telegram này đã được kết nối với một workspace khác.",
+      "tiktok": "Tài khoản TikTok này đã được kết nối với một workspace khác.",
+      "whatsapp": "Số WhatsApp này đã được kết nối với một workspace khác.",
+      "zalo": "Zalo OA này đã được kết nối với một workspace khác."
+    }
   },
   "workspaces": {
     "list": {
@@ -2017,8 +2026,7 @@
   },
   "zalo": {
     "title": "Zalo OA",
-    "refreshPermissions": "Làm mới quyền",
-    "duplicated": "Tài khoản Zalo OA này đã được kết nối với một workspace khác."
+    "refreshPermissions": "Làm mới quyền"
   },
   "telegram": {
     "description": "Tích hợp này cho phép bạn tạo bot Telegram.",

--- a/apps/builder/src/features/integration-instagram/actions/select-account.action.ts
+++ b/apps/builder/src/features/integration-instagram/actions/select-account.action.ts
@@ -19,6 +19,7 @@ import {
 } from "@chatbotx.io/integration-instagram"
 import { AuthType } from "@chatbotx.io/sdk"
 import { createId } from "@chatbotx.io/utils/id"
+import { redirect } from "next/navigation"
 import {
   BRANDING_TITLE,
   getBrandingUrl,
@@ -177,6 +178,14 @@ export const selectAccountAction = authActionClient
           workspaceId,
         }
       } catch (error) {
+        if (error instanceof ChatbotXException) {
+          if (error.code === "channelDuplicated" && parsedInput.workspaceId) {
+            redirect(
+              `/space/${parsedInput.workspaceId}/settings/channels?channel=instagram&error=duplicated`,
+            )
+          }
+          throw error
+        }
         if (isDatabaseError(error) && error.cause.code === "23505") {
           throw new ChatbotXException("Instagram account already connected")
         }

--- a/apps/builder/src/features/integration-instagram/components/instagram-manage.tsx
+++ b/apps/builder/src/features/integration-instagram/components/instagram-manage.tsx
@@ -14,6 +14,7 @@ import { PlusCircleIcon } from "lucide-react"
 import Link from "next/link"
 import { useTranslations } from "next-intl"
 import { use } from "react"
+import { useChannelDuplicatedError } from "@/hooks/use-channel-duplicated-error"
 import type { listIntegrationInstagrams } from "../queries"
 import { InstagramConnect } from "./instagram-connect"
 import { InstagramDisconnect } from "./instagram-disconnect"
@@ -32,6 +33,8 @@ export function InstagramManage({
 }: InstagramManageProps) {
   const [{ data: integrationInstagrams }] = use(promises)
   const t = useTranslations()
+
+  useChannelDuplicatedError("instagram")
 
   if (!publicConfig?.clientId) {
     return (

--- a/apps/builder/src/features/integration-messenger/actions/select-page.action.ts
+++ b/apps/builder/src/features/integration-messenger/actions/select-page.action.ts
@@ -19,6 +19,7 @@ import {
 } from "@chatbotx.io/integration-messenger/apis/page"
 import { AuthType } from "@chatbotx.io/sdk"
 import { createId } from "@chatbotx.io/utils"
+import { redirect } from "next/navigation"
 import {
   BRANDING_TITLE,
   getBrandingUrl,
@@ -59,16 +60,6 @@ export const selectPageAction = authActionClient
           throw new ChatbotXException("Messenger App settings not found")
         }
         const messengerSettings = messengerCredential.config
-
-        // make sure the page is unique
-        const existedPage = await db.query.integrationMessengerModel.findFirst({
-          where: {
-            pageId: parsedInput.pageId,
-          },
-        })
-        if (existedPage) {
-          throw new ChatbotXException("Page is already connected")
-        }
 
         let integrationId = ""
 
@@ -190,6 +181,14 @@ export const selectPageAction = authActionClient
           integrationId,
         }
       } catch (error) {
+        if (error instanceof ChatbotXException) {
+          if (error.code === "channelDuplicated" && parsedInput.workspaceId) {
+            redirect(
+              `/space/${parsedInput.workspaceId}/settings/channels?channel=messenger&error=duplicated`,
+            )
+          }
+          throw error
+        }
         if (isDatabaseError(error) && error.cause.code === "23505") {
           throw new ChatbotXException("Page already connected")
         }

--- a/apps/builder/src/features/integration-messenger/messenger-manage.tsx
+++ b/apps/builder/src/features/integration-messenger/messenger-manage.tsx
@@ -14,6 +14,7 @@ import { PlusCircleIcon } from "lucide-react"
 import Link from "next/link"
 import { useTranslations } from "next-intl"
 import { use } from "react"
+import { useChannelDuplicatedError } from "@/hooks/use-channel-duplicated-error"
 import { MessengerConnect } from "./components/messenger-connect"
 import { MessengerDisconnect } from "./components/messenger-disconnect"
 import { MessengerRefreshPermissions } from "./components/messenger-refresh-permissions"
@@ -32,6 +33,8 @@ export function MessengerManage({
 }: MessengerManageProps) {
   const [{ data: integrationMessengers }] = use(promises)
   const t = useTranslations()
+
+  useChannelDuplicatedError("messenger")
   if (!publicConfig?.clientId) {
     return (
       <div className="flex flex-col gap-2">

--- a/apps/builder/src/features/integration-telegram/actions/connect.action.ts
+++ b/apps/builder/src/features/integration-telegram/actions/connect.action.ts
@@ -5,16 +5,13 @@ import {
   workspaceService,
 } from "@chatbotx.io/business"
 import { ChatbotXException } from "@chatbotx.io/business/errors"
-import {
-  db,
-  isDatabaseError,
-  throwIfExists,
-} from "@chatbotx.io/database/client"
+import { db, isDatabaseError } from "@chatbotx.io/database/client"
 import { integrationTypes } from "@chatbotx.io/database/partials"
 import { integrationTelegramModel } from "@chatbotx.io/database/schema"
 import type { UserModel } from "@chatbotx.io/database/types"
 import type { TelegramAuthValue } from "@chatbotx.io/integration-telegram"
 import { createId } from "@chatbotx.io/utils"
+import { redirect } from "next/navigation"
 import { integrations } from "@/integration"
 import { getOriginUrlFromHeader } from "@/lib/domain"
 import { logger } from "@/lib/log"
@@ -38,13 +35,6 @@ export const connectTelegramAction = authActionClient
         // Validate bot token and fetch bot info from Telegram
         const botData = await integrations.telegram.runAction("connect", {
           botToken,
-        })
-
-        // Make sure the bot is not already connected
-        await throwIfExists({
-          table: integrationTelegramModel,
-          where: { botId: botData.id },
-          message: "Bot is already connected",
         })
 
         // Resolve ownerId before the transaction to avoid an extra read inside it
@@ -111,6 +101,14 @@ export const connectTelegramAction = authActionClient
           return { workspaceId }
         })
       } catch (error) {
+        if (error instanceof ChatbotXException) {
+          if (error.code === "channelDuplicated" && workspaceId) {
+            redirect(
+              `/space/${workspaceId}/settings/channels?channel=telegram&error=duplicated`,
+            )
+          }
+          throw error
+        }
         if (isDatabaseError(error) && error.cause.code === "23505") {
           throw new ChatbotXException("Bot already connected")
         }

--- a/apps/builder/src/features/integration-telegram/telegram-manage.tsx
+++ b/apps/builder/src/features/integration-telegram/telegram-manage.tsx
@@ -12,6 +12,7 @@ import {
 import { PlusCircleIcon } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { use } from "react"
+import { useChannelDuplicatedError } from "@/hooks/use-channel-duplicated-error"
 import { TelegramConnect } from "./components/telegram-connect"
 import { TelegramDisconnect } from "./components/telegram-disconnect"
 import type { listIntegrationTelegrams } from "./queries"
@@ -24,6 +25,8 @@ type TelegramManageProps = {
 export function TelegramManage({ workspaceId, promises }: TelegramManageProps) {
   const [{ data: integrationTelegrams }] = use(promises)
   const t = useTranslations()
+
+  useChannelDuplicatedError("telegram")
 
   return (
     <div className="flex flex-col gap-2">

--- a/apps/builder/src/features/integration-tiktok/actions/connect.action.ts
+++ b/apps/builder/src/features/integration-tiktok/actions/connect.action.ts
@@ -2,11 +2,13 @@ import {
   connectChannelIntegration,
   workspaceService,
 } from "@chatbotx.io/business"
+import { ChatbotXException } from "@chatbotx.io/business/errors"
 import { db } from "@chatbotx.io/database/client"
 import type { TiktokCredential } from "@chatbotx.io/database/partials"
 import { integrationTiktokModel } from "@chatbotx.io/database/schema"
 import type { TiktokAuthValue } from "@chatbotx.io/integration-tiktok"
 import { createId } from "@chatbotx.io/utils"
+import { redirect } from "next/navigation"
 import { integrations } from "@/integration"
 
 export async function connectTiktokHandler({
@@ -33,32 +35,44 @@ export async function connectTiktokHandler({
 
   const { ownerId } = await workspaceService.findById({ id: workspaceId })
 
-  await db.transaction(async (tx) => {
-    await connectChannelIntegration({
-      tx,
-      ownerId,
-      inboxData: {
-        workspaceId,
-        name: displayName,
-        channel: "tiktok",
-        sourceId: authValue.metadata.username,
-      },
-      insertIntegration: async (inboxId) => {
-        await tx
-          .insert(integrationTiktokModel)
-          .values({
-            id: createId(),
-            inboxId,
-            workspaceId,
-            openId,
-            name: displayName,
-            auth: authValue,
-          })
-          .onConflictDoUpdate({
-            target: [integrationTiktokModel.openId],
-            set: { auth: authValue, name: displayName },
-          })
-      },
+  try {
+    await db.transaction(async (tx) => {
+      await connectChannelIntegration({
+        tx,
+        ownerId,
+        inboxData: {
+          workspaceId,
+          name: displayName,
+          channel: "tiktok",
+          sourceId: authValue.metadata.username,
+        },
+        insertIntegration: async (inboxId) => {
+          await tx
+            .insert(integrationTiktokModel)
+            .values({
+              id: createId(),
+              inboxId,
+              workspaceId,
+              openId,
+              name: displayName,
+              auth: authValue,
+            })
+            .onConflictDoUpdate({
+              target: [integrationTiktokModel.openId],
+              set: { auth: authValue, name: displayName },
+            })
+        },
+      })
     })
-  })
+  } catch (error) {
+    if (
+      error instanceof ChatbotXException &&
+      error.code === "channelDuplicated"
+    ) {
+      redirect(
+        `/space/${workspaceId}/settings/channels?channel=tiktok&error=duplicated`,
+      )
+    }
+    throw error
+  }
 }

--- a/apps/builder/src/features/integration-tiktok/tiktok-manage.tsx
+++ b/apps/builder/src/features/integration-tiktok/tiktok-manage.tsx
@@ -13,6 +13,7 @@ import { PlusCircleIcon } from "lucide-react"
 import Link from "next/link"
 import { useTranslations } from "next-intl"
 import { use } from "react"
+import { useChannelDuplicatedError } from "@/hooks/use-channel-duplicated-error"
 import { TiktokDisconnect } from "./components/tiktok-disconnect"
 import { TiktokRefreshToken } from "./components/tiktok-refresh-token"
 import type { listIntegrationTiktoks } from "./queries"
@@ -30,6 +31,8 @@ export function TiktokManage({
 }: TiktokManageProps) {
   const [{ data: integrationTiktoks }] = use(promises)
   const t = useTranslations()
+
+  useChannelDuplicatedError("tiktok")
 
   if (!isEnabled) {
     return (

--- a/apps/builder/src/features/integration-whatsapp/whatsapp-manage.tsx
+++ b/apps/builder/src/features/integration-whatsapp/whatsapp-manage.tsx
@@ -13,6 +13,7 @@ import { PlusCircleIcon } from "lucide-react"
 import Link from "next/link"
 import { useTranslations } from "next-intl"
 import { use } from "react"
+import { useChannelDuplicatedError } from "@/hooks/use-channel-duplicated-error"
 import type { listIntegrationWhatsapps } from "./queries"
 import { WhatsappDisconnectDialog } from "./whatsapp-disconnect-dialog"
 
@@ -29,6 +30,8 @@ export function WhatsappManage({
 }: WhatsappManageProps) {
   const [{ data: integrationWhatsapps }] = use(promises)
   const t = useTranslations()
+
+  useChannelDuplicatedError("whatsapp")
 
   if (!isEnabled) {
     return (

--- a/apps/builder/src/features/integration-zalo/actions/connect-zalo.action.ts
+++ b/apps/builder/src/features/integration-zalo/actions/connect-zalo.action.ts
@@ -2,6 +2,7 @@ import {
   connectChannelIntegration,
   workspaceService,
 } from "@chatbotx.io/business"
+import { ChatbotXException } from "@chatbotx.io/business/errors"
 import { db } from "@chatbotx.io/database/client"
 import type { ZaloCredential } from "@chatbotx.io/database/partials"
 import { integrationZaloModel } from "@chatbotx.io/database/schema"
@@ -29,30 +30,42 @@ export async function connectZaloHandler({
 
   const { ownerId } = await workspaceService.findById({ id: workspaceId })
 
-  await db.transaction(async (tx) => {
-    await connectChannelIntegration({
-      tx,
-      ownerId,
-      inboxData: {
-        workspaceId,
-        name: authValue.metadata.oaName,
-        channel: "zalo",
-        sourceId: authValue.oaId,
-      },
-      insertIntegration: async (inboxId, wasCreated) => {
-        if (!wasCreated) {
-          redirect(
-            `/space/${workspaceId}/settings/channels?channel=zalo&error=duplicated`,
-          )
-        }
-        await tx.insert(integrationZaloModel).values({
-          inboxId,
+  try {
+    await db.transaction(async (tx) => {
+      await connectChannelIntegration({
+        tx,
+        ownerId,
+        inboxData: {
           workspaceId,
-          oaId: authValue.oaId,
-          auth: authValue,
           name: authValue.metadata.oaName,
-        })
-      },
+          channel: "zalo",
+          sourceId: authValue.oaId,
+        },
+        insertIntegration: async (inboxId, wasCreated) => {
+          if (!wasCreated) {
+            redirect(
+              `/space/${workspaceId}/settings/channels?channel=zalo&error=duplicated`,
+            )
+          }
+          await tx.insert(integrationZaloModel).values({
+            inboxId,
+            workspaceId,
+            oaId: authValue.oaId,
+            auth: authValue,
+            name: authValue.metadata.oaName,
+          })
+        },
+      })
     })
-  })
+  } catch (error) {
+    if (
+      error instanceof ChatbotXException &&
+      error.code === "channelDuplicated"
+    ) {
+      redirect(
+        `/space/${workspaceId}/settings/channels?channel=zalo&error=duplicated`,
+      )
+    }
+    throw error
+  }
 }

--- a/apps/builder/src/features/integration-zalo/zalo-manage.tsx
+++ b/apps/builder/src/features/integration-zalo/zalo-manage.tsx
@@ -11,11 +11,9 @@ import {
 } from "@chatbotx.io/ui/components/ui/table"
 import { PlusCircleIcon } from "lucide-react"
 import Link from "next/link"
-import { useSearchParams } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { use } from "react"
-import { toast } from "sonner"
-import { useTimeout } from "usehooks-ts"
+import { useChannelDuplicatedError } from "@/hooks/use-channel-duplicated-error"
 import { ZaloDisconnect } from "./components/zalo-disconnect"
 import { ZaloRefreshPermissions } from "./components/zalo-refresh-permissions"
 import type { listIntegrationZalo } from "./queries"
@@ -33,14 +31,8 @@ export function ZaloManage({
 }: ZaloManageProps) {
   const [{ data: integrationZalos }] = use(promises)
   const t = useTranslations()
-  const searchParams = useSearchParams()
 
-  useTimeout(() => {
-    if (searchParams.get("error") !== "duplicated") {
-      return
-    }
-    toast.error(t("zalo.duplicated"))
-  }, 0)
+  useChannelDuplicatedError("zalo")
 
   if (!isEnabled) {
     return (

--- a/apps/builder/src/hooks/use-channel-duplicated-error.ts
+++ b/apps/builder/src/hooks/use-channel-duplicated-error.ts
@@ -1,0 +1,30 @@
+"use client"
+
+import { useRouter, useSearchParams } from "next/navigation"
+import { useTranslations } from "next-intl"
+import { useEffect } from "react"
+import { toast } from "sonner"
+
+export function useChannelDuplicatedError(channel?: string) {
+  const t = useTranslations("channels")
+  const searchParams = useSearchParams()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (searchParams.get("error") !== "duplicated") {
+      return
+    }
+
+    const key = channel ? `duplicated.${channel}` : "duplicated.generic"
+    const params = new URLSearchParams(searchParams.toString())
+    params.delete("error")
+    const qs = params.size > 0 ? `?${params.toString()}` : ""
+
+    const timer = setTimeout(() => {
+      toast.error(t(key as Parameters<typeof t>[0]), { duration: 5000 })
+      router.replace(`${window.location.pathname}${qs}`, { scroll: false })
+    }, 0)
+
+    return () => clearTimeout(timer)
+  }, [searchParams, t, router, channel])
+}

--- a/packages/business/src/errors.ts
+++ b/packages/business/src/errors.ts
@@ -7,7 +7,7 @@ export class ChatbotXException extends Error {
 
     this.name = this.constructor.name
     if (code) {
-      this.code = "systemError"
+      this.code = code
     }
     if (httpStatusCode) {
       this.httpStatusCode = httpStatusCode
@@ -21,3 +21,9 @@ export class ChatbotXException extends Error {
 
 export const notFoundException = (message: string) =>
   new ChatbotXException(message, "notFound", 404)
+
+export const channelDuplicatedException = () =>
+  new ChatbotXException(
+    "This account is already connected to another workspace.",
+    "channelDuplicated",
+  )

--- a/packages/business/src/inbox/connect-channel.ts
+++ b/packages/business/src/inbox/connect-channel.ts
@@ -1,6 +1,7 @@
 import type { DatabaseClient } from "@chatbotx.io/database/client"
 import type { inboxModel } from "@chatbotx.io/database/schema"
 import type { InboxModel } from "@chatbotx.io/database/types"
+import { channelDuplicatedException } from "../errors"
 import { inboxService } from "./service"
 
 export async function connectChannelIntegration<T>(props: {
@@ -10,6 +11,18 @@ export async function connectChannelIntegration<T>(props: {
   insertIntegration: (inboxId: string, wasCreated: boolean) => Promise<T>
 }): Promise<{ inbox: InboxModel; wasCreated: boolean; integration: T }> {
   const { tx, ownerId, inboxData, insertIntegration } = props
+
+  if (
+    inboxData.sourceId &&
+    (await inboxService.isConnected({
+      tx,
+      channel: inboxData.channel,
+      sourceId: inboxData.sourceId,
+      workspaceId: inboxData.workspaceId ?? "",
+    }))
+  ) {
+    throw channelDuplicatedException()
+  }
 
   const { inbox, wasCreated } = await inboxService.create({
     tx,

--- a/packages/business/src/inbox/service.ts
+++ b/packages/business/src/inbox/service.ts
@@ -1,7 +1,9 @@
 import {
+  and,
   type DatabaseClient,
   db,
   eq,
+  ne,
   relationsFilterToSQL,
 } from "@chatbotx.io/database/client"
 import { inboxStatuses } from "@chatbotx.io/database/partials"
@@ -102,7 +104,7 @@ class InboxService extends BaseService {
           .set({ status: inboxStatuses.enum.connected })
           .where(eq(inboxModel.id, existing.id))
           .returning()
-        return { inbox: updated, wasCreated: false }
+        return { inbox: updated, wasCreated: true }
       }
       return { inbox: existing, wasCreated: false }
     }
@@ -118,6 +120,27 @@ class InboxService extends BaseService {
       .returning()
 
     return { inbox, wasCreated: true }
+  }
+  async isConnected(props: {
+    channel: string
+    sourceId: string
+    workspaceId: string
+    tx?: DatabaseClient
+  }): Promise<boolean> {
+    const client = props.tx ?? db
+    const [row] = await client
+      .select({ id: inboxModel.id })
+      .from(inboxModel)
+      .where(
+        and(
+          eq(inboxModel.channel, props.channel),
+          eq(inboxModel.sourceId, props.sourceId),
+          ne(inboxModel.workspaceId, props.workspaceId),
+          eq(inboxModel.status, inboxStatuses.enum.connected),
+        ),
+      )
+      .limit(1)
+    return !!row
   }
 }
 export const inboxService = new InboxService()


### PR DESCRIPTION
  ## Summary
  - Replace scattered per-channel uniqueness checks with a shared `isConnected()` guard in `connectChannelIntegration()`, ensuring consistent duplicate detection across all channel integrations
  - Fix a pre-existing bug in `ChatbotXException` where `this.code` was always set to `"systemError"` regardless of the `code` argument
  - Add a `useChannelDuplicatedError` hook that detects `?error=duplicated` on redirect, shows a channel-specific toast, and cleans up the URL
  
  ## Changes
  - `packages/business/src/errors.ts` — fix `ChatbotXException` code assignment; add `channelDuplicatedException()` helper
  - `packages/business/src/inbox/service.ts` — add `isConnected()` (cross-workspace check); fix `wasCreated` for reconnected inboxes
  - `packages/business/src/inbox/connect-channel.ts` — pre-check via `isConnected()`, throw on duplicate
  - `apps/builder/src/hooks/use-channel-duplicated-error.ts` — new shared hook for toast + URL cleanup
  - Integration actions (Instagram, Messenger, Telegram, TikTok, Zalo) — catch `channelDuplicated`, redirect; remove old ad-hoc guards
  - Manage components (all 5 channels + WhatsApp) — wire `useChannelDuplicatedError`
  - `messages/en.json` + `messages/vi.json` — unified `channels.duplicated.*` keys
  
  ## Test plan
  - [ ] `pnpm lint`
  - [ ] `pnpm --filter builder check-types`
  - [ ] Connect a channel already connected in another workspace → redirect with channel-specific toast                                                             
  - [ ] Normal first-time connect still works for each channel
  - [ ] Reconnecting a disconnected channel in the same workspace succeeds