### PR TITLE
fix(flows): replace useEffect with triggerValueChange for smtp from address sync

### DIFF
--- a/apps/builder/src/features/flows/react-flow/steps/email/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/email/editor.tsx
@@ -20,7 +20,7 @@ import { MoveVerticalIcon, PlusIcon, XIcon } from "lucide-react"
 import Link from "next/link"
 import { useParams } from "next/navigation"
 import { useTranslations } from "next-intl"
-import { useCallback, useEffect, useRef } from "react"
+import { useCallback, useRef } from "react"
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form"
 import { TiptapEditorField } from "@/components/tiptap/tiptap-editor-field"
 import { useEmailTopicSelectOptions } from "@/features/email-topics/provider/email-topic-hook"
@@ -49,14 +49,6 @@ export default function EmailStepEditor(props: EmailStepEditorProps) {
   const integrationSmtpId = useWatch({
     name: `${parentName}.integrationSmtpId`,
   })
-  // Always sync `from` when the inbox changes so the form value stays consistent
-  // with the editor remount triggered by the `key` prop above.
-  useEffect(() => {
-    setValue(
-      `${parentName}.from`,
-      smtpFromAddressMapRef.current[integrationSmtpId] ?? "",
-    )
-  }, [integrationSmtpId, setValue, parentName])
 
   const { fields, append, move, remove } = useFieldArray({
     control,
@@ -76,6 +68,12 @@ export default function EmailStepEditor(props: EmailStepEditorProps) {
         label={t("fields.smtpChannel.label")}
         name={`${parentName}.integrationSmtpId`}
         options={smtpInboxOptions}
+        triggerValueChange={(value) => {
+          setValue(
+            `${parentName}.from`,
+            smtpFromAddressMapRef.current[value ?? ""] ?? "",
+          )
+        }}
       />
 
       <div className="relative">


### PR DESCRIPTION
## Summary
  - Removes a `useEffect` that synced the `from` address on every `integrationSmtpId` change (ran on every render cycle)
  - Replaces it with a `triggerValueChange` callback on the SMTP channel select so the `from` field only updates when the user actually changes the channel
  
  ## Changes
  - `apps/builder/src/features/flows/react-flow/steps/email/editor.tsx`: removed `useEffect` + import, added `triggerValueChange` prop
  
  ## Test plan
  - [ ] `pnpm lint`
  - [ ] `pnpm --filter builder check-types`
  - [ ] Open a flow email step — selecting a different SMTP channel should update the `from` address
  - [ ] Verify `from` does not reset on unrelated re-renders
