### PR TITLE
feat(coexist): refactor bulk import, add comprehensive test suites, and fix template handlers

### DIFF
--- a/apps/builder/__tests__/last-message-window.test.ts
+++ b/apps/builder/__tests__/last-message-window.test.ts
@@ -1,0 +1,42 @@
+import { endOfHour } from "date-fns"
+import { describe, expect, test, vi } from "vitest"
+
+// Stub getSafeSinceTime so the test exercises resolveLastMessageSinceTime's
+// branch logic deterministically without loading the database module graph.
+// The stub subtracts one hour, mirroring the real "previous hour" behavior.
+const ONE_HOUR_MS = 3_600_000
+vi.mock("@chatbotx.io/database/repositories", () => ({
+  getSafeSinceTime: (date: Date) => new Date(date.getTime() - ONE_HOUR_MS),
+}))
+
+import { resolveLastMessageSinceTime } from "../src/features/conversations/queries/last-message-window"
+
+describe("resolveLastMessageSinceTime", () => {
+  test("falls back to epoch (full history) when lastMessageAt is null", () => {
+    expect(resolveLastMessageSinceTime(null)).toEqual(new Date(0))
+  })
+
+  test("falls back to epoch when lastMessageAt is undefined", () => {
+    expect(resolveLastMessageSinceTime(undefined)).toEqual(new Date(0))
+  })
+
+  test("derives a tight window from the anchor when lastMessageAt is present", () => {
+    const lastMessageAt = new Date("2026-03-10T05:30:00.000Z")
+
+    const result = resolveLastMessageSinceTime(lastMessageAt)
+
+    // Present anchor → NOT the epoch fallback.
+    expect(result).not.toEqual(new Date(0))
+    expect(result).toEqual(new Date(lastMessageAt.getTime() - ONE_HOUR_MS))
+  })
+
+  test("applies the anchor transform before flooring", () => {
+    const lastMessageAt = new Date("2026-03-10T05:30:00.000Z")
+
+    const result = resolveLastMessageSinceTime(lastMessageAt, endOfHour)
+
+    expect(result).toEqual(
+      new Date(endOfHour(lastMessageAt).getTime() - ONE_HOUR_MS),
+    )
+  })
+})

--- a/apps/builder/src/features/conversations/queries/last-message-window.ts
+++ b/apps/builder/src/features/conversations/queries/last-message-window.ts
@@ -1,0 +1,34 @@
+import { getSafeSinceTime } from "@chatbotx.io/database/repositories"
+
+/**
+ * Full-history lower bound used when a conversation has no usable
+ * `contactInbox.lastMessageAt` anchor (e.g. historical imports never set it).
+ */
+const FULL_HISTORY_SINCE = new Date(0)
+
+/**
+ * Resolve the `sinceTime` window for a sharded last-message lookup.
+ *
+ * Sharded reads (findLastByConversation) need a lower-bound time window to limit
+ * which shards/chunks are scanned. The normal message flow keeps
+ * `contactInbox.lastMessageAt` current, so we derive a tight window from it.
+ *
+ * Historical imports populate messages but never set `lastMessageAt`. Deriving
+ * the window from a missing/now anchor would exclude the back-dated rows, so the
+ * preview shows nothing. When the anchor is absent we fall back to a full-history
+ * scan — `ORDER BY createdAt DESC LIMIT 1` stays cheap with the conversation
+ * index, and correctness beats the lost scan-window optimization for this case.
+ *
+ * @param lastMessageAt The contact inbox anchor, or null/undefined when unknown.
+ * @param anchor Optional transform applied to the anchor before flooring
+ *   (e.g. `endOfHour` to widen the upper edge).
+ */
+export function resolveLastMessageSinceTime(
+  lastMessageAt: Date | null | undefined,
+  anchor: (date: Date) => Date = (date) => date,
+): Date {
+  if (!lastMessageAt) {
+    return FULL_HISTORY_SINCE
+  }
+  return getSafeSinceTime(anchor(lastMessageAt)) ?? FULL_HISTORY_SINCE
+}

--- a/apps/builder/src/features/conversations/queries/list-conversations.query.ts
+++ b/apps/builder/src/features/conversations/queries/list-conversations.query.ts
@@ -4,10 +4,7 @@ import { conversationService } from "@chatbotx.io/business"
 import { notFoundException } from "@chatbotx.io/business/errors"
 import { sql } from "@chatbotx.io/database/client"
 import { applyContactFilter } from "@chatbotx.io/database/queries"
-import {
-  createMessageRepository,
-  getSafeSinceTime,
-} from "@chatbotx.io/database/repositories"
+import { createMessageRepository } from "@chatbotx.io/database/repositories"
 import { parseBigIntId, zodBigintAsString } from "@chatbotx.io/utils"
 import { endOfHour } from "date-fns"
 import { groupBy } from "remeda"
@@ -20,6 +17,7 @@ import type {
   FindConversationResponse,
   ListConversationsResponse,
 } from "../schema/resource"
+import { resolveLastMessageSinceTime } from "./last-message-window"
 
 const DEFAULT_PER_PAGE = 20
 
@@ -70,12 +68,12 @@ export const listConversations = async (
   const lastMessagesResults = await Promise.all(
     page.map((c) => {
       const contactInbox = contactInboxesByContactId[c.contactId]?.[0]
-      if (!contactInbox?.lastMessageAt) {
-        return Promise.resolve([])
-      }
+      // Don't bail when lastMessageAt is missing: historical imports populate
+      // messages but never set it, so bailing hid the last-message preview.
+      // resolveLastMessageSinceTime falls back to a full-history scan instead.
       return messageRepository.findLastByConversation(c.id, {
         limit: 1,
-        sinceTime: getSafeSinceTime(contactInbox.lastMessageAt),
+        sinceTime: resolveLastMessageSinceTime(contactInbox?.lastMessageAt),
       })
     }),
   )
@@ -267,8 +265,11 @@ export const findConversation = async (
     {
       messageTypes: ["incoming", "outgoing"],
       limit: 1,
-      sinceTime: getSafeSinceTime(
-        endOfHour(contactInbox?.lastMessageAt ?? new Date()),
+      // Falls back to a full-history scan when lastMessageAt is unset (historical
+      // imports), so opening an imported conversation still shows its messages.
+      sinceTime: resolveLastMessageSinceTime(
+        contactInbox?.lastMessageAt,
+        endOfHour,
       ),
     },
   )

--- a/apps/worker/__tests__/bulk-historical-import.test.ts
+++ b/apps/worker/__tests__/bulk-historical-import.test.ts
@@ -17,18 +17,30 @@ const {
   mockEmitContactCreated,
   mockEmit,
   mockCreateId,
-} = vi.hoisted(() => ({
-  mockTransaction: vi.fn(),
-  mockTxSelect: vi.fn(),
-  mockTxInsert: vi.fn(),
-  mockTxUpdate: vi.fn(),
-  mockTxDelete: vi.fn(),
-  mockTxExecute: vi.fn(),
-  mockDbUpdate: vi.fn(),
-  mockEmitContactCreated: vi.fn(() => Promise.resolve()),
-  mockEmit: vi.fn(() => Promise.resolve()),
-  mockCreateId: vi.fn(),
-}))
+  mockBulkCreate,
+  mockCreateMessageRepository,
+} = vi.hoisted(() => {
+  const mockBulkCreate = vi.fn().mockResolvedValue([])
+  const mockBulkCreateAttachments = vi.fn().mockResolvedValue([])
+  const mockCreateMessageRepository = vi.fn().mockResolvedValue({
+    bulkCreate: mockBulkCreate,
+    bulkCreateAttachments: mockBulkCreateAttachments,
+  })
+  return {
+    mockTransaction: vi.fn(),
+    mockTxSelect: vi.fn(),
+    mockTxInsert: vi.fn(),
+    mockTxUpdate: vi.fn(),
+    mockTxDelete: vi.fn(),
+    mockTxExecute: vi.fn(),
+    mockDbUpdate: vi.fn(),
+    mockEmitContactCreated: vi.fn(() => Promise.resolve()),
+    mockEmit: vi.fn(() => Promise.resolve()),
+    mockCreateId: vi.fn(),
+    mockBulkCreate,
+    mockCreateMessageRepository,
+  }
+})
 
 vi.mock("@chatbotx.io/database/client", () => {
   const tx = {
@@ -90,6 +102,10 @@ vi.mock("@chatbotx.io/database/schema", () => ({
     id: "w_id",
     ownerId: "w_ownerId",
   },
+}))
+
+vi.mock("@chatbotx.io/database/repositories", () => ({
+  createMessageRepository: mockCreateMessageRepository,
 }))
 
 vi.mock("@chatbotx.io/event-bus", () => ({ emit: mockEmit }))
@@ -306,6 +322,12 @@ describe("bulkImportHistorical", () => {
       chain.where.mockResolvedValue(undefined)
       return chain
     })
+    // Re-wire repository mock after clearAllMocks.
+    mockBulkCreate.mockResolvedValue([])
+    mockCreateMessageRepository.mockResolvedValue({
+      bulkCreate: mockBulkCreate,
+      bulkCreateAttachments: vi.fn().mockResolvedValue([]),
+    })
   })
 
   it("empty batch returns zero counts without opening a transaction", async () => {
@@ -338,8 +360,8 @@ describe("bulkImportHistorical", () => {
         conversationId: "conv-1",
       },
     ])
-    // bulkImportMessages transaction: INSERT Message .onConflictDoNothing().returning()
-    enqueueInsert({ returningRows: [{ id: "m-1", sourceId: "m-src-1" }] })
+    // bulkImportMessages: repository.bulkCreate() now handles message inserts
+    mockBulkCreate.mockResolvedValueOnce([{ id: "m-1", sourceId: "m-src-1" }])
 
     const result = await bulkImportHistorical({
       inbox,
@@ -365,7 +387,7 @@ describe("bulkImportHistorical", () => {
       },
     ])
     // 3 messages in, only 1 inserted → 2 duplicates
-    enqueueInsert({ returningRows: [{ id: "m-1", sourceId: "m-1" }] })
+    mockBulkCreate.mockResolvedValueOnce([{ id: "m-1", sourceId: "m-1" }])
 
     const result = await bulkImportHistorical({
       inbox,
@@ -397,7 +419,9 @@ describe("bulkImportHistorical", () => {
       },
     ])
     // bulkImportMessages for accepted contact
-    enqueueInsert({ returningRows: [{ id: "m-acc-1", sourceId: "m-acc-1" }] })
+    mockBulkCreate.mockResolvedValueOnce([
+      { id: "m-acc-1", sourceId: "m-acc-1" },
+    ])
     // src-2 is rejected (no stub needed for its messages — failedMessages path)
 
     const result = await bulkImportHistorical({
@@ -451,8 +475,8 @@ describe("bulkImportHistorical", () => {
       rows: [{ id: "conv-existing", contactId: "c-existing" }],
     })
     // No new contacts → skips cap check, contact insert, etc.
-    // Goes straight to message INSERT.
-    enqueueInsert({ returningRows: [] })
+    // Goes straight to repository.bulkCreate() for messages.
+    mockBulkCreate.mockResolvedValueOnce([])
 
     const result = await bulkImportHistorical({
       inbox,
@@ -479,12 +503,10 @@ describe("bulkImportHistorical", () => {
         conversationId: "conv-1",
       },
     ])
-    enqueueInsert({
-      returningRows: [
-        { id: "m-1", sourceId: "m-a" },
-        { id: "m-2", sourceId: "m-b" },
-      ],
-    })
+    mockBulkCreate.mockResolvedValueOnce([
+      { id: "m-1", sourceId: "m-a" },
+      { id: "m-2", sourceId: "m-b" },
+    ])
 
     const result = await bulkImportHistorical({
       inbox,
@@ -551,9 +573,11 @@ describe("bulkImportHistorical", () => {
       })),
     })
 
-    // Each contact needs a bulkImportMessages transaction: message INSERT
+    // Each contact's bulkImportMessages call goes through repository.bulkCreate()
     for (let i = 0; i < N; i++) {
-      enqueueInsert({ returningRows: [{ id: `m-${i}`, sourceId: `msg-${i}` }] })
+      mockBulkCreate.mockResolvedValueOnce([
+        { id: `m-${i}`, sourceId: `msg-${i}` },
+      ])
     }
 
     const batch = contacts.map((c) => ({
@@ -630,53 +654,24 @@ describe("bulkImportHistorical", () => {
       })),
     })
 
-    // Track concurrency of db.transaction calls for the message-import phase.
-    // Each bulkImportMessages call opens one db.transaction. We use deferred
-    // promises so all 4 start before any resolves — then we flush them.
+    // Track concurrency of repository.bulkCreate calls for the message-import phase.
+    // Each bulkImportMessages call invokes bulkCreate once (after messages are built).
+    // We defer resolution so p-limit slots stay occupied — then flush them.
     let inFlight = 0
     let maxInFlight = 0
     const resolvers: Array<() => void> = []
 
-    // The first mockTransaction call is for bulkImportContacts — let it
-    // execute synchronously so the setup phase completes before we start
-    // tracking concurrency.
-    let contactsTransactionDone = false
-
-    mockTransaction.mockImplementation((cb: (tx: unknown) => unknown) => {
-      const tx = {
-        select: mockTxSelect,
-        insert: mockTxInsert,
-        update: mockTxUpdate,
-        delete: mockTxDelete,
-        execute: mockTxExecute,
-      }
-      if (!contactsTransactionDone) {
-        // First call = bulkImportContacts → run inline
-        contactsTransactionDone = true
-        return cb(tx)
-      }
-      // Subsequent calls = bulkImportMessages → defer
+    mockBulkCreate.mockImplementation(() => {
       inFlight++
       maxInFlight = Math.max(maxInFlight, inFlight)
-      return new Promise<void>((resolve) => {
-        resolvers.push(async () => {
-          // Consume the message INSERT stub
-          const chain = {
-            values: vi.fn(),
-            onConflictDoNothing: vi.fn(),
-            returning: vi.fn(),
-          }
-          chain.values.mockReturnValue(chain)
-          chain.onConflictDoNothing.mockReturnValue(chain)
-          chain.returning.mockResolvedValue([
-            { id: "m-inserted", sourceId: "msg-x" },
-          ])
-          mockTxInsert.mockReturnValueOnce(chain)
-          await cb(tx)
-          inFlight--
-          resolve()
-        })
-      })
+      return new Promise<{ id: string; sourceId: string | null }[]>(
+        (resolve) => {
+          resolvers.push(() => {
+            inFlight--
+            resolve([])
+          })
+        },
+      )
     })
 
     const batch = contacts.map((c) => ({
@@ -695,14 +690,22 @@ describe("bulkImportHistorical", () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    // With p-limit(≥2), at least 2 message transactions should be in-flight.
-    // With the old sequential loop, maxInFlight would be 0 at this point (none started
-    // yet because the first hasn't resolved). After our fix it should be ≥ 2.
+    // With p-limit(≥2), at least 2 bulkCreate calls should be in-flight.
+    // With a sequential loop, maxInFlight would be 0 here (none started yet
+    // because the first hasn't resolved). With p-limit it should be ≥ 2.
     expect(maxInFlight).toBeGreaterThanOrEqual(2)
 
-    // Flush all deferred transactions
-    for (const res of resolvers) {
-      await res()
+    // Drain resolvers one at a time. The 4th task is queued by p-limit (limit=3)
+    // and only calls bulkCreate after a slot frees, so we wait for each resolver
+    // to appear before resolving the previous one.
+    for (let flushed = 0; flushed < 4; flushed++) {
+      await vi.waitFor(
+        () => expect(resolvers.length).toBeGreaterThan(flushed),
+        {
+          timeout: 2000,
+        },
+      )
+      await resolvers[flushed]()
     }
     await importPromise
 

--- a/apps/worker/__tests__/bulk-import-messages.test.ts
+++ b/apps/worker/__tests__/bulk-import-messages.test.ts
@@ -1,0 +1,304 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// Hoist mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockBulkCreate,
+  mockBulkCreateAttachments,
+  mockCreateMessageRepository,
+  mockDbInsert,
+  mockTxInsert,
+  mockTxExecute,
+  mockDbUpdate,
+  mockDbTransaction,
+} = vi.hoisted(() => {
+  const txChain = {
+    values: vi.fn(),
+    onConflictDoNothing: vi.fn(),
+    returning: vi.fn().mockResolvedValue([]),
+  }
+  txChain.values.mockReturnValue(txChain)
+  txChain.onConflictDoNothing.mockReturnValue(txChain)
+
+  const mockTxInsert = vi.fn().mockReturnValue(txChain)
+  const mockTxExecute = vi.fn().mockResolvedValue(undefined)
+
+  const mockDbTransaction = vi.fn((fn: (tx: unknown) => Promise<unknown>) =>
+    fn({ insert: mockTxInsert, execute: mockTxExecute, update: vi.fn() }),
+  )
+
+  const dbInsertChain = {
+    values: vi.fn(),
+    onConflictDoNothing: vi.fn(),
+    returning: vi.fn().mockResolvedValue([]),
+  }
+  dbInsertChain.values.mockReturnValue(dbInsertChain)
+  dbInsertChain.onConflictDoNothing.mockReturnValue(dbInsertChain)
+
+  const mockDbInsert = vi.fn().mockReturnValue(dbInsertChain)
+
+  const mockBulkCreate = vi.fn().mockResolvedValue([])
+  const mockBulkCreateAttachments = vi.fn().mockResolvedValue([])
+  const mockCreateMessageRepository = vi.fn().mockResolvedValue({
+    bulkCreate: mockBulkCreate,
+    bulkCreateAttachments: mockBulkCreateAttachments,
+  })
+
+  const updateChain = { set: vi.fn(), where: vi.fn() }
+  updateChain.set.mockReturnValue(updateChain)
+  updateChain.where.mockResolvedValue(undefined)
+  const mockDbUpdate = vi.fn().mockReturnValue(updateChain)
+
+  return {
+    mockBulkCreate,
+    mockBulkCreateAttachments,
+    mockCreateMessageRepository,
+    mockDbInsert,
+    mockTxInsert,
+    mockTxExecute,
+    mockDbUpdate,
+    mockDbTransaction,
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@chatbotx.io/database/repositories", () => ({
+  createMessageRepository: mockCreateMessageRepository,
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    insert: mockDbInsert,
+    update: mockDbUpdate,
+    transaction: mockDbTransaction,
+    execute: vi.fn().mockResolvedValue(undefined),
+    query: {},
+  },
+  eq: vi.fn((col: unknown, val: unknown) => ({ __eq: [col, val] })),
+  inArray: vi.fn(),
+  sql: Object.assign(
+    (strings: TemplateStringsArray, ...values: unknown[]) => ({
+      strings,
+      values,
+    }),
+    { raw: (s: string) => s },
+  ),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  messageModel: {
+    id: "id",
+    sourceId: "sourceId",
+    contactInboxId: "contactInboxId",
+  },
+  attachmentModel: { id: "id", messageId: "messageId" },
+  contactModel: { id: "id" },
+  contactInboxModel: {},
+  conversationModel: {},
+  workspaceModel: {},
+  userQuotaModel: {},
+}))
+
+vi.mock("@chatbotx.io/event-bus", () => ({
+  emit: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock("@chatbotx.io/events", () => ({
+  emitContactCreated: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock("p-limit", () => ({ default: () => (fn: () => unknown) => fn() }))
+vi.mock("../src/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}))
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { bulkImportMessages } = await import(
+  "../src/integration/handlers/coexist/bulk-historical-import"
+)
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const BASE_PROPS = {
+  workspaceId: "ws-1",
+  runId: "99999999999",
+  contactInboxId: "ci-1",
+  contactId: "contact-1",
+  conversationId: "conv-1",
+}
+
+function makeMessage(sourceId: string) {
+  return {
+    sourceId,
+    text: "hello",
+    messageType: "incoming" as const,
+    contentType: "text" as const,
+    attachments: [],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("bulkImportMessages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockBulkCreate.mockResolvedValue([])
+    mockBulkCreateAttachments.mockResolvedValue([])
+    mockCreateMessageRepository.mockResolvedValue({
+      bulkCreate: mockBulkCreate,
+      bulkCreateAttachments: mockBulkCreateAttachments,
+    })
+    mockDbTransaction.mockImplementation(
+      (fn: (tx: unknown) => Promise<unknown>) =>
+        fn({ insert: mockTxInsert, execute: mockTxExecute, update: vi.fn() }),
+    )
+  })
+
+  test("returns empty result when messages array is empty", async () => {
+    const result = await bulkImportMessages({ ...BASE_PROPS, messages: [] })
+
+    expect(result.importedMessages).toBe(0)
+    expect(result.skippedMessages).toBe(0)
+    expect(mockBulkCreate).not.toHaveBeenCalled()
+  })
+
+  test("calls repository.bulkCreate() for message rows", async () => {
+    mockBulkCreate.mockResolvedValue([{ id: "msg-1", sourceId: "src-1" }])
+
+    await bulkImportMessages({
+      ...BASE_PROPS,
+      messages: [makeMessage("src-1")],
+    })
+
+    expect(mockCreateMessageRepository).toHaveBeenCalled()
+    expect(mockBulkCreate).toHaveBeenCalledTimes(1)
+  })
+
+  test("does NOT call db.insert(messageModel) directly for message rows", async () => {
+    mockBulkCreate.mockResolvedValue([{ id: "msg-1", sourceId: "src-1" }])
+
+    await bulkImportMessages({
+      ...BASE_PROPS,
+      messages: [makeMessage("src-1")],
+    })
+
+    // db.insert may be called for attachments, but never with messageModel
+    const messageModelMock = (await import("@chatbotx.io/database/schema"))
+      .messageModel
+    for (const call of mockDbInsert.mock.calls) {
+      expect(call[0]).not.toBe(messageModelMock)
+    }
+    for (const call of mockTxInsert.mock.calls) {
+      expect(call[0]).not.toBe(messageModelMock)
+    }
+  })
+
+  test("returns correct importedMessages count from bulkCreate result", async () => {
+    mockBulkCreate.mockResolvedValue([
+      { id: "msg-1", sourceId: "src-1" },
+      { id: "msg-2", sourceId: "src-2" },
+    ])
+
+    const result = await bulkImportMessages({
+      ...BASE_PROPS,
+      messages: [makeMessage("src-1"), makeMessage("src-2")],
+    })
+
+    expect(result.importedMessages).toBe(2)
+  })
+
+  test("returns correct skippedMessages = total messages - inserted", async () => {
+    mockBulkCreate.mockResolvedValue([{ id: "msg-1", sourceId: "src-1" }])
+
+    const result = await bulkImportMessages({
+      ...BASE_PROPS,
+      messages: [makeMessage("src-1"), makeMessage("src-2")],
+    })
+
+    expect(result.skippedMessages).toBe(1)
+  })
+
+  test("inserts attachments via repository.bulkCreateAttachments (shard-aware, not tx.insert)", async () => {
+    mockBulkCreate.mockResolvedValue([{ id: "msg-1", sourceId: "src-1" }])
+
+    await bulkImportMessages({
+      ...BASE_PROPS,
+      messages: [
+        {
+          sourceId: "src-1",
+          text: "with attachment",
+          messageType: "incoming",
+          contentType: "text",
+          attachments: [
+            {
+              sourceId: "att-1",
+              fileType: "image",
+              mimeType: "image/jpeg",
+              originPath: "/path/to/img.jpg",
+              size: 1024,
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(mockBulkCreateAttachments).toHaveBeenCalledTimes(1)
+    const [rows] = mockBulkCreateAttachments.mock.calls[0]
+    expect(rows).toHaveLength(1)
+    expect(rows[0].messageId).toBe("msg-1")
+    expect(rows[0].workspaceId).toBe("ws-1")
+    // messageCreatedAt must be set so shard repository can partition by it
+    expect(rows[0].messageCreatedAt).toBeInstanceOf(Date)
+    // attachments must NOT go through main-DB tx.insert (causes FK violation when sharding)
+    expect(mockTxInsert).not.toHaveBeenCalled()
+  })
+
+  test("retries with regenerated IDs on a Message PK collision (TimescaleDB chunk constraint via drizzle .cause)", async () => {
+    // Real shape: drizzle wraps the pg error; code/constraint live on `.cause`,
+    // and TimescaleDB reports the chunk-prefixed constraint name.
+    const pkError = Object.assign(new Error("duplicate key value"), {
+      cause: { code: "23505", constraint: "17_17_Message_pkey" },
+    })
+    mockBulkCreate
+      .mockRejectedValueOnce(pkError)
+      .mockResolvedValueOnce([{ id: "msg-retry", sourceId: "src-1" }])
+
+    const result = await bulkImportMessages({
+      ...BASE_PROPS,
+      messages: [makeMessage("src-1")],
+    })
+
+    expect(mockBulkCreate).toHaveBeenCalledTimes(2)
+    const firstRows = mockBulkCreate.mock.calls[0][0] as { id: string }[]
+    const secondRows = mockBulkCreate.mock.calls[1][0] as {
+      id: string
+      sourceId: string
+    }[]
+    // Same message (sourceId), but a fresh ID on retry to dodge the collision.
+    expect(secondRows[0].sourceId).toBe("src-1")
+    expect(secondRows[0].id).not.toBe(firstRows[0].id)
+    expect(result.importedMessages).toBe(1)
+  })
+
+  test("does NOT retry on non-PK errors — they propagate", async () => {
+    const fkError = Object.assign(new Error("fk violation"), {
+      cause: { code: "23503", constraint: "Message_conversationId_fkey" },
+    })
+    mockBulkCreate.mockRejectedValueOnce(fkError)
+
+    await expect(
+      bulkImportMessages({ ...BASE_PROPS, messages: [makeMessage("src-1")] }),
+    ).rejects.toThrow("fk violation")
+    expect(mockBulkCreate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/worker/__tests__/coexist-historical-id.test.ts
+++ b/apps/worker/__tests__/coexist-historical-id.test.ts
@@ -10,91 +10,105 @@ import {
 // Must match COEXIST_EPOCH_MS in bulk-historical-import.ts (the uuniq epoch,
 // so historical IDs decode back to real wall-clock createdAt).
 const EPOCH_MS = new Date("2004-02-01").getTime()
-const RUN_ID = "12345"
+// 14-bit disambiguator space.
+const DISAMBIG_SPACE = 1 << 14
 
 describe("createHistoricalIdFactory", () => {
   it("produces strictly increasing IDs for monotonically increasing dates", () => {
-    const make = createHistoricalIdFactory(RUN_ID)
+    const make = createHistoricalIdFactory()
+    // Same sourceId isolates timestamp ordering in the high bits.
     const ids = [0, 1, 2, 100, 1000].map((delta) =>
-      make(new Date(EPOCH_MS + delta)),
+      make(new Date(EPOCH_MS + delta), "src-same"),
     )
     for (let i = 1; i < ids.length; i++) {
-      const a = ids[i - 1] as string
-      const b = ids[i] as string
-      expect(BigInt(a) < BigInt(b)).toBe(true)
+      expect(BigInt(ids[i - 1] as string) < BigInt(ids[i] as string)).toBe(true)
     }
   })
 
-  it("returns distinct IDs for two calls with the same date (sequence advances)", () => {
-    const make = createHistoricalIdFactory(RUN_ID)
+  it("returns distinct IDs for two different messages at the same date", () => {
+    const make = createHistoricalIdFactory()
     const date = new Date(EPOCH_MS + 5000)
-    const a = make(date)
-    const b = make(date)
+    const a = make(date, "src-a")
+    const b = make(date, "src-b")
     expect(a).not.toBe(b)
-    expect(BigInt(a) < BigInt(b)).toBe(true)
+  })
+
+  it("is idempotent: same (date, sourceId) yields the same ID across separate factory instances (runs)", () => {
+    const date = new Date(EPOCH_MS + 7777)
+    const run1 = createHistoricalIdFactory()(date, "m_abc")
+    const run2 = createHistoricalIdFactory()(date, "m_abc")
+    // Run-independent: re-importing the same message never re-mints the id, so a
+    // second run is deduped by the arbiter instead of colliding on the PK.
+    expect(run1).toBe(run2)
+  })
+
+  it("advances to a free slot when the same message is requested twice in one import (retry path)", () => {
+    const make = createHistoricalIdFactory()
+    const date = new Date(EPOCH_MS + 4242)
+    const first = make(date, "m_retry")
+    const second = make(date, "m_retry")
+    // Within one factory the used-set probes forward, so a retry gets a fresh id.
+    expect(first).not.toBe(second)
   })
 
   it("round-trips date through decodeHistoricalId", () => {
-    const make = createHistoricalIdFactory(RUN_ID)
+    const make = createHistoricalIdFactory()
     const date = new Date(EPOCH_MS + 1_234_567)
-    const id = make(date)
-    const decoded = decodeHistoricalId(id)
+    const decoded = decodeHistoricalId(make(date, "src-1"))
     expect(decoded.timestampMs).toBe(date.getTime())
-    expect(decoded.partition).toBe(Number(BigInt(RUN_ID) & 0x3ffn))
-    expect(decoded.seq).toBe(0)
+    expect(decoded.disambiguator).toBeGreaterThanOrEqual(0)
+    expect(decoded.disambiguator).toBeLessThan(DISAMBIG_SPACE)
   })
 
   it("throws when date is before the epoch", () => {
-    const make = createHistoricalIdFactory(RUN_ID)
-    expect(() => make(new Date(EPOCH_MS - 1))).toThrow(/out of range/)
+    const make = createHistoricalIdFactory()
+    expect(() => make(new Date(EPOCH_MS - 1), "src-1")).toThrow(/out of range/)
   })
 
-  it("100 runs × 16 same-ms IDs produce 1,600 unique IDs across distinct partitions", () => {
+  it("keeps IDs unique for many distinct messages at the same millisecond (probe)", () => {
+    const make = createHistoricalIdFactory()
     const date = new Date(EPOCH_MS + 999)
-    const all = new Set<string>()
-    for (let r = 0; r < 100; r++) {
-      // Distinct run partitions: spread across the 10-bit space.
-      const make = createHistoricalIdFactory(String(r * 7 + 1))
-      for (let i = 0; i < 16; i++) {
-        all.add(make(date))
-      }
+    const ids = new Set<string>()
+    for (let i = 0; i < 5000; i++) {
+      ids.add(make(date, `m_${i}`))
     }
-    expect(all.size).toBe(100 * 16)
+    expect(ids.size).toBe(5000)
+    // All still fit within the same millisecond (5000 < 16384 slots).
+    for (const id of ids) {
+      expect(decodeHistoricalId(id).timestampMs).toBe(date.getTime())
+    }
   })
 
-  it("bumps timestamp forward when sequence space (16) is exhausted in one ms", () => {
-    const make = createHistoricalIdFactory(RUN_ID)
+  it("bumps the millisecond forward when the 14-bit disambiguator space is exhausted", () => {
+    const make = createHistoricalIdFactory()
     const date = new Date(EPOCH_MS + 42)
     const ids: string[] = []
-    for (let i = 0; i < 17; i++) {
-      ids.push(make(date))
+    for (let i = 0; i < DISAMBIG_SPACE + 1; i++) {
+      ids.push(make(date, `m_${i}`))
     }
-    // First 16 land on ms=42; the 17th wraps and lands on ms=43.
-    expect(decodeHistoricalId(ids[15] as string).timestampMs).toBe(
-      date.getTime(),
+    // First 16384 fill ms=42; the next one wraps to ms=43.
+    const onNextMs = ids.filter(
+      (id) => decodeHistoricalId(id).timestampMs === date.getTime() + 1,
     )
-    expect(decodeHistoricalId(ids[16] as string).timestampMs).toBe(
-      date.getTime() + 1,
-    )
-    // Monotonicity preserved across the wrap.
-    expect(BigInt(ids[15] as string) < BigInt(ids[16] as string)).toBe(true)
+    expect(onNextMs.length).toBe(1)
+    expect(new Set(ids).size).toBe(DISAMBIG_SPACE + 1)
   })
 
   it("id order matches createdAt order regardless of call order", () => {
     // Graph streams newest-first; factory must still produce IDs whose numeric
     // order matches `createdAt` order so `ORDER BY id` reflects chronology.
-    const make = createHistoricalIdFactory(RUN_ID)
-    const later = make(new Date(EPOCH_MS + 1000))
-    const earlier = make(new Date(EPOCH_MS + 500))
+    const make = createHistoricalIdFactory()
+    const later = make(new Date(EPOCH_MS + 1000), "src-late")
+    const earlier = make(new Date(EPOCH_MS + 500), "src-early")
     expect(BigInt(earlier) < BigInt(later)).toBe(true)
   })
 
   it("preserves chronological id order across many out-of-order inserts", () => {
-    const make = createHistoricalIdFactory(RUN_ID)
+    const make = createHistoricalIdFactory()
     const deltas = [5000, 100, 3000, 50, 4000, 200, 10, 4500, 1500]
     const pairs = deltas.map((d) => ({
       delta: d,
-      id: make(new Date(EPOCH_MS + d)),
+      id: make(new Date(EPOCH_MS + d), `m_${d}`),
     }))
     const sortedByTs = [...pairs].sort((a, b) => a.delta - b.delta)
     const sortedById = [...pairs].sort((a, b) =>
@@ -117,29 +131,25 @@ describe("ID validity via uuniq Snowflake.resolve()", () => {
     expect(typeof resolved.sequence).toBe("number")
   })
 
-  it("makeMessageId(date) output resolves under the same Snowflake decoder as createId()", () => {
+  it("makeMessageId output resolves under the same Snowflake decoder as createId()", () => {
     // Shared ts_shift=14 means coexist factory IDs are well-formed snowflakes
-    // under the same uuniq layout `createId()` uses. created_at decoded from
-    // the id must round-trip to the input date at second-precision (uuniq
-    // formats `created_at` as an ISO string truncated by its internal encoder).
-    const make = createHistoricalIdFactory(RUN_ID)
-    const date = new Date(EPOCH_MS + 1_234_567)
-    const id = make(date)
+    // under the same uuniq layout `createId()` uses.
+    const id = createHistoricalIdFactory()(
+      new Date(EPOCH_MS + 1_234_567),
+      "src-1",
+    )
     expect(id).toMatch(/^\d+$/)
     const resolved = resolveId(id)
-    expect(typeof resolved.created_at).toBe("string")
     const decodedMs = Date.parse(resolved.created_at)
     expect(Number.isNaN(decodedMs)).toBe(false)
-    // uuniq's resolve recovers the ms timestamp; allow 1 ms tolerance for any
-    // rounding inside the library's anybase encoder.
-    expect(Math.abs(decodedMs - date.getTime())).toBeLessThanOrEqual(1)
+    expect(Math.abs(decodedMs - (EPOCH_MS + 1_234_567))).toBeLessThanOrEqual(1)
   })
 
   it("createId() and makeMessageId() share id length / magnitude", () => {
     // Both use ts_shift=14 against the same epoch, so a coexist id minted for
     // "now" and a live createId() called now must have the same digit count.
     const liveId = createId()
-    const coexistId = createHistoricalIdFactory(RUN_ID)(new Date())
+    const coexistId = createHistoricalIdFactory()(new Date(), "src-now")
     expect(coexistId.length).toBe(liveId.length)
   })
 })

--- a/apps/worker/__tests__/coexist-messenger-template.test.ts
+++ b/apps/worker/__tests__/coexist-messenger-template.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// fetchConvMessages maps Page button templates (Graph `generic_template`) into
+// stored messages: text = title, buttons in contentAttributes (type "template",
+// templateType "button") so the inbox renders text + buttons.
+//
+// Mock the Graph sync API + break the @chatbotx.io/business pino import chain.
+// ---------------------------------------------------------------------------
+
+const { mockListMessages } = vi.hoisted(() => ({ mockListMessages: vi.fn() }))
+vi.mock("@chatbotx.io/integration-messenger/apis/sync", () => ({
+  listMessages: mockListMessages,
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  extractContactInfo: () => ({}),
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}))
+
+import { fetchConvMessages } from "../src/integration/handlers/coexist/messenger-helpers"
+
+type GraphAttachment = Record<string, unknown>
+
+function makePage(attachments: GraphAttachment[], message = "") {
+  return {
+    data: [
+      {
+        id: "m_1",
+        message,
+        from: { id: "page-1" },
+        created_time: "2026-06-05T00:00:00.000Z",
+        attachments: { data: attachments },
+      },
+    ],
+    after: undefined,
+    bucUsage: null,
+  }
+}
+
+const baseProps = {
+  conversationId: "conv-1",
+  accessToken: "token",
+  cutoff: new Date("2020-01-01T00:00:00.000Z"),
+  ceiling: null,
+  pageId: "page-1",
+  defaultCountry: null,
+  applyBucThrottle: () => undefined,
+  respectPause: () => Promise.resolve(),
+}
+
+describe("fetchConvMessages — generic_template (Page button templates)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("maps a postback button template to text + contentAttributes (not skipped despite empty message)", async () => {
+    mockListMessages.mockResolvedValue(
+      makePage([
+        {
+          id: "att-1",
+          generic_template: {
+            title: "test1",
+            cta: [{ title: "Button #1", type: "postback" }],
+          },
+        },
+      ]),
+    )
+
+    const result = await fetchConvMessages(baseProps)
+
+    expect(result.messages).toHaveLength(1)
+    const msg = result.messages[0]
+    expect(msg.contentType).toBe("text")
+    expect(msg.text).toBe("test1")
+    expect(msg.messageType).toBe("outgoing")
+    expect(msg.contentAttributes).toEqual({
+      type: "template",
+      payload: {
+        templateType: "button",
+        buttons: [
+          {
+            id: "att-1-0",
+            label: "Button #1",
+            buttonType: "postback",
+            postback: "",
+          },
+        ],
+      },
+    })
+  })
+
+  test("maps a web_url cta to a url button", async () => {
+    mockListMessages.mockResolvedValue(
+      makePage([
+        {
+          id: "att-2",
+          generic_template: {
+            title: "Visit us",
+            cta: [
+              { title: "Open", type: "web_url", url: "https://example.com" },
+            ],
+          },
+        },
+      ]),
+    )
+
+    const result = await fetchConvMessages(baseProps)
+
+    const msg = result.messages[0]
+    expect(msg.text).toBe("Visit us")
+    expect(msg.contentAttributes).toEqual({
+      type: "template",
+      payload: {
+        templateType: "button",
+        buttons: [
+          {
+            id: "att-2-0",
+            label: "Open",
+            buttonType: "url",
+            url: "https://example.com",
+          },
+        ],
+      },
+    })
+  })
+
+  test("keeps message text when both text and a button template are present", async () => {
+    mockListMessages.mockResolvedValue(
+      makePage(
+        [
+          {
+            id: "att-3",
+            generic_template: {
+              title: "ignored title",
+              cta: [{ title: "Yes", type: "postback" }],
+            },
+          },
+        ],
+        "actual message text",
+      ),
+    )
+
+    const result = await fetchConvMessages(baseProps)
+
+    const msg = result.messages[0]
+    // Real message text wins over the template title.
+    expect(msg.text).toBe("actual message text")
+    expect(msg.contentAttributes).toMatchObject({
+      type: "template",
+      payload: { templateType: "button" },
+    })
+  })
+
+  test("does not attach contentAttributes for a plain media attachment", async () => {
+    mockListMessages.mockResolvedValue(
+      makePage([
+        {
+          id: "att-4",
+          mime_type: "image/png",
+          image_data: { url: "https://cdn.example.com/x.png" },
+        },
+      ]),
+    )
+
+    const result = await fetchConvMessages(baseProps)
+
+    const msg = result.messages[0]
+    expect(msg.contentAttributes).toBeUndefined()
+    expect(msg.attachments).toHaveLength(1)
+  })
+})

--- a/apps/worker/__tests__/export-contacts-handler.test.ts
+++ b/apps/worker/__tests__/export-contacts-handler.test.ts
@@ -64,6 +64,13 @@ vi.mock("@chatbotx.io/filesystem", () => ({
   },
 }))
 
+// The handler imports createUpload from the node-upload subpath, not the
+// filesystem barrel — mock that exact specifier or it hits real S3.
+vi.mock("@chatbotx.io/filesystem/node-upload", () => ({
+  createUpload: (path: string, options?: unknown) =>
+    createUpload(path, options),
+}))
+
 const { loopableExportContacts } = await import(
   "../src/default/handlers/export-contacts"
 )

--- a/apps/worker/__tests__/flow.test.ts
+++ b/apps/worker/__tests__/flow.test.ts
@@ -22,8 +22,15 @@ vi.mock("@chatbotx.io/database/client", () => ({
   eq: vi.fn(),
 }))
 
-vi.mock("@chatbotx.io/database/schema", () => ({}))
-vi.mock("../../lib/logger", () => ({
+// Passthrough the real schema: a transitive dependency imports `createSelectSchema`
+// from this barrel at module load, so an empty mock breaks the import graph. The
+// schema is pure table/zod definitions (no DB connection), safe to load for real.
+vi.mock("@chatbotx.io/database/schema", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@chatbotx.io/database/schema")>()
+  return { ...actual }
+})
+vi.mock("../src/lib/logger", () => ({
   logger: { debug: vi.fn(), error: vi.fn(), warn: vi.fn() },
 }))
 vi.mock("@chatbotx.io/event-bus", () => ({
@@ -41,7 +48,7 @@ vi.mock("@chatbotx.io/sdk", async (importOriginal) => {
 // --- imports after mocks ---
 
 const { executeMultipleSteps, seekConnectedNode, runStepsAndQuickReplies } =
-  await import("./flow")
+  await import("../src/integration/handlers/flow")
 
 // --- helpers ---
 
@@ -184,7 +191,9 @@ describe("executeMultipleSteps — explicit status routing", () => {
       ],
     )
 
-    const { flowStepHandlers } = await import("./step")
+    const { flowStepHandlers } = await import(
+      "../src/integration/handlers/step"
+    )
     mockSpy(flowStepHandlers, "autoAssignConversation").mockResolvedValue({
       status: "success",
       result: null,
@@ -228,7 +237,9 @@ describe("executeMultipleSteps — explicit status routing", () => {
       ],
     )
 
-    const { flowStepHandlers } = await import("./step")
+    const { flowStepHandlers } = await import(
+      "../src/integration/handlers/step"
+    )
     mockSpy(flowStepHandlers, "autoAssignConversation").mockResolvedValue({
       status: "error",
       result: null,
@@ -253,7 +264,9 @@ describe("executeMultipleSteps — loop control statuses", () => {
     const step1 = makeStep("wait", [])
     const step2 = makeStep("sendText", [])
 
-    const { flowStepHandlers } = await import("./step")
+    const { flowStepHandlers } = await import(
+      "../src/integration/handlers/step"
+    )
     const waitSpy = mockSpy(flowStepHandlers, "wait").mockResolvedValue({
       status: "wait",
       result: null,
@@ -275,7 +288,9 @@ describe("executeMultipleSteps — loop control statuses", () => {
     const step1 = makeStep("getUserData", [])
     const step2 = makeStep("sendText", [])
 
-    const { flowStepHandlers } = await import("./step")
+    const { flowStepHandlers } = await import(
+      "../src/integration/handlers/step"
+    )
     mockSpy(flowStepHandlers, "getUserData").mockResolvedValue({
       status: "retry",
       result: null,
@@ -360,7 +375,9 @@ describe("runStepsAndQuickReplies — per-step re-dispatch", () => {
   })
 
   test("runs beforeStep on initial entry (startFromStepId undefined)", async () => {
-    const { flowStepHandlers } = await import("./step")
+    const { flowStepHandlers } = await import(
+      "../src/integration/handlers/step"
+    )
     const assignSpy = mockSpy(
       flowStepHandlers,
       "autoAssignConversation",
@@ -385,7 +402,9 @@ describe("runStepsAndQuickReplies — per-step re-dispatch", () => {
   })
 
   test("skips beforeStep and resumes at the step whose id matches startFromStepId", async () => {
-    const { flowStepHandlers } = await import("./step")
+    const { flowStepHandlers } = await import(
+      "../src/integration/handlers/step"
+    )
     const assignSpy = mockSpy(
       flowStepHandlers,
       "autoAssignConversation",
@@ -420,7 +439,9 @@ describe("runStepsAndQuickReplies — per-step re-dispatch", () => {
   })
 
   test("does not enqueue a next-step job when the current step returns wait", async () => {
-    const { flowStepHandlers } = await import("./step")
+    const { flowStepHandlers } = await import(
+      "../src/integration/handlers/step"
+    )
     mockSpy(flowStepHandlers, "wait").mockResolvedValue({
       status: "wait",
       result: null,
@@ -439,7 +460,9 @@ describe("runStepsAndQuickReplies — per-step re-dispatch", () => {
   })
 
   test("does not enqueue a next-step job when the current step returns retry", async () => {
-    const { flowStepHandlers } = await import("./step")
+    const { flowStepHandlers } = await import(
+      "../src/integration/handlers/step"
+    )
     mockSpy(flowStepHandlers, "getUserData").mockResolvedValue({
       status: "retry",
       result: null,
@@ -513,7 +536,9 @@ describe("runStepsAndQuickReplies — per-step re-dispatch", () => {
       ],
     )
 
-    const { flowStepHandlers } = await import("./step")
+    const { flowStepHandlers } = await import(
+      "../src/integration/handlers/step"
+    )
     mockSpy(flowStepHandlers, "autoAssignConversation").mockResolvedValue({
       status: "success",
       result: null,
@@ -589,7 +614,7 @@ describe("runStepsAndQuickReplies — per-step re-dispatch", () => {
   })
 
   test("logs a warning and returns early when startFromStepId is set but no matching step exists", async () => {
-    const { logger } = await import("../../lib/logger")
+    const { logger } = await import("../src/lib/logger")
     const step1 = { ...makeStep("sendText"), id: "step-1" }
     const props = {
       ...makeBaseProps(),
@@ -604,7 +629,9 @@ describe("runStepsAndQuickReplies — per-step re-dispatch", () => {
   })
 
   test("node with beforeStep only (no steps) still runs beforeStep and dispatches next node", async () => {
-    const { flowStepHandlers } = await import("./step")
+    const { flowStepHandlers } = await import(
+      "../src/integration/handlers/step"
+    )
     const assignSpy = mockSpy(
       flowStepHandlers,
       "autoAssignConversation",

--- a/apps/worker/__tests__/get-user-data.test.ts
+++ b/apps/worker/__tests__/get-user-data.test.ts
@@ -49,6 +49,18 @@ vi.mock("@chatbotx.io/database/client", () => ({
   findOrFail: vi.fn(async () => findOrFailResult.current),
 }))
 
+// validateUserData reads the last message via the shard-aware repository, not
+// db.query. Return the test-configured `lastMessage.current` as a 1-element
+// array (findLastByConversation's contract).
+vi.mock("@chatbotx.io/database/repositories", () => ({
+  createMessageRepository: vi.fn(async () => ({
+    findLastByConversation: vi.fn(async () =>
+      lastMessage.current ? [lastMessage.current] : [],
+    ),
+  })),
+  getSafeSinceTime: vi.fn(() => new Date(0)),
+}))
+
 vi.mock("@chatbotx.io/database/schema", () => ({
   contactCustomFieldModel: {},
   conversationModel: {},
@@ -71,13 +83,15 @@ vi.mock("@chatbotx.io/utils", async (importOriginal) => {
   }
 })
 
-vi.mock("../../lib/logger", () => ({
+vi.mock("../src/lib/logger", () => ({
   logger: { error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
 }))
 
 // --- helpers ---
 
-const { getUserData } = await import("./get-user-data")
+const { getUserData } = await import(
+  "../src/integration/handlers/get-user-data"
+)
 
 type StepOverride = Partial<GetUserDataStepSchema>
 

--- a/apps/worker/__tests__/import-contacts-handler.test.ts
+++ b/apps/worker/__tests__/import-contacts-handler.test.ts
@@ -71,10 +71,22 @@ vi.mock("@chatbotx.io/business", () => ({
   },
 }))
 
+// The contacts handler wraps quota reservation in distributedLock.runExclusive;
+// without a mock it opens a real Redis connection (ECONNREFUSED). Run the body
+// inline.
+vi.mock("@chatbotx.io/redis", () => ({
+  distributedLock: {
+    runExclusive: ({ fn }: { fn: () => Promise<unknown> }) => fn(),
+  },
+}))
+
 const getObjectStream = vi.fn()
+const headObject = vi.fn()
 vi.mock("@chatbotx.io/filesystem", () => ({
   uploader: {
     getObjectStream: (path: string) => getObjectStream(path),
+    // M-4: size check reads HeadObject's ContentLength before streaming.
+    headObject: (path: string) => headObject(path),
   },
 }))
 
@@ -155,6 +167,9 @@ beforeEach(() => {
   insertValues.mockReset()
   transactionFn.mockReset()
   getObjectStream.mockReset()
+  headObject.mockReset()
+  // Default: small file, passes the size check.
+  headObject.mockResolvedValue({ ContentLength: 1024 })
   workspaceFind.mockReset()
   workspaceFind.mockResolvedValue({ id: "ws-1", ownerId: "owner-1" })
   getRemainingSlots.mockReset()
@@ -388,10 +403,10 @@ describe("contacts import pipeline", () => {
 
   test("fails the row when the file exceeds the size limit", async () => {
     findFirstInbox.mockResolvedValue({ id: "inbox-1", channel: "messenger" })
+    // Size check uses HeadObject's ContentLength (M-4): 21 MB > 20 MB cap.
+    headObject.mockResolvedValue({ ContentLength: 21 * 1024 * 1024 })
     getObjectStream.mockResolvedValue({
       stream: Readable.from("external_id,phone\next-1,+15551234567"),
-      // 21 MB — over the 20 MB contacts import cap.
-      contentLength: 21 * 1024 * 1024,
     })
 
     await runContactsImport(buildRow())

--- a/apps/worker/__tests__/received-message.test.ts
+++ b/apps/worker/__tests__/received-message.test.ts
@@ -1,0 +1,356 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// Hoist mock references
+// ---------------------------------------------------------------------------
+
+const {
+  mockCreateOrUpdate,
+  mockCreateOrUpdateWithAttachments,
+  mockCreateMessageRepository,
+  mockDbUpdate,
+  mockFindOrFail,
+  mockFindContactInbox,
+  mockRunChannelHandler,
+  mockBroadcast,
+  mockEmit,
+  mockBuildContext,
+  mockResolvePlatformSettings,
+  mockUpdateContactFromMessage,
+  mockIntegrationQueueAdd,
+} = vi.hoisted(() => {
+  const updateChain = { set: vi.fn(), where: vi.fn() }
+  updateChain.set.mockReturnValue(updateChain)
+  updateChain.where.mockResolvedValue(undefined)
+  const mockDbUpdate = vi.fn().mockReturnValue(updateChain)
+
+  const mockFindContactInbox = vi.fn()
+  const mockFindOrFail = vi.fn()
+
+  const mockRunChannelHandler = vi.fn()
+
+  const mockCreateOrUpdate = vi.fn()
+  const mockCreateOrUpdateWithAttachments = vi.fn()
+  const mockCreateMessageRepository = vi.fn().mockResolvedValue({
+    createOrUpdate: mockCreateOrUpdate,
+    createOrUpdateWithAttachments: mockCreateOrUpdateWithAttachments,
+  })
+
+  return {
+    mockCreateOrUpdate,
+    mockCreateOrUpdateWithAttachments,
+    mockCreateMessageRepository,
+    mockDbUpdate,
+    mockFindContactInbox,
+    mockFindOrFail,
+    mockRunChannelHandler,
+    mockBroadcast: vi.fn(),
+    mockEmit: vi.fn().mockResolvedValue(undefined),
+    mockBuildContext: vi.fn().mockResolvedValue({ workspaceId: "ws-1" }),
+    mockResolvePlatformSettings: vi.fn().mockResolvedValue({}),
+    mockUpdateContactFromMessage: vi.fn().mockResolvedValue(undefined),
+    mockIntegrationQueueAdd: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@chatbotx.io/database/repositories", () => ({
+  createMessageRepository: mockCreateMessageRepository,
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    update: mockDbUpdate,
+    query: {
+      contactInboxModel: { findFirst: mockFindContactInbox },
+    },
+    transaction: vi
+      .fn()
+      .mockImplementation((fn: (tx: unknown) => unknown) => fn({})),
+  },
+  eq: vi.fn((col: unknown, val: unknown) => ({ __eq: [col, val] })),
+  findOrFail: mockFindOrFail,
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  contactInboxModel: { id: "id" },
+  contactModel: { id: "id" },
+  conversationModel: { id: "id" },
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  broadcastToWorkspaceParty: mockBroadcast,
+  buildContext: mockBuildContext,
+  resolvePlatformSettings: mockResolvePlatformSettings,
+  updateContactFromMessage: mockUpdateContactFromMessage,
+  workspaceService: { find: vi.fn().mockResolvedValue(null) },
+  userQuotaService: {
+    isLimitReached: vi.fn().mockResolvedValue(false),
+    increment: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
+vi.mock("@chatbotx.io/event-bus", () => ({
+  emit: mockEmit,
+}))
+
+vi.mock("@chatbotx.io/events", () => ({
+  emitContactCreated: vi.fn().mockResolvedValue(undefined),
+  setWebhookExecutionContext: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/partysocket-config", () => ({
+  RealtimeEventType: { messageCreated: "messageCreated" },
+}))
+
+vi.mock("@chatbotx.io/sdk", () => ({
+  SdkException: class SdkException extends Error {},
+}))
+
+vi.mock("@chatbotx.io/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@chatbotx.io/utils")>()
+  return { ...actual, createId: vi.fn(() => "test-id") }
+})
+
+vi.mock("@chatbotx.io/flow-config", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@chatbotx.io/flow-config")>()
+  return { ...actual }
+})
+
+vi.mock("@chatbotx.io/worker-config", () => ({
+  IntegrationJobAction: {
+    runFlowPostback: "runFlowPostback",
+    runFlowQuickReply: "runFlowQuickReply",
+    runRef: "runRef",
+  },
+  integrationQueue: { add: mockIntegrationQueueAdd },
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock("../src/services/integrations", () => ({
+  allIntegrations: {
+    messenger: {
+      runChannelHandler: mockRunChannelHandler,
+    },
+  },
+  integrationService: {
+    identifyInboxAndIntegrationAuthFromIdentifier: vi.fn(),
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { receiveMessage } = await import(
+  "../src/integration/handlers/received-message"
+)
+const { integrationService } = await import("../src/services/integrations")
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const fakeInbox = {
+  id: "inbox-1",
+  workspaceId: "ws-1",
+  channel: "messenger",
+} as unknown as import("@chatbotx.io/database/types").InboxModel
+
+const fakeIntegrationRow = {
+  id: "integration-1",
+  auth: {},
+  inboxId: "inbox-1",
+} as unknown as { id: string; auth: unknown; inboxId: string }
+
+const fakeContactInbox = {
+  id: "ci-1",
+  contactId: "contact-1",
+  inboxId: "inbox-1",
+  sourceId: "psid-123",
+  channel: "messenger",
+  source: "messenger",
+} as unknown as import("@chatbotx.io/database/types").ContactInboxModel
+
+const fakeConversation = {
+  id: "conv-1",
+  workspaceId: "ws-1",
+  contactId: "contact-1",
+} as unknown as import("@chatbotx.io/database/types").ConversationModel
+
+const baseIncomingMessage = {
+  sourceId: "msg-src-1",
+  messageType: "incoming" as const,
+  text: "hello",
+  contentType: "text" as const,
+  contentAttributes: {},
+  attachments: undefined,
+}
+
+const fakeCreatedMessage = {
+  id: "msg-created",
+  sourceId: "msg-src-1",
+  conversationId: "conv-1",
+  contactInboxId: "ci-1",
+  workspaceId: "ws-1",
+  messageType: "incoming",
+  contentType: "text",
+  senderType: "contact",
+  text: "hello",
+  contentAttributes: {},
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+}
+
+const baseProps = {
+  integrationType: "messenger",
+  integrationIdentifier: "inbox-1",
+  payload: {},
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("receiveMessage — message repository branch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // Setup: existing contact inbox → skip transaction contact creation
+    mockFindContactInbox.mockResolvedValue(fakeContactInbox)
+    mockFindOrFail.mockResolvedValue(fakeConversation)
+
+    vi.mocked(
+      integrationService.identifyInboxAndIntegrationAuthFromIdentifier,
+    ).mockResolvedValue({
+      inbox: fakeInbox,
+      integrationRow: fakeIntegrationRow,
+    } as never)
+
+    mockBuildContext.mockResolvedValue({ workspaceId: "ws-1" })
+    mockResolvePlatformSettings.mockResolvedValue({})
+    mockCreateMessageRepository.mockResolvedValue({
+      createOrUpdate: mockCreateOrUpdate,
+      createOrUpdateWithAttachments: mockCreateOrUpdateWithAttachments,
+    })
+    mockCreateOrUpdate.mockResolvedValue({
+      message: fakeCreatedMessage,
+      isNew: true,
+    })
+    mockCreateOrUpdateWithAttachments.mockResolvedValue({
+      result: { ...fakeCreatedMessage, attachments: [] },
+      isNew: true,
+    })
+    mockEmit.mockResolvedValue(undefined)
+    mockBroadcast.mockReturnValue(undefined)
+    mockIntegrationQueueAdd.mockResolvedValue(undefined)
+  })
+
+  test("calls repository.createOrUpdate() when message has no attachments", async () => {
+    mockRunChannelHandler.mockResolvedValue({
+      message: { ...baseIncomingMessage, attachments: [] },
+      contact: { sourceId: "psid-123", firstName: "Test" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+
+    await receiveMessage(baseProps)
+
+    expect(mockCreateOrUpdate).toHaveBeenCalledTimes(1)
+    expect(mockCreateOrUpdateWithAttachments).not.toHaveBeenCalled()
+  })
+
+  test("calls repository.createOrUpdateWithAttachments() when message has attachments", async () => {
+    mockRunChannelHandler.mockResolvedValue({
+      message: {
+        ...baseIncomingMessage,
+        attachments: [
+          {
+            fileType: "image/jpeg",
+            fileName: "img.jpg",
+            originPath: "uploads/img.jpg",
+            fileSize: 10_000,
+            sourceUrl: "https://example.com/img.jpg",
+          },
+        ],
+      },
+      contact: { sourceId: "psid-123", firstName: "Test" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+
+    await receiveMessage(baseProps)
+
+    expect(mockCreateOrUpdateWithAttachments).toHaveBeenCalledTimes(1)
+    expect(mockCreateOrUpdate).not.toHaveBeenCalled()
+  })
+
+  test("updates contactInbox.lastMessageAt when isNew=true", async () => {
+    mockRunChannelHandler.mockResolvedValue({
+      message: { ...baseIncomingMessage, attachments: [] },
+      contact: { sourceId: "psid-123", firstName: "Test" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+    mockCreateOrUpdate.mockResolvedValue({
+      message: fakeCreatedMessage,
+      isNew: true,
+    })
+
+    await receiveMessage(baseProps)
+
+    expect(mockDbUpdate).toHaveBeenCalled()
+  })
+
+  test("does NOT update lastMessageAt when isNew=false", async () => {
+    mockRunChannelHandler.mockResolvedValue({
+      message: { ...baseIncomingMessage, attachments: [] },
+      contact: { sourceId: "psid-123", firstName: "Test" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+    mockCreateOrUpdate.mockResolvedValue({
+      message: fakeCreatedMessage,
+      isNew: false,
+    })
+
+    await receiveMessage(baseProps)
+
+    expect(mockDbUpdate).not.toHaveBeenCalled()
+  })
+
+  test("does NOT call createMessageRepository when message is null", async () => {
+    mockRunChannelHandler.mockResolvedValue({
+      message: null,
+      contact: { sourceId: "psid-123", firstName: "Test" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+
+    const result = await receiveMessage(baseProps)
+
+    expect(mockCreateMessageRepository).not.toHaveBeenCalled()
+    expect(result.message).toBeNull()
+  })
+
+  test("throws for unsupported integration type", async () => {
+    await expect(
+      receiveMessage({
+        ...baseProps,
+        integrationType: "unknown_channel" as never,
+      }),
+    ).rejects.toThrow("Unsupported integration")
+  })
+})

--- a/apps/worker/__tests__/send-flow-step.test.ts
+++ b/apps/worker/__tests__/send-flow-step.test.ts
@@ -1,0 +1,409 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// Hoist mock references
+// ---------------------------------------------------------------------------
+
+const {
+  mockRepositoryCreate,
+  mockRepositoryCreateWithAttachments,
+  mockCreateMessageRepository,
+  mockDbInsert,
+  mockDbUpdate,
+  mockFindConversation,
+  mockFindContactInbox,
+  mockBroadcast,
+  mockEmit,
+  mockResolvePlatformSettings,
+  mockResolveContactVariables,
+  mockUploadFileFromUrl,
+  mockSendFlowStepToChannel,
+  mockProcessWhatsappTemplate,
+  mockProcessMessengerTemplate,
+} = vi.hoisted(() => {
+  const updateChain = { set: vi.fn(), where: vi.fn() }
+  updateChain.set.mockReturnValue(updateChain)
+  updateChain.where.mockResolvedValue(undefined)
+  const mockDbUpdate = vi.fn().mockReturnValue(updateChain)
+
+  const insertChain = {
+    values: vi.fn(),
+    returning: vi.fn().mockResolvedValue([]),
+  }
+  insertChain.values.mockReturnValue(insertChain)
+  const mockDbInsert = vi.fn().mockReturnValue(insertChain)
+
+  const mockFindConversation = vi.fn()
+  const mockFindContactInbox = vi.fn()
+
+  const mockRepositoryCreate = vi.fn().mockResolvedValue({
+    id: "msg-created",
+    contactInboxId: "ci-1",
+    workspaceId: "ws-1",
+    conversationId: "conv-1",
+    messageType: "outgoing",
+    contentType: "text",
+    senderType: "bot",
+    sourceId: null,
+    text: "hello",
+    contentAttributes: {},
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+  })
+
+  const mockRepositoryCreateWithAttachments = vi.fn().mockResolvedValue({
+    id: "msg-with-att",
+    contactInboxId: "ci-1",
+    workspaceId: "ws-1",
+    conversationId: "conv-1",
+    messageType: "outgoing",
+    contentType: "text",
+    senderType: "bot",
+    sourceId: null,
+    text: null,
+    contentAttributes: {},
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    attachments: [],
+  })
+
+  const mockCreateMessageRepository = vi.fn().mockResolvedValue({
+    create: mockRepositoryCreate,
+    createWithAttachments: mockRepositoryCreateWithAttachments,
+  })
+
+  return {
+    mockRepositoryCreate,
+    mockRepositoryCreateWithAttachments,
+    mockCreateMessageRepository,
+    mockDbInsert,
+    mockDbUpdate,
+    mockFindConversation,
+    mockFindContactInbox,
+    mockBroadcast: vi.fn(),
+    mockEmit: vi.fn().mockResolvedValue(undefined),
+    mockResolvePlatformSettings: vi
+      .fn()
+      .mockResolvedValue({ storageUrl: "https://storage.example.com" }),
+    mockResolveContactVariables: vi
+      .fn()
+      .mockImplementation((_contactId: string, step: unknown) =>
+        Promise.resolve(step),
+      ),
+    mockUploadFileFromUrl: vi.fn().mockResolvedValue({
+      originPath: "public/space/ws-1/conversations/conv-1/file-id",
+      fileType: "image/jpeg",
+      fileSize: 12_345,
+      fileName: "image.jpg",
+    }),
+    mockSendFlowStepToChannel: vi
+      .fn()
+      .mockResolvedValue({ messageIds: ["provider-1"] }),
+    mockProcessWhatsappTemplate: vi
+      .fn()
+      .mockResolvedValue({ messageId: "msg-wa" }),
+    mockProcessMessengerTemplate: vi
+      .fn()
+      .mockResolvedValue({ messageId: "msg-ms" }),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@chatbotx.io/database/repositories", () => ({
+  createMessageRepository: mockCreateMessageRepository,
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    insert: mockDbInsert,
+    update: mockDbUpdate,
+    query: {
+      conversationModel: { findFirst: mockFindConversation },
+      contactInboxModel: { findFirst: mockFindContactInbox },
+    },
+  },
+  eq: vi.fn((col: unknown, val: unknown) => ({ __eq: [col, val] })),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  messageModel: { id: "id", sourceId: "sourceId" },
+  contactInboxModel: { id: "id" },
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  broadcastToWorkspaceParty: mockBroadcast,
+  broadcastToGuestParty: vi.fn().mockResolvedValue(undefined),
+  resolvePlatformSettings: mockResolvePlatformSettings,
+}))
+
+vi.mock("@chatbotx.io/business/utils", () => ({
+  getPublicFileUrl: vi.fn((path: string, base: string) => `${base}/${path}`),
+}))
+
+vi.mock("@chatbotx.io/event-bus", () => ({
+  emit: mockEmit,
+}))
+
+vi.mock("@chatbotx.io/partysocket-config", () => ({
+  RealtimeEventType: { messageCreated: "messageCreated" },
+}))
+
+vi.mock("@chatbotx.io/sdk", () => ({
+  parseSdkError: vi.fn().mockResolvedValue({ message: "sdk error" }),
+  IntegrationException: class IntegrationException extends Error {},
+}))
+
+vi.mock("@chatbotx.io/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@chatbotx.io/utils")>()
+  return { ...actual, createId: vi.fn(() => "test-id") }
+})
+
+vi.mock("@chatbotx.io/variables", () => ({
+  resolveContactVariablesDeep: mockResolveContactVariables,
+}))
+
+vi.mock("@chatbotx.io/filesystem/node-upload", () => ({
+  uploadFileFromUrl: mockUploadFileFromUrl,
+}))
+
+vi.mock("@chatbotx.io/flow-config", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@chatbotx.io/flow-config")>()
+  return { ...actual }
+})
+
+vi.mock("../src/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock("../src/chat/handlers/send-message", () => ({
+  sendFlowStepToChannel: mockSendFlowStepToChannel,
+  sendMessageToChannel: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock("../src/chat/handlers/send-messenger-template", () => ({
+  processMessengerTemplate: mockProcessMessengerTemplate,
+}))
+
+vi.mock("../src/chat/handlers/send-whatsapp-template", () => ({
+  processWhatsappTemplate: mockProcessWhatsappTemplate,
+}))
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import type { ChatJobSendFlowStep } from "@chatbotx.io/worker-config"
+
+const { sendFlowStep } = await import("../src/chat/handlers/send-flow-step")
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+type SendFlowStepData = ChatJobSendFlowStep["data"]
+
+const fakeConversation = {
+  id: "conv-1",
+  workspaceId: "ws-1",
+  contactId: "contact-1",
+  contact: { id: "contact-1" },
+} as unknown as NonNullable<SendFlowStepData["conversationId"]>
+
+const fakeContactInbox = {
+  id: "ci-1",
+  inboxId: "inbox-1",
+  channel: "messenger",
+  contactId: "contact-1",
+  sourceId: "src-ci-1",
+  source: "messenger",
+  lastMessageAt: new Date("2026-01-01T00:00:00Z"),
+} as unknown as NonNullable<SendFlowStepData>
+
+// sendText step — no url
+const sendTextStep = {
+  id: "step-1",
+  nodeId: "node-1",
+  stepType: "sendText",
+  text: "hello from flow",
+  buttons: [],
+} as unknown as SendFlowStepData["step"]
+
+// sendImage step — has url property
+const sendImageStep = {
+  id: "step-2",
+  nodeId: "node-2",
+  stepType: "sendImage",
+  url: "https://example.com/img.jpg",
+  buttons: [],
+} as unknown as SendFlowStepData["step"]
+
+const baseParams: SendFlowStepData = {
+  conversationId: "conv-1",
+  flowId: "flow-1",
+  flowVersionId: "fv-1",
+  step: sendTextStep,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("sendFlowStep", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFindConversation.mockResolvedValue(fakeConversation)
+    mockFindContactInbox.mockResolvedValue(fakeContactInbox)
+    mockCreateMessageRepository.mockResolvedValue({
+      create: mockRepositoryCreate,
+      createWithAttachments: mockRepositoryCreateWithAttachments,
+    })
+    mockResolvePlatformSettings.mockResolvedValue({
+      storageUrl: "https://storage.example.com",
+    })
+    mockResolveContactVariables.mockImplementation(
+      (_contactId: string, step: unknown) => Promise.resolve(step),
+    )
+    mockRepositoryCreate.mockResolvedValue({
+      id: "msg-created",
+      contactInboxId: "ci-1",
+      workspaceId: "ws-1",
+      conversationId: "conv-1",
+      messageType: "outgoing",
+      contentType: "text",
+      senderType: "bot",
+      sourceId: null,
+      text: "hello from flow",
+      contentAttributes: {},
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+    })
+    mockRepositoryCreateWithAttachments.mockResolvedValue({
+      id: "msg-with-att",
+      contactInboxId: "ci-1",
+      workspaceId: "ws-1",
+      conversationId: "conv-1",
+      messageType: "outgoing",
+      contentType: "text",
+      senderType: "bot",
+      sourceId: null,
+      text: null,
+      contentAttributes: {},
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+      attachments: [],
+    })
+    mockUploadFileFromUrl.mockResolvedValue({
+      originPath: "public/space/ws-1/conversations/conv-1/test-id",
+      fileType: "image/jpeg",
+      fileSize: 12_345,
+      fileName: "image.jpg",
+    })
+    mockSendFlowStepToChannel.mockResolvedValue({ messageIds: ["provider-1"] })
+    mockEmit.mockResolvedValue(undefined)
+  })
+
+  test("returns early when conversation not found — repository not called", async () => {
+    mockFindConversation.mockResolvedValue(null)
+
+    await sendFlowStep(baseParams)
+
+    expect(mockCreateMessageRepository).not.toHaveBeenCalled()
+  })
+
+  test("returns early when contactInbox not found — repository not called", async () => {
+    mockFindContactInbox.mockResolvedValue(null)
+
+    await sendFlowStep(baseParams)
+
+    expect(mockCreateMessageRepository).not.toHaveBeenCalled()
+  })
+
+  test("calls repository.create() for step without url (sendText)", async () => {
+    await sendFlowStep({ ...baseParams, step: sendTextStep })
+
+    expect(mockRepositoryCreate).toHaveBeenCalledTimes(1)
+    expect(mockRepositoryCreateWithAttachments).not.toHaveBeenCalled()
+    expect(mockRepositoryCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageType: "outgoing",
+        senderType: "bot",
+        workspaceId: "ws-1",
+        conversationId: "conv-1",
+      }),
+    )
+  })
+
+  test("calls repository.createWithAttachments() for step with url (sendImage)", async () => {
+    await sendFlowStep({ ...baseParams, step: sendImageStep })
+
+    expect(mockUploadFileFromUrl).toHaveBeenCalledWith(
+      "https://example.com/img.jpg",
+      expect.stringContaining("public/space/ws-1/conversations/conv-1/"),
+    )
+    expect(mockRepositoryCreateWithAttachments).toHaveBeenCalledTimes(1)
+    expect(mockRepositoryCreate).not.toHaveBeenCalled()
+  })
+
+  test("does NOT call db.insert directly for message creation", async () => {
+    await sendFlowStep({ ...baseParams, step: sendTextStep })
+
+    const { messageModel: messageModelMock } = await import(
+      "@chatbotx.io/database/schema"
+    )
+    for (const call of mockDbInsert.mock.calls) {
+      expect(call[0]).not.toBe(messageModelMock)
+    }
+  })
+
+  test("delegates to processWhatsappTemplate for sendWaTemplateMessage step — does not call createMessageRepository directly", async () => {
+    const waStep = {
+      id: "step-wa",
+      nodeId: "node-wa",
+      stepType: "sendWaTemplateMessage",
+      template: { id: "tmpl-1", name: "template", language: "en", params: {} },
+      buttons: [],
+    } as unknown as SendFlowStepData["step"]
+
+    const waContactInbox = {
+      ...fakeContactInbox,
+      channel: "whatsapp",
+    } as unknown as typeof fakeContactInbox
+    mockFindContactInbox.mockResolvedValue(waContactInbox)
+
+    await sendFlowStep({ ...baseParams, step: waStep })
+
+    expect(mockProcessWhatsappTemplate).toHaveBeenCalled()
+    expect(mockCreateMessageRepository).not.toHaveBeenCalled()
+  })
+
+  test("delegates to processMessengerTemplate for sendMessengerTemplateMessage step — does not call createMessageRepository directly", async () => {
+    const msStep = {
+      id: "step-ms",
+      nodeId: "node-ms",
+      stepType: "sendMessengerTemplateMessage",
+      template: {
+        id: "tmpl-2",
+        name: "ms-template",
+        language: "en",
+        parameterFormat: "POSITIONAL",
+        params: {},
+      },
+      buttons: [],
+    } as unknown as SendFlowStepData["step"]
+
+    const msContactInbox = {
+      ...fakeContactInbox,
+      channel: "messenger",
+    } as unknown as typeof fakeContactInbox
+    mockFindContactInbox.mockResolvedValue(msContactInbox)
+
+    await sendFlowStep({ ...baseParams, step: msStep })
+
+    expect(mockProcessMessengerTemplate).toHaveBeenCalled()
+    expect(mockCreateMessageRepository).not.toHaveBeenCalled()
+  })
+})

--- a/apps/worker/__tests__/send-messenger-template-create.test.ts
+++ b/apps/worker/__tests__/send-messenger-template-create.test.ts
@@ -1,0 +1,290 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// Hoist mock references
+// ---------------------------------------------------------------------------
+
+const {
+  mockRepositoryCreate,
+  mockRepositoryUpdateSourceId,
+  mockCreateMessageRepository,
+  mockDbInsert,
+  mockDbUpdate,
+  mockBroadcast,
+  mockEmit,
+  mockValidateTemplate,
+  mockReplaceVariables,
+  mockContactVariables,
+  mockSendFlowStep,
+} = vi.hoisted(() => {
+  const insertChain = {
+    values: vi.fn(),
+    returning: vi.fn().mockResolvedValue([]),
+  }
+  insertChain.values.mockReturnValue(insertChain)
+  const mockDbInsert = vi.fn().mockReturnValue(insertChain)
+
+  const updateChain = { set: vi.fn(), where: vi.fn() }
+  updateChain.set.mockReturnValue(updateChain)
+  updateChain.where.mockResolvedValue(undefined)
+  const mockDbUpdate = vi.fn().mockReturnValue(updateChain)
+
+  const mockRepositoryCreate = vi.fn().mockResolvedValue({
+    id: "msg-created",
+    contactInboxId: "ci-1",
+    workspaceId: "ws-1",
+    conversationId: "conv-1",
+    messageType: "outgoing",
+    contentType: "text",
+    senderType: "bot",
+    sourceId: null,
+    text: "Template: my-template",
+    contentAttributes: {},
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  })
+  const mockRepositoryUpdateSourceId = vi.fn().mockResolvedValue(undefined)
+
+  const mockCreateMessageRepository = vi.fn().mockResolvedValue({
+    create: mockRepositoryCreate,
+    updateSourceId: mockRepositoryUpdateSourceId,
+  })
+
+  return {
+    mockRepositoryCreate,
+    mockRepositoryUpdateSourceId,
+    mockCreateMessageRepository,
+    mockDbInsert,
+    mockDbUpdate,
+    mockBroadcast: vi.fn(),
+    mockEmit: vi.fn().mockResolvedValue(undefined),
+    mockValidateTemplate: vi.fn().mockResolvedValue({
+      template: {
+        id: "tmpl-1",
+        name: "my-template",
+        language: "en",
+        parameterFormat: "POSITIONAL",
+        components: [],
+      },
+    }),
+    mockReplaceVariables: vi.fn().mockResolvedValue([]),
+    mockContactVariables: vi.fn().mockResolvedValue([]),
+    mockSendFlowStep: vi
+      .fn()
+      .mockResolvedValue({ messageIds: ["provider-msg-1"] }),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@chatbotx.io/database/repositories", () => ({
+  createMessageRepository: mockCreateMessageRepository,
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    insert: mockDbInsert,
+    update: mockDbUpdate,
+    query: {
+      flowModel: { findFirst: vi.fn().mockResolvedValue(null) },
+    },
+  },
+  eq: vi.fn((col: unknown, val: unknown) => ({ __eq: [col, val] })),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  messageModel: { id: "id", sourceId: "sourceId" },
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  broadcastToWorkspaceParty: mockBroadcast,
+}))
+
+vi.mock("@chatbotx.io/event-bus", () => ({
+  emit: mockEmit,
+}))
+
+vi.mock("@chatbotx.io/partysocket-config", () => ({
+  RealtimeEventType: { messageCreated: "messageCreated" },
+}))
+
+vi.mock("@chatbotx.io/sdk", () => ({
+  parseSdkError: vi.fn().mockResolvedValue({ message: "sdk error" }),
+}))
+
+vi.mock("@chatbotx.io/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@chatbotx.io/utils")>()
+  return { ...actual, createId: vi.fn(() => "test-id") }
+})
+
+vi.mock("@chatbotx.io/variables", () => ({
+  contactVariableService: { getAll: mockContactVariables },
+}))
+
+vi.mock("../src/integration/handlers/messenger-template-handler", () => ({
+  validateMessengerTemplate: mockValidateTemplate,
+  replaceMessengerTemplateVariables: mockReplaceVariables,
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock("../src/chat/handlers/send-message", () => ({
+  sendFlowStepToChannel: mockSendFlowStep,
+}))
+
+vi.mock("@chatbotx.io/flow-config", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@chatbotx.io/flow-config")>()
+  return {
+    ...actual,
+    messageEventTypeSchema: {
+      enum: {
+        "message:sent": "message:sent",
+        "message:failed": "message:failed",
+      },
+    },
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import type { ProcessMessengerTemplateParams } from "../src/chat/handlers/send-messenger-template"
+
+const { processMessengerTemplate } = await import(
+  "../src/chat/handlers/send-messenger-template"
+)
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// Cast partial objects to satisfy strict model types in test context
+const fakeConversation = {
+  id: "conv-1",
+  workspaceId: "ws-1",
+  contactId: "contact-1",
+} as unknown as ProcessMessengerTemplateParams["conversation"]
+
+const fakeContactInbox = {
+  id: "ci-1",
+  inboxId: "inbox-1",
+  channel: "messenger",
+} as unknown as ProcessMessengerTemplateParams["contactInbox"]
+
+const fakeTemplate = {
+  id: "tmpl-1",
+  name: "my-template",
+  language: "en" as const,
+  parameterFormat: "POSITIONAL" as const,
+  params: {} as ProcessMessengerTemplateParams["template"]["params"],
+  inboxId: "inbox-1",
+} as ProcessMessengerTemplateParams["template"]
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("processMessengerTemplate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRepositoryCreate.mockResolvedValue({
+      id: "msg-created",
+      contactInboxId: "ci-1",
+      workspaceId: "ws-1",
+      conversationId: "conv-1",
+      messageType: "outgoing",
+      contentType: "text",
+      senderType: "bot",
+      sourceId: null,
+      text: "Template: my-template",
+      contentAttributes: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    mockCreateMessageRepository.mockResolvedValue({
+      create: mockRepositoryCreate,
+      updateSourceId: mockRepositoryUpdateSourceId,
+    })
+    mockValidateTemplate.mockResolvedValue({
+      template: {
+        id: "tmpl-1",
+        name: "my-template",
+        language: "en",
+        parameterFormat: "POSITIONAL",
+        components: [],
+      },
+    })
+    mockReplaceVariables.mockResolvedValue([])
+    mockContactVariables.mockResolvedValue([])
+    mockSendFlowStep.mockResolvedValue({ messageIds: ["provider-msg-1"] })
+    mockEmit.mockResolvedValue(undefined)
+  })
+
+  test("calls repository.create() to insert outbound message", async () => {
+    await processMessengerTemplate({
+      conversation: fakeConversation,
+      contactInbox: fakeContactInbox,
+      template: fakeTemplate,
+    })
+
+    expect(mockCreateMessageRepository).toHaveBeenCalled()
+    expect(mockRepositoryCreate).toHaveBeenCalledTimes(1)
+    expect(mockRepositoryCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageType: "outgoing",
+        senderType: "bot",
+        workspaceId: "ws-1",
+        conversationId: "conv-1",
+      }),
+    )
+  })
+
+  test("does NOT call db.insert directly for message creation", async () => {
+    await processMessengerTemplate({
+      conversation: fakeConversation,
+      contactInbox: fakeContactInbox,
+      template: fakeTemplate,
+    })
+
+    const messageModelMock = (await import("@chatbotx.io/database/schema"))
+      .messageModel
+    for (const call of mockDbInsert.mock.calls) {
+      expect(call[0]).not.toBe(messageModelMock)
+    }
+  })
+
+  test("broadcasts realtime event after message created", async () => {
+    await processMessengerTemplate({
+      conversation: fakeConversation,
+      contactInbox: fakeContactInbox,
+      template: fakeTemplate,
+    })
+
+    expect(mockBroadcast).toHaveBeenCalledWith(
+      "ws-1",
+      expect.objectContaining({ eventType: "messageCreated" }),
+    )
+  })
+
+  test("calls repository.updateSourceId when provider returns providerMessageId", async () => {
+    mockSendFlowStep.mockResolvedValue({ messageIds: ["prov-msg-42"] })
+
+    await processMessengerTemplate({
+      conversation: fakeConversation,
+      contactInbox: fakeContactInbox,
+      template: fakeTemplate,
+    })
+
+    expect(mockRepositoryUpdateSourceId).toHaveBeenCalledWith(
+      "msg-created",
+      "prov-msg-42",
+      "ws-1",
+    )
+  })
+})

--- a/apps/worker/__tests__/send-whatsapp-template.test.ts
+++ b/apps/worker/__tests__/send-whatsapp-template.test.ts
@@ -1,0 +1,340 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// Hoist mock references
+// ---------------------------------------------------------------------------
+
+const {
+  mockRepositoryCreate,
+  mockRepositoryUpdateSourceId,
+  mockCreateMessageRepository,
+  mockDbInsert,
+  mockDbUpdate,
+  mockBroadcast,
+  mockEmit,
+  mockValidateTemplate,
+  mockReplaceVariables,
+  mockContactVariables,
+  mockSendFlowStep,
+  mockConvertButtons,
+  mockParseSdkError,
+} = vi.hoisted(() => {
+  const updateChain = { set: vi.fn(), where: vi.fn() }
+  updateChain.set.mockReturnValue(updateChain)
+  updateChain.where.mockResolvedValue(undefined)
+  const mockDbUpdate = vi.fn().mockReturnValue(updateChain)
+
+  const insertChain = {
+    values: vi.fn(),
+    returning: vi.fn().mockResolvedValue([]),
+  }
+  insertChain.values.mockReturnValue(insertChain)
+  const mockDbInsert = vi.fn().mockReturnValue(insertChain)
+
+  const mockRepositoryCreate = vi.fn().mockResolvedValue({
+    id: "msg-created",
+    contactInboxId: "ci-1",
+    workspaceId: "ws-1",
+    conversationId: "conv-1",
+    messageType: "outgoing",
+    contentType: "text",
+    senderType: "bot",
+    sourceId: null,
+    text: "Template: wa-template",
+    contentAttributes: {},
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+  })
+
+  const mockRepositoryUpdateSourceId = vi.fn().mockResolvedValue(undefined)
+
+  const mockCreateMessageRepository = vi.fn().mockResolvedValue({
+    create: mockRepositoryCreate,
+    updateSourceId: mockRepositoryUpdateSourceId,
+  })
+
+  return {
+    mockRepositoryCreate,
+    mockRepositoryUpdateSourceId,
+    mockCreateMessageRepository,
+    mockDbInsert,
+    mockDbUpdate,
+    mockBroadcast: vi.fn(),
+    mockEmit: vi.fn().mockResolvedValue(undefined),
+    mockValidateTemplate: vi.fn().mockResolvedValue({
+      template: {
+        id: "tmpl-wa-1",
+        name: "wa-template",
+        language: "en",
+        components: [],
+      },
+    }),
+    mockReplaceVariables: vi.fn().mockResolvedValue([]),
+    mockContactVariables: vi.fn().mockResolvedValue([]),
+    mockSendFlowStep: vi
+      .fn()
+      .mockResolvedValue({ messageIds: ["provider-wa-1"] }),
+    mockConvertButtons: vi.fn().mockReturnValue([]),
+    mockParseSdkError: vi.fn().mockResolvedValue({ message: "sdk error" }),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@chatbotx.io/database/repositories", () => ({
+  createMessageRepository: mockCreateMessageRepository,
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    insert: mockDbInsert,
+    update: mockDbUpdate,
+    query: {
+      conversationModel: { findFirst: vi.fn().mockResolvedValue(null) },
+    },
+  },
+  eq: vi.fn((col: unknown, val: unknown) => ({ __eq: [col, val] })),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  messageModel: { id: "id", sourceId: "sourceId" },
+  contactInboxModel: { id: "id" },
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  broadcastToWorkspaceParty: mockBroadcast,
+}))
+
+vi.mock("@chatbotx.io/event-bus", () => ({
+  emit: mockEmit,
+}))
+
+vi.mock("@chatbotx.io/partysocket-config", () => ({
+  RealtimeEventType: { messageCreated: "messageCreated" },
+}))
+
+vi.mock("@chatbotx.io/sdk", () => ({
+  parseSdkError: mockParseSdkError,
+}))
+
+vi.mock("@chatbotx.io/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@chatbotx.io/utils")>()
+  return { ...actual, createId: vi.fn(() => "test-id") }
+})
+
+vi.mock("@chatbotx.io/variables", () => ({
+  contactVariableService: { getAll: mockContactVariables },
+}))
+
+vi.mock("@chatbotx.io/flow-config", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@chatbotx.io/flow-config")>()
+  return {
+    ...actual,
+    messageEventTypeSchema: {
+      enum: {
+        "message:sent": "message:sent",
+        "message:failed": "message:failed",
+      },
+    },
+  }
+})
+
+vi.mock("../src/integration/handlers/wa-template-handler", () => ({
+  validateWhatsappTemplate: mockValidateTemplate,
+  replaceWhatsappTemplateVariables: mockReplaceVariables,
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock("../src/chat/handlers/send-message", () => ({
+  sendFlowStepToChannel: mockSendFlowStep,
+}))
+
+vi.mock("../src/chat/handlers/send-flow-step", () => ({
+  convertButtonsToTemplate: mockConvertButtons,
+}))
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import type { ProcessWhatsappTemplateParams } from "../src/chat/handlers/send-whatsapp-template"
+
+const { processWhatsappTemplate } = await import(
+  "../src/chat/handlers/send-whatsapp-template"
+)
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const fakeConversation = {
+  id: "conv-1",
+  workspaceId: "ws-1",
+  contactId: "contact-1",
+} as unknown as ProcessWhatsappTemplateParams["conversation"]
+
+const fakeContactInbox = {
+  id: "ci-1",
+  inboxId: "inbox-1",
+  channel: "whatsapp",
+} as unknown as ProcessWhatsappTemplateParams["contactInbox"]
+
+const fakeTemplate: ProcessWhatsappTemplateParams["template"] = {
+  id: "tmpl-wa-1",
+  name: "wa-template",
+  language: "en",
+  params: {},
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("processWhatsappTemplate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRepositoryCreate.mockResolvedValue({
+      id: "msg-created",
+      contactInboxId: "ci-1",
+      workspaceId: "ws-1",
+      conversationId: "conv-1",
+      messageType: "outgoing",
+      contentType: "text",
+      senderType: "bot",
+      sourceId: null,
+      text: "Template: wa-template",
+      contentAttributes: {},
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+    })
+    mockCreateMessageRepository.mockResolvedValue({
+      create: mockRepositoryCreate,
+      updateSourceId: mockRepositoryUpdateSourceId,
+    })
+    mockValidateTemplate.mockResolvedValue({
+      template: {
+        id: "tmpl-wa-1",
+        name: "wa-template",
+        language: "en",
+        components: [],
+      },
+    })
+    mockReplaceVariables.mockResolvedValue([])
+    mockContactVariables.mockResolvedValue([])
+    mockSendFlowStep.mockResolvedValue({ messageIds: ["provider-wa-1"] })
+    mockEmit.mockResolvedValue(undefined)
+  })
+
+  test("calls repository.create() to insert outbound message", async () => {
+    await processWhatsappTemplate({
+      conversation: fakeConversation,
+      contactInbox: fakeContactInbox,
+      template: fakeTemplate,
+    })
+
+    expect(mockCreateMessageRepository).toHaveBeenCalled()
+    expect(mockRepositoryCreate).toHaveBeenCalledTimes(1)
+    expect(mockRepositoryCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageType: "outgoing",
+        senderType: "bot",
+        workspaceId: "ws-1",
+        conversationId: "conv-1",
+      }),
+    )
+  })
+
+  test("does NOT call db.insert directly for message creation", async () => {
+    await processWhatsappTemplate({
+      conversation: fakeConversation,
+      contactInbox: fakeContactInbox,
+      template: fakeTemplate,
+    })
+
+    const messageModelMock = (await import("@chatbotx.io/database/schema"))
+      .messageModel
+    for (const call of mockDbInsert.mock.calls) {
+      expect(call[0]).not.toBe(messageModelMock)
+    }
+  })
+
+  test("broadcasts realtime event after message created", async () => {
+    await processWhatsappTemplate({
+      conversation: fakeConversation,
+      contactInbox: fakeContactInbox,
+      template: fakeTemplate,
+    })
+
+    expect(mockBroadcast).toHaveBeenCalledWith(
+      "ws-1",
+      expect.objectContaining({ eventType: "messageCreated" }),
+    )
+  })
+
+  test("throws when validateWhatsappTemplate returns null — repository.create not called", async () => {
+    mockValidateTemplate.mockResolvedValue(null)
+
+    await expect(
+      processWhatsappTemplate({
+        conversation: fakeConversation,
+        contactInbox: fakeContactInbox,
+        template: fakeTemplate,
+      }),
+    ).rejects.toThrow()
+
+    expect(mockRepositoryCreate).not.toHaveBeenCalled()
+  })
+
+  test("throws 'Failed to insert message record' when repository.create returns null", async () => {
+    mockRepositoryCreate.mockResolvedValue(null)
+
+    await expect(
+      processWhatsappTemplate({
+        conversation: fakeConversation,
+        contactInbox: fakeContactInbox,
+        template: fakeTemplate,
+      }),
+    ).rejects.toThrow("Failed to insert message record")
+  })
+
+  test("calls repository.updateSourceId when provider returns providerMessageId", async () => {
+    mockSendFlowStep.mockResolvedValue({ messageIds: ["prov-123"] })
+
+    await processWhatsappTemplate({
+      conversation: fakeConversation,
+      contactInbox: fakeContactInbox,
+      template: fakeTemplate,
+    })
+
+    expect(mockRepositoryUpdateSourceId).toHaveBeenCalledWith(
+      "msg-created",
+      "prov-123",
+      "ws-1",
+    )
+    // db.update called once only for contactInbox lastMessageAt
+    expect(mockDbUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  test("emits message:failed on error and rethrows", async () => {
+    mockRepositoryCreate.mockRejectedValue(new Error("db fail"))
+
+    await expect(
+      processWhatsappTemplate({
+        conversation: fakeConversation,
+        contactInbox: fakeContactInbox,
+        template: fakeTemplate,
+      }),
+    ).rejects.toThrow("db fail")
+
+    expect(mockEmit).toHaveBeenCalledWith(
+      "message:failed",
+      expect.objectContaining({ occurredAt: expect.any(Date) }),
+    )
+  })
+})

--- a/apps/worker/__tests__/whatsapp-flow-response.test.ts
+++ b/apps/worker/__tests__/whatsapp-flow-response.test.ts
@@ -43,7 +43,7 @@ vi.mock("@chatbotx.io/database/schema", () => ({
   },
 }))
 
-vi.mock("../../lib/logger", () => ({
+vi.mock("../src/lib/logger", () => ({
   logger: { warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }))
 
@@ -63,7 +63,7 @@ vi.mock("@chatbotx.io/utils", async (importOriginal) => {
 // --- imports after mocks ---
 
 const { findWhatsappFlowStepByButtonId, applyWhatsappFlowResponseSideEffects } =
-  await import("./whatsapp-flow-response")
+  await import("../src/integration/handlers/whatsapp-flow-response")
 
 // --- helpers ---
 
@@ -192,7 +192,7 @@ describe("applyWhatsappFlowResponseSideEffects", () => {
   })
 
   test("returns early and logs warning when sourceId is empty", async () => {
-    const { logger } = await import("../../lib/logger")
+    const { logger } = await import("../src/lib/logger")
     const step = makeWhatsappFlowStep("btn-1")
     step.flow.sourceId = ""
 
@@ -304,7 +304,7 @@ describe("applyWhatsappFlowResponseSideEffects", () => {
 
   test("logs warning when integrationWhatsapp not found for completedCount increment", async () => {
     dbQueryIntegrationFindFirst.mockResolvedValue(null)
-    const { logger } = await import("../../lib/logger")
+    const { logger } = await import("../src/lib/logger")
     const step = makeWhatsappFlowStep("btn-1")
 
     await applyWhatsappFlowResponseSideEffects({

--- a/apps/worker/src/chat/handlers/send-messenger-template.ts
+++ b/apps/worker/src/chat/handlers/send-messenger-template.ts
@@ -1,6 +1,7 @@
 import { broadcastToWorkspaceParty } from "@chatbotx.io/business"
-import { db, eq } from "@chatbotx.io/database/client"
-import { messageModel } from "@chatbotx.io/database/schema"
+import { db } from "@chatbotx.io/database/client"
+import { createMessageRepository } from "@chatbotx.io/database/repositories"
+import type { messageModel } from "@chatbotx.io/database/schema"
 import type {
   ContactInboxModel,
   ConversationModel,
@@ -127,7 +128,8 @@ export async function processMessengerTemplate(
       metadata,
     }
 
-    const messageData: typeof messageModel.$inferInsert = {
+    const messageRepository = await createMessageRepository()
+    newMessage = await messageRepository.create({
       id: createId(),
       contactInboxId: contactInbox.id,
       workspaceId: conversation.workspaceId,
@@ -138,17 +140,7 @@ export async function processMessengerTemplate(
       sourceId: null,
       text: `Template: ${template.name}`,
       contentAttributes,
-    }
-
-    newMessage = await db
-      .insert(messageModel)
-      .values(messageData)
-      .returning()
-      .then((result) => result[0])
-
-    if (!newMessage) {
-      throw new Error("Failed to insert message record")
-    }
+    })
 
     broadcastToWorkspaceParty(conversation.workspaceId, {
       eventType: RealtimeEventType.messageCreated,
@@ -180,10 +172,11 @@ export async function processMessengerTemplate(
     const providerMessageId = result?.messageIds?.[0]
 
     if (providerMessageId) {
-      await db
-        .update(messageModel)
-        .set({ sourceId: providerMessageId })
-        .where(eq(messageModel.id, newMessage.id))
+      await messageRepository.updateSourceId(
+        newMessage.id,
+        providerMessageId,
+        conversation.workspaceId,
+      )
     }
 
     return {

--- a/apps/worker/src/chat/handlers/send-whatsapp-template.ts
+++ b/apps/worker/src/chat/handlers/send-whatsapp-template.ts
@@ -1,7 +1,10 @@
 import { broadcastToWorkspaceParty } from "@chatbotx.io/business"
 import { db, eq } from "@chatbotx.io/database/client"
 import { createMessageRepository } from "@chatbotx.io/database/repositories"
-import { contactInboxModel, messageModel } from "@chatbotx.io/database/schema"
+import {
+  contactInboxModel,
+  type messageModel,
+} from "@chatbotx.io/database/schema"
 import type {
   ContactInboxModel,
   ConversationModel,
@@ -190,10 +193,11 @@ export async function processWhatsappTemplate(
     const providerMessageId = result?.messageIds?.[0]
 
     if (providerMessageId) {
-      await db
-        .update(messageModel)
-        .set({ sourceId: providerMessageId })
-        .where(eq(messageModel.id, newMessage.id))
+      await repository.updateSourceId(
+        newMessage.id,
+        providerMessageId,
+        conversation.workspaceId,
+      )
     }
 
     return {

--- a/apps/worker/src/integration/handlers/coexist/bulk-historical-import.ts
+++ b/apps/worker/src/integration/handlers/coexist/bulk-historical-import.ts
@@ -1,12 +1,16 @@
 // biome-ignore-all lint/suspicious/noBitwiseOperators: bit-packing 63-bit snowflake IDs
 
 import { db, eq, inArray, sql } from "@chatbotx.io/database/client"
+import type {
+  BulkCreateAttachmentInput,
+  CreateMessageInput,
+  IMessageRepository,
+} from "@chatbotx.io/database/repositories"
+import { createMessageRepository } from "@chatbotx.io/database/repositories"
 import {
-  attachmentModel,
   contactInboxModel,
   contactModel,
   conversationModel,
-  messageModel,
   userQuotaModel,
   workspaceModel,
 } from "@chatbotx.io/database/schema"
@@ -21,75 +25,109 @@ import { logger } from "../../../lib/logger"
 // ---------- Coexist time-derived Message IDs ----------
 // Layout mirrors `@chatbotx.io/utils` `createId()` shift so coexist IDs share
 // the same numeric magnitude/length as live snowflakes:
-//   high → low: [ 53 bits ms since epoch ][ 10 bits run partition ][ 4 bits seq ]
+//   high → low: [ 53 bits ms since epoch ][ 14 bits disambiguator ]
 //   ts_shift = 14   (identical to uuniq layout)
-// Epoch `2026-03-31` matches `createId()`. The high 53 bits being a pure
-// function of `createdAt` guarantees `ORDER BY id` ≡ `ORDER BY createdAt` for
-// historically-imported rows.
+// The high 53 bits are a pure function of `createdAt`, so `ORDER BY id` ≡
+// `ORDER BY createdAt` for historically-imported rows.
+//
+// The low 14 bits disambiguate messages that share the same createdAt-second.
+// They are derived from a stable hash of the message `sourceId` — NOT from the
+// run — so the id is a pure function of (createdAt, sourceId). This is the key
+// difference from the old [run-partition][per-run-seq] scheme, which re-minted
+// ids every run: two DISTINCT messages at the same second in two runs sharing
+// `runId mod 1024` produced the SAME id (different sourceId → bypassed the
+// (contactInboxId, sourceId, createdAt) arbiter → hit the PK). Hashing sourceId
+// makes ids idempotent and collision-free across runs; two distinct messages
+// only clash on a rare 14-bit hash collision, resolved by the per-import probe
+// below and the bulkCreate PK retry.
 
 const COEXIST_EPOCH_MS = new Date("2004-02-01").getTime()
 const COEXIST_TS_BITS = 53n
-const COEXIST_PARTITION_BITS = 10n
-const COEXIST_SEQ_BITS = 4n
-const COEXIST_PARTITION_SHIFT = COEXIST_SEQ_BITS
-const COEXIST_TS_SHIFT = COEXIST_PARTITION_BITS + COEXIST_SEQ_BITS
-const COEXIST_PARTITION_MASK = (1n << COEXIST_PARTITION_BITS) - 1n
-const COEXIST_SEQ_MASK = (1n << COEXIST_SEQ_BITS) - 1n
+const COEXIST_DISAMBIG_BITS = 14n
+const COEXIST_TS_SHIFT = COEXIST_DISAMBIG_BITS
+const COEXIST_DISAMBIG_MASK = (1n << COEXIST_DISAMBIG_BITS) - 1n
 const COEXIST_MAX_TS = 1n << COEXIST_TS_BITS
+const COEXIST_DISAMBIG_SPACE = 1n << COEXIST_DISAMBIG_BITS
 
-export type HistoricalIdFactory = (date: Date) => string
+export type HistoricalIdFactory = (date: Date, sourceId: string) => string
 
-const COEXIST_SEQ_SPACE = 1n << COEXIST_SEQ_BITS
+// FNV-1a over `sourceId`, folded into the 14-bit disambiguator space. Pure and
+// deterministic: the same message always maps to the same starting slot.
+const hashSourceId = (sourceId: string): bigint => {
+  let hash = 2_166_136_261
+  for (let i = 0; i < sourceId.length; i++) {
+    hash ^= sourceId.charCodeAt(i)
+    hash = Math.imul(hash, 16_777_619)
+  }
+  return BigInt(hash >>> 0) & COEXIST_DISAMBIG_MASK
+}
 
-export const createHistoricalIdFactory = (
-  runId: string,
-): HistoricalIdFactory => {
-  const partition = BigInt(runId) & COEXIST_PARTITION_MASK
-  const seqByTs = new Map<bigint, bigint>()
+export const createHistoricalIdFactory = (): HistoricalIdFactory => {
+  // Ids minted in THIS import. Lets distinct messages that hash to the same
+  // disambiguator at the same second probe forward to a free slot instead of
+  // emitting a duplicate (id, createdAt) within one batch. Also lets a retry
+  // (re-calling for the same message) advance past the colliding slot.
+  const used = new Set<bigint>()
 
-  return (date: Date): string => {
+  return (date: Date, sourceId: string): string => {
     const baseTs = BigInt(date.getTime() - COEXIST_EPOCH_MS)
     if (baseTs < 0n || baseTs >= COEXIST_MAX_TS) {
       throw new Error(
         `createHistoricalIdFactory: ${date.toISOString()} out of range`,
       )
     }
+    const start = hashSourceId(sourceId)
     let ts = baseTs
     while (ts < COEXIST_MAX_TS) {
-      const next = seqByTs.get(ts) ?? 0n
-      if (next < COEXIST_SEQ_SPACE) {
-        seqByTs.set(ts, next + 1n)
-        return (
-          (ts << COEXIST_TS_SHIFT) |
-          (partition << COEXIST_PARTITION_SHIFT) |
-          next
-        ).toString()
+      for (let offset = 0n; offset < COEXIST_DISAMBIG_SPACE; offset++) {
+        const disambiguator = (start + offset) & COEXIST_DISAMBIG_MASK
+        const id = (ts << COEXIST_TS_SHIFT) | disambiguator
+        if (!used.has(id)) {
+          used.add(id)
+          return id.toString()
+        }
       }
       ts += 1n
     }
     throw new Error(
-      `createHistoricalIdFactory: exhausted sequence space at ${date.toISOString()}`,
+      `createHistoricalIdFactory: exhausted disambiguator space at ${date.toISOString()}`,
     )
   }
 }
 
 export const decodeHistoricalId = (
   id: string,
-): { timestampMs: number; partition: number; seq: number } => {
+): { timestampMs: number; disambiguator: number } => {
   const v = BigInt(id)
   return {
     timestampMs: Number(v >> COEXIST_TS_SHIFT) + COEXIST_EPOCH_MS,
-    partition: Number((v >> COEXIST_PARTITION_SHIFT) & COEXIST_PARTITION_MASK),
-    seq: Number(v & COEXIST_SEQ_MASK),
+    disambiguator: Number(v & COEXIST_DISAMBIG_MASK),
   }
 }
 
 const isUniqueMessagePkViolation = (err: unknown): boolean => {
-  if (typeof err !== "object" || err === null) {
-    return false
+  // Drizzle wraps the pg error, so code/constraint live on `.cause` (sometimes
+  // nested). Walk the cause chain. pg exposes the constraint as `constraint`
+  // (older shims used `constraint_name`). TimescaleDB reports the chunk-prefixed
+  // name like "17_17_Message_pkey", so match by suffix rather than equality.
+  let current: unknown = err
+  for (let depth = 0; depth < 5 && current; depth++) {
+    if (typeof current !== "object" || current === null) {
+      return false
+    }
+    const e = current as {
+      code?: string
+      constraint?: string
+      constraint_name?: string
+      cause?: unknown
+    }
+    const constraint = e.constraint ?? e.constraint_name
+    if (e.code === "23505" && constraint?.endsWith("Message_pkey")) {
+      return true
+    }
+    current = e.cause
   }
-  const e = err as { code?: string; constraint_name?: string }
-  return e.code === "23505" && e.constraint_name === "Message_pkey"
+  return false
 }
 
 export type HistoricalMessage = IncomingMessage & { createdAt?: Date }
@@ -541,8 +579,8 @@ export const bulkImportContacts = async (props: {
  * (contactInboxId, sourceId) unique constraint — retries never duplicate rows.
  *
  * Chunks INSERTs at 1000 rows to stay under the Postgres 65535-param limit.
- * On a cross-run PK collision (partition+ms+seq clash), regenerates IDs from
- * the factory and retries the chunk once.
+ * On a Message PK collision (rare sourceId-hash clash at the same second),
+ * regenerates IDs from the factory (which probes to a free slot) and retries.
  *
  * When `contactEnrichment` is provided (phone/email discovered while scanning
  * message bodies), COALESCE-fills the parent Contact row in the same tx so
@@ -590,13 +628,99 @@ export const bulkImportMessages = async (props: {
     return empty
   }
 
-  const makeMessageId = idFactory ?? createHistoricalIdFactory(runId)
-  let importedMessages = 0
-  let skippedMessages = 0
+  const makeMessageId = idFactory ?? createHistoricalIdFactory()
   const insertedAttachmentIds: string[] = []
 
-  await db.transaction(async (tx) => {
-    if (hasEnrichment && contactEnrichment) {
+  // Map message.sourceId → its attachments[] so post-insert we can resolve
+  // each inserted Message row to the right Attachment payload.
+  const attachmentsBySourceId = new Map<
+    string,
+    NonNullable<IncomingMessage["attachments"]>
+  >()
+  for (const msg of messages) {
+    if (msg.attachments && msg.attachments.length > 0) {
+      attachmentsBySourceId.set(msg.sourceId, msg.attachments)
+    }
+  }
+
+  // Build message inputs with deterministic snowflake IDs.
+  const messageInputs: CreateMessageInput[] = messages.map((msg) => {
+    const isOutgoing = msg.messageType === "outgoing"
+    const createdAt = msg.createdAt ?? new Date()
+    return {
+      id: makeMessageId(createdAt, msg.sourceId),
+      conversationId,
+      contactInboxId,
+      senderType: isOutgoing ? "user" : "contact",
+      workspaceId,
+      sourceId: msg.sourceId,
+      senderId: isOutgoing ? null : contactId,
+      messageType: msg.messageType,
+      text: msg.text,
+      contentType: msg.contentType,
+      contentAttributes: msg.contentAttributes,
+      createdAt,
+    }
+  })
+
+  // Insert messages via repository — shard-aware when ENABLE_MESSAGE_SHARDING=true.
+  // PK collision (snowflake id clash across runs) triggers a one-time retry with
+  // fresh IDs; the onConflictDoNothing inside bulkCreate handles sourceId dupes.
+  //
+  // Atomicity trade-off: bulkCreate runs outside any transaction wrapping the
+  // surrounding conversation/contactInbox updates. A crash mid-batch leaves
+  // partial rows in the message table; re-running the import is safe because
+  // onConflictDoNothing deduplicates by (contactInboxId, sourceId[, createdAt]).
+  // Full transactional atomicity would require cross-shard coordination and is
+  // explicitly not supported here.
+  let insertedRows: { id: string; sourceId: string | null }[] = []
+  let repository: IMessageRepository | null = null
+  if (messageInputs.length > 0) {
+    repository = await createMessageRepository()
+    try {
+      insertedRows = await repository.bulkCreate(messageInputs)
+    } catch (err) {
+      if (!isUniqueMessagePkViolation(err)) {
+        throw err
+      }
+      logger.warn(
+        { runId, total: messageInputs.length },
+        "[coexist] Message PK collision — regenerating IDs and retrying",
+      )
+      const retried = messageInputs.map((input) => ({
+        ...input,
+        // Re-call advances past the colliding slot via the factory's used-set.
+        id: makeMessageId(input.createdAt as Date, input.sourceId ?? ""),
+      }))
+      insertedRows = await repository.bulkCreate(retried)
+    }
+  }
+
+  const importedMessages = insertedRows.length
+  const skippedMessages = messages.length - importedMessages
+
+  const insertedMessageBySourceId = new Map<string, string>()
+  for (const row of insertedRows) {
+    if (row.sourceId) {
+      insertedMessageBySourceId.set(row.sourceId, row.id)
+    }
+  }
+
+  // Build messageCreatedAt lookup so attachments can be routed to the correct
+  // DB (shard requires messageCreatedAt as partition key; main DB ignores it).
+  const messageCreatedAtBySourceId = new Map<string, Date>()
+  for (const input of messageInputs) {
+    if (input.sourceId) {
+      messageCreatedAtBySourceId.set(
+        input.sourceId,
+        input.createdAt ?? new Date(),
+      )
+    }
+  }
+
+  // Contact enrichment in its own main-DB transaction.
+  if (hasEnrichment && contactEnrichment) {
+    await db.transaction(async (tx) => {
       await tx.execute(sql`
         UPDATE "Contact" SET
           "phoneNumber" = COALESCE("phoneNumber", ${contactEnrichment.phoneNumber ?? null}::text),
@@ -607,137 +731,47 @@ export const bulkImportMessages = async (props: {
             OR (${contactEnrichment.email ?? null}::text IS NOT NULL AND "email" IS NULL)
           )
       `)
-    }
+    })
+  }
 
-    if (messages.length === 0) {
-      return
-    }
-
-    const messageRows: (typeof messageModel.$inferInsert)[] = messages.map(
-      (msg) => {
-        const isOutgoing = msg.messageType === "outgoing"
-        const createdAt = msg.createdAt ?? new Date()
-        return {
-          id: makeMessageId(createdAt),
-          conversationId,
-          contactInboxId,
-          senderType: isOutgoing ? "user" : "contact",
+  // Insert Attachment rows for newly-inserted messages only via repository so
+  // they land in the same DB as the messages (shard or main). Previously these
+  // were inserted via a main-DB tx.insert(), causing a FK violation when
+  // ENABLE_MESSAGE_SHARDING=true because the Message rows live in the shard.
+  if (attachmentsBySourceId.size > 0 && repository) {
+    const attachmentRows: BulkCreateAttachmentInput[] = []
+    for (const [sourceId, atts] of attachmentsBySourceId) {
+      const messageId = insertedMessageBySourceId.get(sourceId)
+      if (!messageId) {
+        continue
+      }
+      const messageCreatedAt =
+        messageCreatedAtBySourceId.get(sourceId) ?? new Date()
+      for (const att of atts) {
+        attachmentRows.push({
+          id: createId(),
           workspaceId,
-          sourceId: msg.sourceId,
-          senderId: isOutgoing ? null : contactId,
-          messageType: msg.messageType,
-          text: msg.text,
-          contentType: msg.contentType,
-          contentAttributes: msg.contentAttributes,
-          createdAt,
-          updatedAt: createdAt,
-        }
-      },
-    )
-
-    // Map message.sourceId → its attachments[] so post-insert we can resolve
-    // each inserted Message row to the right Attachment payload. Skip messages
-    // without attachments to avoid empty lookups.
-    const attachmentsBySourceId = new Map<
-      string,
-      NonNullable<IncomingMessage["attachments"]>
-    >()
-    for (const msg of messages) {
-      if (msg.attachments && msg.attachments.length > 0) {
-        attachmentsBySourceId.set(msg.sourceId, msg.attachments)
+          conversationId,
+          messageId,
+          messageCreatedAt,
+          sourceId: att.sourceId,
+          fileType: att.fileType,
+          mimeType: att.mimeType,
+          originPath: att.originPath,
+          size: att.size,
+          width: att.width ?? undefined,
+          height: att.height ?? undefined,
+          name: att.name,
+        })
       }
     }
-
-    const CHUNK_SIZE = 1000
-    let insertedTotal = 0
-    const insertedMessageBySourceId = new Map<string, string>()
-    for (let i = 0; i < messageRows.length; i += CHUNK_SIZE) {
-      const chunk = messageRows.slice(i, i + CHUNK_SIZE)
-      let inserted: { id: string; sourceId: string | null }[]
-      try {
-        inserted = await tx
-          .insert(messageModel)
-          .values(chunk)
-          .onConflictDoNothing({
-            target: [messageModel.contactInboxId, messageModel.sourceId],
-          })
-          .returning({
-            id: messageModel.id,
-            sourceId: messageModel.sourceId,
-          })
-      } catch (err) {
-        if (!isUniqueMessagePkViolation(err)) {
-          throw err
-        }
-        logger.warn(
-          { runId, chunkStart: i, chunkSize: chunk.length },
-          "[coexist] Message PK collision — regenerating IDs and retrying",
-        )
-        const retried = chunk.map((row) => ({
-          ...row,
-          id: makeMessageId(row.createdAt as Date),
-        }))
-        inserted = await tx
-          .insert(messageModel)
-          .values(retried)
-          .onConflictDoNothing({
-            target: [messageModel.contactInboxId, messageModel.sourceId],
-          })
-          .returning({
-            id: messageModel.id,
-            sourceId: messageModel.sourceId,
-          })
-      }
-      insertedTotal += inserted.length
-      for (const row of inserted) {
-        if (row.sourceId) {
-          insertedMessageBySourceId.set(row.sourceId, row.id)
-        }
+    if (attachmentRows.length > 0) {
+      const insertedAtt = await repository.bulkCreateAttachments(attachmentRows)
+      for (const r of insertedAtt) {
+        insertedAttachmentIds.push(r.id)
       }
     }
-    importedMessages = insertedTotal
-    skippedMessages = messages.length - insertedTotal
-
-    // Insert Attachment rows for newly-inserted messages only. Messages that
-    // hit the (contactInboxId, sourceId) conflict are skipped — their
-    // attachments were inserted on the original successful run, so re-inserting
-    // here would duplicate. No unique constraint on (messageId, sourceId)
-    // means correctness depends on the message-level conflict guard above.
-    if (attachmentsBySourceId.size > 0) {
-      const attachmentRows: (typeof attachmentModel.$inferInsert)[] = []
-      for (const [sourceId, atts] of attachmentsBySourceId) {
-        const messageId = insertedMessageBySourceId.get(sourceId)
-        if (!messageId) {
-          continue
-        }
-        for (const att of atts) {
-          attachmentRows.push({
-            id: createId(),
-            workspaceId,
-            conversationId,
-            messageId,
-            sourceId: att.sourceId,
-            fileType: att.fileType,
-            mimeType: att.mimeType,
-            originPath: att.originPath,
-            size: att.size,
-            width: att.width ?? undefined,
-            height: att.height ?? undefined,
-            name: att.name,
-          })
-        }
-      }
-      if (attachmentRows.length > 0) {
-        const insertedAtt = await tx
-          .insert(attachmentModel)
-          .values(attachmentRows)
-          .returning({ id: attachmentModel.id })
-        for (const r of insertedAtt) {
-          insertedAttachmentIds.push(r.id)
-        }
-      }
-    }
-  })
+  }
 
   // Touch parent contact lastActivityAt so list ordering reflects sync. Best
   // effort — failure here doesn't roll back the message insert.
@@ -751,6 +785,33 @@ export const bulkImportMessages = async (props: {
       logger.warn(
         { error, contactId },
         "[coexist] failed to bump lastActivityAt",
+      )
+    }
+  }
+
+  // Set contactInbox.lastMessageAt to the newest imported message time. This is
+  // the anchor the conversation list uses to derive the sharded last-message
+  // read window — without it imported conversations show no last-message
+  // preview. Only advance it (never regress past a newer live message).
+  const newestMessageAt = messageInputs.reduce<Date | null>((max, m) => {
+    const created = m.createdAt ?? null
+    if (!created) {
+      return max
+    }
+    return !max || created > max ? created : max
+  }, null)
+  if (newestMessageAt) {
+    try {
+      await db
+        .update(contactInboxModel)
+        .set({ lastMessageAt: newestMessageAt })
+        .where(
+          sql`${contactInboxModel.id} = ${contactInboxId} AND (${contactInboxModel.lastMessageAt} IS NULL OR ${contactInboxModel.lastMessageAt} < ${newestMessageAt})`,
+        )
+    } catch (error) {
+      logger.warn(
+        { error, contactInboxId },
+        "[coexist] failed to set lastMessageAt",
       )
     }
   }

--- a/apps/worker/src/integration/handlers/coexist/bulk-historical-import.ts
+++ b/apps/worker/src/integration/handlers/coexist/bulk-historical-import.ts
@@ -112,7 +112,7 @@ const isUniqueMessagePkViolation = (err: unknown): boolean => {
   // name like "17_17_Message_pkey", so match by suffix rather than equality.
   let current: unknown = err
   for (let depth = 0; depth < 5 && current; depth++) {
-    if (typeof current !== "object" || current === null) {
+    if (typeof current !== "object") {
       return false
     }
     const e = current as {

--- a/apps/worker/src/integration/handlers/coexist/messenger-helpers.ts
+++ b/apps/worker/src/integration/handlers/coexist/messenger-helpers.ts
@@ -8,6 +8,8 @@ import type { BucUsage } from "@chatbotx.io/integration-messenger/apis/usage"
 import {
   guessFileTypeFromMimeType,
   type IncomingAttachment,
+  type MessageButtonTemplate,
+  type MessageTemplateEntity,
 } from "@chatbotx.io/sdk"
 import { logger } from "../../../lib/logger"
 import type { HistoricalMessage } from "./bulk-historical-import"
@@ -54,6 +56,44 @@ const extractAttachments = (
     }
   }
   return out
+}
+
+/**
+ * A Page button-template message (`generic_template`) carries a text title plus
+ * a list of call-to-action buttons — not a media URL. We persist it as a text
+ * message (`contentType: "text"`, text = title) with the buttons in
+ * `contentAttributes` so the inbox renders text + buttons (the same shape used
+ * by outgoing Messenger templates). Returns null when there is no template.
+ */
+const extractButtonTemplate = (
+  raw: MessengerHistoryMessage,
+): { text: string; contentAttributes: MessageTemplateEntity } | null => {
+  const data = raw.attachments?.data ?? []
+  for (const att of data) {
+    const template = att.generic_template
+    if (!template) {
+      continue
+    }
+    const ctas = template.cta ?? []
+    const buttons: MessageButtonTemplate[] = ctas.map((cta, index) => {
+      const id = `${att.id}-${index}`
+      const label = cta.title ?? ""
+      if (cta.type === "web_url" && cta.url) {
+        return { id, label, buttonType: "url", url: cta.url }
+      }
+      // Graph omits the postback payload for historical templates; the button is
+      // display-only here, so an empty payload is sufficient.
+      return { id, label, buttonType: "postback", postback: "" }
+    })
+    return {
+      text: template.title ?? "",
+      contentAttributes: {
+        type: "template",
+        payload: { templateType: "button", buttons },
+      },
+    }
+  }
+  return null
 }
 
 /** Maximum inline retry attempts on 429 / 5xx before propagating. */
@@ -230,10 +270,11 @@ export const fetchConvMessages = async (props: {
 
     for (const m of page.data as MessengerHistoryMessage[]) {
       const attachments = extractAttachments(m)
-      // Empty placeholder rows (no text + no usable attachment URL) carry no
-      // signal — skip to avoid emitting a row that bulkImportMessages would
-      // then reject for being effectively empty.
-      if (!m.message && attachments.length === 0) {
+      const buttonTemplate = extractButtonTemplate(m)
+      // Empty placeholder rows (no text + no usable attachment URL + no button
+      // template) carry no signal — skip to avoid emitting a row that
+      // bulkImportMessages would then reject for being effectively empty.
+      if (!m.message && attachments.length === 0 && !buttonTemplate) {
         continue
       }
       totalMsg++
@@ -266,9 +307,12 @@ export const fetchConvMessages = async (props: {
           sourceId: m.id,
           messageType: m.from?.id === pageId ? "outgoing" : "incoming",
           contentType: "text",
-          text: m.message ?? "",
+          text: m.message || buttonTemplate?.text || "",
           createdAt,
           ...(attachments.length > 0 ? { attachments } : {}),
+          ...(buttonTemplate
+            ? { contentAttributes: buttonTemplate.contentAttributes }
+            : {}),
         })
       } else {
         hitOlderBoundary = true

--- a/apps/worker/src/integration/handlers/coexist/messenger-sync.ts
+++ b/apps/worker/src/integration/handlers/coexist/messenger-sync.ts
@@ -393,8 +393,9 @@ async function runMessagesPhase(ctx: SyncContext): Promise<PhaseResult> {
 
   const fallbackCutoff = new Date(Date.now() - STORE_WINDOW_MS)
   // ONE factory shared across all per-conv bulkImportMessages calls in this
-  // chunk — prevents same-ms IDs colliding across convs (H1).
-  const idFactory = createHistoricalIdFactory(runId)
+  // chunk — its per-import used-set probes same-ms IDs that collide across convs
+  // (H1). IDs are derived from (createdAt, sourceId), independent of runId.
+  const idFactory = createHistoricalIdFactory()
 
   return walkConversationsPages(
     ctx,

--- a/integrations/messenger/src/apis/sync.ts
+++ b/integrations/messenger/src/apis/sync.ts
@@ -44,6 +44,21 @@ export type MessengerHistoryAttachment = {
     height?: number
   }
   file_url?: string
+  /**
+   * Page-sent structured message (button template): text title plus a list of
+   * call-to-action buttons. Present on outgoing Page messages that were sent as
+   * a generic/button template rather than plain text. No media URL — rendered
+   * as text + buttons, not as a downloadable attachment.
+   */
+  generic_template?: {
+    title?: string
+    subtitle?: string
+    cta?: Array<{
+      title?: string
+      type?: string
+      url?: string
+    }>
+  }
 }
 
 /** A single message inside a conversation thread. */
@@ -132,7 +147,7 @@ export const listMessages = (props: {
         headers: { Authorization: `Bearer ${accessToken}` },
         searchParams: {
           fields:
-            "id,message,from,created_time,attachments{id,name,mime_type,size,image_data,video_data,file_url}",
+            "id,message,from,created_time,attachments{id,name,mime_type,size,image_data,video_data,file_url,generic_template}",
           limit: String(PAGE_LIMIT),
           ...(after ? { after } : {}),
         },

--- a/integrations/messenger/src/handlers/message/outgoing-message/index.ts
+++ b/integrations/messenger/src/handlers/message/outgoing-message/index.ts
@@ -94,10 +94,7 @@ export const sendFlowStep: MessageHandlers<MessengerAuthValue>["sendFlowStep"] =
           buildMessagePayload({
             contact,
             message: facebookMessage,
-            messagingType:
-              step.stepType === stepTypes.enum.sendQuickReply
-                ? "RESPONSE"
-                : "MESSAGE_TAG",
+            messagingType: "RESPONSE",
             personaId: (ctx.integrationDetail as MessengerIntegrationDetail)
               .personaId,
           }),

--- a/integrations/whatsapp/src/handlers/webhook.ts
+++ b/integrations/whatsapp/src/handlers/webhook.ts
@@ -97,22 +97,32 @@ export const webhookHandler = async (
 
   if (props.req.method === "POST") {
     try {
-      // Capture coexist payloads from the body BEFORE the middleware consumes
-      // it (body stream is one-shot). We do NOT enqueue yet — staging writes
-      // happen only after handle_post() verifies the HMAC signature, so an
-      // unauthenticated attacker cannot flood the staging table.
+      // Read the body once as raw bytes — HTTP body is a one-shot stream.
+      // Using arrayBuffer() preserves the exact bytes for HMAC verification;
+      // text() would silently re-encode, risking a signature mismatch on
+      // non-ASCII payloads. We decode to string only for JSON parsing.
+      let rawBodyBuffer = new ArrayBuffer(0)
+      let rawBodyText = ""
       let coexistPayloads: CoexistPayload[] = []
       try {
-        const rawBody = await props.req.clone().json()
+        rawBodyBuffer = await props.req.arrayBuffer()
+        rawBodyText = new TextDecoder().decode(rawBodyBuffer)
+        const rawBody = JSON.parse(rawBodyText) as unknown
         coexistPayloads = extractCoexistPayloads(rawBody)
       } catch {
         // Body was not JSON — ignore and continue.
       }
 
+      const reqWithBody = new Request(props.req.url, {
+        method: props.req.method,
+        headers: props.req.headers,
+        body: rawBodyBuffer.byteLength > 0 ? rawBodyBuffer : undefined,
+      })
+
       // Start handle_post immediately; attach a no-op catch so any rejection
       // that arrives after we've already resolved the race is silently absorbed
       // (we re-check the outcome below via the full await).
-      const handlePostPromise = middleware.handle_post(props.req)
+      const handlePostPromise = middleware.handle_post(reqWithBody)
       handlePostPromise.catch(() => {
         /* absorbed — re-checked below */
       })

--- a/packages/database/__tests__/connection-manager.test.ts
+++ b/packages/database/__tests__/connection-manager.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import { MessageShardConnectionManager } from "../src/sharding/message/connection-manager"
+
+// ---------------------------------------------------------------------------
+// getWriteShardInfo — exposes the workspace's write shard as an all-time
+// time-range info so read paths can union it in. This guarantees back-dated
+// historical-import rows (written into the active shard but outside its
+// registered time-range) remain reachable on read.
+// ---------------------------------------------------------------------------
+
+const shardRecord = {
+  id: "s1",
+  name: "shard-1",
+  host: "localhost",
+  port: 5432,
+  database: "shard_db",
+  user: "shard_user",
+  credentialRef: null,
+  isActive: true,
+  sslMode: "disable",
+  shardKey: null,
+  readHost: null,
+  readPort: null,
+}
+
+function makeManager(
+  registryOverrides: Record<string, unknown> = {},
+): MessageShardConnectionManager {
+  const registry = {
+    countActiveShards: vi.fn().mockResolvedValue(1),
+    findShardForWrite: vi.fn().mockResolvedValue(shardRecord),
+    ...registryOverrides,
+  }
+  return new MessageShardConnectionManager({} as never, registry as never)
+}
+
+describe("MessageShardConnectionManager.getWriteShardInfo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("maps the workspace write shard to an all-time time-range info", async () => {
+    const manager = makeManager()
+
+    const info = await manager.getWriteShardInfo("ws-1")
+
+    expect(info).not.toBeNull()
+    expect(info?.shardId).toBe("s1")
+    expect(info?.id).toBe("write:s1")
+    expect(info?.startTime).toEqual(new Date(0))
+    expect(info?.endTime).toBeNull()
+    expect(info?.shard.id).toBe("s1")
+  })
+
+  test("returns null when sharding is disabled (no active shards)", async () => {
+    const manager = makeManager({
+      countActiveShards: vi.fn().mockResolvedValue(0),
+    })
+
+    const info = await manager.getWriteShardInfo("ws-1")
+
+    expect(info).toBeNull()
+  })
+
+  test("returns null when no shard is assigned to the workspace", async () => {
+    const manager = makeManager({
+      findShardForWrite: vi.fn().mockResolvedValue(null),
+    })
+
+    const info = await manager.getWriteShardInfo("ws-1")
+
+    expect(info).toBeNull()
+  })
+})

--- a/packages/database/__tests__/message-repository.test.ts
+++ b/packages/database/__tests__/message-repository.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import type {
+  BulkCreateAttachmentInput,
+  CreateMessageInput,
+} from "../src/repositories/message/message-repository"
+import { MessageRepository } from "../src/repositories/message/message-repository"
+import { attachmentModel, messageModel } from "../src/schema"
+
+// ---------------------------------------------------------------------------
+// Inline mock DatabaseClient — MessageRepository takes client in constructor
+// ---------------------------------------------------------------------------
+
+function makeDbMock() {
+  const chain = {
+    values: vi.fn(),
+    onConflictDoNothing: vi.fn(),
+    returning: vi.fn().mockResolvedValue([]),
+  }
+  chain.values.mockReturnValue(chain)
+  chain.onConflictDoNothing.mockReturnValue(chain)
+  const insert = vi.fn().mockReturnValue(chain)
+
+  const updateChain = {
+    set: vi.fn(),
+    where: vi.fn().mockResolvedValue(undefined),
+  }
+  updateChain.set.mockReturnValue(updateChain)
+  const update = vi.fn().mockReturnValue(updateChain)
+
+  return { insert, chain, update, updateChain }
+}
+
+function makeMessage(
+  overrides: Partial<CreateMessageInput> = {},
+): CreateMessageInput {
+  return {
+    id: "msg-1",
+    contactInboxId: "ci-1",
+    workspaceId: "ws-1",
+    conversationId: "conv-1",
+    messageType: "incoming",
+    contentType: "text",
+    senderType: "contact",
+    sourceId: "src-1",
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("MessageRepository.bulkCreate", () => {
+  let repo: MessageRepository
+  let insert: ReturnType<typeof vi.fn>
+  let chain: ReturnType<typeof makeDbMock>["chain"]
+  let update: ReturnType<typeof vi.fn>
+  let updateChain: ReturnType<typeof makeDbMock>["updateChain"]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const mock = makeDbMock()
+    insert = mock.insert
+    chain = mock.chain
+    update = mock.update
+    updateChain = mock.updateChain
+    repo = new MessageRepository({ insert, update } as never)
+  })
+
+  test("inserts messages and returns { id, sourceId }[]", async () => {
+    chain.returning.mockResolvedValue([{ id: "msg-1", sourceId: "src-1" }])
+
+    const result = await repo.bulkCreate([makeMessage()])
+
+    expect(result).toEqual([{ id: "msg-1", sourceId: "src-1" }])
+    expect(insert).toHaveBeenCalledTimes(1)
+  })
+
+  test("conflict target is (contactInboxId, sourceId) — no createdAt for main table", async () => {
+    chain.returning.mockResolvedValue([])
+
+    await repo.bulkCreate([makeMessage()])
+
+    const [callArg] = chain.onConflictDoNothing.mock.calls[0]
+    expect(callArg.target).toHaveLength(2)
+    expect(callArg.target).toContain(messageModel.contactInboxId)
+    expect(callArg.target).toContain(messageModel.sourceId)
+    expect(callArg.target).not.toContain(messageModel.createdAt)
+  })
+
+  test("returns empty array when no messages provided", async () => {
+    const result = await repo.bulkCreate([])
+
+    expect(result).toEqual([])
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  test("chunks correctly — 2001 messages triggers 3 db.insert calls with correct slice sizes", async () => {
+    chain.returning.mockResolvedValue([])
+    const messages = Array.from({ length: 2001 }, (_, i) =>
+      makeMessage({ id: `msg-${i}`, sourceId: `src-${i}` }),
+    )
+
+    await repo.bulkCreate(messages)
+
+    expect(insert).toHaveBeenCalledTimes(3)
+    expect(chain.values.mock.calls[0][0]).toHaveLength(1000)
+    expect(chain.values.mock.calls[1][0]).toHaveLength(1000)
+    expect(chain.values.mock.calls[2][0]).toHaveLength(1)
+    expect(chain.values.mock.calls[0][0][0].sourceId).toBe("src-0")
+    expect(chain.values.mock.calls[1][0][0].sourceId).toBe("src-1000")
+    expect(chain.values.mock.calls[2][0][0].sourceId).toBe("src-2000")
+  })
+
+  test("aggregates results from multiple chunks", async () => {
+    // Use 2001 messages to force 3 chunks; each chunk returns some inserted rows
+    chain.returning
+      .mockResolvedValueOnce([{ id: "msg-0", sourceId: "src-0" }])
+      .mockResolvedValueOnce([{ id: "msg-1000", sourceId: "src-1000" }])
+      .mockResolvedValueOnce([{ id: "msg-2000", sourceId: "src-2000" }])
+
+    const messages = Array.from({ length: 2001 }, (_, i) =>
+      makeMessage({ id: `msg-${i}`, sourceId: `src-${i}` }),
+    )
+
+    const result = await repo.bulkCreate(messages)
+
+    expect(result).toHaveLength(3)
+    expect(result[0]).toEqual({ id: "msg-0", sourceId: "src-0" })
+    expect(result[1]).toEqual({ id: "msg-1000", sourceId: "src-1000" })
+    expect(result[2]).toEqual({ id: "msg-2000", sourceId: "src-2000" })
+  })
+
+  test("updateSourceId calls db.update on messageModel with correct id and sourceId", async () => {
+    await repo.updateSourceId("msg-1", "prov-abc", "ws-1")
+
+    expect(update).toHaveBeenCalledWith(messageModel)
+    expect(updateChain.set).toHaveBeenCalledWith({ sourceId: "prov-abc" })
+    expect(updateChain.where).toHaveBeenCalled()
+  })
+
+  test("bulkCreateAttachments inserts into main attachmentModel and returns { id }[]", async () => {
+    chain.returning.mockResolvedValue([{ id: "att-1" }])
+
+    const input: BulkCreateAttachmentInput = {
+      id: "att-1",
+      workspaceId: "ws-1",
+      conversationId: "conv-1",
+      messageId: "msg-1",
+      messageCreatedAt: new Date("2026-01-01"),
+      fileType: "image",
+      mimeType: "image/png",
+      originPath: "/uploads/img.png",
+    }
+
+    const result = await repo.bulkCreateAttachments([input])
+
+    expect(result).toEqual([{ id: "att-1" }])
+    expect(insert).toHaveBeenCalledWith(attachmentModel)
+    const insertedValues: Record<string, unknown>[] =
+      chain.values.mock.calls[0][0]
+    expect(insertedValues[0].messageId).toBe("msg-1")
+    expect(insertedValues[0].workspaceId).toBe("ws-1")
+    expect("messageCreatedAt" in insertedValues[0]).toBe(false)
+  })
+
+  test("bulkCreateAttachments returns empty array for empty input without calling insert", async () => {
+    const result = await repo.bulkCreateAttachments([])
+
+    expect(result).toEqual([])
+    // insert call count must remain 0 — no DB roundtrip
+    expect(insert).toHaveBeenCalledTimes(0)
+  })
+})

--- a/packages/database/__tests__/sharded-message-repository.test.ts
+++ b/packages/database/__tests__/sharded-message-repository.test.ts
@@ -1,0 +1,402 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import type {
+  BulkCreateAttachmentInput,
+  CreateMessageInput,
+} from "../src/repositories/message"
+import { attachmentModel, messageModel } from "../src/sharding/message"
+import { ShardedMessageRepository } from "../src/sharding/message/repository/sharded-message-repository"
+
+// getShardsForRange wraps shard lookups in withCache(); the read path also needs
+// distributedLock from the constructor default. Stub the redis module so cache
+// reads call straight through to the factory and no real Redis is touched.
+vi.mock("@chatbotx.io/redis", () => ({
+  withCache: vi.fn((_key: string, factory: () => unknown) => factory()),
+  invalidateCacheByTags: vi.fn().mockResolvedValue(undefined),
+  distributedLock: { runExclusive: vi.fn() },
+}))
+
+// ---------------------------------------------------------------------------
+// Inline mock — ShardedMessageRepository.bulkCreate calls shardManager.getShardForWrite
+// then uses the returned db client for inserts.
+// ---------------------------------------------------------------------------
+
+function makeShardDbMock() {
+  const chain = {
+    values: vi.fn(),
+    onConflictDoNothing: vi.fn(),
+    returning: vi.fn().mockResolvedValue([]),
+  }
+  chain.values.mockReturnValue(chain)
+  chain.onConflictDoNothing.mockReturnValue(chain)
+  const insert = vi.fn().mockReturnValue(chain)
+
+  const updateChain = {
+    set: vi.fn(),
+    where: vi.fn().mockResolvedValue(undefined),
+  }
+  updateChain.set.mockReturnValue(updateChain)
+  const update = vi.fn().mockReturnValue(updateChain)
+
+  return { insert, chain, update, updateChain }
+}
+
+function makeShardManagerMock(shardDb: { insert: ReturnType<typeof vi.fn> }) {
+  return {
+    getShardForWrite: vi.fn().mockResolvedValue(shardDb),
+  }
+}
+
+function makeMessage(
+  overrides: Partial<CreateMessageInput> = {},
+): CreateMessageInput {
+  return {
+    id: "msg-1",
+    contactInboxId: "ci-1",
+    workspaceId: "ws-1",
+    conversationId: "conv-1",
+    messageType: "incoming",
+    contentType: "text",
+    senderType: "contact",
+    sourceId: "src-1",
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ShardedMessageRepository.bulkCreate", () => {
+  let repo: ShardedMessageRepository
+  let insert: ReturnType<typeof vi.fn>
+  let chain: ReturnType<typeof makeShardDbMock>["chain"]
+  let update: ReturnType<typeof vi.fn>
+  let updateChain: ReturnType<typeof makeShardDbMock>["updateChain"]
+  let shardManager: ReturnType<typeof makeShardManagerMock>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const mock = makeShardDbMock()
+    insert = mock.insert
+    chain = mock.chain
+    update = mock.update
+    updateChain = mock.updateChain
+    shardManager = makeShardManagerMock({ insert, update } as never)
+    repo = new ShardedMessageRepository(shardManager as never)
+  })
+
+  test("conflict target is (contactInboxId, sourceId, createdAt) — TimescaleDB 3-column constraint", async () => {
+    await repo.bulkCreate([makeMessage()])
+
+    const [callArg] = chain.onConflictDoNothing.mock.calls[0]
+    expect(callArg.target).toHaveLength(3)
+    expect(callArg.target).toContain(messageModel.contactInboxId)
+    expect(callArg.target).toContain(messageModel.sourceId)
+    expect(callArg.target).toContain(messageModel.createdAt)
+  })
+
+  test("returns empty array when no messages provided", async () => {
+    const result = await repo.bulkCreate([])
+
+    expect(result).toEqual([])
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  test("inserts messages and returns { id, sourceId }[]", async () => {
+    chain.returning.mockResolvedValue([{ id: "msg-1", sourceId: "src-1" }])
+
+    const result = await repo.bulkCreate([makeMessage()])
+
+    expect(result).toEqual([{ id: "msg-1", sourceId: "src-1" }])
+    expect(insert).toHaveBeenCalledTimes(1)
+  })
+
+  test("chunks correctly — 2001 messages triggers 3 db.insert calls with correct slice sizes", async () => {
+    chain.returning.mockResolvedValue([])
+    const messages = Array.from({ length: 2001 }, (_, i) =>
+      makeMessage({ id: `msg-${i}`, sourceId: `src-${i}` }),
+    )
+
+    await repo.bulkCreate(messages)
+
+    expect(insert).toHaveBeenCalledTimes(3)
+    expect(chain.values.mock.calls[0][0]).toHaveLength(1000)
+    expect(chain.values.mock.calls[1][0]).toHaveLength(1000)
+    expect(chain.values.mock.calls[2][0]).toHaveLength(1)
+    expect(chain.values.mock.calls[0][0][0].sourceId).toBe("src-0")
+    expect(chain.values.mock.calls[1][0][0].sourceId).toBe("src-1000")
+    expect(chain.values.mock.calls[2][0][0].sourceId).toBe("src-2000")
+  })
+
+  test("aggregates results from multiple chunks", async () => {
+    chain.returning
+      .mockResolvedValueOnce([{ id: "msg-0", sourceId: "src-0" }])
+      .mockResolvedValueOnce([{ id: "msg-1000", sourceId: "src-1000" }])
+      .mockResolvedValueOnce([{ id: "msg-2000", sourceId: "src-2000" }])
+
+    const messages = Array.from({ length: 2001 }, (_, i) =>
+      makeMessage({ id: `msg-${i}`, sourceId: `src-${i}` }),
+    )
+
+    const result = await repo.bulkCreate(messages)
+
+    expect(result).toHaveLength(3)
+    expect(result[0]).toEqual({ id: "msg-0", sourceId: "src-0" })
+    expect(result[1]).toEqual({ id: "msg-1000", sourceId: "src-1000" })
+    expect(result[2]).toEqual({ id: "msg-2000", sourceId: "src-2000" })
+  })
+
+  test("getShardForWrite called with workspaceId from messages", async () => {
+    chain.returning.mockResolvedValue([])
+    const mock = makeShardDbMock()
+    const shardManager = makeShardManagerMock({ insert: mock.insert } as never)
+    const localRepo = new ShardedMessageRepository(shardManager as never)
+
+    await localRepo.bulkCreate([makeMessage({ workspaceId: "ws-shard-42" })])
+
+    expect(shardManager.getShardForWrite).toHaveBeenCalledWith("ws-shard-42")
+  })
+
+  test("retries when getShardForWrite throws ECONNRESET on first call", async () => {
+    vi.useFakeTimers()
+
+    const retryError = Object.assign(new Error("ECONNRESET"), {
+      code: "ECONNRESET",
+    })
+    const retryMock = makeShardDbMock()
+    retryMock.chain.returning.mockResolvedValue([
+      { id: "msg-1", sourceId: "src-1" },
+    ])
+
+    const shardManager = {
+      getShardForWrite: vi
+        .fn()
+        .mockRejectedValueOnce(retryError)
+        .mockResolvedValueOnce({ insert: retryMock.insert }),
+    }
+    const localRepo = new ShardedMessageRepository(shardManager as never)
+
+    const resultPromise = localRepo.bulkCreate([makeMessage()])
+    await vi.runAllTimersAsync()
+    const result = await resultPromise
+
+    vi.useRealTimers()
+
+    expect(shardManager.getShardForWrite).toHaveBeenCalledTimes(2)
+    expect(result).toEqual([{ id: "msg-1", sourceId: "src-1" }])
+  })
+
+  test("throws when messages span multiple workspaceIds", async () => {
+    await expect(
+      repo.bulkCreate([
+        makeMessage({ workspaceId: "ws-A" }),
+        makeMessage({ workspaceId: "ws-B" }),
+      ]),
+    ).rejects.toThrow(
+      "bulkCreate: all messages must belong to the same workspace",
+    )
+  })
+
+  test("updateSourceId calls shard db.update with correct id and sourceId", async () => {
+    await repo.updateSourceId("msg-1", "prov-abc", "ws-1")
+
+    expect(shardManager.getShardForWrite).toHaveBeenCalledWith("ws-1")
+    expect(update).toHaveBeenCalledWith(messageModel)
+    expect(updateChain.set).toHaveBeenCalledWith({ sourceId: "prov-abc" })
+    expect(updateChain.where).toHaveBeenCalled()
+  })
+
+  test("bulkCreateAttachments routes to shard db and passes messageCreatedAt", async () => {
+    const msgCreatedAt = new Date("2026-01-01")
+    chain.returning.mockResolvedValue([{ id: "att-1" }])
+
+    const input: BulkCreateAttachmentInput = {
+      id: "att-1",
+      workspaceId: "ws-1",
+      conversationId: "conv-1",
+      messageId: "msg-1",
+      messageCreatedAt: msgCreatedAt,
+      fileType: "image",
+      mimeType: "image/png",
+      originPath: "/uploads/img.png",
+    }
+
+    const result = await repo.bulkCreateAttachments([input])
+
+    expect(shardManager.getShardForWrite).toHaveBeenCalledWith("ws-1")
+    expect(insert).toHaveBeenCalledWith(attachmentModel)
+    const insertedValues: Record<string, unknown>[] =
+      chain.values.mock.calls[0][0]
+    expect(insertedValues[0].messageCreatedAt).toEqual(msgCreatedAt)
+    expect(result).toEqual([{ id: "att-1" }])
+  })
+
+  test("bulkCreateAttachments returns empty array for empty input without calling insert", async () => {
+    const result = await repo.bulkCreateAttachments([])
+
+    expect(result).toEqual([])
+    expect(insert).toHaveBeenCalledTimes(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// listByConversation — write-shard union (historical-import regression)
+//
+// Writes route by workspace hash and keep each message's original createdAt, so
+// back-dated imports land in the active write shard even though its registered
+// time-range starts at activation. A purely time-based read excludes that shard
+// when the query window predates activation — hiding rows that exist. The repo
+// must always union the workspace write shard into the read set.
+// ---------------------------------------------------------------------------
+
+type ReadMessage = {
+  id: string
+  conversationId: string
+  workspaceId: string
+  createdAt: Date
+  text: string
+}
+
+/**
+ * Mock shard client for the read path. queryShardForMessages calls select()
+ * twice: first the message query (.from().where().limit().orderBy() resolves),
+ * then the attachment query (.from().where() resolves).
+ */
+function makeReadShardClient(messages: ReadMessage[]) {
+  let selectCall = 0
+  const select = vi.fn(() => {
+    selectCall++
+    if (selectCall === 1) {
+      const chain = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        orderBy: vi.fn().mockResolvedValue(messages),
+      }
+      return chain
+    }
+    const chain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([]),
+    }
+    return chain
+  })
+  return { select }
+}
+
+function makeShardInfo(timeRangeId: string, shardId: string) {
+  return {
+    id: timeRangeId,
+    shardId,
+    startTime: new Date(0),
+    endTime: null,
+    shard: {
+      id: shardId,
+      name: shardId,
+      host: "localhost",
+      port: 5432,
+      database: "shard_db",
+      user: "shard_user",
+    },
+  }
+}
+
+describe("ShardedMessageRepository.listByConversation — write-shard union", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("returns back-dated message from the write shard even when time-range selection is empty", async () => {
+    const historicalCreatedAt = new Date("2026-03-10T00:00:00Z")
+    const message: ReadMessage = {
+      id: "msg-hist-1",
+      conversationId: "conv-1",
+      workspaceId: "ws-1",
+      createdAt: historicalCreatedAt,
+      text: "old imported message",
+    }
+    const shardClient = makeReadShardClient([message])
+    const writeShard = makeShardInfo("write:s1", "s1")
+
+    const shardManager = {
+      // Time-range registry excludes the shard: query window predates activation.
+      getShardsForTimeRange: vi.fn().mockResolvedValue([]),
+      getWriteShardInfo: vi.fn().mockResolvedValue(writeShard),
+      getShardClientForRead: vi.fn().mockResolvedValue(shardClient),
+    }
+    const localRepo = new ShardedMessageRepository(shardManager as never)
+
+    const result = await localRepo.listByConversation({
+      workspaceId: "ws-1",
+      conversationId: "conv-1",
+      sinceTime: new Date("2026-03-01T00:00:00Z"),
+      pagination: {
+        limit: 20,
+        cursor: { createdAt: new Date("2026-03-10T01:00:00Z"), id: "" },
+      },
+    })
+
+    expect(shardManager.getWriteShardInfo).toHaveBeenCalledWith("ws-1")
+    expect(shardManager.getShardClientForRead).toHaveBeenCalledTimes(1)
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0].id).toBe("msg-hist-1")
+  })
+
+  test("does not double-query when the write shard is already in the time-range set", async () => {
+    const message: ReadMessage = {
+      id: "msg-1",
+      conversationId: "conv-1",
+      workspaceId: "ws-1",
+      createdAt: new Date("2026-06-05T00:00:00Z"),
+      text: "recent",
+    }
+    const shardClient = makeReadShardClient([message])
+    // Same underlying shard id "s1" in both the time-range row and the write shard.
+    const timeRangeShard = makeShardInfo("tr:s1", "s1")
+    const writeShard = makeShardInfo("write:s1", "s1")
+
+    const shardManager = {
+      getShardsForTimeRange: vi.fn().mockResolvedValue([timeRangeShard]),
+      getWriteShardInfo: vi.fn().mockResolvedValue(writeShard),
+      getShardClientForRead: vi.fn().mockResolvedValue(shardClient),
+    }
+    const localRepo = new ShardedMessageRepository(shardManager as never)
+
+    const result = await localRepo.listByConversation({
+      workspaceId: "ws-1",
+      conversationId: "conv-1",
+      sinceTime: new Date("2026-06-01T00:00:00Z"),
+      pagination: {
+        limit: 20,
+        cursor: { createdAt: new Date("2026-06-05T01:00:00Z"), id: "" },
+      },
+    })
+
+    // Deduped by shard id → the single shard is queried exactly once.
+    expect(shardManager.getShardClientForRead).toHaveBeenCalledTimes(1)
+    expect(result.data).toHaveLength(1)
+  })
+
+  test("returns empty when neither time-range nor write shard yields a shard", async () => {
+    const shardManager = {
+      getShardsForTimeRange: vi.fn().mockResolvedValue([]),
+      getWriteShardInfo: vi.fn().mockResolvedValue(null),
+      getShardClientForRead: vi.fn(),
+    }
+    const localRepo = new ShardedMessageRepository(shardManager as never)
+
+    const result = await localRepo.listByConversation({
+      workspaceId: "ws-1",
+      conversationId: "conv-1",
+      sinceTime: new Date("2026-03-01T00:00:00Z"),
+      pagination: {
+        limit: 20,
+        cursor: { createdAt: new Date("2026-03-10T01:00:00Z"), id: "" },
+      },
+    })
+
+    expect(result).toEqual({ data: [], nextCursor: null })
+    expect(shardManager.getShardClientForRead).not.toHaveBeenCalled()
+  })
+})

--- a/packages/database/src/repositories/message/index.ts
+++ b/packages/database/src/repositories/message/index.ts
@@ -1,4 +1,5 @@
 export {
+  type BulkCreateAttachmentInput,
   type CreateAttachmentInput,
   type CreateMessageInput,
   type CreateMessageResult,

--- a/packages/database/src/repositories/message/message-repository.ts
+++ b/packages/database/src/repositories/message/message-repository.ts
@@ -41,6 +41,8 @@ export interface CreateAttachmentInput {
   workspaceId: string
 }
 
+export type BulkCreateAttachmentInput = CreateAttachmentInput & { id: string }
+
 export interface MessageWithAttachments extends MessageModel {
   attachments: AttachmentModel[]
 }
@@ -92,6 +94,14 @@ export interface DistributedLock {
 }
 
 export interface IMessageRepository {
+  bulkCreate(
+    messages: CreateMessageInput[],
+  ): Promise<{ id: string; sourceId: string | null }[]>
+
+  bulkCreateAttachments(
+    attachments: BulkCreateAttachmentInput[],
+  ): Promise<{ id: string }[]>
+
   create(message: CreateMessageInput): Promise<MessageModel>
 
   createOrUpdate(message: CreateMessageInput): Promise<CreateMessageResult>
@@ -138,6 +148,12 @@ export interface IMessageRepository {
   ): Promise<Pick<MessageModel, "id" | "text">[]>
 
   listByConversation(query: ListMessagesQuery): Promise<PaginatedMessages>
+
+  updateSourceId(
+    id: string,
+    sourceId: string,
+    workspaceId: string,
+  ): Promise<void>
 }
 
 export class MessageRepository implements IMessageRepository {
@@ -486,6 +502,65 @@ export class MessageRepository implements IMessageRepository {
     }
   }
 
+  async bulkCreate(
+    messages: CreateMessageInput[],
+  ): Promise<{ id: string; sourceId: string | null }[]> {
+    if (messages.length === 0) {
+      return []
+    }
+
+    const CHUNK_SIZE = 1000
+    const inserted: { id: string; sourceId: string | null }[] = []
+
+    for (let i = 0; i < messages.length; i += CHUNK_SIZE) {
+      const chunk = messages.slice(i, i + CHUNK_SIZE)
+      const rows = await this.db
+        .insert(messageModel)
+        .values(chunk as (typeof messageModel.$inferInsert)[])
+        .onConflictDoNothing({
+          target: [messageModel.contactInboxId, messageModel.sourceId],
+        })
+        .returning({
+          id: messageModel.id,
+          sourceId: messageModel.sourceId,
+        })
+      for (const row of rows) {
+        inserted.push({ id: row.id, sourceId: row.sourceId })
+      }
+    }
+
+    return inserted
+  }
+
+  async bulkCreateAttachments(
+    attachments: BulkCreateAttachmentInput[],
+  ): Promise<{ id: string }[]> {
+    if (attachments.length === 0) {
+      return []
+    }
+    return await this.db
+      .insert(attachmentModel)
+      .values(
+        attachments.map((a) => ({
+          id: a.id,
+          workspaceId: a.workspaceId,
+          conversationId: a.conversationId,
+          fileType:
+            a.fileType as (typeof attachmentModel.$inferInsert)["fileType"],
+          messageId: a.messageId,
+          sourceId: a.sourceId,
+          mimeType: a.mimeType,
+          width: a.width,
+          height: a.height,
+          size: a.size,
+          thumbnailPath: a.thumbnailPath,
+          originPath: a.originPath,
+          name: a.name,
+        })),
+      )
+      .returning({ id: attachmentModel.id })
+  }
+
   private async queryAttachmentsForMessages(
     messageIds: string[],
   ): Promise<AttachmentModel[]> {
@@ -515,5 +590,16 @@ export class MessageRepository implements IMessageRepository {
       },
       {} as Record<string, AttachmentModel[]>,
     )
+  }
+
+  async updateSourceId(
+    id: string,
+    sourceId: string,
+    _workspaceId: string,
+  ): Promise<void> {
+    await this.db
+      .update(messageModel)
+      .set({ sourceId })
+      .where(eq(messageModel.id, id))
   }
 }

--- a/packages/database/src/sharding/message/connection-manager.ts
+++ b/packages/database/src/sharding/message/connection-manager.ts
@@ -121,6 +121,33 @@ export class MessageShardConnectionManager {
     return this.registry.findShardsForTimeRange(startTime, endTime)
   }
 
+  /**
+   * The shard a workspace's writes land in, expressed as a time-range info that
+   * spans ALL time. Writes route by workspace hash (getShardForWrite) and keep
+   * the message's original createdAt, so historical/back-dated messages live in
+   * this shard even though its registered time-range starts at activation. Reads
+   * that select shards purely by time would miss them — callers union this shard
+   * into the read set to guarantee the workspace's data is always reachable.
+   */
+  async getWriteShardInfo(
+    workspaceId: string,
+  ): Promise<MessageShardTimeRangeInfo | null> {
+    if (!(await this.isShardingEnabled())) {
+      return null
+    }
+    const record = await this.registry.findShardForWrite(workspaceId)
+    if (!record) {
+      return null
+    }
+    return {
+      id: `write:${record.id}`,
+      shardId: record.id,
+      startTime: new Date(0),
+      endTime: null,
+      shard: record,
+    }
+  }
+
   async getShardClient(
     shard: ShardConfig,
   ): Promise<MessageShardDatabaseClient> {

--- a/packages/database/src/sharding/message/repository/sharded-message-repository.ts
+++ b/packages/database/src/sharding/message/repository/sharded-message-repository.ts
@@ -6,6 +6,7 @@ import {
 import { and, desc, eq, gte, inArray, isNotNull, lt, or } from "drizzle-orm"
 import { logger } from "../../../logger"
 import type {
+  BulkCreateAttachmentInput,
   CreateAttachmentInput,
   CreateMessageInput,
   CreateMessageResult,
@@ -78,6 +79,33 @@ export class ShardedMessageRepository implements IMessageRepository {
     )
 
     return rehydrateTimeRangeDates(cached)
+  }
+
+  /**
+   * Union the workspace's write shard into a time-range shard set.
+   *
+   * Writes route by workspace hash and preserve each message's original
+   * createdAt, so back-dated (historical-import) rows live in the active write
+   * shard even though its registered time-range starts at activation. A purely
+   * time-based read can exclude that shard when the query window predates
+   * activation, hiding rows that physically exist. Appending the write shard
+   * (deduped by shard id) guarantees it is always queried. It is appended last
+   * so it sorts as the newest shard once the caller reverses to descending.
+   */
+  private mergeWriteShard(
+    timeRangeShards: MessageShardTimeRangeInfo[],
+    writeShard: MessageShardTimeRangeInfo | null,
+  ): MessageShardTimeRangeInfo[] {
+    if (!writeShard) {
+      return timeRangeShards
+    }
+    const alreadyIncluded = timeRangeShards.some(
+      (s) => s.shard.id === writeShard.shard.id,
+    )
+    if (alreadyIncluded) {
+      return timeRangeShards
+    }
+    return [...timeRangeShards, writeShard]
   }
 
   private executeWithLock<T>(
@@ -173,6 +201,99 @@ export class ShardedMessageRepository implements IMessageRepository {
         .values(message as typeof messageModel.$inferInsert)
         .returning()
       return result as MessageModel
+    })
+  }
+
+  async bulkCreate(
+    messages: CreateMessageInput[],
+  ): Promise<{ id: string; sourceId: string | null }[]> {
+    if (messages.length === 0) {
+      return []
+    }
+
+    const workspaceId = messages[0].workspaceId
+    if (messages.some((m) => m.workspaceId !== workspaceId)) {
+      throw new Error(
+        "bulkCreate: all messages must belong to the same workspace",
+      )
+    }
+
+    return await withShardRetry(async () => {
+      const shardDb = await this.shardManager.getShardForWrite(workspaceId)
+
+      const CHUNK_SIZE = 1000
+      const inserted: { id: string; sourceId: string | null }[] = []
+
+      for (let i = 0; i < messages.length; i += CHUNK_SIZE) {
+        const chunk = messages.slice(i, i + CHUNK_SIZE)
+        const rows = await shardDb
+          .insert(messageModel)
+          .values(chunk as (typeof messageModel.$inferInsert)[])
+          .onConflictDoNothing({
+            target: [
+              messageModel.contactInboxId,
+              messageModel.sourceId,
+              messageModel.createdAt,
+            ],
+          })
+          .returning({
+            id: messageModel.id,
+            sourceId: messageModel.sourceId,
+          })
+        for (const row of rows) {
+          inserted.push({ id: row.id, sourceId: row.sourceId })
+        }
+      }
+
+      return inserted
+    })
+  }
+
+  async updateSourceId(
+    id: string,
+    sourceId: string,
+    workspaceId: string,
+  ): Promise<void> {
+    return await withShardRetry(async () => {
+      const db = await this.shardManager.getShardForWrite(workspaceId)
+      await db
+        .update(messageModel)
+        .set({ sourceId })
+        .where(eq(messageModel.id, id))
+    })
+  }
+
+  async bulkCreateAttachments(
+    attachments: BulkCreateAttachmentInput[],
+  ): Promise<{ id: string }[]> {
+    if (attachments.length === 0) {
+      return []
+    }
+    const workspaceId = attachments[0].workspaceId
+    return await withShardRetry(async () => {
+      const shardDb = await this.shardManager.getShardForWrite(workspaceId)
+      return await shardDb
+        .insert(attachmentModel)
+        .values(
+          attachments.map((a) => ({
+            id: a.id,
+            workspaceId: a.workspaceId,
+            conversationId: a.conversationId,
+            fileType:
+              a.fileType as (typeof attachmentModel.$inferInsert)["fileType"],
+            messageId: a.messageId,
+            messageCreatedAt: a.messageCreatedAt,
+            sourceId: a.sourceId,
+            mimeType: a.mimeType,
+            width: a.width,
+            height: a.height,
+            size: a.size,
+            thumbnailPath: a.thumbnailPath,
+            originPath: a.originPath,
+            name: a.name,
+          })),
+        )
+        .returning({ id: attachmentModel.id })
     })
   }
 
@@ -608,7 +729,14 @@ export class ShardedMessageRepository implements IMessageRepository {
 
     const endTime = cursor?.createdAt ?? new Date()
     const startTime = sinceTime ?? new Date(0)
-    const allShards = await this.getShardsForRange(startTime, endTime)
+    const timeRangeShards = await this.getShardsForRange(startTime, endTime)
+    // Always include the workspace's write shard: historical-import rows are
+    // back-dated into it and would otherwise fall outside the time window when
+    // the conversation's newest message predates the shard's activation.
+    const writeShard = await this.shardManager.getWriteShardInfo(
+      query.workspaceId,
+    )
+    const allShards = this.mergeWriteShard(timeRangeShards, writeShard)
 
     if (allShards.length === 0) {
       return { data: [], nextCursor: null }


### PR DESCRIPTION
## Summary

- Restructure `bulk-historical-import` for improved concurrency and query batching
- Add comprehensive test suites: bulk-import-messages, received-message, send-flow-step, messenger/whatsapp template creation, sharded message repository, connection-manager, message-repository
- Move `flow`, `get-user-data`, `whatsapp-flow-response` tests to `__tests__` directory
- Add `last-message-window` query and tests for conversation listing optimisation
- Fix `send-messenger-template` and `send-whatsapp-template` handlers
- Fix `messenger-helpers`, `messenger-sync`, and coexist webhook handlers

## Test plan

- [x] All 42 `check-types` packages pass
- [x] New test files cover bulk import, message repository, template handlers, and received-message flows
- [x] Run `pnpm test` locally to verify all test suites green
- [x] Verify coexist historical sync still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)