### PR TITLE
feat(admin): add platform admin screen with scoped platform credentials

### DIFF
--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -2362,6 +2362,12 @@
     "title": "QR Code Generator",
     "description": "Create and manage your QR codes."
   },
+  "platformAdmin": {
+    "platformCredentials": {
+      "title": "Platform Credentials",
+      "description": "Global default developer apps used by all workspaces that don't have their own white-label credentials."
+    }
+  },
   "platformCredentials": {
     "title": "Platform Credentials"
   },

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -2373,6 +2373,12 @@
     "title": "QR Code",
     "description": "Share this code so people open your tracking link."
   },
+  "platformAdmin": {
+    "platformCredentials": {
+      "title": "Thông tin xác thực nền tảng",
+      "description": "Ứng dụng nhà phát triển mặc định dùng chung cho mọi workspace chưa có thông tin xác thực white-label riêng."
+    }
+  },
   "platformCredentials": {
     "title": "Thông tin nền tảng"
   },

--- a/apps/builder/next.config.ts
+++ b/apps/builder/next.config.ts
@@ -94,10 +94,7 @@ const nextConfig: NextConfig = {
       },
     ]
   },
-  allowedDevOrigins: [
-    new URL(env.NEXT_PUBLIC_BUILDER_URL).host,
-    "supposedly-driven-cheetah.ngrok-free.app",
-  ],
+  allowedDevOrigins: [new URL(env.NEXT_PUBLIC_BUILDER_URL).host],
 }
 
 export default withNextIntl(nextConfig)

--- a/apps/builder/src/app/admin/layout.tsx
+++ b/apps/builder/src/app/admin/layout.tsx
@@ -1,0 +1,26 @@
+import { isSuperAdmin } from "@chatbotx.io/business"
+import { notFound } from "next/navigation"
+import { isCloud } from "@/env"
+import { getCurrentUser } from "@/lib/auth/utils"
+
+/**
+ * SaaS-operator console. Gated to the real platform admin
+ * (PLATFORM_ADMIN_EMAIL) and only meaningful in cloud — self-hosted admins
+ * already manage the platform-scoped credentials through `/manage`.
+ */
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const user = await getCurrentUser()
+  if (!(user && isCloud() && isSuperAdmin(user))) {
+    return notFound()
+  }
+
+  return (
+    <main className="mx-auto w-full max-w-5xl p-4 pb-24 sm:px-6 sm:pt-6">
+      {children}
+    </main>
+  )
+}

--- a/apps/builder/src/app/admin/page.tsx
+++ b/apps/builder/src/app/admin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation"
+
+export default function AdminPage() {
+  redirect("/admin/platform-credentials")
+}

--- a/apps/builder/src/app/admin/platform-credentials/page.tsx
+++ b/apps/builder/src/app/admin/platform-credentials/page.tsx
@@ -1,0 +1,24 @@
+import { getTranslations } from "next-intl/server"
+import { Suspense } from "react"
+import { ManagePlatformCredentials } from "@/features/platform-credentials/manage-platform-credentials"
+
+export default async function AdminPlatformCredentialsPage() {
+  const t = await getTranslations()
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <h3 className="font-bold text-lg sm:text-xl">
+          {t("platformAdmin.platformCredentials.title")}
+        </h3>
+        <p className="text-muted-foreground text-sm">
+          {t("platformAdmin.platformCredentials.description")}
+        </p>
+      </div>
+
+      <Suspense>
+        <ManagePlatformCredentials scope="platform" />
+      </Suspense>
+    </div>
+  )
+}

--- a/apps/builder/src/features/platform-credentials/giphy/giphy-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/giphy/giphy-settings.tsx
@@ -27,6 +27,7 @@ import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { useState } from "react"
 import { toast } from "sonner"
+import { useCredentialScope } from "../provider/credential-scope-context"
 import { updateGiphySettingsAction } from "./update-giphy-settings.action"
 
 export function GiphySettings({ isConfigured }: { isConfigured: boolean }) {
@@ -103,10 +104,11 @@ export function EditGiphySettingsForm({
   onClose?: () => void
 }) {
   const t = useTranslations()
+  const scope = useCredentialScope()
 
   const { form, handleSubmitWithAction, resetFormAndAction } =
     useHookFormAction(
-      updateGiphySettingsAction,
+      updateGiphySettingsAction.bind(null, scope),
       zodResolver(giphyCredentialUpdateSchema),
       {
         actionProps: {

--- a/apps/builder/src/features/platform-credentials/giphy/update-giphy-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/giphy/update-giphy-settings.action.ts
@@ -3,17 +3,15 @@
 import { platformCredentialService } from "@chatbotx.io/business"
 import {
   type GiphyCredential,
-  type GiphyCredentialUpdate,
   giphyCredentialUpdateSchema,
 } from "@chatbotx.io/database/partials"
-import type { UserModel } from "@chatbotx.io/database/types"
 import ky from "ky"
 import { getTranslations } from "next-intl/server"
 import { returnValidationErrors } from "next-safe-action"
 
-import { isCloud } from "@/env"
 import { logger } from "@/lib/log"
 import { authActionClient } from "@/lib/safe-action"
+import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
 
 const isValidGiphyApiKey = async (apiKey: string) => {
   try {
@@ -30,45 +28,38 @@ const isValidGiphyApiKey = async (apiKey: string) => {
 }
 
 export const updateGiphySettingsAction = authActionClient
+  .bindArgsSchemas([credentialScopeSchema])
   .inputSchema(giphyCredentialUpdateSchema)
-  .action(
-    async ({
-      ctx,
-      parsedInput,
-    }: {
-      ctx: { user: UserModel }
-      parsedInput: GiphyCredentialUpdate
-    }) => {
-      const scopedUserId = isCloud() ? ctx.user.id : undefined
-      const existing = await platformCredentialService.findDecrypted({
-        userId: scopedUserId,
-        type: "giphy",
-      })
+  .action(async ({ ctx, bindArgsParsedInputs: [scope], parsedInput }) => {
+    const scopedUserId = resolveCredentialScopedUserId(ctx.user, scope)
+    const existing = await platformCredentialService.findDecrypted({
+      userId: scopedUserId,
+      type: "giphy",
+    })
 
-      if (parsedInput.apiKey) {
-        const isValid = await isValidGiphyApiKey(parsedInput.apiKey)
-        if (!isValid) {
-          const t = await getTranslations()
-          return returnValidationErrors(giphyCredentialUpdateSchema, {
-            apiKey: {
-              _errors: [t("platformSettings.errors.giphyApiKeyInvalid")],
-            },
-          })
-        }
-      }
-
-      const apiKey = parsedInput.apiKey || existing?.config.apiKey
-      if (!apiKey) {
+    if (parsedInput.apiKey) {
+      const isValid = await isValidGiphyApiKey(parsedInput.apiKey)
+      if (!isValid) {
         const t = await getTranslations()
-        throw new Error(t("platformSettings.errors.giphyApiKeyRequired"))
+        return returnValidationErrors(giphyCredentialUpdateSchema, {
+          apiKey: {
+            _errors: [t("platformSettings.errors.giphyApiKeyInvalid")],
+          },
+        })
       }
+    }
 
-      const config: GiphyCredential = { apiKey }
+    const apiKey = parsedInput.apiKey || existing?.config.apiKey
+    if (!apiKey) {
+      const t = await getTranslations()
+      throw new Error(t("platformSettings.errors.giphyApiKeyRequired"))
+    }
 
-      await platformCredentialService.upsert({
-        userId: scopedUserId,
-        type: "giphy",
-        config,
-      })
-    },
-  )
+    const config: GiphyCredential = { apiKey }
+
+    await platformCredentialService.upsert({
+      userId: scopedUserId,
+      type: "giphy",
+      config,
+    })
+  })

--- a/apps/builder/src/features/platform-credentials/google/google-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/google/google-settings.tsx
@@ -30,6 +30,7 @@ import { useTranslations } from "next-intl"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
+import { useCredentialScope } from "../provider/credential-scope-context"
 import { updateGoogleSettingsAction } from "./update-google-settings.action"
 
 export function GoogleSettings({
@@ -140,10 +141,11 @@ export function GoogleEditSettingsForm({
   onClose?: () => void
 }) {
   const t = useTranslations()
+  const scope = useCredentialScope()
 
   const { form, handleSubmitWithAction, resetFormAndAction } =
     useHookFormAction(
-      updateGoogleSettingsAction,
+      updateGoogleSettingsAction.bind(null, scope),
       zodResolver(googleCredentialUpdateSchema),
       {
         actionProps: {

--- a/apps/builder/src/features/platform-credentials/google/update-google-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/google/update-google-settings.action.ts
@@ -3,55 +3,45 @@
 import { platformCredentialService } from "@chatbotx.io/business"
 import {
   type GoogleCredential,
-  type GoogleCredentialUpdate,
   googleCredentialUpdateSchema,
 } from "@chatbotx.io/database/partials"
-import type { UserModel } from "@chatbotx.io/database/types"
 import { getTranslations } from "next-intl/server"
 
-import { isCloud } from "@/env"
 import { authActionClient } from "@/lib/safe-action"
+import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
 
 export const updateGoogleSettingsAction = authActionClient
+  .bindArgsSchemas([credentialScopeSchema])
   .inputSchema(googleCredentialUpdateSchema)
-  .action(
-    async ({
-      ctx,
-      parsedInput,
-    }: {
-      ctx: { user: UserModel }
-      parsedInput: GoogleCredentialUpdate
-    }) => {
-      const scopedUserId = isCloud() ? ctx.user.id : undefined
-      const existing = await platformCredentialService.findDecrypted({
-        userId: scopedUserId,
-        type: "google",
-      })
+  .action(async ({ ctx, bindArgsParsedInputs: [scope], parsedInput }) => {
+    const scopedUserId = resolveCredentialScopedUserId(ctx.user, scope)
+    const existing = await platformCredentialService.findDecrypted({
+      userId: scopedUserId,
+      type: "google",
+    })
 
-      const t = await getTranslations()
+    const t = await getTranslations()
 
-      const clientSecret =
-        parsedInput.clientSecret || existing?.config.clientSecret
-      if (!clientSecret) {
-        throw new Error(t("platformSettings.errors.googleClientSecretRequired"))
-      }
+    const clientSecret =
+      parsedInput.clientSecret || existing?.config.clientSecret
+    if (!clientSecret) {
+      throw new Error(t("platformSettings.errors.googleClientSecretRequired"))
+    }
 
-      const verifyToken =
-        parsedInput.verifyToken || existing?.config.verifyToken
-      if (!verifyToken) {
-        throw new Error(t("platformSettings.errors.googleVerifyTokenRequired"))
-      }
+    const verifyToken = parsedInput.verifyToken || existing?.config.verifyToken
+    if (!verifyToken) {
+      throw new Error(t("platformSettings.errors.googleVerifyTokenRequired"))
+    }
 
-      const config: GoogleCredential = {
-        clientId: parsedInput.clientId,
-        clientSecret,
-        verifyToken,
-      }
+    const config: GoogleCredential = {
+      clientId: parsedInput.clientId,
+      clientSecret,
+      verifyToken,
+    }
 
-      await platformCredentialService.upsert({
-        userId: scopedUserId,
-        type: "google",
-        config,
-      })
-    },
-  )
+    await platformCredentialService.upsert({
+      userId: scopedUserId,
+      type: "google",
+      config,
+    })
+  })

--- a/apps/builder/src/features/platform-credentials/instagram/instagram-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/instagram/instagram-settings.tsx
@@ -30,6 +30,7 @@ import { useTranslations } from "next-intl"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
+import { useCredentialScope } from "../provider/credential-scope-context"
 import { updateInstagramSettingAction } from "./update-instagram-settings.action"
 
 export function InstagramSettings({
@@ -173,10 +174,11 @@ export function EditInstagramSettingsForm({
   onClose?: () => void
 }) {
   const t = useTranslations()
+  const scope = useCredentialScope()
 
   const { form, handleSubmitWithAction, resetFormAndAction } =
     useHookFormAction(
-      updateInstagramSettingAction,
+      updateInstagramSettingAction.bind(null, scope),
       zodResolver(instagramCredentialUpdateSchema),
       {
         actionProps: {

--- a/apps/builder/src/features/platform-credentials/instagram/update-instagram-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/instagram/update-instagram-settings.action.ts
@@ -3,47 +3,38 @@
 import { platformCredentialService } from "@chatbotx.io/business"
 import {
   type InstagramCredential,
-  type InstagramCredentialUpdate,
   instagramCredentialUpdateSchema,
 } from "@chatbotx.io/database/partials"
-import type { UserModel } from "@chatbotx.io/database/types"
 
-import { isCloud } from "@/env"
 import { authActionClient } from "@/lib/safe-action"
+import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
 
 export const updateInstagramSettingAction = authActionClient
+  .bindArgsSchemas([credentialScopeSchema])
   .inputSchema(instagramCredentialUpdateSchema)
-  .action(
-    async ({
-      ctx,
-      parsedInput,
-    }: {
-      ctx: { user: UserModel }
-      parsedInput: InstagramCredentialUpdate
-    }) => {
-      const scopedUserId = isCloud() ? ctx.user.id : undefined
-      const existing = await platformCredentialService.findDecrypted({
-        userId: scopedUserId,
-        type: "instagram",
-      })
+  .action(async ({ ctx, bindArgsParsedInputs: [scope], parsedInput }) => {
+    const scopedUserId = resolveCredentialScopedUserId(ctx.user, scope)
+    const existing = await platformCredentialService.findDecrypted({
+      userId: scopedUserId,
+      type: "instagram",
+    })
 
-      const clientSecret =
-        parsedInput.clientSecret || existing?.config.clientSecret
-      if (!clientSecret) {
-        throw new Error("App Secret is required to configure Instagram.")
-      }
+    const clientSecret =
+      parsedInput.clientSecret || existing?.config.clientSecret
+    if (!clientSecret) {
+      throw new Error("App Secret is required to configure Instagram.")
+    }
 
-      const config: InstagramCredential = {
-        clientId: parsedInput.clientId,
-        version: parsedInput.version,
-        verifyToken: parsedInput.verifyToken,
-        clientSecret,
-      }
+    const config: InstagramCredential = {
+      clientId: parsedInput.clientId,
+      version: parsedInput.version,
+      verifyToken: parsedInput.verifyToken,
+      clientSecret,
+    }
 
-      await platformCredentialService.upsert({
-        userId: scopedUserId,
-        type: "instagram",
-        config,
-      })
-    },
-  )
+    await platformCredentialService.upsert({
+      userId: scopedUserId,
+      type: "instagram",
+      config,
+    })
+  })

--- a/apps/builder/src/features/platform-credentials/manage-platform-credentials.tsx
+++ b/apps/builder/src/features/platform-credentials/manage-platform-credentials.tsx
@@ -4,18 +4,28 @@ import { GiphySettings } from "./giphy/giphy-settings"
 import { GoogleSettings } from "./google/google-settings"
 import { InstagramSettings } from "./instagram/instagram-settings"
 import { MessengerSettings } from "./messenger/messenger-settings"
+import { CredentialScopeProvider } from "./provider/credential-scope-context"
+import type { CredentialScope } from "./scope"
 import { TiktokSettings } from "./tiktok/tiktok-settings"
 import { WhatsappSettings } from "./whatsapp/whatsapp-settings"
 import { ZaloSettings } from "./zalo/zalo-settings"
 
 type ManagePlatformCredentialsProps = {
-  userId: string
+  /**
+   * `"user"` (default): white-label customer editing their own credentials in
+   * cloud, or the platform-global credentials when self-hosted.
+   * `"platform"`: the SaaS operator editing the global default credentials.
+   */
+  scope?: CredentialScope
+  userId?: string
 }
 
 export async function ManagePlatformCredentials({
+  scope = "user",
   userId,
 }: ManagePlatformCredentialsProps) {
-  const scopedUserId = isCloud() ? userId : undefined
+  const isUserScope = scope === "user"
+  const scopedUserId = isUserScope && isCloud() ? userId : undefined
 
   const [
     whatsappResult,
@@ -53,15 +63,17 @@ export async function ManagePlatformCredentials({
     tiktokResult.status === "fulfilled" ? tiktokResult.value : undefined
 
   return (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-      <MessengerSettings publicConfig={messenger?.publicConfig ?? null} />
-      <InstagramSettings publicConfig={instagram?.publicConfig ?? null} />
-      <GoogleSettings publicConfig={google?.publicConfig ?? null} />
-      {/* <StripeSettings publicConfig={stripe?.publicConfig ?? null} /> */}
-      <WhatsappSettings publicConfig={whatsapp?.publicConfig ?? null} />
-      <ZaloSettings publicConfig={zalo?.publicConfig ?? null} />
-      <TiktokSettings publicConfig={tiktok?.publicConfig ?? null} />
-      <GiphySettings isConfigured={giphy !== undefined} />
-    </div>
+    <CredentialScopeProvider scope={scope}>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <MessengerSettings publicConfig={messenger?.publicConfig ?? null} />
+        <InstagramSettings publicConfig={instagram?.publicConfig ?? null} />
+        <GoogleSettings publicConfig={google?.publicConfig ?? null} />
+        {/* <StripeSettings publicConfig={stripe?.publicConfig ?? null} /> */}
+        <WhatsappSettings publicConfig={whatsapp?.publicConfig ?? null} />
+        <ZaloSettings publicConfig={zalo?.publicConfig ?? null} />
+        <TiktokSettings publicConfig={tiktok?.publicConfig ?? null} />
+        <GiphySettings isConfigured={giphy !== undefined} />
+      </div>
+    </CredentialScopeProvider>
   )
 }

--- a/apps/builder/src/features/platform-credentials/messenger/messenger-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/messenger/messenger-settings.tsx
@@ -30,6 +30,7 @@ import { useTranslations } from "next-intl"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
+import { useCredentialScope } from "../provider/credential-scope-context"
 import { updateMessengerSettingAction } from "./update-messenger-settings.action"
 
 export function MessengerSettings({
@@ -177,10 +178,11 @@ export function EditMessengerSettingsForm({
   onClose?: () => void
 }) {
   const t = useTranslations()
+  const scope = useCredentialScope()
 
   const { form, handleSubmitWithAction, resetFormAndAction } =
     useHookFormAction(
-      updateMessengerSettingAction,
+      updateMessengerSettingAction.bind(null, scope),
       zodResolver(messengerCredentialUpdateSchema),
       {
         actionProps: {

--- a/apps/builder/src/features/platform-credentials/messenger/update-messenger-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/messenger/update-messenger-settings.action.ts
@@ -3,49 +3,40 @@
 import { platformCredentialService } from "@chatbotx.io/business"
 import {
   type MessengerCredential,
-  type MessengerCredentialUpdate,
   messengerCredentialUpdateSchema,
 } from "@chatbotx.io/database/partials"
-import type { UserModel } from "@chatbotx.io/database/types"
 import { getTranslations } from "next-intl/server"
-import { isCloud } from "@/env"
 import { authActionClient } from "@/lib/safe-action"
+import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
 
 export const updateMessengerSettingAction = authActionClient
+  .bindArgsSchemas([credentialScopeSchema])
   .inputSchema(messengerCredentialUpdateSchema)
-  .action(
-    async ({
-      ctx,
-      parsedInput,
-    }: {
-      ctx: { user: UserModel }
-      parsedInput: MessengerCredentialUpdate
-    }) => {
-      const scopedUserId = isCloud() ? ctx.user.id : undefined
-      const existing = await platformCredentialService.findDecrypted({
-        userId: scopedUserId,
-        type: "messenger",
-      })
+  .action(async ({ ctx, bindArgsParsedInputs: [scope], parsedInput }) => {
+    const scopedUserId = resolveCredentialScopedUserId(ctx.user, scope)
+    const existing = await platformCredentialService.findDecrypted({
+      userId: scopedUserId,
+      type: "messenger",
+    })
 
-      const t = await getTranslations()
+    const t = await getTranslations()
 
-      const clientSecret =
-        parsedInput.clientSecret || existing?.config.clientSecret
-      if (!clientSecret) {
-        throw new Error(t("platformSettings.errors.messengerAppSecretRequired"))
-      }
+    const clientSecret =
+      parsedInput.clientSecret || existing?.config.clientSecret
+    if (!clientSecret) {
+      throw new Error(t("platformSettings.errors.messengerAppSecretRequired"))
+    }
 
-      const config: MessengerCredential = {
-        clientId: parsedInput.clientId,
-        version: parsedInput.version,
-        verifyToken: parsedInput.verifyToken,
-        clientSecret,
-      }
+    const config: MessengerCredential = {
+      clientId: parsedInput.clientId,
+      version: parsedInput.version,
+      verifyToken: parsedInput.verifyToken,
+      clientSecret,
+    }
 
-      await platformCredentialService.upsert({
-        userId: scopedUserId,
-        type: "messenger",
-        config,
-      })
-    },
-  )
+    await platformCredentialService.upsert({
+      userId: scopedUserId,
+      type: "messenger",
+      config,
+    })
+  })

--- a/apps/builder/src/features/platform-credentials/provider/credential-scope-context.tsx
+++ b/apps/builder/src/features/platform-credentials/provider/credential-scope-context.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { createContext, type ReactNode, useContext } from "react"
+import type { CredentialScope } from "../scope"
+
+const CredentialScopeContext = createContext<CredentialScope>("user")
+
+export function CredentialScopeProvider({
+  scope,
+  children,
+}: {
+  scope: CredentialScope
+  children: ReactNode
+}) {
+  return (
+    <CredentialScopeContext.Provider value={scope}>
+      {children}
+    </CredentialScopeContext.Provider>
+  )
+}
+
+export function useCredentialScope(): CredentialScope {
+  return useContext(CredentialScopeContext)
+}

--- a/apps/builder/src/features/platform-credentials/scope.ts
+++ b/apps/builder/src/features/platform-credentials/scope.ts
@@ -1,0 +1,28 @@
+import { isSuperAdmin } from "@chatbotx.io/business"
+import type { UserModel } from "@chatbotx.io/database/types"
+import { z } from "zod"
+import { isCloud } from "@/env"
+
+export const credentialScopeSchema = z.enum(["user", "platform"])
+export type CredentialScope = z.infer<typeof credentialScopeSchema>
+
+/**
+ * Resolve the DB `userId` scope for a credential read/write.
+ *
+ * - `"platform"` → NULL (global default credentials). Requires super admin.
+ * - `"user"`     → the caller's own credentials in cloud, or the platform-global
+ *                  credentials when self-hosted. Preserves the historical
+ *                  white-label `/manage` behavior.
+ */
+export function resolveCredentialScopedUserId(
+  user: UserModel,
+  scope: CredentialScope,
+): string | undefined {
+  if (scope === "platform") {
+    if (!isSuperAdmin(user)) {
+      throw new Error("Unauthorized")
+    }
+    return
+  }
+  return isCloud() ? user.id : undefined
+}

--- a/apps/builder/src/features/platform-credentials/tiktok/tiktok-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/tiktok/tiktok-settings.tsx
@@ -30,6 +30,7 @@ import { useTranslations } from "next-intl"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
+import { useCredentialScope } from "../provider/credential-scope-context"
 import { updateTiktokSettingAction } from "./update-tiktok-settings.action"
 
 export function TiktokSettings({
@@ -141,11 +142,12 @@ export function EditTiktokSettingsForm({
   onClose?: () => void
 }) {
   const t = useTranslations()
+  const scope = useCredentialScope()
   const isConfigured = publicConfig !== null
 
   const { form, handleSubmitWithAction, resetFormAndAction } =
     useHookFormAction(
-      updateTiktokSettingAction,
+      updateTiktokSettingAction.bind(null, scope),
       zodResolver(tiktokCredentialUpdateSchema),
       {
         actionProps: {

--- a/apps/builder/src/features/platform-credentials/tiktok/update-tiktok-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/tiktok/update-tiktok-settings.action.ts
@@ -3,47 +3,38 @@
 import { platformCredentialService } from "@chatbotx.io/business"
 import {
   type TiktokCredential,
-  type TiktokCredentialUpdate,
   tiktokCredentialUpdateSchema,
 } from "@chatbotx.io/database/partials"
-import type { UserModel } from "@chatbotx.io/database/types"
 import { getTranslations } from "next-intl/server"
-import { isCloud } from "@/env"
 import { authActionClient } from "@/lib/safe-action"
+import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
 
 export const updateTiktokSettingAction = authActionClient
+  .bindArgsSchemas([credentialScopeSchema])
   .inputSchema(tiktokCredentialUpdateSchema)
-  .action(
-    async ({
-      ctx,
-      parsedInput,
-    }: {
-      ctx: { user: UserModel }
-      parsedInput: TiktokCredentialUpdate
-    }) => {
-      const scopedUserId = isCloud() ? ctx.user.id : undefined
-      const existing = await platformCredentialService.findDecrypted({
-        userId: scopedUserId,
-        type: "tiktok",
-      })
+  .action(async ({ ctx, bindArgsParsedInputs: [scope], parsedInput }) => {
+    const scopedUserId = resolveCredentialScopedUserId(ctx.user, scope)
+    const existing = await platformCredentialService.findDecrypted({
+      userId: scopedUserId,
+      type: "tiktok",
+    })
 
-      const t = await getTranslations()
+    const t = await getTranslations()
 
-      const clientSecret =
-        parsedInput.clientSecret || existing?.config.clientSecret
-      if (!clientSecret) {
-        throw new Error(t("platformSettings.errors.tiktokAppSecretRequired"))
-      }
+    const clientSecret =
+      parsedInput.clientSecret || existing?.config.clientSecret
+    if (!clientSecret) {
+      throw new Error(t("platformSettings.errors.tiktokAppSecretRequired"))
+    }
 
-      const config: TiktokCredential = {
-        clientId: parsedInput.clientId,
-        clientSecret,
-      }
+    const config: TiktokCredential = {
+      clientId: parsedInput.clientId,
+      clientSecret,
+    }
 
-      await platformCredentialService.upsert({
-        userId: scopedUserId,
-        type: "tiktok",
-        config,
-      })
-    },
-  )
+    await platformCredentialService.upsert({
+      userId: scopedUserId,
+      type: "tiktok",
+      config,
+    })
+  })

--- a/apps/builder/src/features/platform-credentials/whatsapp/update-whatsapp-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/whatsapp/update-whatsapp-settings.action.ts
@@ -3,63 +3,54 @@
 import { platformCredentialService } from "@chatbotx.io/business"
 import {
   type WhatsappCredential,
-  type WhatsappCredentialUpdate,
   whatsappCredentialUpdateSchema,
 } from "@chatbotx.io/database/partials"
-import type { UserModel } from "@chatbotx.io/database/types"
 import { getTranslations } from "next-intl/server"
 
-import { isCloud } from "@/env"
 import { authActionClient } from "@/lib/safe-action"
+import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
 
 export const updateWhatsappSettingsAction = authActionClient
+  .bindArgsSchemas([credentialScopeSchema])
   .inputSchema(whatsappCredentialUpdateSchema)
-  .action(
-    async ({
-      ctx,
-      parsedInput,
-    }: {
-      ctx: { user: UserModel }
-      parsedInput: WhatsappCredentialUpdate
-    }) => {
-      const scopedUserId = isCloud() ? ctx.user.id : undefined
-      const existing = await platformCredentialService.findDecrypted({
-        userId: scopedUserId,
-        type: "whatsapp",
-      })
+  .action(async ({ ctx, bindArgsParsedInputs: [scope], parsedInput }) => {
+    const scopedUserId = resolveCredentialScopedUserId(ctx.user, scope)
+    const existing = await platformCredentialService.findDecrypted({
+      userId: scopedUserId,
+      type: "whatsapp",
+    })
 
-      const t = await getTranslations()
+    const t = await getTranslations()
 
-      const clientSecret =
-        parsedInput.clientSecret || existing?.config.clientSecret
-      if (!clientSecret) {
-        throw new Error(t("platformSettings.errors.whatsappAppSecretRequired"))
-      }
+    const clientSecret =
+      parsedInput.clientSecret || existing?.config.clientSecret
+    if (!clientSecret) {
+      throw new Error(t("platformSettings.errors.whatsappAppSecretRequired"))
+    }
 
-      const systemUserToken =
-        parsedInput.systemUserToken || existing?.config.systemUserToken
-      if (!systemUserToken) {
-        throw new Error(
-          t("platformSettings.errors.whatsappSystemUserTokenRequired"),
-        )
-      }
+    const systemUserToken =
+      parsedInput.systemUserToken || existing?.config.systemUserToken
+    if (!systemUserToken) {
+      throw new Error(
+        t("platformSettings.errors.whatsappSystemUserTokenRequired"),
+      )
+    }
 
-      const config: WhatsappCredential = {
-        clientId: parsedInput.clientId,
-        version: parsedInput.version,
-        configId: parsedInput.configId,
-        systemUserId: parsedInput.systemUserId,
-        businessId: parsedInput.businessId,
-        businessName: parsedInput.businessName,
-        verifyToken: parsedInput.verifyToken,
-        clientSecret,
-        systemUserToken,
-      }
+    const config: WhatsappCredential = {
+      clientId: parsedInput.clientId,
+      version: parsedInput.version,
+      configId: parsedInput.configId,
+      systemUserId: parsedInput.systemUserId,
+      businessId: parsedInput.businessId,
+      businessName: parsedInput.businessName,
+      verifyToken: parsedInput.verifyToken,
+      clientSecret,
+      systemUserToken,
+    }
 
-      await platformCredentialService.upsert({
-        userId: scopedUserId,
-        type: "whatsapp",
-        config,
-      })
-    },
-  )
+    await platformCredentialService.upsert({
+      userId: scopedUserId,
+      type: "whatsapp",
+      config,
+    })
+  })

--- a/apps/builder/src/features/platform-credentials/whatsapp/whatsapp-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/whatsapp/whatsapp-settings.tsx
@@ -30,6 +30,7 @@ import { useTranslations } from "next-intl"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
+import { useCredentialScope } from "../provider/credential-scope-context"
 import { updateWhatsappSettingsAction } from "./update-whatsapp-settings.action"
 
 export function WhatsappSettings({
@@ -194,10 +195,11 @@ export function EditWhatsappSettingsForm({
   onClose?: () => void
 }) {
   const t = useTranslations()
+  const scope = useCredentialScope()
 
   const { form, handleSubmitWithAction, resetFormAndAction } =
     useHookFormAction(
-      updateWhatsappSettingsAction,
+      updateWhatsappSettingsAction.bind(null, scope),
       zodResolver(whatsappCredentialUpdateSchema),
       {
         actionProps: {

--- a/apps/builder/src/features/platform-credentials/zalo/update-zalo-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/zalo/update-zalo-settings.action.ts
@@ -3,50 +3,41 @@
 import { platformCredentialService } from "@chatbotx.io/business"
 import {
   type ZaloCredential,
-  type ZaloCredentialUpdate,
   zaloCredentialUpdateSchema,
 } from "@chatbotx.io/database/partials"
-import type { UserModel } from "@chatbotx.io/database/types"
 import { getTranslations } from "next-intl/server"
 
-import { isCloud } from "@/env"
 import { authActionClient } from "@/lib/safe-action"
+import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
 
 export const updateZaloSettingsAction = authActionClient
+  .bindArgsSchemas([credentialScopeSchema])
   .inputSchema(zaloCredentialUpdateSchema)
-  .action(
-    async ({
-      ctx,
-      parsedInput,
-    }: {
-      ctx: { user: UserModel }
-      parsedInput: ZaloCredentialUpdate
-    }) => {
-      const scopedUserId = isCloud() ? ctx.user.id : undefined
-      const existing = await platformCredentialService.findDecrypted({
-        userId: scopedUserId,
-        type: "zalo",
-      })
+  .action(async ({ ctx, bindArgsParsedInputs: [scope], parsedInput }) => {
+    const scopedUserId = resolveCredentialScopedUserId(ctx.user, scope)
+    const existing = await platformCredentialService.findDecrypted({
+      userId: scopedUserId,
+      type: "zalo",
+    })
 
-      const t = await getTranslations()
+    const t = await getTranslations()
 
-      const clientSecret =
-        parsedInput.clientSecret || existing?.config.clientSecret
-      if (!clientSecret) {
-        throw new Error(t("platformSettings.errors.zaloAppSecretRequired"))
-      }
+    const clientSecret =
+      parsedInput.clientSecret || existing?.config.clientSecret
+    if (!clientSecret) {
+      throw new Error(t("platformSettings.errors.zaloAppSecretRequired"))
+    }
 
-      const config: ZaloCredential = {
-        clientId: parsedInput.clientId,
-        version: parsedInput.version,
-        verifyToken: parsedInput.verifyToken,
-        clientSecret,
-      }
+    const config: ZaloCredential = {
+      clientId: parsedInput.clientId,
+      version: parsedInput.version,
+      verifyToken: parsedInput.verifyToken,
+      clientSecret,
+    }
 
-      await platformCredentialService.upsert({
-        userId: scopedUserId,
-        type: "zalo",
-        config,
-      })
-    },
-  )
+    await platformCredentialService.upsert({
+      userId: scopedUserId,
+      type: "zalo",
+      config,
+    })
+  })

--- a/apps/builder/src/features/platform-credentials/zalo/zalo-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/zalo/zalo-settings.tsx
@@ -30,6 +30,7 @@ import { useTranslations } from "next-intl"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
+import { useCredentialScope } from "../provider/credential-scope-context"
 import { updateZaloSettingsAction } from "./update-zalo-settings.action"
 
 export function ZaloSettings({
@@ -171,10 +172,11 @@ export function EditZaloSettingsForm({
   onClose?: () => void
 }) {
   const t = useTranslations()
+  const scope = useCredentialScope()
 
   const { form, handleSubmitWithAction, resetFormAndAction } =
     useHookFormAction(
-      updateZaloSettingsAction,
+      updateZaloSettingsAction.bind(null, scope),
       zodResolver(zaloCredentialUpdateSchema),
       {
         actionProps: {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsdown",
     "check-types": "tsc --noEmit",
-    "dev": "concurrently pnpm:worker:*",
+    "dev": "concurrently pnpm:worker:* | pino-pretty",
     "https": "pnpm dev",
     "schedule": "dotenv -e ../../.env -- tsx --watch src/schedule/worker.ts",
     "test": "vitest run --passWithNoTests",
@@ -93,6 +93,7 @@
     "@types/node": "24.x",
     "concurrently": "^9.2.1",
     "dotenv-cli": "^11.0.0",
+    "pino-pretty": "^13.1.3",
     "tsdown": "0.21.10",
     "vitest": "^4.1.0"
   }

--- a/packages/business/src/user/index.ts
+++ b/packages/business/src/user/index.ts
@@ -10,3 +10,14 @@ export const isPlatformAdmin = async (user: UserModel): Promise<boolean> => {
   const { PLATFORM_ADMIN_EMAIL } = keys()
   return Boolean(PLATFORM_ADMIN_EMAIL && user.email === PLATFORM_ADMIN_EMAIL)
 }
+
+/**
+ * The real SaaS operator (super admin), identified by PLATFORM_ADMIN_EMAIL in
+ * every edition (cloud included). Distinct from `isPlatformAdmin`, which in
+ * cloud means "white-label user". The super admin manages the platform-scoped
+ * (NULL userId) default credentials that serve non-white-label customers.
+ */
+export const isSuperAdmin = (user: UserModel): boolean => {
+  const { PLATFORM_ADMIN_EMAIL } = keys()
+  return Boolean(PLATFORM_ADMIN_EMAIL && user.email === PLATFORM_ADMIN_EMAIL)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -740,6 +740,9 @@ importers:
       dotenv-cli:
         specifier: ^11.0.0
         version: 11.0.0
+      pino-pretty:
+        specifier: ^13.1.3
+        version: 13.1.3
       tsdown:
         specifier: 0.21.10
         version: 0.21.10(oxc-resolver@11.20.0)(typescript@5.9.3)


### PR DESCRIPTION
## Summary
- Add a super-admin-only `/admin` area for managing **platform-scoped** (NULL `userId`) default credentials that serve non-white-label customers.
- Introduce an explicit `CredentialScope` (`"user"` | `"platform"`) so the same platform-credentials UI/actions can read & write either the caller's own credentials or the global platform defaults.
- Separate the SaaS operator (`isSuperAdmin`) from the white-label user (`isPlatformAdmin`), which previously shared the same `PLATFORM_ADMIN_EMAIL` check.

## Changes
- **`app/admin/`** — new gated layout (super-admin + cloud only, else `notFound()`), index redirect to `/admin/platform-credentials`, and the platform-credentials page rendering `ManagePlatformCredentials scope="platform"`.
- **`features/platform-credentials/scope.ts`** — `credentialScopeSchema` + `resolveCredentialScopedUserId()` to map a scope to the DB `userId` (platform → NULL w/ super-admin guard; user → own id in cloud, global when self-hosted).
- **`provider/credential-scope-context.tsx`** — context to propagate the active scope to all credential settings components.
- **All `*-settings.tsx` + `update-*-settings.action.ts`** (giphy, google, instagram, messenger, tiktok, whatsapp, zalo) — thread the credential scope through reads and update actions.
- **`packages/business/src/user/index.ts`** — add `isSuperAdmin` helper.
- **`apps/worker`** — pipe dev logs through `pino-pretty`; **`next.config.ts`** — drop stale ngrok dev origin.

## Test plan
- [ ] `pnpm lint`
- [ ] `pnpm --filter builder check-types`
- [ ] As super admin in cloud: `/admin/platform-credentials` loads; saving updates the NULL-userId platform defaults.
- [ ] As a non-super-admin / non-cloud user: `/admin` returns 404.
- [ ] White-label `/manage` credential flow still reads/writes user-scoped credentials unchanged.