### PR TITLE
fix(messenger): add pages_utility_messaging scope to OAuth

### DIFF
--- a/integrations/messenger/src/apis/auth.ts
+++ b/integrations/messenger/src/apis/auth.ts
@@ -17,6 +17,7 @@ const MESSENGER_SCOPES = [
   "pages_messaging",
   "pages_show_list",
   "business_management",
+  "pages_utility_messaging",
 ]
 
 export function generateAuthUrl({


### PR DESCRIPTION
## Summary

- Add `pages_utility_messaging` to the Messenger OAuth scope list in `integrations/messenger/src/apis/auth.ts`
- This scope is required for sending utility messages (order confirmations, appointment reminders, shipping updates) which fall under Messenger's utility messaging policy — separate from standard promotional messaging limits

## Test plan

- [ ] Re-authorize a Messenger page connection and verify the new scope appears in the Facebook permission dialog
- [ ] Confirm existing Messenger functionality (send/receive messages, tag sync) is unaffected