### PR TITLE
fix: tag upserts respect partial unique index

### DIFF
--- a/apps/builder/src/features/contacts/actions/__tests__/contact-tag-actions.test.ts
+++ b/apps/builder/src/features/contacts/actions/__tests__/contact-tag-actions.test.ts
@@ -82,6 +82,7 @@ vi.mock("@chatbotx.io/database/client", () => ({
   }),
   and: (...args: unknown[]) => ({ and: args }),
   eq: (col: unknown, val: unknown) => ({ eq: [col, val] }),
+  isNull: (col: unknown) => ({ isNull: col }),
   inArray: (col: unknown, vals: unknown) => ({ inArray: [col, vals] }),
   notInArray: (col: unknown, vals: unknown) => ({ notInArray: [col, vals] }),
 }))

--- a/apps/builder/src/features/contacts/actions/add-contact-tag.action.ts
+++ b/apps/builder/src/features/contacts/actions/add-contact-tag.action.ts
@@ -1,7 +1,14 @@
 "use server"
 
 import { contactService, tagSyncService } from "@chatbotx.io/business"
-import { and, db, eq, findOrFail, inArray } from "@chatbotx.io/database/client"
+import {
+  and,
+  db,
+  eq,
+  findOrFail,
+  inArray,
+  isNull,
+} from "@chatbotx.io/database/client"
 import { contactsToTagsModel, tagModel } from "@chatbotx.io/database/schema"
 import { emitTagApplied, emitTagRemoved } from "@chatbotx.io/events"
 import { invalidateCacheByTags } from "@chatbotx.io/redis"
@@ -61,6 +68,7 @@ export const addContactTags = async ({
       )
       .onConflictDoNothing({
         target: [tagModel.workspaceId, tagModel.name],
+        where: isNull(tagModel.deletedAt),
       })
 
     return await tx.query.tagModel.findMany({

--- a/apps/builder/src/features/contacts/actions/update-contact-tag.action.ts
+++ b/apps/builder/src/features/contacts/actions/update-contact-tag.action.ts
@@ -1,7 +1,7 @@
 "use server"
 
 import { contactService, tagSyncService } from "@chatbotx.io/business"
-import { and, db, eq, notInArray } from "@chatbotx.io/database/client"
+import { and, db, eq, isNull, notInArray } from "@chatbotx.io/database/client"
 import { contactsToTagsModel, tagModel } from "@chatbotx.io/database/schema"
 import { emitTagApplied, emitTagRemoved } from "@chatbotx.io/events"
 import { invalidateCacheByTags } from "@chatbotx.io/redis"
@@ -68,6 +68,7 @@ export const updateContactTags = async ({
           )
           .onConflictDoNothing({
             target: [tagModel.workspaceId, tagModel.name],
+            where: isNull(tagModel.deletedAt),
           })
       }
 

--- a/apps/worker/__tests__/messenger-label-webhook.test.ts
+++ b/apps/worker/__tests__/messenger-label-webhook.test.ts
@@ -58,6 +58,7 @@ vi.mock("@chatbotx.io/database/client", () => ({
   },
   and: (...args: unknown[]) => args,
   eq: (...args: unknown[]) => args,
+  isNull: (...args: unknown[]) => args,
 }))
 
 vi.mock("@chatbotx.io/database/schema", () => ({

--- a/apps/worker/__tests__/sync-channel-labels.test.ts
+++ b/apps/worker/__tests__/sync-channel-labels.test.ts
@@ -91,6 +91,7 @@ vi.mock("@chatbotx.io/database/client", () => ({
     }),
   },
   sql: vi.fn((strings: TemplateStringsArray) => strings.raw.join("")),
+  isNull: (...args: unknown[]) => args,
 }))
 
 // ---------------------------------------------------------------------------

--- a/apps/worker/__tests__/zalo-label-webhook.test.ts
+++ b/apps/worker/__tests__/zalo-label-webhook.test.ts
@@ -69,6 +69,7 @@ vi.mock("@chatbotx.io/database/client", () => {
     },
     and: (...args: unknown[]) => args,
     eq: (...args: unknown[]) => args,
+    isNull: (...args: unknown[]) => args,
     inArray: inArraySpy,
   }
 })

--- a/apps/worker/src/default/handlers/sync-channel-labels.ts
+++ b/apps/worker/src/default/handlers/sync-channel-labels.ts
@@ -1,5 +1,5 @@
 import { buildContext } from "@chatbotx.io/business"
-import { db, sql } from "@chatbotx.io/database/client"
+import { db, isNull, sql } from "@chatbotx.io/database/client"
 import { type ChannelType, channelTypes } from "@chatbotx.io/database/partials"
 import {
   contactsToTagsModel,
@@ -186,6 +186,7 @@ async function upsertLabelMapping(props: {
     .values({ id: createId(), name: label.name, workspaceId })
     .onConflictDoUpdate({
       target: [tagModel.workspaceId, tagModel.name],
+      targetWhere: isNull(tagModel.deletedAt),
       set: { name: sql`EXCLUDED.name` },
     })
     .returning({ id: tagModel.id })

--- a/apps/worker/src/integration/handlers/messenger-label-webhook.ts
+++ b/apps/worker/src/integration/handlers/messenger-label-webhook.ts
@@ -1,4 +1,4 @@
-import { and, db, eq } from "@chatbotx.io/database/client"
+import { and, db, eq, isNull } from "@chatbotx.io/database/client"
 import { channelTypes } from "@chatbotx.io/database/partials"
 import {
   contactsToTagsModel,
@@ -147,6 +147,7 @@ async function upsertTagAndChannel(props: {
       .values({ id: createId(), name, workspaceId })
       .onConflictDoNothing({
         target: [tagModel.workspaceId, tagModel.name],
+        where: isNull(tagModel.deletedAt),
       })
       .returning({ id: tagModel.id })
     tagId =

--- a/apps/worker/src/integration/handlers/zalo-label-webhook.ts
+++ b/apps/worker/src/integration/handlers/zalo-label-webhook.ts
@@ -1,4 +1,4 @@
-import { and, db, eq, inArray } from "@chatbotx.io/database/client"
+import { and, db, eq, inArray, isNull } from "@chatbotx.io/database/client"
 import { channelTypes } from "@chatbotx.io/database/partials"
 import {
   contactsToTagsModel,
@@ -194,6 +194,7 @@ async function ensureTagAndChannel(props: {
       .values({ id: createId(), workspaceId, name })
       .onConflictDoNothing({
         target: [tagModel.workspaceId, tagModel.name],
+        where: isNull(tagModel.deletedAt),
       })
       .returning({ id: tagModel.id })
     tag =


### PR DESCRIPTION
## Summary

Creating or applying a tag could fail at runtime because tag upserts didn't
match the partial unique index on `Tag (workspaceId, name)` (limited to
non-deleted rows). This makes every tag upsert declare the matching predicate
so the conflict handling resolves correctly.

Verified the generated SQL against a live database: inserts are idempotent
(a duplicate is a no-op) and a conflicting insert returns no row, as expected.

## Test plan

- [x] Worker + builder unit tests pass
- [x] Live DB check: insert + duplicate insert behave correctly
- [ ] Manual: create a tag, then create/apply the same tag name again — no error