### PR TITLE
refactor: streamline tag and channel label sync handlers

### DIFF
--- a/apps/worker/__tests__/inbox-labels.test.ts
+++ b/apps/worker/__tests__/inbox-labels.test.ts
@@ -1,0 +1,541 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// Mutable state holders (controlled per test)
+// ---------------------------------------------------------------------------
+const queryResults = {
+  integrationMessengerFindFirst: null as unknown,
+  integrationZaloFindFirst: null as unknown,
+  tagModelFindFirst: null as unknown,
+  tagChannelFindFirst: null as unknown,
+  contactInboxFindMany: [] as unknown[],
+}
+const insertReturning = { current: [] as unknown[] }
+
+// ---------------------------------------------------------------------------
+// DB mock — chainable builder
+// ---------------------------------------------------------------------------
+function makeChain(): Record<string, unknown> {
+  const builder: Record<string, unknown> = {}
+  const noop = () => builder
+  builder.values = vi.fn(noop)
+  builder.onConflictDoNothing = vi.fn(noop)
+  builder.where = vi.fn(noop)
+  builder.returning = vi.fn(async () => insertReturning.current)
+  return builder
+}
+const insertChain = makeChain()
+const deleteChain = makeChain()
+;(deleteChain.where as ReturnType<typeof vi.fn>).mockImplementation(
+  async () => undefined,
+)
+
+// Soft-delete path: db.update(tagModel).set().where().returning()
+const updateReturning = { current: [] as unknown[] }
+const updateChain: Record<string, unknown> = {}
+updateChain.set = vi.fn(() => updateChain)
+updateChain.where = vi.fn(() => updateChain)
+updateChain.returning = vi.fn(async () => updateReturning.current)
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      integrationMessengerModel: {
+        findFirst: vi.fn(
+          async () => queryResults.integrationMessengerFindFirst,
+        ),
+      },
+      integrationZaloModel: {
+        findFirst: vi.fn(async () => queryResults.integrationZaloFindFirst),
+      },
+      tagModel: {
+        findFirst: vi.fn(async () => queryResults.tagModelFindFirst),
+      },
+      tagChannelModel: {
+        findFirst: vi.fn(async () => queryResults.tagChannelFindFirst),
+      },
+      contactInboxModel: {
+        findMany: vi.fn(async () => queryResults.contactInboxFindMany),
+      },
+    },
+    insert: vi.fn(() => insertChain),
+    delete: vi.fn(() => deleteChain),
+    update: vi.fn(() => updateChain),
+  },
+  and: (...args: unknown[]) => args,
+  eq: (...args: unknown[]) => args,
+  inArray: (...args: unknown[]) => args,
+  isNull: (...args: unknown[]) => args,
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  tagModel: { id: "id", workspaceId: "workspaceId", name: "name" },
+  tagChannelModel: {
+    id: "id",
+    tagId: "tagId",
+    channelType: "channelType",
+    integrationId: "integrationId",
+    workspaceId: "workspaceId",
+    externalLabelId: "externalLabelId",
+  },
+  contactsToTagsModel: { contactId: "contactId", tagId: "tagId" },
+  contactToTagChannelModel: {
+    tagId: "tagId",
+    tagChannelId: "tagChannelId",
+    contactInboxId: "contactInboxId",
+  },
+}))
+
+vi.mock("@chatbotx.io/database/partials", () => ({
+  channelTypes: { enum: { messenger: "messenger", zalo: "zalo" } },
+}))
+
+const enqueueDelete = vi.fn(async () => undefined)
+vi.mock("@chatbotx.io/business", () => ({
+  tagSyncService: { enqueueDelete },
+}))
+
+const invalidateCacheByTags = vi.fn(async () => undefined)
+vi.mock("@chatbotx.io/redis", () => ({ invalidateCacheByTags }))
+
+const emitTagApplied = vi.fn(async () => undefined)
+const emitTagRemoved = vi.fn(async () => undefined)
+vi.mock("@chatbotx.io/events", () => ({ emitTagApplied, emitTagRemoved }))
+
+let idCounter = 0
+vi.mock("@chatbotx.io/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@chatbotx.io/utils")>()
+  return { ...actual, createId: vi.fn(() => `generated-${++idCounter}`) }
+})
+
+vi.mock("../src/lib/logger", () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+}))
+
+// ---------------------------------------------------------------------------
+// Lazy imports AFTER mocks
+// ---------------------------------------------------------------------------
+const { handleChannelLabelWebhook } = await import(
+  "../src/integration/handlers/inbox_labels"
+)
+const { logger } = await import("../src/lib/logger")
+const { db } = await import("@chatbotx.io/database/client")
+const {
+  tagModel,
+  tagChannelModel,
+  contactsToTagsModel,
+  contactToTagChannelModel,
+} = await import("@chatbotx.io/database/schema")
+
+const dbInsert = db.insert as ReturnType<typeof vi.fn>
+const dbDelete = db.delete as ReturnType<typeof vi.fn>
+const dbUpdate = db.update as ReturnType<typeof vi.fn>
+const loggerWarn = logger.warn as ReturnType<typeof vi.fn>
+const messengerFindFirst = db.query.integrationMessengerModel
+  .findFirst as ReturnType<typeof vi.fn>
+const zaloFindFirst = db.query.integrationZaloModel.findFirst as ReturnType<
+  typeof vi.fn
+>
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+const PAGE_ID = "page-1"
+const OA_ID = "oa-1"
+const WS_ID = "ws-1"
+const INBOX_ID = "inbox-1"
+const LABEL_ID = "label-ext-1"
+const LABEL_NAME = "VIP"
+const PSID = "psid-1"
+
+function messengerIntegration(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "intg-msg-1",
+    workspaceId: WS_ID,
+    inboxId: INBOX_ID,
+    pageId: PAGE_ID,
+    syncTagEnabledAt: new Date("2026-01-01"),
+    ...overrides,
+  }
+}
+function zaloIntegration(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "intg-zalo-1",
+    workspaceId: WS_ID,
+    inboxId: INBOX_ID,
+    oaId: OA_ID,
+    syncTagEnabledAt: new Date("2026-01-01"),
+    ...overrides,
+  }
+}
+
+function messengerPayload(value: Record<string, unknown>) {
+  return {
+    object: "page",
+    entry: [
+      {
+        id: PAGE_ID,
+        time: 1_700_000_000,
+        changes: [{ field: "inbox_labels", value }],
+      },
+    ],
+  }
+}
+
+function messengerData(value: Record<string, unknown>) {
+  return {
+    integrationType: "messenger" as const,
+    integrationIdentifier: PAGE_ID,
+    payload: messengerPayload(value),
+  }
+}
+function zaloData(payload: unknown) {
+  return {
+    integrationType: "zalo" as const,
+    integrationIdentifier: OA_ID,
+    payload,
+  }
+}
+
+beforeEach(() => {
+  queryResults.integrationMessengerFindFirst = null
+  queryResults.integrationZaloFindFirst = null
+  queryResults.tagModelFindFirst = null
+  queryResults.tagChannelFindFirst = null
+  queryResults.contactInboxFindMany = []
+  insertReturning.current = []
+  updateReturning.current = []
+  idCounter = 0
+
+  vi.clearAllMocks()
+  ;(insertChain.values as ReturnType<typeof vi.fn>).mockReturnValue(insertChain)
+  ;(
+    insertChain.onConflictDoNothing as ReturnType<typeof vi.fn>
+  ).mockReturnValue(insertChain)
+  ;(insertChain.returning as ReturnType<typeof vi.fn>).mockImplementation(
+    async () => insertReturning.current,
+  )
+  ;(deleteChain.where as ReturnType<typeof vi.fn>).mockImplementation(
+    async () => undefined,
+  )
+  ;(updateChain.set as ReturnType<typeof vi.fn>).mockReturnValue(updateChain)
+  ;(updateChain.where as ReturnType<typeof vi.fn>).mockReturnValue(updateChain)
+  ;(updateChain.returning as ReturnType<typeof vi.fn>).mockImplementation(
+    async () => updateReturning.current,
+  )
+  dbInsert.mockReturnValue(insertChain)
+  dbDelete.mockReturnValue(deleteChain)
+  dbUpdate.mockReturnValue(updateChain)
+  messengerFindFirst.mockImplementation(
+    async () => queryResults.integrationMessengerFindFirst,
+  )
+  zaloFindFirst.mockImplementation(
+    async () => queryResults.integrationZaloFindFirst,
+  )
+})
+
+// ===========================================================================
+// Dispatch / guards
+// ===========================================================================
+describe("handleChannelLabelWebhook — dispatch", () => {
+  test("warns and stops for an unsupported channel", async () => {
+    await handleChannelLabelWebhook({
+      // @ts-expect-error — testing an unsupported channel value
+      integrationType: "telegram",
+      integrationIdentifier: "x",
+      payload: {},
+    })
+
+    expect(loggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "telegram" }),
+      "inbox labels: unsupported channel",
+    )
+    expect(dbInsert).not.toHaveBeenCalled()
+  })
+
+  test("stops when integration is not found", async () => {
+    queryResults.integrationMessengerFindFirst = null
+    await handleChannelLabelWebhook(
+      messengerData({
+        action: "add",
+        user: { id: PSID },
+        label: { id: LABEL_ID, page_label_name: LABEL_NAME },
+      }),
+    )
+    expect(dbInsert).not.toHaveBeenCalled()
+    expect(loggerWarn).not.toHaveBeenCalled()
+  })
+
+  test("stops when tag sync is disabled", async () => {
+    queryResults.integrationMessengerFindFirst = messengerIntegration({
+      syncTagEnabledAt: null,
+    })
+    await handleChannelLabelWebhook(
+      messengerData({
+        action: "add",
+        user: { id: PSID },
+        label: { id: LABEL_ID, page_label_name: LABEL_NAME },
+      }),
+    )
+    expect(dbInsert).not.toHaveBeenCalled()
+  })
+
+  test("warns on invalid payload", async () => {
+    queryResults.integrationMessengerFindFirst = messengerIntegration()
+    await handleChannelLabelWebhook({
+      integrationType: "messenger",
+      integrationIdentifier: PAGE_ID,
+      payload: { not: "a webhook" },
+    })
+    expect(loggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "messenger" }),
+      "inbox labels: invalid payload",
+    )
+  })
+})
+
+// ===========================================================================
+// Messenger
+// ===========================================================================
+describe("handleChannelLabelWebhook — messenger", () => {
+  beforeEach(() => {
+    queryResults.integrationMessengerFindFirst = messengerIntegration()
+  })
+
+  test("add assigns + emits applied when the tag channel already exists", async () => {
+    queryResults.tagChannelFindFirst = { id: "tc-1", tagId: "tag-1" }
+    queryResults.contactInboxFindMany = [{ id: "ci-1", contactId: "c-1" }]
+    insertReturning.current = [{ contactId: "c-1" }] // newly linked
+
+    await handleChannelLabelWebhook(
+      messengerData({
+        action: "add",
+        user: { id: PSID },
+        label: { id: LABEL_ID, page_label_name: LABEL_NAME },
+      }),
+    )
+
+    expect(dbInsert).toHaveBeenCalledWith(contactsToTagsModel)
+    expect(dbInsert).toHaveBeenCalledWith(contactToTagChannelModel)
+    expect(emitTagApplied).toHaveBeenCalledWith(WS_ID, "c-1", "tag-1")
+  })
+
+  test("add creates tag + channel from page_label_name, then assigns", async () => {
+    queryResults.tagChannelFindFirst = null
+    queryResults.tagModelFindFirst = null
+    insertReturning.current = [{ id: "new-id" }]
+    queryResults.contactInboxFindMany = [{ id: "ci-1", contactId: "c-1" }]
+
+    await handleChannelLabelWebhook(
+      messengerData({
+        action: "add",
+        user: { id: PSID },
+        label: { id: LABEL_ID, page_label_name: LABEL_NAME },
+      }),
+    )
+
+    expect(dbInsert).toHaveBeenCalledWith(tagModel)
+    expect(dbInsert).toHaveBeenCalledWith(tagChannelModel)
+    expect(dbInsert).toHaveBeenCalledWith(contactsToTagsModel)
+    expect(dbInsert).toHaveBeenCalledWith(contactToTagChannelModel)
+  })
+
+  test("add skips when tag is missing and no name in payload", async () => {
+    queryResults.tagChannelFindFirst = null
+    queryResults.tagModelFindFirst = null
+
+    await handleChannelLabelWebhook(
+      messengerData({
+        action: "add",
+        user: { id: PSID },
+        label: { id: LABEL_ID }, // no page_label_name
+      }),
+    )
+
+    expect(dbInsert).not.toHaveBeenCalled()
+  })
+
+  test("add without user is a no-op", async () => {
+    await handleChannelLabelWebhook(
+      messengerData({
+        action: "add",
+        label: { id: LABEL_ID, page_label_name: LABEL_NAME },
+      }),
+    )
+    expect(dbInsert).not.toHaveBeenCalled()
+  })
+
+  test("remove unassigns: deletes channel mapping + contact tag + emits removed", async () => {
+    queryResults.tagChannelFindFirst = { id: "tc-1", tagId: "tag-1" }
+    queryResults.contactInboxFindMany = [{ id: "ci-1", contactId: "c-1" }]
+
+    await handleChannelLabelWebhook(
+      messengerData({
+        action: "remove",
+        user: { id: PSID },
+        label: { id: LABEL_ID },
+      }),
+    )
+
+    expect(dbDelete).toHaveBeenCalledWith(contactToTagChannelModel)
+    expect(dbDelete).toHaveBeenCalledWith(contactsToTagsModel)
+    expect(emitTagRemoved).toHaveBeenCalledWith(WS_ID, "c-1", "tag-1")
+  })
+
+  test("remove without user is a no-op", async () => {
+    await handleChannelLabelWebhook(
+      messengerData({ action: "remove", label: { id: LABEL_ID } }),
+    )
+    expect(dbDelete).not.toHaveBeenCalled()
+  })
+
+  test("unknown action is a no-op", async () => {
+    await handleChannelLabelWebhook(
+      messengerData({
+        action: "rename",
+        user: { id: PSID },
+        label: { id: LABEL_ID },
+      }),
+    )
+    expect(dbInsert).not.toHaveBeenCalled()
+    expect(dbDelete).not.toHaveBeenCalled()
+  })
+})
+
+// ===========================================================================
+// Zalo
+// ===========================================================================
+describe("handleChannelLabelWebhook — zalo", () => {
+  beforeEach(() => {
+    queryResults.integrationZaloFindFirst = zaloIntegration()
+  })
+
+  test("add_user_to_tag assigns the batch of users", async () => {
+    queryResults.tagChannelFindFirst = { id: "tc-1", tagId: "tag-1" }
+    queryResults.contactInboxFindMany = [
+      { id: "ci-1", contactId: "c-1" },
+      { id: "ci-2", contactId: "c-2" },
+    ]
+
+    await handleChannelLabelWebhook(
+      zaloData({
+        event_name: "add_user_to_tag",
+        oa_id: OA_ID,
+        tag: { name: LABEL_NAME, user_ids: ["u-1", "u-2"] },
+      }),
+    )
+
+    expect(dbInsert).toHaveBeenCalledWith(contactsToTagsModel)
+    expect(dbInsert).toHaveBeenCalledWith(contactToTagChannelModel)
+  })
+
+  test("add_user_to_tag with empty user_ids ensures the label only", async () => {
+    queryResults.tagChannelFindFirst = null
+    queryResults.tagModelFindFirst = null
+    insertReturning.current = [{ id: "new-id" }]
+
+    await handleChannelLabelWebhook(
+      zaloData({
+        event_name: "add_user_to_tag",
+        oa_id: OA_ID,
+        tag: { name: LABEL_NAME },
+      }),
+    )
+
+    expect(dbInsert).toHaveBeenCalledWith(tagModel)
+    expect(dbInsert).toHaveBeenCalledWith(tagChannelModel)
+    expect(dbInsert).not.toHaveBeenCalledWith(contactsToTagsModel)
+  })
+
+  test("remove_user_from_tag unassigns the batch", async () => {
+    queryResults.tagChannelFindFirst = { id: "tc-1", tagId: "tag-1" }
+    queryResults.contactInboxFindMany = [
+      { id: "ci-1", contactId: "c-1" },
+      { id: "ci-2", contactId: "c-2" },
+    ]
+
+    await handleChannelLabelWebhook(
+      zaloData({
+        event_name: "remove_user_from_tag",
+        oa_id: OA_ID,
+        tag: { name: LABEL_NAME, user_ids: ["u-1", "u-2"] },
+      }),
+    )
+
+    expect(dbDelete).toHaveBeenCalledWith(contactToTagChannelModel)
+    expect(dbDelete).toHaveBeenCalledWith(contactsToTagsModel)
+    expect(emitTagRemoved).toHaveBeenCalledTimes(2)
+  })
+
+  test("remove_user_from_tag with empty user_ids is a no-op", async () => {
+    await handleChannelLabelWebhook(
+      zaloData({
+        event_name: "remove_user_from_tag",
+        oa_id: OA_ID,
+        tag: { name: LABEL_NAME },
+      }),
+    )
+    expect(dbDelete).not.toHaveBeenCalled()
+  })
+
+  test("remove_user_from_tag is a no-op when the tag channel is missing", async () => {
+    queryResults.tagChannelFindFirst = null
+    await handleChannelLabelWebhook(
+      zaloData({
+        event_name: "remove_user_from_tag",
+        oa_id: OA_ID,
+        tag: { name: LABEL_NAME, user_ids: ["u-1"] },
+      }),
+    )
+    expect(dbDelete).not.toHaveBeenCalled()
+  })
+
+  test("remove_tag enqueues a channel-scoped delete + keeps the workspace tag", async () => {
+    queryResults.tagChannelFindFirst = { id: "tc-1", tagId: "tag-1" }
+
+    await handleChannelLabelWebhook(
+      zaloData({
+        event_name: "remove_tag",
+        oa_id: OA_ID,
+        tag: { name: LABEL_NAME },
+      }),
+    )
+
+    expect(enqueueDelete).toHaveBeenCalledWith({
+      workspaceId: WS_ID,
+      tagId: "tag-1",
+      channelType: "zalo",
+      integrationId: "intg-zalo-1",
+    })
+    // No workspace-wide tag delete from the webhook.
+    expect(dbUpdate).not.toHaveBeenCalled()
+  })
+
+  test("remove_tag is a no-op when the label is not mapped locally", async () => {
+    queryResults.tagChannelFindFirst = null
+
+    await handleChannelLabelWebhook(
+      zaloData({
+        event_name: "remove_tag",
+        oa_id: OA_ID,
+        tag: { name: LABEL_NAME },
+      }),
+    )
+
+    expect(enqueueDelete).not.toHaveBeenCalled()
+  })
+
+  test("warns on invalid zalo payload", async () => {
+    await handleChannelLabelWebhook(
+      zaloData({
+        event_name: "bogus",
+        oa_id: OA_ID,
+        tag: { name: LABEL_NAME },
+      }),
+    )
+    expect(loggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "zalo" }),
+      "inbox labels: invalid payload",
+    )
+  })
+})

--- a/apps/worker/__tests__/messenger-label-webhook.test.ts
+++ b/apps/worker/__tests__/messenger-label-webhook.test.ts
@@ -294,7 +294,8 @@ describe("handleMessengerLabelWebhook — integration guard", () => {
     await handleMessengerLabelWebhook(
       makeData(
         makePayload({
-          action: "create_label",
+          action: "add",
+          user: { id: USER_PSID },
           label: { id: LABEL_ID, page_label_name: LABEL_NAME },
         }),
       ),
@@ -311,289 +312,14 @@ describe("handleMessengerLabelWebhook — integration guard", () => {
     await handleMessengerLabelWebhook(
       makeData(
         makePayload({
-          action: "create_label",
+          action: "add",
+          user: { id: USER_PSID },
           label: { id: LABEL_ID, page_label_name: LABEL_NAME },
         }),
       ),
     )
 
     expect(dbInsert).not.toHaveBeenCalled()
-  })
-})
-
-describe("handleMessengerLabelWebhook — create_label", () => {
-  beforeEach(() => {
-    queryResults.integrationMessengerFindFirst = makeIntegration()
-  })
-
-  test("returns early when page_label_name is missing", async () => {
-    // label with no page_label_name (FB omits it on user add/remove events)
-    await handleMessengerLabelWebhook(
-      makeData(
-        makePayload({ action: "create_label", label: { id: LABEL_ID } }),
-      ),
-    )
-
-    expect(dbInsert).not.toHaveBeenCalled()
-  })
-
-  test("skips tag insert when tag already exists by name", async () => {
-    queryResults.tagModelFindFirst = { id: "existing-tag-id" }
-    insertReturning.current = [{ id: "tc-new-1" }]
-
-    await handleMessengerLabelWebhook(
-      makeData(
-        makePayload({
-          action: "create_label",
-          label: { id: LABEL_ID, page_label_name: LABEL_NAME },
-        }),
-      ),
-    )
-
-    // tagModel insert should NOT be called because tag was found
-    const insertCalls = dbInsert.mock.calls.map((c: unknown[]) => c[0])
-    expect(insertCalls).not.toContain(tagModel)
-    // tagChannelModel insert SHOULD be called
-    expect(insertCalls).toContain(tagChannelModel)
-  })
-
-  test("inserts tag with onConflictDoNothing when tag not found", async () => {
-    queryResults.tagModelFindFirst = null
-    insertReturning.current = [{ id: "new-tag-id" }]
-
-    // tagChannelModel insert also returns an id
-    let insertCallCount = 0
-    dbInsert.mockImplementation((_model: unknown) => {
-      insertCallCount++
-      return insertChain
-    })
-    ;(insertChain.returning as ReturnType<typeof vi.fn>).mockImplementation(
-      () => {
-        // First insert = tagModel → return tag id
-        // Second insert = tagChannelModel → return tagChannel id
-        return Promise.resolve(
-          insertCallCount === 1 ? [{ id: "new-tag-id" }] : [{ id: "tc-new-1" }],
-        )
-      },
-    )
-
-    await handleMessengerLabelWebhook(
-      makeData(
-        makePayload({
-          action: "create_label",
-          label: { id: LABEL_ID, page_label_name: LABEL_NAME },
-        }),
-      ),
-    )
-
-    expect(dbInsert).toHaveBeenCalledWith(tagModel)
-    expect(insertChain.onConflictDoNothing).toHaveBeenCalled()
-  })
-
-  test("falls back to tagModel findFirst when insert returns empty (race)", async () => {
-    queryResults.tagModelFindFirst = null
-    // First insert (tagModel) returns empty → triggers fallback findFirst
-    // Fallback findFirst returns an id
-    let _insertCallCount = 0
-    dbInsert.mockImplementation(() => {
-      _insertCallCount++
-      return insertChain
-    })
-    ;(insertChain.returning as ReturnType<typeof vi.fn>).mockImplementation(
-      async () => [],
-    )
-    // Set up the fallback findFirst to return a tag
-    tagFindFirst
-      .mockResolvedValueOnce(null) // initial check → not found
-      .mockResolvedValueOnce({ id: "race-tag-id" }) // fallback after empty insert
-
-    // tagChannelModel insert returns id
-    insertReturning.current = [{ id: "tc-race-1" }]
-    ;(insertChain.returning as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce([]) // tagModel insert → empty
-      .mockResolvedValueOnce([{ id: "tc-race-1" }]) // tagChannel insert → ok
-
-    await handleMessengerLabelWebhook(
-      makeData(
-        makePayload({
-          action: "create_label",
-          label: { id: LABEL_ID, page_label_name: LABEL_NAME },
-        }),
-      ),
-    )
-
-    // findFirst called twice: initial check + fallback
-    expect(tagFindFirst).toHaveBeenCalledTimes(2)
-    // tagChannelModel insert was reached (tag was resolved via fallback)
-    expect(dbInsert).toHaveBeenCalledWith(tagChannelModel)
-  })
-
-  test("returns undefined (no-op) when both tag insert and fallback return nothing", async () => {
-    queryResults.tagModelFindFirst = null
-    tagFindFirst.mockResolvedValue(null) // all findFirst calls → null
-    ;(insertChain.returning as ReturnType<typeof vi.fn>).mockResolvedValue([]) // insert returns empty
-
-    await handleMessengerLabelWebhook(
-      makeData(
-        makePayload({
-          action: "create_label",
-          label: { id: LABEL_ID, page_label_name: LABEL_NAME },
-        }),
-      ),
-    )
-
-    // Should not insert tagChannel since tagId is undefined
-    const insertCalls = dbInsert.mock.calls.map((c: unknown[]) => c[0])
-    expect(insertCalls).not.toContain(tagChannelModel)
-  })
-
-  test("falls back to tagChannelModel findFirst when tagChannel insert returns empty", async () => {
-    queryResults.tagModelFindFirst = { id: "existing-tag-id" }
-    queryResults.tagChannelFindFirst = { id: "existing-tc-id" }
-
-    // tagChannel insert returns empty → triggers findFirst fallback
-    ;(insertChain.returning as ReturnType<typeof vi.fn>).mockResolvedValue([])
-
-    await handleMessengerLabelWebhook(
-      makeData(
-        makePayload({
-          action: "create_label",
-          label: { id: LABEL_ID, page_label_name: LABEL_NAME },
-        }),
-      ),
-    )
-
-    // tagChannelModel findFirst should be called as fallback
-    expect(tagChannelFindFirst).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.anything(),
-        columns: { id: true },
-      }),
-    )
-  })
-
-  test("uses createId for new tag and tagChannel ids", async () => {
-    queryResults.tagModelFindFirst = null
-    createId.mockReturnValueOnce("tag-new-id").mockReturnValueOnce("tc-new-id")
-    let callIdx = 0
-    ;(insertChain.returning as ReturnType<typeof vi.fn>).mockImplementation(
-      () => {
-        callIdx++
-        return Promise.resolve(
-          callIdx === 1 ? [{ id: "tag-new-id" }] : [{ id: "tc-new-id" }],
-        )
-      },
-    )
-
-    await handleMessengerLabelWebhook(
-      makeData(
-        makePayload({
-          action: "create_label",
-          label: { id: LABEL_ID, page_label_name: LABEL_NAME },
-        }),
-      ),
-    )
-
-    expect(createId).toHaveBeenCalled()
-    // Values passed to insert should include the generated ids
-    const valuesCalls = (insertChain.values as ReturnType<typeof vi.fn>).mock
-      .calls
-    expect(
-      valuesCalls.some(
-        (c: unknown[]) =>
-          (c[0] as Record<string, unknown>)?.id === "tag-new-id",
-      ),
-    ).toBe(true)
-  })
-})
-
-describe("handleMessengerLabelWebhook — delete_label (workspace isolation)", () => {
-  beforeEach(() => {
-    queryResults.integrationMessengerFindFirst = makeIntegration()
-  })
-
-  test("calls db.delete(tagChannelModel) with correct where clause", async () => {
-    await handleMessengerLabelWebhook(
-      makeData(
-        makePayload({
-          action: "delete_label",
-          label: { id: LABEL_ID },
-        }),
-      ),
-    )
-
-    expect(dbDelete).toHaveBeenCalledWith(tagChannelModel)
-    expect(deleteChain.where).toHaveBeenCalled()
-  })
-
-  test("where clause includes workspaceId — workspace isolation", async () => {
-    await handleMessengerLabelWebhook(
-      makeData(
-        makePayload({
-          action: "delete_label",
-          label: { id: LABEL_ID },
-        }),
-      ),
-    )
-
-    const whereArgs = (deleteChain.where as ReturnType<typeof vi.fn>).mock
-      .calls[0]
-    // The `and(...)` call returns its args as an array (per our mock)
-    // whereArgs[0] is the result of and(...conditions)
-    const conditions = whereArgs[0] as unknown[]
-    // Conditions should include workspaceId, channelType, integrationId, externalLabelId
-    expect(conditions).toHaveLength(4)
-  })
-
-  test("where clause uses integration.workspaceId (not some other workspace)", async () => {
-    const integration = makeIntegration({ workspaceId: "ws-specific" })
-    queryResults.integrationMessengerFindFirst = integration
-
-    await handleMessengerLabelWebhook(
-      makeData(
-        makePayload({
-          action: "delete_label",
-          label: { id: LABEL_ID },
-        }),
-      ),
-    )
-
-    // eq() mock returns its args — find the eq call with workspaceId field
-    // The and() wrapper returns array of eq results
-    // Each eq() call is captured in the conditions
-    const whereArgs = (deleteChain.where as ReturnType<typeof vi.fn>).mock
-      .calls[0]
-    const conditions = whereArgs[0] as unknown[][]
-    // One condition should be [tagChannelModel.workspaceId, "ws-specific"]
-    const wsCondition = conditions.find(
-      (c) => Array.isArray(c) && c[1] === "ws-specific",
-    )
-    expect(wsCondition).toBeDefined()
-  })
-
-  test("scopes delete by integrationId and externalLabelId", async () => {
-    await handleMessengerLabelWebhook(
-      makeData(
-        makePayload({
-          action: "delete_label",
-          label: { id: "specific-label-ext-id" },
-        }),
-      ),
-    )
-
-    const whereArgs = (deleteChain.where as ReturnType<typeof vi.fn>).mock
-      .calls[0]
-    const conditions = whereArgs[0] as unknown[][]
-    // externalLabelId condition
-    const labelCondition = conditions.find(
-      (c) => Array.isArray(c) && c[1] === "specific-label-ext-id",
-    )
-    expect(labelCondition).toBeDefined()
-    // integrationId condition
-    const integrationCondition = conditions.find(
-      (c) => Array.isArray(c) && c[1] === INTEGRATION_ID,
-    )
-    expect(integrationCondition).toBeDefined()
   })
 })
 
@@ -833,6 +559,95 @@ describe("handleMessengerLabelWebhook — remove_label", () => {
       (c) => Array.isArray(c) && c[1] === "ci-specific",
     )
     expect(ciCondition).toBeDefined()
+  })
+})
+
+describe("handleMessengerLabelWebhook — short action aliases (add/remove)", () => {
+  beforeEach(() => {
+    queryResults.integrationMessengerFindFirst = makeIntegration()
+  })
+
+  test("'remove' behaves like remove_label (unassigns)", async () => {
+    queryResults.contactInboxFindFirst = { id: "ci-1", contactId: "contact-1" }
+    queryResults.tagChannelFindFirst = { id: "tc-1", tagId: "tag-1" }
+
+    await handleMessengerLabelWebhook(
+      makeData(
+        makePayload({
+          action: "remove",
+          user: { id: USER_PSID },
+          label: { id: LABEL_ID },
+        }),
+      ),
+    )
+
+    expect(dbDelete).toHaveBeenCalledWith(contactToTagChannelModel)
+    expect(loggerWarn).not.toHaveBeenCalled()
+  })
+
+  test("'add' assigns when the tag channel already exists", async () => {
+    queryResults.contactInboxFindFirst = { id: "ci-1", contactId: "contact-1" }
+    queryResults.tagChannelFindFirst = { id: "tc-1", tagId: "tag-1" }
+
+    await handleMessengerLabelWebhook(
+      makeData(
+        makePayload({
+          action: "add",
+          user: { id: USER_PSID },
+          label: { id: LABEL_ID },
+        }),
+      ),
+    )
+
+    expect(dbInsert).toHaveBeenCalledWith(contactsToTagsModel)
+    expect(dbInsert).toHaveBeenCalledWith(contactToTagChannelModel)
+    expect(loggerWarn).not.toHaveBeenCalled()
+  })
+})
+
+describe("handleMessengerLabelWebhook — add creates missing tag", () => {
+  beforeEach(() => {
+    queryResults.integrationMessengerFindFirst = makeIntegration()
+    queryResults.contactInboxFindFirst = { id: "ci-1", contactId: "contact-1" }
+    queryResults.tagChannelFindFirst = null // not synced locally yet
+  })
+
+  test("creates tag + channel from page_label_name in payload, then assigns", async () => {
+    queryResults.tagModelFindFirst = null
+    insertReturning.current = [{ id: "new-id" }]
+
+    await handleMessengerLabelWebhook(
+      makeData(
+        makePayload({
+          action: "add",
+          user: { id: USER_PSID },
+          label: { id: LABEL_ID, page_label_name: LABEL_NAME },
+        }),
+      ),
+    )
+
+    // upsert created the tag + channel, then assigned to the contact
+    expect(dbInsert).toHaveBeenCalledWith(tagModel)
+    expect(dbInsert).toHaveBeenCalledWith(tagChannelModel)
+    expect(dbInsert).toHaveBeenCalledWith(contactsToTagsModel)
+    expect(dbInsert).toHaveBeenCalledWith(contactToTagChannelModel)
+    expect(loggerWarn).not.toHaveBeenCalled()
+  })
+
+  test("skips when the tag is missing and the payload carries no name", async () => {
+    queryResults.tagModelFindFirst = null
+
+    await handleMessengerLabelWebhook(
+      makeData(
+        makePayload({
+          action: "add",
+          user: { id: USER_PSID },
+          label: { id: LABEL_ID }, // no page_label_name
+        }),
+      ),
+    )
+
+    expect(dbInsert).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/worker/__tests__/sync-tag-delete.test.ts
+++ b/apps/worker/__tests__/sync-tag-delete.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, test, vi } from "vitest"
 
 // ── db spies ──────────────────────────────────────────────────────────────────
 const findManyTagChannel = vi.fn()
+const findManyContactToTagChannel = vi.fn()
+const findManyContactsToTags = vi.fn()
+const findManyContactInbox = vi.fn()
 const findMessengerIntegrationFirst = vi.fn()
 const findZaloIntegrationFirst = vi.fn()
 
@@ -18,6 +21,15 @@ vi.mock("@chatbotx.io/database/client", () => ({
       tagChannelModel: {
         findMany: (...args: unknown[]) => findManyTagChannel(...args),
       },
+      contactToTagChannelModel: {
+        findMany: (...args: unknown[]) => findManyContactToTagChannel(...args),
+      },
+      contactsToTagsModel: {
+        findMany: (...args: unknown[]) => findManyContactsToTags(...args),
+      },
+      contactInboxModel: {
+        findMany: (...args: unknown[]) => findManyContactInbox(...args),
+      },
       integrationMessengerModel: {
         findFirst: (...args: unknown[]) =>
           findMessengerIntegrationFirst(...args),
@@ -25,7 +37,6 @@ vi.mock("@chatbotx.io/database/client", () => ({
       integrationZaloModel: {
         findFirst: (...args: unknown[]) => findZaloIntegrationFirst(...args),
       },
-      contactInboxModel: { findFirst: vi.fn().mockResolvedValue(null) },
     },
     delete: (model: unknown) => ({
       where: (cond: unknown) => {
@@ -46,13 +57,32 @@ vi.mock("@chatbotx.io/database/schema", () => ({
     __name: "ContactToTagChannel",
     tagId: "ContactToTagChannel.tagId",
     tagChannelId: "ContactToTagChannel.tagChannelId",
+    contactInboxId: "ContactToTagChannel.contactInboxId",
   },
-  tagChannelModel: { __name: "TagChannel" },
-  contactsToTagsModel: { __name: "ContactsToTags" },
-  tagModel: { __name: "Tag", deletedAt: "Tag.deletedAt" },
+  tagChannelModel: { __name: "TagChannel", id: "TagChannel.id" },
+  contactsToTagsModel: {
+    __name: "ContactsToTags",
+    tagId: "ContactsToTags.tagId",
+    contactId: "ContactsToTags.contactId",
+  },
+  tagModel: { __name: "Tag", id: "Tag.id", deletedAt: "Tag.deletedAt" },
   contactInboxModel: { __name: "ContactInbox" },
   integrationMessengerModel: { __name: "IntegrationMessenger" },
   integrationZaloModel: { __name: "IntegrationZalo" },
+}))
+
+vi.mock("@chatbotx.io/database/utils", () => ({
+  // Single-pass chunkById: the query builder pages by id; with our small fixed
+  // result sets it returns < chunkSize on the first call and stops.
+  chunkById: async (
+    queryBuilder: (lastId: string | null) => Promise<{ id: string }[]>,
+    options: { callback: (rows: { id: string }[]) => Promise<unknown> },
+  ) => {
+    const rows = await queryBuilder(null)
+    if (rows.length > 0) {
+      await options.callback(rows)
+    }
+  },
 }))
 
 vi.mock("@chatbotx.io/business", () => ({
@@ -132,11 +162,23 @@ const ENABLED_ZALO = {
 const runDelete = () =>
   handleSyncTag({ action: "delete", workspaceId: WS, tagId: TAG_ID })
 
-// Helper: extract __name from a model sentinel
+const runScopedDelete = (channelType: string, integrationId: string) =>
+  handleSyncTag({
+    action: "delete",
+    workspaceId: WS,
+    tagId: TAG_ID,
+    channelType: channelType as "messenger" | "zalo",
+    integrationId,
+  })
+
 const modelName = (m: unknown) => (m as { __name: string }).__name
+const deletedModelNames = () => dbDeleteCalls.map((c) => modelName(c.model))
 
 beforeEach(() => {
   findManyTagChannel.mockReset()
+  findManyContactToTagChannel.mockReset()
+  findManyContactsToTags.mockReset()
+  findManyContactInbox.mockReset()
   findMessengerIntegrationFirst.mockReset()
   findZaloIntegrationFirst.mockReset()
   messengerDeleteLabel.mockReset()
@@ -144,112 +186,75 @@ beforeEach(() => {
   dbDeleteCalls.length = 0
 
   findManyTagChannel.mockResolvedValue([])
+  findManyContactToTagChannel.mockResolvedValue([])
+  findManyContactsToTags.mockResolvedValue([])
+  findManyContactInbox.mockResolvedValue([])
   findMessengerIntegrationFirst.mockResolvedValue(ENABLED_MESSENGER)
   findZaloIntegrationFirst.mockResolvedValue(ENABLED_ZALO)
   messengerDeleteLabel.mockResolvedValue(undefined)
   zaloRemoveTag.mockResolvedValue(undefined)
 })
 
-describe("syncTagDelete — child cleanup order", () => {
-  test("reads TagChannel rows for the tag before any delete", async () => {
-    await runDelete()
-    expect(findManyTagChannel).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({ tagId: TAG_ID }),
-      }),
-    )
-  })
-
-  test("deletes ContactToTagChannel first (step 3)", async () => {
-    await runDelete()
-    expect(modelName(dbDeleteCalls[0]?.model)).toBe("ContactToTagChannel")
-  })
-
-  test("deletes TagChannel second (step 4)", async () => {
-    await runDelete()
-    expect(modelName(dbDeleteCalls[1]?.model)).toBe("TagChannel")
-  })
-
-  test("deletes ContactsToTags third (step 5)", async () => {
-    await runDelete()
-    expect(modelName(dbDeleteCalls[2]?.model)).toBe("ContactsToTags")
-  })
-
-  test("hard-deletes Tag last (step 6)", async () => {
-    await runDelete()
-    expect(modelName(dbDeleteCalls[3]?.model)).toBe("Tag")
-  })
-
-  test("deletion order: ContactToTagChannel → TagChannel → ContactsToTags → Tag", async () => {
-    await runDelete()
-    expect(dbDeleteCalls).toHaveLength(4)
-    expect(dbDeleteCalls.map((c) => modelName(c.model))).toEqual([
-      "ContactToTagChannel",
-      "TagChannel",
-      "ContactsToTags",
-      "Tag",
-    ])
-  })
-
-  test("hard-delete WHERE includes isNotNull(deletedAt) guard", async () => {
-    await runDelete()
-    const condStr = JSON.stringify(dbDeleteCalls[3]?.condition)
-    expect(condStr).toContain("isNotNull")
-  })
-})
-
-describe("syncTagDelete — ContactToTagChannel scoping", () => {
-  test("no channels: deletes ContactToTagChannel by bare tagId (fallback)", async () => {
-    findManyTagChannel.mockResolvedValue([])
-
-    await runDelete()
-
-    const condStr = JSON.stringify(dbDeleteCalls[0]?.condition)
-    // fallback uses eq(tagId) not inArray(tagChannelId)
-    expect(condStr).toContain("ContactToTagChannel.tagId")
-    expect(condStr).not.toContain("inArray")
-  })
-
-  test("with channels: deletes ContactToTagChannel by tagChannelId via inArray", async () => {
+// ============================================================================
+// Full workspace delete (delete-tag-action): callApi=true + Tag row removed
+// ============================================================================
+describe("syncTagDelete — full workspace delete", () => {
+  test("does NOT call any channel label API (temporarily disabled)", async () => {
     findManyTagChannel.mockResolvedValue([MESSENGER_CHANNEL, ZALO_CHANNEL])
 
     await runDelete()
 
-    const condStr = JSON.stringify(dbDeleteCalls[0]?.condition)
-    expect(condStr).toContain("inArray")
-    expect(condStr).toContain("tc-1")
-    expect(condStr).toContain("tc-2")
+    expect(messengerDeleteLabel).not.toHaveBeenCalled()
+    expect(zaloRemoveTag).not.toHaveBeenCalled()
+    // cleanup + Tag delete still happen
+    expect(deletedModelNames().at(-1)).toBe("Tag")
   })
-})
 
-describe("syncTagDelete — channel label deletion", () => {
-  test("messenger channel: calls deleteLabel API with externalLabelId", async () => {
+  test("hard-deletes the Tag row LAST, with the isNotNull(deletedAt) guard", async () => {
     findManyTagChannel.mockResolvedValue([MESSENGER_CHANNEL])
 
     await runDelete()
 
-    expect(messengerDeleteLabel).toHaveBeenCalledTimes(1)
-    expect(messengerDeleteLabel).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          labelId: MESSENGER_CHANNEL.externalLabelId,
-        }),
-      }),
-    )
+    const last = dbDeleteCalls.at(-1)
+    expect(modelName(last?.model)).toBe("Tag")
+    expect(JSON.stringify(last?.condition)).toContain("isNotNull")
   })
 
-  test("zalo channel: calls removeTag API with externalLabelId", async () => {
-    findManyTagChannel.mockResolvedValue([ZALO_CHANNEL])
+  test("per channel: deletes ContactToTagChannel + ContactsToTags + TagChannel, then Tag", async () => {
+    findManyTagChannel.mockResolvedValue([MESSENGER_CHANNEL])
+    findManyContactToTagChannel.mockResolvedValue([{ contactInboxId: "ci-1" }])
+    findManyContactInbox.mockResolvedValue([{ contactId: "c-1" }])
 
     await runDelete()
 
-    expect(zaloRemoveTag).toHaveBeenCalledTimes(1)
-    expect(zaloRemoveTag).toHaveBeenCalledWith(
-      expect.objectContaining({ tagName: ZALO_CHANNEL.externalLabelId }),
-    )
+    const names = deletedModelNames()
+    expect(names).toContain("ContactToTagChannel")
+    expect(names).toContain("ContactsToTags")
+    expect(names).toContain("TagChannel")
+    expect(names.at(-1)).toBe("Tag")
   })
 
-  test("skips messenger label delete when integration sync disabled", async () => {
+  test("catch-all removes manually-applied ContactToTag (no channel mapping)", async () => {
+    findManyTagChannel.mockResolvedValue([]) // tag never synced to a channel
+    findManyContactsToTags.mockResolvedValue([{ contactId: "c-manual" }])
+
+    await runDelete()
+
+    const names = deletedModelNames()
+    expect(names).toContain("ContactsToTags")
+    expect(names.at(-1)).toBe("Tag")
+  })
+
+  test("no channels, no manual links → only the Tag row is deleted", async () => {
+    findManyTagChannel.mockResolvedValue([])
+    findManyContactsToTags.mockResolvedValue([])
+
+    await runDelete()
+
+    expect(deletedModelNames()).toEqual(["Tag"])
+  })
+
+  test("deletes the Tag regardless of integration sync state (API disabled)", async () => {
     findManyTagChannel.mockResolvedValue([MESSENGER_CHANNEL])
     findMessengerIntegrationFirst.mockResolvedValue({
       ...ENABLED_MESSENGER,
@@ -259,26 +264,38 @@ describe("syncTagDelete — channel label deletion", () => {
     await runDelete()
 
     expect(messengerDeleteLabel).not.toHaveBeenCalled()
-    // DB cleanup still proceeds
-    expect(dbDeleteCalls).toHaveLength(4)
+    expect(deletedModelNames().at(-1)).toBe("Tag")
+  })
+})
+
+// ============================================================================
+// Channel-scoped delete (inbound webhook): no API, no Tag row
+// ============================================================================
+describe("syncTagDelete — channel-scoped (webhook)", () => {
+  test("does NOT call the channel API and does NOT delete the Tag row", async () => {
+    findManyTagChannel.mockResolvedValue([ZALO_CHANNEL])
+    findManyContactToTagChannel.mockResolvedValue([{ contactInboxId: "ci-1" }])
+    findManyContactInbox.mockResolvedValue([{ contactId: "c-1" }])
+
+    await runScopedDelete("zalo", "zalo-int-1")
+
+    // The channel already removed the label → no API call.
+    expect(zaloRemoveTag).not.toHaveBeenCalled()
+    expect(messengerDeleteLabel).not.toHaveBeenCalled()
+
+    const names = deletedModelNames()
+    expect(names).toContain("ContactToTagChannel")
+    expect(names).toContain("ContactsToTags")
+    expect(names).toContain("TagChannel")
+    // Tag row is kept.
+    expect(names).not.toContain("Tag")
   })
 
-  test("continues DB cleanup even when channel API throws", async () => {
-    findManyTagChannel.mockResolvedValue([MESSENGER_CHANNEL])
-    messengerDeleteLabel.mockRejectedValue(new Error("Facebook API down"))
+  test("no-op when the tag is not mapped on that channel", async () => {
+    findManyTagChannel.mockResolvedValue([])
 
-    await runDelete()
+    await runScopedDelete("zalo", "zalo-int-1")
 
-    expect(dbDeleteCalls).toHaveLength(4)
-  })
-
-  test("deletes labels on every channel before DB cleanup", async () => {
-    findManyTagChannel.mockResolvedValue([MESSENGER_CHANNEL, ZALO_CHANNEL])
-
-    await runDelete()
-
-    expect(messengerDeleteLabel).toHaveBeenCalledTimes(1)
-    expect(zaloRemoveTag).toHaveBeenCalledTimes(1)
-    expect(dbDeleteCalls).toHaveLength(4)
+    expect(dbDeleteCalls).toHaveLength(0)
   })
 })

--- a/apps/worker/__tests__/sync-tag.test.ts
+++ b/apps/worker/__tests__/sync-tag.test.ts
@@ -18,6 +18,8 @@ const queryResults = {
   integrationMessengerFindFirst: null as unknown,
   integrationZaloFindFirst: null as unknown,
   contactInboxFindMany: [] as unknown[],
+  contactToTagChannelFindMany: [] as unknown[],
+  contactsToTagsFindMany: [] as unknown[],
   selectRows: [] as unknown[],
 }
 
@@ -92,6 +94,12 @@ vi.mock("@chatbotx.io/database/client", () => ({
       },
       contactInboxModel: {
         findMany: vi.fn(async () => queryResults.contactInboxFindMany),
+      },
+      contactToTagChannelModel: {
+        findMany: vi.fn(async () => queryResults.contactToTagChannelFindMany),
+      },
+      contactsToTagsModel: {
+        findMany: vi.fn(async () => queryResults.contactsToTagsFindMany),
       },
     },
     insert: vi.fn(() => insertChain),
@@ -259,6 +267,8 @@ beforeEach(() => {
   queryResults.integrationMessengerFindFirst = null
   queryResults.integrationZaloFindFirst = null
   queryResults.contactInboxFindMany = []
+  queryResults.contactToTagChannelFindMany = []
+  queryResults.contactsToTagsFindMany = []
   queryResults.selectRows = []
   insertReturning.current = []
   updateReturning.current = []
@@ -847,7 +857,7 @@ describe("syncTagDetach", () => {
 // ===========================================================================
 
 describe("syncTagDelete", () => {
-  test("messenger channel → deleteLabel called with correct labelId", async () => {
+  test("messenger channel → label API NOT called (temporarily disabled), tag deleted", async () => {
     const channel = {
       channelType: "messenger",
       integrationId: "intg-msg-1",
@@ -862,19 +872,12 @@ describe("syncTagDelete", () => {
       tagId: "tag-1",
     })
 
-    expect(messengerRunChannelHandler).toHaveBeenCalledWith(
-      "bot",
-      "deleteLabel",
-      expect.objectContaining({
-        ctx: fakeCtx,
-        data: { labelId: channel.externalLabelId },
-      }),
-    )
+    expect(messengerRunChannelHandler).not.toHaveBeenCalled()
     // tag row deleted
     expect(db.delete).toHaveBeenCalled()
   })
 
-  test("zalo channel → removeTag called with correct tagName", async () => {
+  test("zalo channel → label API NOT called (temporarily disabled), tag deleted", async () => {
     const channel = {
       channelType: "zalo",
       integrationId: "intg-zalo-1",
@@ -889,17 +892,11 @@ describe("syncTagDelete", () => {
       tagId: "tag-1",
     })
 
-    expect(zaloRunAction).toHaveBeenCalledWith(
-      "removeTag",
-      expect.objectContaining({
-        ctx: fakeCtx,
-        tagName: channel.externalLabelId,
-      }),
-    )
+    expect(zaloRunAction).not.toHaveBeenCalled()
     expect(db.delete).toHaveBeenCalled()
   })
 
-  test("error isolation — first channel delete failure does not abort second channel or tag delete", async () => {
+  test("processes every channel then deletes the tag row", async () => {
     const ch1 = {
       channelType: "messenger",
       integrationId: "intg-msg-1",
@@ -911,13 +908,7 @@ describe("syncTagDelete", () => {
       externalLabelId: "label-2",
     }
     queryResults.tagChannelFindMany = [ch1, ch2]
-    // First integration has sync enabled, second also
     queryResults.integrationMessengerFindFirst = makeMessengerIntegration()
-
-    // First deleteLabel throws
-    messengerRunChannelHandler
-      .mockRejectedValueOnce(new Error("FB error"))
-      .mockResolvedValueOnce(undefined)
 
     await expect(
       handleSyncTag({
@@ -927,11 +918,8 @@ describe("syncTagDelete", () => {
       }),
     ).resolves.toBeUndefined()
 
-    // Both channels attempted
-    expect(messengerRunChannelHandler).toHaveBeenCalledTimes(2)
     // Tag row delete still called
     expect(db.delete).toHaveBeenCalled()
-    expect(logger.warn).toHaveBeenCalled()
   })
 
   test("sync-disabled context (syncTagEnabledAt=null) → skip API but still delete tag row", async () => {
@@ -970,7 +958,7 @@ describe("syncTagDelete", () => {
     expect(db.delete).toHaveBeenCalled()
   })
 
-  test("multiple channels (messenger + zalo) — both API calls made then tag deleted", async () => {
+  test("multiple channels (messenger + zalo) → no API calls, tag deleted", async () => {
     const messengerChannel = {
       channelType: "messenger",
       integrationId: "intg-msg-1",
@@ -991,12 +979,49 @@ describe("syncTagDelete", () => {
       tagId: "tag-1",
     })
 
-    expect(messengerRunChannelHandler).toHaveBeenCalledWith(
-      "bot",
-      "deleteLabel",
-      expect.anything(),
-    )
-    expect(zaloRunAction).toHaveBeenCalledWith("removeTag", expect.anything())
+    expect(messengerRunChannelHandler).not.toHaveBeenCalled()
+    expect(zaloRunAction).not.toHaveBeenCalled()
     expect(db.delete).toHaveBeenCalled()
+  })
+
+  // ── channel-scoped delete (inbound webhook) ──────────────────────────────
+
+  test("channel-scoped → deletes only this channel's rows + contacts, keeps Tag, no channel API", async () => {
+    queryResults.tagChannelFindMany = [makeTagChannel()] // id tc-1, messenger
+    queryResults.contactToTagChannelFindMany = [{ contactInboxId: "ci-1" }]
+    queryResults.contactInboxFindMany = [{ contactId: "contact-1" }]
+
+    await handleSyncTag({
+      action: "delete",
+      workspaceId: "ws-1",
+      tagId: "tag-1",
+      channelType: "messenger",
+      integrationId: "intg-msg-1",
+    })
+
+    // Inbound webhook: the channel already removed the label → no API call.
+    expect(messengerRunChannelHandler).not.toHaveBeenCalled()
+    // chunkById paged the channel's contact assignments
+    expect(
+      db.query.contactToTagChannelModel.findMany as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalled()
+    // exactly 3 deletes: contactToTagChannel + contactsToTags + tagChannel.
+    // The Tag row is NOT deleted (workspace delete = 4).
+    expect(db.delete).toHaveBeenCalledTimes(3)
+  })
+
+  test("channel-scoped → no-op when the tag is not mapped on that channel", async () => {
+    queryResults.tagChannelFindMany = []
+
+    await handleSyncTag({
+      action: "delete",
+      workspaceId: "ws-1",
+      tagId: "tag-1",
+      channelType: "messenger",
+      integrationId: "intg-msg-1",
+    })
+
+    expect(messengerRunChannelHandler).not.toHaveBeenCalled()
+    expect(db.delete).not.toHaveBeenCalled()
   })
 })

--- a/apps/worker/src/default/handlers/sync-tag.ts
+++ b/apps/worker/src/default/handlers/sync-tag.ts
@@ -13,6 +13,7 @@ import type {
   IntegrationMessengerModel,
   IntegrationZaloModel,
 } from "@chatbotx.io/database/types"
+import { chunkById } from "@chatbotx.io/database/utils"
 import { integration as integrationMessenger } from "@chatbotx.io/integration-messenger"
 import type { MessengerAuthValue } from "@chatbotx.io/integration-messenger/schema"
 import { integration as integrationZalo } from "@chatbotx.io/integration-zalo"
@@ -21,6 +22,8 @@ import { distributedLock } from "@chatbotx.io/redis"
 import { createId } from "@chatbotx.io/utils"
 import type { JobSyncTag } from "@chatbotx.io/worker-config"
 import { logger } from "../../lib/logger"
+
+const DELETE_CHUNK_SIZE = 500
 
 type TagWithName = { id: string; name: string; workspaceId: string }
 
@@ -465,14 +468,130 @@ async function unassignOnChannel(props: {
 // local Tag row (cascading TagChannel / ContactToTagChannel / ContactToTag).
 // ---------------------------------------------------------------------------
 
-async function syncTagDelete(props: {
+async function syncTagDelete(props: JobSyncTagDelete): Promise<void> {
+  const { workspaceId, tagId, channelType, integrationId } = props
+
+  // Channel-scoped delete (inbound webhook): the tag was deleted on ONE channel.
+  // Clean only that channel's mappings + the contacts tagged via it; keep the
+  // workspace Tag and every other channel intact. The channel already removed
+  // the label, so we do NOT call its API again (callApi: false).
+  if (channelType && integrationId) {
+    const channels = await db.query.tagChannelModel.findMany({
+      where: { tagId, workspaceId, channelType, integrationId },
+      columns: {
+        id: true,
+        channelType: true,
+        integrationId: true,
+        externalLabelId: true,
+      },
+    })
+    for (const channel of channels) {
+      await deleteTagOnChannel({ workspaceId, tagId, channel, callApi: false })
+    }
+    return
+  }
+
+  await deleteTagOnChannels({ workspaceId, tagId })
+}
+
+type JobSyncTagDelete = Extract<JobSyncTag["data"], { action: "delete" }>
+
+type TagChannelRef = {
+  id: string
+  channelType: string
+  integrationId: string
+  externalLabelId: string
+}
+
+/**
+ * Cleanup for a tag on a SINGLE channel (the reusable unit).
+ * Deletes that channel's ContactToTagChannel + the ContactToTag for exactly its
+ * contacts (id-paged via chunkById) + the TagChannel row. Does NOT touch the Tag
+ * row. `callApi: true` also deletes the label on the channel via the SDK
+ * (outbound delete); inbound webhooks pass false since the label is already gone.
+ */
+async function deleteTagOnChannel(props: {
+  workspaceId: string
+  tagId: string
+  channel: TagChannelRef
+  callApi: boolean
+}): Promise<void> {
+  const { workspaceId, tagId, channel, callApi } = props
+
+  if (callApi) {
+    try {
+      await deleteLabelOnChannel({ workspaceId, channel })
+    } catch (error) {
+      logger.warn(
+        { tagId, channel, error },
+        "syncTag(delete): skip per-channel API error",
+      )
+    }
+  }
+
+  // Page this channel's contact assignments by contactInboxId, deleting the
+  // channel rows + the workspace tag for those contacts as we go.
+  await chunkById(
+    (lastId) =>
+      db.query.contactToTagChannelModel
+        .findMany({
+          where: {
+            tagChannelId: { in: [channel.id] },
+            ...(lastId ? { contactInboxId: { gt: lastId } } : {}),
+          },
+          orderBy: { contactInboxId: "asc" },
+          limit: DELETE_CHUNK_SIZE,
+          columns: { contactInboxId: true },
+        })
+        .then((rows) => rows.map((row) => ({ id: row.contactInboxId }))),
+    {
+      chunkSize: DELETE_CHUNK_SIZE,
+      callback: async (batch) => {
+        const contactInboxIds = batch.map((row) => row.id)
+
+        const inboxes = await db.query.contactInboxModel.findMany({
+          where: { id: { in: contactInboxIds } },
+          columns: { contactId: true },
+        })
+        const contactIds = [...new Set(inboxes.map((inbox) => inbox.contactId))]
+
+        await db
+          .delete(contactToTagChannelModel)
+          .where(
+            and(
+              eq(contactToTagChannelModel.tagChannelId, channel.id),
+              inArray(contactToTagChannelModel.contactInboxId, contactInboxIds),
+            ),
+          )
+
+        if (contactIds.length > 0) {
+          await db
+            .delete(contactsToTagsModel)
+            .where(
+              and(
+                eq(contactsToTagsModel.tagId, tagId),
+                inArray(contactsToTagsModel.contactId, contactIds),
+              ),
+            )
+        }
+        return true
+      },
+    },
+  )
+
+  await db.delete(tagChannelModel).where(eq(tagChannelModel.id, channel.id))
+}
+
+/**
+ * Full workspace delete (delete-tag-action): removes the tag from EVERY channel
+ * (via deleteTagOnChannel, calling each channel's API) and deletes the Tag row.
+ */
+async function deleteTagOnChannels(props: {
   workspaceId: string
   tagId: string
 }): Promise<void> {
   const { workspaceId, tagId } = props
 
-  // Read mappings BEFORE the local delete so the external label ids are
-  // available for the API calls.
   const channels = await db.query.tagChannelModel.findMany({
     where: { tagId, workspaceId },
     columns: {
@@ -483,41 +602,52 @@ async function syncTagDelete(props: {
     },
   })
 
+  // Isolate per-channel failures so one bad channel can't block the others or
+  // the final Tag delete.
+  // NOTE: calling the channel API to delete the label is temporarily disabled
+  // (callApi: false). Flip back to true to remove the label on the channel too.
   for (const channel of channels) {
     try {
-      await deleteLabelOnChannel({ workspaceId, channel })
+      await deleteTagOnChannel({ workspaceId, tagId, channel, callApi: false })
     } catch (error) {
       logger.warn(
         { tagId, channel, error },
-        "syncTag(delete): skip per-channel delete error",
+        "syncTag(delete): skip per-channel cleanup error",
       )
     }
   }
 
-  const tagChannelIds = channels.map((c) => c.id)
-
-  // Explicit child cleanup in dependency order (no reliance on FK cascade).
-  // Scope by tagChannelId (workspace-scoped) rather than bare tagId for defense-in-depth.
-  await db
-    .delete(contactToTagChannelModel)
-    .where(
-      tagChannelIds.length > 0
-        ? inArray(contactToTagChannelModel.tagChannelId, tagChannelIds)
-        : eq(contactToTagChannelModel.tagId, tagId),
-    )
-
-  await db
-    .delete(tagChannelModel)
-    .where(
-      and(
-        eq(tagChannelModel.tagId, tagId),
-        eq(tagChannelModel.workspaceId, workspaceId),
-      ),
-    )
-
-  await db
-    .delete(contactsToTagsModel)
-    .where(eq(contactsToTagsModel.tagId, tagId))
+  // Catch-all for ContactToTag applied manually (no channel mapping). ContactToTag
+  // has a composite PK (no `id`), so page by contactId.
+  await chunkById(
+    (lastId) =>
+      db.query.contactsToTagsModel
+        .findMany({
+          where: {
+            tagId,
+            ...(lastId ? { contactId: { gt: lastId } } : {}),
+          },
+          orderBy: { contactId: "asc" },
+          limit: DELETE_CHUNK_SIZE,
+          columns: { contactId: true },
+        })
+        .then((rows) => rows.map((row) => ({ id: row.contactId }))),
+    {
+      chunkSize: DELETE_CHUNK_SIZE,
+      callback: async (batch) => {
+        const contactIds = batch.map((row) => row.id)
+        await db
+          .delete(contactsToTagsModel)
+          .where(
+            and(
+              eq(contactsToTagsModel.tagId, tagId),
+              inArray(contactsToTagsModel.contactId, contactIds),
+            ),
+          )
+        return true
+      },
+    },
+  )
 
   await db
     .delete(tagModel)

--- a/apps/worker/src/integration/handlers/inbox_labels/channels/messenger.ts
+++ b/apps/worker/src/integration/handlers/inbox_labels/channels/messenger.ts
@@ -1,0 +1,58 @@
+import { db } from "@chatbotx.io/database/client"
+import { channelTypes } from "@chatbotx.io/database/partials"
+import { messengerWebhookEventSchema } from "@chatbotx.io/integration-messenger/schema"
+import type { Channel } from "../types"
+
+/**
+ * Facebook Messenger custom labels.
+ * - Resolve the page integration by `pageId`.
+ * - Webhook field `inbox_labels`, action `add` / `remove` for a single user.
+ *   Facebook includes the label name (`page_label_name`) on these events, so a
+ *   tag can be created locally on the fly.
+ */
+export const messengerChannel: Channel = {
+  async loadContext(pageId) {
+    const integration = await db.query.integrationMessengerModel.findFirst({
+      where: { pageId },
+    })
+    if (!integration?.syncTagEnabledAt) {
+      return null
+    }
+    return {
+      channelType: channelTypes.enum.messenger,
+      workspaceId: integration.workspaceId,
+      integrationId: integration.id,
+      inboxId: integration.inboxId,
+    }
+  },
+
+  toEvents(payload) {
+    const parsed = messengerWebhookEventSchema.safeParse(payload)
+    if (!parsed.success) {
+      return null
+    }
+
+    const change = parsed.data.entry[0]?.changes?.find(
+      (entryChange) => entryChange.field === "inbox_labels",
+    )
+    if (!change) {
+      return []
+    }
+
+    const { action, user, label } = change.value
+    if (action === "add" && user) {
+      return [
+        {
+          type: "assign",
+          labelId: label.id,
+          labelName: label.page_label_name ?? "",
+          userIds: [user.id],
+        },
+      ]
+    }
+    if (action === "remove" && user) {
+      return [{ type: "unassign", labelId: label.id, userIds: [user.id] }]
+    }
+    return []
+  },
+}

--- a/apps/worker/src/integration/handlers/inbox_labels/channels/zalo.ts
+++ b/apps/worker/src/integration/handlers/inbox_labels/channels/zalo.ts
@@ -1,0 +1,59 @@
+import { db } from "@chatbotx.io/database/client"
+import { channelTypes } from "@chatbotx.io/database/partials"
+import { z } from "zod"
+import type { Channel } from "../types"
+
+/**
+ * Zalo OA tags. Tags are identified by NAME (the name is the external id).
+ * - Resolve the OA integration by `oaId`.
+ * - Events: `add_user_to_tag` / `remove_user_from_tag` (batch of user ids,
+ *   up to 200) and `remove_tag` (delete the whole label).
+ */
+const zaloTagEventSchema = z.object({
+  app_id: z.string().optional(),
+  event_name: z.enum(["add_user_to_tag", "remove_user_from_tag", "remove_tag"]),
+  oa_id: z.string(),
+  tag: z.object({
+    name: z.string(),
+    user_ids: z.array(z.string()).max(200).optional(),
+  }),
+  timestamp: z.string().optional(),
+})
+
+export const zaloChannel: Channel = {
+  async loadContext(oaId) {
+    const integration = await db.query.integrationZaloModel.findFirst({
+      where: { oaId },
+    })
+    if (!integration?.syncTagEnabledAt) {
+      return null
+    }
+    return {
+      channelType: channelTypes.enum.zalo,
+      workspaceId: integration.workspaceId,
+      integrationId: integration.id,
+      inboxId: integration.inboxId,
+    }
+  },
+
+  toEvents(payload) {
+    const parsed = zaloTagEventSchema.safeParse(payload)
+    if (!parsed.success) {
+      return null
+    }
+
+    const { event_name, tag } = parsed.data
+    const userIds = tag.user_ids ?? []
+
+    if (event_name === "add_user_to_tag") {
+      // Empty user_ids → ensure the label exists locally (no assignment).
+      return [
+        { type: "assign", labelId: tag.name, labelName: tag.name, userIds },
+      ]
+    }
+    if (event_name === "remove_user_from_tag") {
+      return [{ type: "unassign", labelId: tag.name, userIds }]
+    }
+    return [{ type: "deleteLabel", labelId: tag.name }]
+  },
+}

--- a/apps/worker/src/integration/handlers/inbox_labels/index.ts
+++ b/apps/worker/src/integration/handlers/inbox_labels/index.ts
@@ -1,0 +1,53 @@
+import { logger } from "../../../lib/logger"
+import { messengerChannel } from "./channels/messenger"
+import { zaloChannel } from "./channels/zalo"
+import { applyEvent } from "./sync"
+import type { Channel, ChannelLabelWebhookData, ChannelType } from "./types"
+
+export type { ChannelLabelWebhookData } from "./types"
+
+/**
+ * Channel registry. Add a new channel by implementing a `Channel` and
+ * registering it here — nothing else in this folder needs to change.
+ */
+const CHANNELS: Record<ChannelType, Channel> = {
+  messenger: messengerChannel,
+  zalo: zaloChannel,
+}
+
+/**
+ * Single entry point for every inbox-label webhook (mirror channel labels/tags
+ * into local tags). Flow: resolve channel → load context → normalize payload to
+ * events → apply each event via the shared core.
+ */
+export async function handleChannelLabelWebhook(
+  data: ChannelLabelWebhookData,
+): Promise<void> {
+  const channel = CHANNELS[data.integrationType]
+  if (!channel) {
+    logger.warn(
+      { channel: data.integrationType },
+      "inbox labels: unsupported channel",
+    )
+    return
+  }
+
+  // null → integration not found OR tag sync disabled
+  const ctx = await channel.loadContext(data.integrationIdentifier)
+  if (!ctx) {
+    return
+  }
+
+  const events = channel.toEvents(data.payload)
+  if (events === null) {
+    logger.warn(
+      { channel: data.integrationType },
+      "inbox labels: invalid payload",
+    )
+    return
+  }
+
+  for (const event of events) {
+    await applyEvent(ctx, event)
+  }
+}

--- a/apps/worker/src/integration/handlers/inbox_labels/sync.ts
+++ b/apps/worker/src/integration/handlers/inbox_labels/sync.ts
@@ -1,0 +1,289 @@
+import { tagSyncService } from "@chatbotx.io/business"
+import { and, db, eq, inArray, isNull } from "@chatbotx.io/database/client"
+import {
+  contactsToTagsModel,
+  contactToTagChannelModel,
+  tagChannelModel,
+  tagModel,
+} from "@chatbotx.io/database/schema"
+import { emitTagApplied, emitTagRemoved } from "@chatbotx.io/events"
+import { createId } from "@chatbotx.io/utils"
+import { logger } from "../../../lib/logger"
+import type { LabelContext, LabelEvent } from "./types"
+
+/**
+ * Apply one normalized label event. Channel-agnostic: the channel identity
+ * lives in `ctx`, so every DB operation here is written once and reused by
+ * every channel.
+ */
+export function applyEvent(
+  ctx: LabelContext,
+  event: LabelEvent,
+): Promise<void> {
+  switch (event.type) {
+    case "assign":
+      return assignLabel(ctx, event)
+    case "unassign":
+      return unassignLabel(ctx, event)
+    case "deleteLabel":
+      return removeLabel(ctx, event)
+    default:
+      throw new Error(
+        `Unsupported inbox label event: ${(event as { type: string }).type}`,
+      )
+  }
+}
+
+async function assignLabel(
+  ctx: LabelContext,
+  event: Extract<LabelEvent, { type: "assign" }>,
+): Promise<void> {
+  const mapping = await ensureTagChannel(ctx, event.labelId, event.labelName)
+  if (!mapping || event.userIds.length === 0) {
+    return
+  }
+
+  const inboxes = await findInboxes(ctx.inboxId, event.userIds)
+  if (inboxes.length === 0) {
+    return
+  }
+
+  // Link the workspace tag to the contacts; capture the newly-linked ones so we
+  // emit "tag applied" exactly once per new pair (same as add-contact-tag).
+  const linked = await db
+    .insert(contactsToTagsModel)
+    .values(
+      inboxes.map((inbox) => ({
+        contactId: inbox.contactId,
+        tagId: mapping.tagId,
+      })),
+    )
+    .onConflictDoNothing()
+    .returning({ contactId: contactsToTagsModel.contactId })
+
+  // Record the per-channel assignment (used for reconciliation / detach).
+  await db
+    .insert(contactToTagChannelModel)
+    .values(
+      inboxes.map((inbox) => ({
+        tagId: mapping.tagId,
+        tagChannelId: mapping.tagChannelId,
+        contactInboxId: inbox.id,
+      })),
+    )
+    .onConflictDoNothing()
+
+  await emitForContacts(
+    ctx.workspaceId,
+    linked.map((row) => row.contactId),
+    mapping.tagId,
+    emitTagApplied,
+  )
+}
+
+async function unassignLabel(
+  ctx: LabelContext,
+  event: Extract<LabelEvent, { type: "unassign" }>,
+): Promise<void> {
+  if (event.userIds.length === 0) {
+    return
+  }
+
+  const tagChannel = await findTagChannel(ctx, event.labelId)
+  if (!tagChannel) {
+    return
+  }
+
+  const inboxes = await findInboxes(ctx.inboxId, event.userIds)
+  if (inboxes.length === 0) {
+    return
+  }
+
+  // Remove the per-channel assignment record.
+  await db.delete(contactToTagChannelModel).where(
+    and(
+      eq(contactToTagChannelModel.tagChannelId, tagChannel.id),
+      inArray(
+        contactToTagChannelModel.contactInboxId,
+        inboxes.map((inbox) => inbox.id),
+      ),
+    ),
+  )
+
+  // Remove the workspace tag from those contacts — same as remove-contact-tag.
+  const contactIds = inboxes.map((inbox) => inbox.contactId)
+  await db
+    .delete(contactsToTagsModel)
+    .where(
+      and(
+        eq(contactsToTagsModel.tagId, tagChannel.tagId),
+        inArray(contactsToTagsModel.contactId, contactIds),
+      ),
+    )
+
+  await emitForContacts(
+    ctx.workspaceId,
+    contactIds,
+    tagChannel.tagId,
+    emitTagRemoved,
+  )
+}
+
+/** Best-effort tag events (failures must not fail the webhook). */
+async function emitForContacts(
+  workspaceId: string,
+  contactIds: string[],
+  tagId: string,
+  emit: (
+    workspaceId: string,
+    contactId: string,
+    tagId: string,
+  ) => Promise<void>,
+): Promise<void> {
+  for (const contactId of contactIds) {
+    try {
+      await emit(workspaceId, contactId, tagId)
+    } catch (error) {
+      logger.warn({ tagId, error }, "inbox labels: failed to emit tag event")
+    }
+  }
+}
+
+async function removeLabel(
+  ctx: LabelContext,
+  event: Extract<LabelEvent, { type: "deleteLabel" }>,
+): Promise<void> {
+  // Map the external label back to the local tag.
+  const tagChannel = await findTagChannel(ctx, event.labelId)
+  if (!tagChannel) {
+    return
+  }
+
+  // The tag was deleted on THIS channel only — keep the workspace Tag. Enqueue a
+  // channel-scoped delete so the queue removes just this channel's mappings +
+  // the contacts tagged via it (NOT a workspace-wide delete-tag).
+  await tagSyncService.enqueueDelete({
+    workspaceId: ctx.workspaceId,
+    tagId: tagChannel.tagId,
+    channelType: ctx.channelType,
+    integrationId: ctx.integrationId,
+  })
+}
+
+// ── DB helpers ──────────────────────────────────────────
+
+function findInboxes(inboxId: string, sourceIds: string[]) {
+  return db.query.contactInboxModel.findMany({
+    where: { inboxId, sourceId: { in: sourceIds } },
+    columns: { id: true, contactId: true },
+  })
+}
+
+function findTagChannel(ctx: LabelContext, externalLabelId: string) {
+  return db.query.tagChannelModel.findFirst({
+    where: {
+      workspaceId: ctx.workspaceId,
+      channelType: ctx.channelType,
+      integrationId: ctx.integrationId,
+      externalLabelId,
+    },
+    columns: { id: true, tagId: true },
+  })
+}
+
+/** Get-or-create the tag (by name) and its channel mapping (by external id). */
+async function ensureTagChannel(
+  ctx: LabelContext,
+  externalLabelId: string,
+  name: string,
+): Promise<{ tagId: string; tagChannelId: string } | undefined> {
+  const existing = await findTagChannel(ctx, externalLabelId)
+  if (existing) {
+    return { tagId: existing.tagId, tagChannelId: existing.id }
+  }
+  if (!name) {
+    return // cannot create a tag without a name
+  }
+
+  const tagId = await ensureTag(ctx.workspaceId, name)
+  if (!tagId) {
+    return
+  }
+
+  const tagChannelId = await ensureChannel(ctx, tagId, externalLabelId)
+  return tagChannelId ? { tagId, tagChannelId } : undefined
+}
+
+async function ensureTag(
+  workspaceId: string,
+  name: string,
+): Promise<string | undefined> {
+  const where = { workspaceId, name, deletedAt: { isNull: true as const } }
+
+  const found = await db.query.tagModel.findFirst({
+    where,
+    columns: { id: true },
+  })
+  if (found) {
+    return found.id
+  }
+
+  const [created] = await db
+    .insert(tagModel)
+    .values({ id: createId(), workspaceId, name })
+    .onConflictDoNothing({
+      // Tag_workspaceId_name_key is a partial unique index (deletedAt IS NULL).
+      target: [tagModel.workspaceId, tagModel.name],
+      where: isNull(tagModel.deletedAt),
+    })
+    .returning({ id: tagModel.id })
+  if (created) {
+    return created.id
+  }
+
+  // Lost a race against a concurrent insert — read the winner back.
+  const retry = await db.query.tagModel.findFirst({
+    where,
+    columns: { id: true },
+  })
+  return retry?.id
+}
+
+async function ensureChannel(
+  ctx: LabelContext,
+  tagId: string,
+  externalLabelId: string,
+): Promise<string | undefined> {
+  const [created] = await db
+    .insert(tagChannelModel)
+    .values({
+      id: createId(),
+      workspaceId: ctx.workspaceId,
+      tagId,
+      channelType: ctx.channelType,
+      integrationId: ctx.integrationId,
+      externalLabelId,
+    })
+    .onConflictDoNothing({
+      target: [
+        tagChannelModel.tagId,
+        tagChannelModel.channelType,
+        tagChannelModel.integrationId,
+      ],
+    })
+    .returning({ id: tagChannelModel.id })
+  if (created) {
+    return created.id
+  }
+
+  const retry = await db.query.tagChannelModel.findFirst({
+    where: {
+      tagId,
+      workspaceId: ctx.workspaceId,
+      channelType: ctx.channelType,
+      integrationId: ctx.integrationId,
+    },
+    columns: { id: true },
+  })
+  return retry?.id
+}

--- a/apps/worker/src/integration/handlers/inbox_labels/types.ts
+++ b/apps/worker/src/integration/handlers/inbox_labels/types.ts
@@ -1,0 +1,37 @@
+import type { channelTypes } from "@chatbotx.io/database/partials"
+
+export type ChannelType =
+  | typeof channelTypes.enum.messenger
+  | typeof channelTypes.enum.zalo
+
+/** Everything the DB layer needs, resolved once per webhook. */
+export type LabelContext = {
+  channelType: ChannelType
+  workspaceId: string
+  integrationId: string
+  inboxId: string
+}
+
+/** Channel-agnostic meaning of an inbox-label webhook. */
+export type LabelEvent =
+  | { type: "assign"; labelId: string; labelName: string; userIds: string[] }
+  | { type: "unassign"; labelId: string; userIds: string[] }
+  | { type: "deleteLabel"; labelId: string }
+
+/**
+ * A channel plugs in with two functions:
+ * - `loadContext`: resolve the integration by its external id; return null when
+ *   it is missing or tag sync is disabled.
+ * - `toEvents`: validate + normalize the raw webhook payload into events;
+ *   return null for an invalid payload.
+ */
+export type Channel = {
+  loadContext: (identifier: string) => Promise<LabelContext | null>
+  toEvents: (payload: unknown) => LabelEvent[] | null
+}
+
+export type ChannelLabelWebhookData = {
+  integrationType: ChannelType
+  integrationIdentifier: string
+  payload: unknown
+}

--- a/apps/worker/src/integration/handlers/messenger-label-webhook.ts
+++ b/apps/worker/src/integration/handlers/messenger-label-webhook.ts
@@ -6,6 +6,7 @@ import {
   tagChannelModel,
   tagModel,
 } from "@chatbotx.io/database/schema"
+import type { IntegrationMessengerModel } from "@chatbotx.io/database/types"
 import { messengerWebhookEventSchema } from "@chatbotx.io/integration-messenger/schema"
 import { createId } from "@chatbotx.io/utils"
 import { logger } from "../../lib/logger"
@@ -34,7 +35,10 @@ export async function handleMessengerLabelWebhook(
   if (!labelChange) {
     return
   }
-  const { action, user, label } = labelChange.value
+  const { action: rawAction, user, label } = labelChange.value
+  // Facebook sends short action names (add/remove/create/delete) on some API
+  // versions and the *_label long forms on others. Normalize to long forms.
+  const action = normalizeLabelAction(rawAction)
 
   const integration = await db.query.integrationMessengerModel.findFirst({
     where: { pageId },
@@ -44,55 +48,37 @@ export async function handleMessengerLabelWebhook(
   }
 
   switch (action) {
-    case "create_label":
-      if (!label.page_label_name) {
-        return
-      }
-      await upsertTagAndChannel({
-        workspaceId: integration.workspaceId,
-        integrationId: integration.id,
-        externalLabelId: label.id,
-        name: label.page_label_name,
-      })
-      return
-
-    case "delete_label":
-      await db
-        .delete(tagChannelModel)
-        .where(
-          and(
-            eq(tagChannelModel.workspaceId, integration.workspaceId),
-            eq(tagChannelModel.channelType, channelTypes.enum.messenger),
-            eq(tagChannelModel.integrationId, integration.id),
-            eq(tagChannelModel.externalLabelId, label.id),
-          ),
-        )
-      return
-
     case "add_label": {
       if (!user) {
         return
       }
-      const result = await resolveContactAndTagChannel({
-        workspaceId: integration.workspaceId,
-        inboxId: integration.inboxId,
-        sourceId: user.id,
-        integrationId: integration.id,
-        externalLabelId: label.id,
+      const contactInbox = await db.query.contactInboxModel.findFirst({
+        where: { inboxId: integration.inboxId, sourceId: user.id },
+        columns: { id: true, contactId: true },
       })
-      if (!result) {
+      if (!contactInbox) {
+        return
+      }
+      // Get-or-create the tag + channel mapping: the label may exist on
+      // Facebook but not locally yet (created on the FB side, never synced).
+      const mapping = await getOrCreateTagChannel({
+        integration,
+        externalLabelId: label.id,
+        name: label.page_label_name,
+      })
+      if (!mapping) {
         return
       }
       await db
         .insert(contactsToTagsModel)
-        .values({ contactId: result.contactId, tagId: result.tagId })
+        .values({ contactId: contactInbox.contactId, tagId: mapping.tagId })
         .onConflictDoNothing()
       await db
         .insert(contactToTagChannelModel)
         .values({
-          tagId: result.tagId,
-          tagChannelId: result.tagChannelId,
-          contactInboxId: result.contactInboxId,
+          tagId: mapping.tagId,
+          tagChannelId: mapping.tagChannelId,
+          contactInboxId: contactInbox.id,
         })
         .onConflictDoNothing()
       return
@@ -126,6 +112,55 @@ export async function handleMessengerLabelWebhook(
     default:
       logger.warn({ action }, "messenger inbox_labels: unknown action")
   }
+}
+
+function normalizeLabelAction(action: string): string {
+  switch (action) {
+    case "add":
+      return "add_label"
+    case "remove":
+      return "remove_label"
+    default:
+      return action
+  }
+}
+
+/**
+ * Resolve the local tag + channel mapping for an external label, creating it
+ * when the label exists on Facebook but hasn't been synced locally yet. The
+ * label name comes from the webhook payload (Facebook includes
+ * `page_label_name` on add/remove events).
+ */
+async function getOrCreateTagChannel(props: {
+  integration: IntegrationMessengerModel
+  externalLabelId: string
+  name?: string
+}): Promise<{ tagId: string; tagChannelId: string } | undefined> {
+  const { integration, externalLabelId, name } = props
+
+  const existing = await db.query.tagChannelModel.findFirst({
+    where: {
+      workspaceId: integration.workspaceId,
+      channelType: channelTypes.enum.messenger,
+      integrationId: integration.id,
+      externalLabelId,
+    },
+    columns: { id: true, tagId: true },
+  })
+  if (existing) {
+    return { tagId: existing.tagId, tagChannelId: existing.id }
+  }
+
+  if (!name) {
+    return
+  }
+
+  return upsertTagAndChannel({
+    workspaceId: integration.workspaceId,
+    integrationId: integration.id,
+    externalLabelId,
+    name,
+  })
 }
 
 async function upsertTagAndChannel(props: {

--- a/packages/business/src/tag/sync.service.ts
+++ b/packages/business/src/tag/sync.service.ts
@@ -56,18 +56,33 @@ class TagSyncService extends BaseService {
   }
 
   /**
-   * Enqueue outbound delete of a tag. The worker deletes the label on each
-   * sync-enabled channel and then deletes the Tag row (cascading TagChannel /
-   * ContactToTagChannel / ContactToTag). Pure Redis enqueue.
+   * Enqueue a tag delete.
+   *
+   * - Workspace delete (no channel scope): the worker removes the label on every
+   *   sync-enabled channel and deletes the Tag row (cascading TagChannel /
+   *   ContactToTagChannel / ContactToTag) — used by delete-tag-action.
+   * - Channel-scoped delete (channelType + integrationId): the tag was deleted on
+   *   one channel only (inbound webhook). The worker removes just that channel's
+   *   mappings + the contacts tagged via it; the Tag row stays.
+   *
+   * Pure Redis enqueue.
    */
   async enqueueDelete(props: {
     workspaceId: string
     tagId: string
+    channelType?: ChannelType
+    integrationId?: string
   }): Promise<void> {
-    const { workspaceId, tagId } = props
+    const { workspaceId, tagId, channelType, integrationId } = props
     await defaultQueue.add(DefaultJobAction.syncTag, {
       type: DefaultJobAction.syncTag,
-      data: { action: "delete", workspaceId, tagId },
+      data: {
+        action: "delete",
+        workspaceId,
+        tagId,
+        channelType,
+        integrationId,
+      },
     })
   }
 

--- a/packages/worker-config/src/queues/default/index.ts
+++ b/packages/worker-config/src/queues/default/index.ts
@@ -95,7 +95,17 @@ export type JobSyncTag = {
         contactId: string
         tagId: string
       }
-    | { action: "delete"; workspaceId: string; tagId: string }
+    | {
+        action: "delete"
+        workspaceId: string
+        tagId: string
+        // Scope the delete to a single channel (inbound webhook): only that
+        // channel's mappings + the contacts tagged via it are removed, the Tag
+        // row stays. When omitted, the tag is deleted everywhere (the Tag row
+        // included) — see delete-tag-action.
+        channelType?: ChannelType
+        integrationId?: string
+      }
 }
 
 export type JobSyncChannelLabels = {


### PR DESCRIPTION
## Summary

Refactor the tag and channel label sync flow (Messenger, Zalo) to be cleaner and easier to extend.

- Move per-channel label webhook handling into a dedicated `inbox_labels/` module (messenger, zalo).
- Simplify the `sync-tag` handler and the tag sync service.
- Update the worker queue config accordingly.
- No user-facing behavior change — internal structure cleanup only.

## Test
- [x] Typecheck pass (42 packages)
- [x] Lint pass
- [x] Tag/label sync test suites pass