### PR TITLE
fix(builder): use Promise.allSettled when creating messages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,10 @@ name: Build and Push Docker Images
 
 on:
   push:
-    branches: [ main ]
-    tags: [ "v*" ]
+    branches: [main]
+    tags: ["v*"]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
     inputs:
       environment:
@@ -83,11 +83,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
-
-      - name: Create .env file from secrets
-        uses: 0ndt/envfile@v2
-        with:
-          secrets: ${{ toJSON(secrets) }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/apps/builder/src/features/messages/actions/create-message.action.ts
+++ b/apps/builder/src/features/messages/actions/create-message.action.ts
@@ -180,7 +180,7 @@ export const createMessage = async (props: {
     }),
   ]
 
-  await Promise.all(promises)
+  await Promise.allSettled(promises)
 
   return messageWithAttachments
 }

--- a/apps/builder/src/features/messages/actions/create-webchat-message.action.ts
+++ b/apps/builder/src/features/messages/actions/create-webchat-message.action.ts
@@ -244,7 +244,7 @@ export async function handleCreateWebchatMessage({
     }
 
     if (promises.length > 0) {
-      await Promise.all(promises)
+      await Promise.allSettled(promises)
     }
 
     return newMessage

--- a/apps/mcp-server/docker/Dockerfile
+++ b/apps/mcp-server/docker/Dockerfile
@@ -20,7 +20,7 @@ ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 WORKDIR /app
 COPY --from=pre /app/out/json/ .
-COPY --from=pre /app/.env .env
+# COPY --from=pre /app/.env .env
 RUN pnpm install --frozen-lockfile
 
 COPY --from=pre /app/out/full/ .

--- a/apps/realtime/docker/Dockerfile
+++ b/apps/realtime/docker/Dockerfile
@@ -26,7 +26,7 @@ COPY --from=pre /app/out/json/ .
 RUN pnpm install --frozen-lockfile
 
 COPY --from=pre /app/out/full/ .
-COPY --from=pre /app/.env .env
+# COPY --from=pre /app/.env .env
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 EXPOSE 1999

--- a/apps/worker/docker/Dockerfile
+++ b/apps/worker/docker/Dockerfile
@@ -20,7 +20,7 @@ ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 WORKDIR /app
 COPY --from=pre /app/out/json/ .
-COPY --from=pre /app/.env .env
+# COPY --from=pre /app/.env .env
 RUN pnpm install --frozen-lockfile
 
 COPY --from=pre /app/out/full/ .


### PR DESCRIPTION
## Summary
- A single rejected side-effect promise (e.g. analytics, realtime broadcast) was aborting the entire message-creation flow via `Promise.all`. Switch to `Promise.allSettled` so the message is still persisted/returned even when an auxiliary task fails.
- Stop baking `.env` into Docker images and drop the secrets-to-`.env` CI step — env is injected at runtime, so this avoids shipping stale secrets.

## Changes
- `apps/builder/src/features/messages/actions/create-message.action.ts` — `Promise.all` → `Promise.allSettled`
- `apps/builder/src/features/messages/actions/create-webchat-message.action.ts` — `Promise.all` → `Promise.allSettled`
- `.github/workflows/release.yml` — remove unused `0ndt/envfile` `.env`-from-secrets step and tidy trigger formatting
- `apps/worker/docker/Dockerfile`, `apps/realtime/docker/Dockerfile`, `apps/mcp-server/docker/Dockerfile` — stop copying `.env` into the image

## Test plan
- [ ] pnpm lint
- [ ] pnpm --filter builder check-types
- [ ] Send a message via web chat and standard channel; confirm it persists even if a side-effect task fails
- [ ] Build worker/realtime/mcp-server images and confirm they run with runtime-injected env