### PR TITLE
fix(redis): degrade gracefully on cache errors and memoize connections

### DIFF
--- a/packages/redis/src/cache-utils.ts
+++ b/packages/redis/src/cache-utils.ts
@@ -1,3 +1,4 @@
+import logger from "@chatbotx.io/logger"
 import { distributedStore } from "."
 
 export const withCache = async <T>(
@@ -10,28 +11,44 @@ export const withCache = async <T>(
   },
 ): Promise<T> => {
   const { ttl = 24 * 60 * 60, tags = [], dynamicTags } = options || {}
-  const cached = await distributedStore.get<T>(key)
-  if (cached) {
-    return cached
+
+  // Cache reads must never break callers: on a Redis failure (timeout, cold
+  // connection, server down) fall back to the source function instead of
+  // propagating. See cache-connection.ts — cache commands are configured to
+  // fail fast so callers can degrade gracefully.
+  try {
+    const cached = await distributedStore.get<T>(key)
+    if (cached) {
+      return cached
+    }
+  } catch (err) {
+    logger.debug({ err, key }, "Cache read failed, falling back to source")
   }
 
-  // Skip cache if result is null or undefined
   const result = await fn()
+  // Skip cache write if result is null or undefined
   if (result === null || result === undefined) {
     return result
   }
-  await distributedStore.put(key, result, ttl)
 
-  // Add tags to the cache
-  const dynamicTagsResult = dynamicTags?.(result)
-  const allTags = [...tags, ...(dynamicTagsResult || [])]
-  if (allTags.length > 0) {
-    await Promise.all(
-      allTags.map(async (tag) => {
-        await distributedStore.sadd(`tags:${tag}`, key)
-        await distributedStore.expire(`tags:${tag}`, ttl)
-      }),
-    )
+  // Cache writes are best-effort: a failure here must not break the caller,
+  // which already has a valid result from the source function.
+  try {
+    await distributedStore.put(key, result, ttl)
+
+    // Add tags to the cache
+    const dynamicTagsResult = dynamicTags?.(result)
+    const allTags = [...tags, ...(dynamicTagsResult || [])]
+    if (allTags.length > 0) {
+      await Promise.all(
+        allTags.map(async (tag) => {
+          await distributedStore.sadd(`tags:${tag}`, key)
+          await distributedStore.expire(`tags:${tag}`, ttl)
+        }),
+      )
+    }
+  } catch (err) {
+    logger.debug({ err, key }, "Cache write failed, returning source result")
   }
 
   return result

--- a/packages/redis/src/connections/cache-connection.ts
+++ b/packages/redis/src/connections/cache-connection.ts
@@ -20,13 +20,14 @@ export const cacheConnections = {
 
   async useExisting(): Promise<Redis> {
     if (cacheInstance) {
-      return await cacheInstance
+      return cacheInstance
     }
-    return mutexLock.runExclusive(async () => {
-      if (cacheInstance !== null && cacheInstance !== undefined) {
+    return await mutexLock.runExclusive(async () => {
+      if (cacheInstance) {
         return cacheInstance
       }
-      return await cacheConnections.create()
+      cacheInstance = await cacheConnections.create()
+      return cacheInstance
     })
   },
 

--- a/packages/redis/src/connections/queue-connection.ts
+++ b/packages/redis/src/connections/queue-connection.ts
@@ -14,13 +14,14 @@ export const queueConnections = {
 
   async useExisting(): Promise<Redis> {
     if (queueConnection) {
-      return await queueConnection
+      return queueConnection
     }
-    return mutexLock.runExclusive(async () => {
-      if (queueConnection !== null && queueConnection !== undefined) {
+    return await mutexLock.runExclusive(async () => {
+      if (queueConnection) {
         return queueConnection
       }
-      return await queueConnections.create()
+      queueConnection = await queueConnections.create()
+      return queueConnection
     })
   },
 

--- a/packages/redis/src/connections/sequence-connection.ts
+++ b/packages/redis/src/connections/sequence-connection.ts
@@ -14,13 +14,14 @@ export const sequenceConnections = {
 
   async useExisting(): Promise<Redis> {
     if (sequenceConnection) {
-      return await sequenceConnection
+      return sequenceConnection
     }
-    return mutexLock.runExclusive(async () => {
-      if (sequenceConnection !== null && sequenceConnection !== undefined) {
+    return await mutexLock.runExclusive(async () => {
+      if (sequenceConnection) {
         return sequenceConnection
       }
-      return await sequenceConnections.create()
+      sequenceConnection = await sequenceConnections.create()
+      return sequenceConnection
     })
   },
 


### PR DESCRIPTION
## Summary
- Redis cache failures (timeout, cold connection, server down) no longer propagate to callers — `withCache` falls back to the source function so a flaky cache can't break requests.
- Fixed `useExisting()` in the cache/queue/sequence connections, which previously discarded the created instance and re-opened a connection on every call instead of memoizing it.

## Changes
- `packages/redis/src/cache-utils.ts` — wrap cache reads and writes in try/catch; reads fall back to the source on error, writes are best-effort. Added debug logging via `@chatbotx.io/logger`.
- `packages/redis/src/connections/cache-connection.ts` — assign the created connection back to `cacheInstance` inside the mutex before returning.
- `packages/redis/src/connections/queue-connection.ts` — same memoization fix for `queueConnection`.
- `packages/redis/src/connections/sequence-connection.ts` — same memoization fix for `sequenceConnection`.

## Test plan
- [ ] `pnpm lint`
- [ ] `pnpm --filter @chatbotx.io/redis check-types`
- [ ] Manual: simulate Redis outage and confirm cached calls fall back to source without throwing
- [ ] Manual: confirm `useExisting()` reuses a single connection (no connection churn under load)