### PR TITLE
fix(flows): correct flow upload path param and pass workspaceId

### DIFF
--- a/apps/builder/src/components/direct-upload.tsx
+++ b/apps/builder/src/components/direct-upload.tsx
@@ -19,6 +19,7 @@ import { useTranslations } from "next-intl"
 import { useMemo, useRef } from "react"
 import { useFormContext, useWatch } from "react-hook-form"
 import { toast } from "sonner"
+import { useWorkspaceId } from "@/hooks/routing"
 
 export function DirectUploadOrInsertLink({
   parentName,
@@ -32,6 +33,7 @@ export function DirectUploadOrInsertLink({
   onSuccess?: (url: string) => void
 }) {
   const t = useTranslations()
+  const workspaceId = useWorkspaceId()
 
   const { setValue, getValues, control } = useFormContext()
   const uploadMode = useWatch({ control, name: `${parentName}.mode` }) || "file"
@@ -105,6 +107,7 @@ export function DirectUploadOrInsertLink({
         }}
         triggerRef={triggerRef}
         uploadPath={uploadPath}
+        workspaceId={workspaceId}
       />
 
       {uploadMode === "file" ? (
@@ -133,6 +136,7 @@ export function DirectUploadOrInsertLink({
             }}
             triggerRef={triggerRef}
             uploadPath={uploadPath}
+            workspaceId={workspaceId}
           />
           {publicUrl && publicUrl.length > 0 ? (
             <Button
@@ -144,15 +148,18 @@ export function DirectUploadOrInsertLink({
               {fileType === "image" ? (
                 <Image
                   alt={stepId}
-                  fill={true}
-                  objectFit="contain"
+                  className="h-full w-full object-contain"
+                  height={1000}
                   src={publicUrl}
+                  width={1000}
                 />
               ) : (
-                <>
-                  <fileConfigs.icon className="size-5" />
-                  <span className="flex-1 truncate">{publicUrl}</span>
-                </>
+                <div className="flex w-full min-w-0 items-center gap-2 px-3">
+                  <fileConfigs.icon className="size-5 flex-none" />
+                  <span className="min-w-0 flex-1 truncate text-left">
+                    {publicUrl}
+                  </span>
+                </div>
               )}
             </Button>
           ) : (

--- a/apps/builder/src/features/flows/react-flow/components/page-element-builder/index.tsx
+++ b/apps/builder/src/features/flows/react-flow/components/page-element-builder/index.tsx
@@ -19,7 +19,7 @@ type BuilderProps = {
   type: PageElementType
 }
 export function PageElementBuilder({ type, parentName }: BuilderProps) {
-  const params = useParams<{ workspaceId: string; flowId: string }>()
+  const params = useParams<{ workspaceId: string; id: string }>()
 
   const t = useTranslations()
   switch (type) {
@@ -42,7 +42,7 @@ export function PageElementBuilder({ type, parentName }: BuilderProps) {
         <DirectUploadOrInsertLink
           fileType="image"
           parentName={parentName}
-          uploadPath={`public/space/${params.workspaceId}/flows/${params.flowId}/elements/${parentName}`}
+          uploadPath={`public/space/${params.workspaceId}/flows/${params.id}/elements/${parentName}`}
         />
       )
     case pageElementTypes.enum.button:

--- a/apps/builder/src/features/flows/react-flow/nodes/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/nodes/editor.tsx
@@ -371,15 +371,7 @@ export const NodeEditor = memo((props: NodeEditorProps) => {
                         <div className="w-4">{"\u00A0"}</div>
                       )
                     })()}
-                    <div
-                      className={cn(
-                        "break-word flex-1",
-                        // biome-ignore lint/suspicious/noExplicitAny: wip
-                        (field as any).stepType === stepTypes.enum.sendCarousel
-                          ? "overflow-hidden"
-                          : "",
-                      )}
-                    >
+                    <div className={cn("break-word flex-1 overflow-hidden")}>
                       <DynamicStepEditor
                         key={field.id}
                         parentName={`steps.${index}`}

--- a/apps/builder/src/features/flows/react-flow/steps/send-audio/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-audio/editor.tsx
@@ -10,7 +10,7 @@ type SendAudioStepEditorProps = {
 }
 
 const SendAudioStepEditor = ({ parentName }: SendAudioStepEditorProps) => {
-  const params = useParams<{ workspaceId: string; flowId: string }>()
+  const params = useParams<{ workspaceId: string; id: string }>()
   const { getValues } = useFormContext()
   const stepId = getValues(`${parentName}.id`)
 
@@ -20,7 +20,7 @@ const SendAudioStepEditor = ({ parentName }: SendAudioStepEditorProps) => {
         <DirectUploadOrInsertLink
           fileType="audio"
           parentName={parentName}
-          uploadPath={`public/space/${params.workspaceId}/flows/${params.flowId}/steps/${stepId}`}
+          uploadPath={`public/space/${params.workspaceId}/flows/${params.id}/steps/${stepId}`}
         />
       </div>
       <div className="bg-slate-200 px-3 py-2 dark:bg-neutral-900">

--- a/apps/builder/src/features/flows/react-flow/steps/send-card/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-card/editor.tsx
@@ -12,7 +12,7 @@ type SendCardStepEditorProps = {
 }
 
 const SendCardStepEditor = ({ parentName }: SendCardStepEditorProps) => {
-  const params = useParams<{ workspaceId: string; flowId: string }>()
+  const params = useParams<{ workspaceId: string; id: string }>()
   const { register, getValues } = useFormContext()
   const t = useTranslations()
   const stepId = getValues(`${parentName}.id`)
@@ -23,7 +23,7 @@ const SendCardStepEditor = ({ parentName }: SendCardStepEditorProps) => {
         <DirectUploadOrInsertLink
           fileType="image"
           parentName={`${parentName}.image`}
-          uploadPath={`public/space/${params.workspaceId}/flows/${params.flowId}/steps/${stepId}`}
+          uploadPath={`public/space/${params.workspaceId}/flows/${params.id}/steps/${stepId}`}
         />
         <Input
           placeholder={`${t("fields.title.placeholder")} (required)`}

--- a/apps/builder/src/features/flows/react-flow/steps/send-file/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-file/editor.tsx
@@ -10,7 +10,7 @@ type SendFileStepEditorProps = {
 }
 
 const SendFileStepEditor = ({ parentName }: SendFileStepEditorProps) => {
-  const params = useParams<{ workspaceId: string; flowId: string }>()
+  const params = useParams<{ workspaceId: string; id: string }>()
   const { getValues } = useFormContext()
   const stepId = getValues(`${parentName}.id`)
 
@@ -20,7 +20,7 @@ const SendFileStepEditor = ({ parentName }: SendFileStepEditorProps) => {
         <DirectUploadOrInsertLink
           fileType="file"
           parentName={parentName}
-          uploadPath={`public/space/${params.workspaceId}/flows/${params.flowId}/steps/${stepId}`}
+          uploadPath={`public/space/${params.workspaceId}/flows/${params.id}/steps/${stepId}`}
         />
       </div>
       <div className="bg-slate-200 px-3 py-2 dark:bg-neutral-900">

--- a/apps/builder/src/features/flows/react-flow/steps/send-image/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-image/editor.tsx
@@ -10,7 +10,7 @@ type SendImageStepEditorProps = {
 }
 
 const SendImageStepEditor = ({ parentName }: SendImageStepEditorProps) => {
-  const params = useParams<{ workspaceId: string; flowId: string }>()
+  const params = useParams<{ workspaceId: string; id: string }>()
   const { getValues } = useFormContext()
   const stepId = getValues(`${parentName}.id`)
 
@@ -20,7 +20,7 @@ const SendImageStepEditor = ({ parentName }: SendImageStepEditorProps) => {
         <DirectUploadOrInsertLink
           fileType="image"
           parentName={parentName}
-          uploadPath={`public/space/${params.workspaceId}/flows/${params.flowId}/steps/${stepId}`}
+          uploadPath={`public/space/${params.workspaceId}/flows/${params.id}/steps/${stepId}`}
         />
       </div>
       <div className="bg-slate-200 px-3 py-2 dark:bg-neutral-900">

--- a/apps/builder/src/features/flows/react-flow/steps/send-video/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-video/editor.tsx
@@ -10,7 +10,7 @@ type SendVideoStepEditorProps = {
 }
 
 const SendVideoStepEditor = ({ parentName }: SendVideoStepEditorProps) => {
-  const params = useParams<{ workspaceId: string; flowId: string }>()
+  const params = useParams<{ workspaceId: string; id: string }>()
   const { getValues } = useFormContext()
   const stepId = getValues(`${parentName}.id`)
 
@@ -20,7 +20,7 @@ const SendVideoStepEditor = ({ parentName }: SendVideoStepEditorProps) => {
         <DirectUploadOrInsertLink
           fileType="video"
           parentName={parentName}
-          uploadPath={`public/space/${params.workspaceId}/flows/${params.flowId}/steps/${stepId}`}
+          uploadPath={`public/space/${params.workspaceId}/flows/${params.id}/steps/${stepId}`}
         />
       </div>
       <div className="bg-slate-200 px-3 py-2 dark:bg-neutral-900">

--- a/packages/ui/src/components/uploader/direct-upload-button.tsx
+++ b/packages/ui/src/components/uploader/direct-upload-button.tsx
@@ -16,7 +16,7 @@ import {
  */
 export type DirectUploadButtonProps = FileUploadProps & {
   /** Workspace ID for the upload */
-  workspaceId?: string
+  workspaceId: string
   /** The base path where files will be uploaded to S3 */
   uploadPath?: string
   /** Custom upload handler URL, defaults to /api/presigned-upload */


### PR DESCRIPTION
## Summary
- Flow step editors built S3 upload paths from `params.flowId`, a route param that doesn't exist — uploads landed under an `undefined` flow folder. They now use the actual `id` param.
- `workspaceId` is now threaded through to the direct upload button and made required, so uploads are scoped to the correct workspace.
- Removed a stray `console.log` debug statement and fixed the image preview sizing/layout.

## Changes
- `apps/builder/.../flows/react-flow/steps/{send-audio,send-card,send-file,send-image,send-video}/editor.tsx` — `params.flowId` → `params.id`.
- `apps/builder/.../flows/react-flow/components/page-element-builder/index.tsx` — same param fix.
- `apps/builder/src/components/direct-upload.tsx` — pass `workspaceId` (via `useWorkspaceId()`) to upload buttons; fix image preview sizing and file-link layout.
- `apps/builder/.../flows/react-flow/nodes/editor.tsx` — simplify carousel overflow class.
- `packages/ui/src/components/uploader/direct-upload-button.tsx` — `workspaceId` now required; remove debug `console.log`.

## Test plan
- [x] pnpm lint (ultracite, ran via pre-commit)
- [x] pnpm --filter builder check-types (ran via pre-commit)
- [ ] Manually verify file/image/audio/video/card uploads in the flow builder land under the correct `public/space/<workspaceId>/flows/<flowId>/...` path
- [ ] Verify image preview renders at correct size in send-image/send-card editors