### PR TITLE
fix(worker): use igId column for instagram integration lookup

### DIFF
--- a/apps/worker/src/services/integrations.ts
+++ b/apps/worker/src/services/integrations.ts
@@ -87,7 +87,7 @@ export const integrationService = {
       }
       case "instagram": {
         modelName = "IntegrationInstagram"
-        columnName = "pageId"
+        columnName = "igId"
         break
       }
       case "tiktok": {


### PR DESCRIPTION
## Summary
  - Fixes Instagram webhook integration by correcting the column name used to look up integrations                                                                  
  - The Instagram model uses `igId` (not `pageId`) as its identifier — wrong column caused webhook matching to fail

  ## Changes
  - `apps/worker/src/services/integrations.ts`: `columnName` from `"pageId"` → `"igId"` in the `"instagram"` switch case

  ## Test plan
  - [ ] `pnpm lint`
  - [ ] `pnpm --filter worker check-types`                                                                                                                          
  - [ ] Trigger an Instagram webhook event and verify it routes to the correct integration
