### PR TITLE
fix(flows): correct email template variable and add tiktok integration field

### DIFF
--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -114,6 +114,7 @@ export type InboxWithIntegrations = InboxModel & {
   integrationWhatsapp?: IntegrationWhatsappModel | null
   integrationZalo?: IntegrationZaloModel | null
   integrationSmtp?: IntegrationSmtpModel | null
+  integrationTiktok?: IntegrationTiktokModel | null
 }
 
 export type ContactOnSmartDelayModel =

--- a/packages/flow-config/src/steps/email.ts
+++ b/packages/flow-config/src/steps/email.ts
@@ -135,7 +135,7 @@ export const emailStepDefaultFn = (
     {
       id: createId(),
       type: pageElementTypes.enum.text,
-      text: `You received this email from {{page_name}}. If you would like to unsubscribe, <a href="${UNSUBSCRIBE_PLACEHOLDER}">click here</a>`,
+      text: `You received this email from {{page_user_name}}. If you would like to unsubscribe, <a href="${UNSUBSCRIBE_PLACEHOLDER}">click here</a>`,
     },
   ],
   ...props,

--- a/packages/variables/src/helpers/integration-fields.ts
+++ b/packages/variables/src/helpers/integration-fields.ts
@@ -100,6 +100,8 @@ export const getIntegrationField = async (
           return inbox.integrationWhatsapp?.name ?? null
         case channelTypes.enum.zalo:
           return inbox.integrationZalo?.name ?? null
+        case channelTypes.enum.tiktok:
+          return inbox.integrationTiktok?.name ?? null
         case channelTypes.enum.telegram:
           return inbox.integrationTelegram?.name ?? null
         case channelTypes.enum.webchat:


### PR DESCRIPTION
## Summary
  - Fix incorrect variable `{{page_name}}` → `{{page_user_name}}` in email step default footer template
  - Add missing `tiktok` case to `getIntegrationField` so TikTok inbox names resolve correctly in variables
  - Add `integrationTiktok` to `InboxWithIntegrations` type to support the field lookup
  
  ## Changes
  - `packages/flow-config/src/steps/email.ts` — correct variable name in unsubscribe footer
  - `packages/variables/src/helpers/integration-fields.ts` — add `tiktok` channel case
  - `packages/database/src/types.ts` — extend `InboxWithIntegrations` with `integrationTiktok`
  
  ## Test plan
  - [ ] `pnpm lint`
  - [ ] `pnpm --filter @chatbotx.io/flow-config check-types`
  - [ ] `pnpm --filter @chatbotx.io/variables check-types`
  - [ ] `pnpm --filter @chatbotx.io/database check-types`
  - [ ] Create an email flow step and verify default footer renders `{{page_user_name}}`
  - [ ] Verify a TikTok inbox's integration name resolves correctly in flow variable context
