### PR TITLE
fix(messenger): improve outgoing message handling and channel send behavior

### DIFF
--- a/.agents/skills/feature-scaffold/SKILL.md
+++ b/.agents/skills/feature-scaffold/SKILL.md
@@ -130,6 +130,13 @@ export const createItemAction = workspaceActionClient
   )
 ```
 
+## Tests
+
+- Put builder app-level tests for actions, routes, API behavior, cache behavior,
+  or cross-feature behavior in `apps/builder/__tests__/`.
+- Use colocated `src/features/**/__tests__` only for narrow component/unit tests
+  that are clearly owned by that feature.
+
 ### Action Clients
 
 - `workspaceActionClient` — requires workspace membership

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,7 @@ pnpm --filter @chatbotx.io/database make:migration <name>
 
 - **Windsurf rules:** `.windsurf/rules/` (Next.js conventions, Ultracite standards).
 - **Agent skills (detailed runbooks):** `.agents/skills/` — notably `turborepo-workflow`, `feature-scaffold`, `orpc-api`, `drizzle-database`, `integration-channel`, `worker-development`.
+- **Test placement:** use `<workspace>/__tests__/` for app/package/integration-level tests, especially tests covering actions, routes, API behavior, cache behavior, worker behavior, or multiple feature boundaries (e.g. `apps/builder/__tests__`, `apps/worker/__tests__`, `packages/sdk/__tests__`, `integrations/messenger/__tests__`). Use colocated `src/**/__tests__` only for narrow unit/component tests clearly owned by that module.
 - **Quality bar:** Run `pnpm lint` (and typecheck scripts for touched packages) before considering work done. Keep changes scoped to the requested behavior.
 
 ## Key invariants for AI agents

--- a/apps/builder/__tests__/upload-logo-action.test.ts
+++ b/apps/builder/__tests__/upload-logo-action.test.ts
@@ -1,0 +1,226 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const updateReturning: { current: unknown[] } = { current: [] }
+const workspaceMembers: { current: { userId: string }[] } = { current: [] }
+const workspace: { current: { logo: string | null } | undefined } = {
+  current: { logo: null },
+}
+
+const updateBuilder = {
+  set: vi.fn(),
+  where: vi.fn(),
+  returning: vi.fn(),
+}
+
+function wireUpdateBuilder() {
+  updateBuilder.set.mockImplementation(() => updateBuilder)
+  updateBuilder.where.mockImplementation(() => updateBuilder)
+  updateBuilder.returning.mockImplementation(() =>
+    Promise.resolve(updateReturning.current),
+  )
+}
+wireUpdateBuilder()
+
+const selectBuilder = {
+  from: vi.fn(),
+  where: vi.fn(),
+}
+
+function wireSelectBuilder() {
+  selectBuilder.from.mockImplementation(() => selectBuilder)
+  selectBuilder.where.mockImplementation(() =>
+    Promise.resolve(workspaceMembers.current),
+  )
+}
+wireSelectBuilder()
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    update: vi.fn(() => updateBuilder),
+    select: vi.fn(() => selectBuilder),
+    query: {
+      workspaceModel: {
+        findFirst: vi.fn(() => Promise.resolve(workspace.current)),
+      },
+    },
+  },
+  and: (...args: unknown[]) => ({ and: args }),
+  eq: (col: unknown, val: unknown) => ({ eq: [col, val] }),
+  isNull: (col: unknown) => ({ isNull: col }),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  workspaceModel: {
+    id: "workspace.id",
+    logo: "workspace.logo",
+  },
+  workspaceMemberModel: {
+    userId: "workspaceMember.userId",
+    workspaceId: "workspaceMember.workspaceId",
+  },
+}))
+
+const uploadFileFromUrl = vi.fn()
+vi.mock("@chatbotx.io/filesystem/node-upload", () => ({
+  uploadFileFromUrl,
+}))
+
+const invalidateCacheByTags = vi.fn()
+vi.mock("@chatbotx.io/redis", () => ({
+  invalidateCacheByTags,
+}))
+
+const createId = vi.fn(() => "logo-id")
+vi.mock("@chatbotx.io/utils", () => ({
+  createId,
+}))
+
+const { updateWorkspaceLogo } = await import(
+  "../src/features/workspaces/actions/upload-logo"
+)
+const { db } = await import("@chatbotx.io/database/client")
+
+function createIntegration(profilePictureUrl?: string) {
+  return {
+    runChannelHandler: vi.fn(async () => profilePictureUrl),
+  }
+}
+
+function createFailingIntegration() {
+  return {
+    runChannelHandler: vi.fn(() =>
+      Promise.reject(new Error("profile picture failed")),
+    ),
+  }
+}
+
+function createCtx() {
+  return {
+    storagePrefix: "public/space/ws-1",
+    auth: { authType: "none" as const },
+    platform: {
+      appUrl: "https://app.example.com",
+      wsUrl: "wss://realtime.example.com",
+      storageUrl: "https://storage.example.com",
+      getRealtimeAuthHeaders: vi.fn(async () => ({})),
+    },
+  }
+}
+
+function resetMocks() {
+  vi.clearAllMocks()
+  wireUpdateBuilder()
+  wireSelectBuilder()
+  vi.mocked(db.update).mockImplementation(
+    () => updateBuilder as unknown as ReturnType<typeof db.update>,
+  )
+  vi.mocked(db.select).mockImplementation(
+    () => selectBuilder as unknown as ReturnType<typeof db.select>,
+  )
+  createId.mockReturnValue("logo-id")
+  uploadFileFromUrl.mockResolvedValue({
+    originPath: "public/space/ws-1/logos/logo-id.jpg",
+  })
+  workspace.current = { logo: null }
+  updateReturning.current = [{ id: "ws-1" }]
+  workspaceMembers.current = [{ userId: "user-1" }, { userId: "user-2" }]
+}
+
+describe("updateWorkspaceLogo", () => {
+  beforeEach(resetMocks)
+
+  test("uploads integration profile picture and stores it when workspace logo is null", async () => {
+    const integration = createIntegration("https://example.com/logo.jpg")
+    const ctx = createCtx()
+
+    await updateWorkspaceLogo({
+      id: "ws-1",
+      integration,
+      ctx,
+    })
+
+    expect(integration.runChannelHandler).toHaveBeenCalledWith(
+      "bot",
+      "getProfilePictureUrl",
+      { ctx },
+    )
+    expect(uploadFileFromUrl).toHaveBeenCalledWith(
+      "https://example.com/logo.jpg",
+      "public/space/ws-1/logos/logo-id.jpg",
+    )
+    expect(updateBuilder.set).toHaveBeenCalledWith({
+      logo: "public/space/ws-1/logos/logo-id.jpg",
+    })
+    expect(updateBuilder.where).toHaveBeenCalledWith({
+      and: [{ eq: ["workspace.id", "ws-1"] }, { isNull: "workspace.logo" }],
+    })
+    expect(selectBuilder.where).toHaveBeenCalledWith({
+      eq: ["workspaceMember.workspaceId", "ws-1"],
+    })
+    expect(invalidateCacheByTags).toHaveBeenCalledWith([
+      "workspaces:ws-1",
+      "users:user-1:workspace-members",
+      "users:user-2:workspace-members",
+    ])
+  })
+
+  test("does not update workspace when integration has no profile picture", async () => {
+    const integration = createIntegration()
+
+    await updateWorkspaceLogo({
+      id: "ws-1",
+      integration,
+      ctx: createCtx(),
+    })
+
+    expect(uploadFileFromUrl).not.toHaveBeenCalled()
+    expect(db.update).not.toHaveBeenCalled()
+    expect(invalidateCacheByTags).not.toHaveBeenCalled()
+  })
+
+  test("does not update workspace when profile picture lookup fails", async () => {
+    const integration = createFailingIntegration()
+
+    await updateWorkspaceLogo({
+      id: "ws-1",
+      integration,
+      ctx: createCtx(),
+    })
+
+    expect(uploadFileFromUrl).not.toHaveBeenCalled()
+    expect(db.update).not.toHaveBeenCalled()
+    expect(invalidateCacheByTags).not.toHaveBeenCalled()
+  })
+
+  test("does not update workspace when profile picture upload fails", async () => {
+    uploadFileFromUrl.mockRejectedValue(new Error("upload failed"))
+    const integration = createIntegration("https://example.com/logo.jpg")
+
+    await updateWorkspaceLogo({
+      id: "ws-1",
+      integration,
+      ctx: createCtx(),
+    })
+
+    expect(db.update).not.toHaveBeenCalled()
+    expect(invalidateCacheByTags).not.toHaveBeenCalled()
+  })
+
+  test("does not fetch or upload profile picture when workspace already has a logo", async () => {
+    workspace.current = { logo: "public/space/ws-1/logos/existing.jpg" }
+    const integration = createIntegration("https://example.com/logo.jpg")
+
+    await updateWorkspaceLogo({
+      id: "ws-1",
+      integration,
+      ctx: createCtx(),
+    })
+
+    expect(integration.runChannelHandler).not.toHaveBeenCalled()
+    expect(uploadFileFromUrl).not.toHaveBeenCalled()
+    expect(db.update).not.toHaveBeenCalled()
+    expect(db.select).not.toHaveBeenCalled()
+    expect(invalidateCacheByTags).not.toHaveBeenCalled()
+  })
+})

--- a/apps/builder/src/features/flows/components/select-flow-dialog.tsx
+++ b/apps/builder/src/features/flows/components/select-flow-dialog.tsx
@@ -21,10 +21,16 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hooks"
 import { Loader2 } from "lucide-react"
 import { useTranslations } from "next-intl"
+import { useAction } from "next-safe-action/hooks"
 import { useEffect, useMemo, useState } from "react"
 import { useWatch } from "react-hook-form"
 import { toast } from "sonner"
 import { useChatStore } from "@/features/chat/store/chat-store-provider"
+import { disableBotAction } from "@/features/conversations/actions/disable-bot.action"
+import {
+  BOT_DISABLE_DURATION_MS,
+  isConversationActive,
+} from "@/features/conversations/utils/bot-state"
 import { createMessageAction } from "@/features/messages/actions/create-message.action"
 import { createMessageRequest } from "@/features/messages/schema/mutation"
 import {
@@ -60,11 +66,31 @@ export function SelectFlowDialog({
     return map
   }, [nodesSelectOptions])
 
-  const { activeConversationId, conversations } = useChatStore((state) => state)
+  const { activeConversationId, conversations, updateConversation } =
+    useChatStore((state) => state)
 
   const conversation = useMemo(
     () => conversations.find((c) => c.id === activeConversationId) ?? null,
     [conversations, activeConversationId],
+  )
+
+  const { execute: disableBot } = useAction(
+    disableBotAction.bind(null, conversation?.workspaceId ?? ""),
+    {
+      onSuccess: () => {
+        if (conversation) {
+          updateConversation(conversation.id, {
+            botEnabled: false,
+            botResumeAt: new Date(Date.now() + BOT_DISABLE_DURATION_MS),
+          })
+        }
+      },
+      onError: ({ error }) => {
+        if (error.serverError) {
+          toast.error(error.serverError)
+        }
+      },
+    },
   )
 
   const { form, handleSubmitWithAction, resetFormAndAction } =
@@ -78,6 +104,9 @@ export function SelectFlowDialog({
       {
         actionProps: {
           onSuccess: () => {
+            if (conversation && isConversationActive(conversation)) {
+              disableBot({ ids: [conversation.id] })
+            }
             setOpen(false)
             resetFormAndAction()
           },

--- a/apps/builder/src/features/integration-instagram/actions/select-account.action.ts
+++ b/apps/builder/src/features/integration-instagram/actions/select-account.action.ts
@@ -62,117 +62,111 @@ export const selectAccountAction = authActionClient
         }
         const instagramSettings = instagramCredential.config
 
-        const { createdWorkspace, brandingCtx } = await db.transaction(
-          async (tx) => {
-            const longLivedToken = await exchangeLongLivedToken(
-              instagramSettings,
-              parsedInput.accessToken,
-            )
+        const { brandingCtx } = await db.transaction(async (tx) => {
+          const longLivedToken = await exchangeLongLivedToken(
+            instagramSettings,
+            parsedInput.accessToken,
+          )
 
-            let createdWorkspace = false
-            if (!workspaceId) {
-              const workspace = await workspaceService.create({
-                tx,
-                createdBy: ctx.user.id,
-                data: {
-                  name: parsedInput.igName,
-                  timezone: "UTC",
-                  ownerId: ctx.user.id,
-                },
-              })
-              workspaceId = workspace.id
-              createdWorkspace = true
-            }
-
-            const { appUrl } = await resolvePlatformSettings({
-              workspaceId,
+          if (!workspaceId) {
+            const workspace = await workspaceService.create({
               tx,
-            })
-
-            await subscribePageToInstagramWebhook({
-              pageId: parsedInput.pageId,
-              accessToken: longLivedToken,
-              version: instagramSettings.version,
-            })
-
-            const auth: InstagramAuthValue = {
-              authType: AuthType.oauth2,
-              clientId: instagramSettings.clientId,
-              clientSecret: instagramSettings.clientSecret,
-              redirectUrl: "",
-              tokens: {
-                accessToken: longLivedToken,
-              },
-              metadata: {
-                igId: parsedInput.igId,
-                igName: parsedInput.igName,
-                pageId: parsedInput.pageId,
-                version: instagramSettings.version,
-              },
-            }
-
-            const { integration: integrationRow } =
-              await connectChannelIntegration({
-                tx,
-                ownerId,
-                inboxData: {
-                  id: createId(),
-                  workspaceId: workspaceId as string,
-                  name: parsedInput.igName,
-                  channel: "instagram",
-                  sourceId: parsedInput.igId,
-                },
-                insertIntegration: async (inboxId) =>
-                  tx
-                    .insert(integrationInstagramModel)
-                    .values({
-                      id: createId(),
-                      workspaceId: workspaceId as string,
-                      inboxId,
-                      igId: parsedInput.igId,
-                      pageId: parsedInput.pageId,
-                      auth,
-                      name: parsedInput.igName,
-                      username: parsedInput.igUsername,
-                      persistentMenus: [
-                        {
-                          label: BRANDING_TITLE,
-                          type: "url" as const,
-                          url: getBrandingUrl("instagram", appUrl),
-                        },
-                      ],
-                      conversationStarters: [],
-                    })
-                    .returning()
-                    .then((result) => result[0]),
-              })
-
-            const brandingCtx = await buildContext({
-              workspaceId,
-              integrationType: "instagram",
-              integration: {
-                ...integrationRow,
-                auth: integrationRow.auth as InstagramAuthValue,
+              createdBy: ctx.user.id,
+              data: {
+                name: parsedInput.igName,
+                timezone: "UTC",
+                ownerId: ctx.user.id,
               },
             })
+            workspaceId = workspace.id
+          }
 
-            await integrationInstagram.runChannelHandler("bot", "addBranding", {
-              ctx: brandingCtx,
-              title: BRANDING_TITLE,
-              url: getBrandingUrl("instagram", appUrl),
-            })
-
-            return { createdWorkspace, brandingCtx }
-          },
-        )
-
-        if (createdWorkspace) {
-          await updateWorkspaceLogo({
-            id: workspaceId as string,
-            integration: integrationInstagram,
-            ctx: brandingCtx,
+          const { appUrl } = await resolvePlatformSettings({
+            workspaceId,
+            tx,
           })
-        }
+
+          await subscribePageToInstagramWebhook({
+            pageId: parsedInput.pageId,
+            accessToken: longLivedToken,
+            version: instagramSettings.version,
+          })
+
+          const auth: InstagramAuthValue = {
+            authType: AuthType.oauth2,
+            clientId: instagramSettings.clientId,
+            clientSecret: instagramSettings.clientSecret,
+            redirectUrl: "",
+            tokens: {
+              accessToken: longLivedToken,
+            },
+            metadata: {
+              igId: parsedInput.igId,
+              igName: parsedInput.igName,
+              pageId: parsedInput.pageId,
+              version: instagramSettings.version,
+            },
+          }
+
+          const { integration: integrationRow } =
+            await connectChannelIntegration({
+              tx,
+              ownerId,
+              inboxData: {
+                id: createId(),
+                workspaceId: workspaceId as string,
+                name: parsedInput.igName,
+                channel: "instagram",
+                sourceId: parsedInput.igId,
+              },
+              insertIntegration: async (inboxId) =>
+                tx
+                  .insert(integrationInstagramModel)
+                  .values({
+                    id: createId(),
+                    workspaceId: workspaceId as string,
+                    inboxId,
+                    igId: parsedInput.igId,
+                    pageId: parsedInput.pageId,
+                    auth,
+                    name: parsedInput.igName,
+                    username: parsedInput.igUsername,
+                    persistentMenus: [
+                      {
+                        label: BRANDING_TITLE,
+                        type: "url" as const,
+                        url: getBrandingUrl("instagram", appUrl),
+                      },
+                    ],
+                    conversationStarters: [],
+                  })
+                  .returning()
+                  .then((result) => result[0]),
+            })
+
+          const brandingCtx = await buildContext({
+            workspaceId,
+            integrationType: "instagram",
+            integration: {
+              ...integrationRow,
+              auth: integrationRow.auth as InstagramAuthValue,
+            },
+          })
+
+          await integrationInstagram.runChannelHandler("bot", "addBranding", {
+            ctx: brandingCtx,
+            title: BRANDING_TITLE,
+            url: getBrandingUrl("instagram", appUrl),
+          })
+
+          return { brandingCtx }
+        })
+
+        await updateWorkspaceLogo({
+          id: workspaceId as string,
+          integration: integrationInstagram,
+          ctx: brandingCtx,
+        })
 
         return {
           workspaceId,

--- a/apps/builder/src/features/integration-messenger/actions/select-page.action.ts
+++ b/apps/builder/src/features/integration-messenger/actions/select-page.action.ts
@@ -66,115 +66,109 @@ export const selectPageAction = authActionClient
 
         let integrationId = ""
 
-        const { createdWorkspace, brandingCtx } = await db.transaction(
-          async (tx) => {
-            const longLivedToken = await exchangeLongLivedToken(
-              messengerSettings,
-              parsedInput.accessToken,
-            )
+        const { brandingCtx } = await db.transaction(async (tx) => {
+          const longLivedToken = await exchangeLongLivedToken(
+            messengerSettings,
+            parsedInput.accessToken,
+          )
 
-            let createdWorkspace = false
-            if (!workspaceId) {
-              const workspace = await workspaceService.create({
-                tx,
-                createdBy: ctx.user.id,
-                data: {
-                  name: parsedInput.pageName,
-                  timezone: "UTC",
-                  ownerId: ctx.user.id,
-                },
-              })
-              workspaceId = workspace.id
-              createdWorkspace = true
-            }
-
-            const { appUrl } = await resolvePlatformSettings({
-              workspaceId,
+          if (!workspaceId) {
+            const workspace = await workspaceService.create({
               tx,
-            })
-
-            await subscribePageToAppWebhook({
-              pageId: parsedInput.pageId,
-              accessToken: longLivedToken,
-              version: messengerSettings.version,
-            })
-
-            const auth: MessengerAuthValue = {
-              authType: AuthType.oauth2,
-              clientId: messengerSettings.clientId,
-              clientSecret: messengerSettings.clientSecret,
-              redirectUrl: "",
-              tokens: {
-                accessToken: longLivedToken,
+              createdBy: ctx.user.id,
+              data: {
+                name: parsedInput.pageName,
+                timezone: "UTC",
+                ownerId: ctx.user.id,
               },
-              metadata: {
-                pageId: parsedInput.pageId,
-                pageName: parsedInput.pageName,
-                version: messengerSettings.version,
-              },
-            }
-
-            const { integration: integrationRow } =
-              await connectChannelIntegration({
-                tx,
-                ownerId: platformOwnerId,
-                inboxData: {
-                  id: createId(),
-                  workspaceId: workspaceId as string,
-                  name: parsedInput.pageName,
-                  channel: "messenger",
-                  sourceId: parsedInput.pageId,
-                },
-                insertIntegration: async (inboxId) =>
-                  tx
-                    .insert(integrationMessengerModel)
-                    .values({
-                      id: createId(),
-                      workspaceId: workspaceId as string,
-                      inboxId,
-                      pageId: parsedInput.pageId,
-                      auth,
-                      name: parsedInput.pageName,
-                      persistentMenus: [
-                        {
-                          label: BRANDING_TITLE,
-                          type: "url" as const,
-                          url: getBrandingUrl("messenger", appUrl),
-                        },
-                      ],
-                      conversationStarters: [],
-                      personas: [],
-                    })
-                    .returning()
-                    .then((result) => result[0]),
-              })
-
-            integrationId = integrationRow.id
-            connectedIntegrationId = integrationRow?.id
-
-            const brandingCtx = await buildContext({
-              workspaceId,
-              integrationType: "messenger",
-              integration: { ...integrationRow, auth },
             })
+            workspaceId = workspace.id
+          }
 
-            await integrationMessenger.runChannelHandler("bot", "addBranding", {
-              ctx: brandingCtx,
-              title: BRANDING_TITLE,
-              url: getBrandingUrl("messenger", appUrl),
-            })
-
-            return { createdWorkspace, brandingCtx }
-          },
-        )
-
-        if (createdWorkspace) {
-          await updateWorkspaceLogo({
-            id: workspaceId as string,
-            integration: integrationMessenger,
-            ctx: brandingCtx,
+          const { appUrl } = await resolvePlatformSettings({
+            workspaceId,
+            tx,
           })
-        }
+
+          await subscribePageToAppWebhook({
+            pageId: parsedInput.pageId,
+            accessToken: longLivedToken,
+            version: messengerSettings.version,
+          })
+
+          const auth: MessengerAuthValue = {
+            authType: AuthType.oauth2,
+            clientId: messengerSettings.clientId,
+            clientSecret: messengerSettings.clientSecret,
+            redirectUrl: "",
+            tokens: {
+              accessToken: longLivedToken,
+            },
+            metadata: {
+              pageId: parsedInput.pageId,
+              pageName: parsedInput.pageName,
+              version: messengerSettings.version,
+            },
+          }
+
+          const { integration: integrationRow } =
+            await connectChannelIntegration({
+              tx,
+              ownerId: platformOwnerId,
+              inboxData: {
+                id: createId(),
+                workspaceId: workspaceId as string,
+                name: parsedInput.pageName,
+                channel: "messenger",
+                sourceId: parsedInput.pageId,
+              },
+              insertIntegration: async (inboxId) =>
+                tx
+                  .insert(integrationMessengerModel)
+                  .values({
+                    id: createId(),
+                    workspaceId: workspaceId as string,
+                    inboxId,
+                    pageId: parsedInput.pageId,
+                    auth,
+                    name: parsedInput.pageName,
+                    persistentMenus: [
+                      {
+                        label: BRANDING_TITLE,
+                        type: "url" as const,
+                        url: getBrandingUrl("messenger", appUrl),
+                      },
+                    ],
+                    conversationStarters: [],
+                    personas: [],
+                  })
+                  .returning()
+                  .then((result) => result[0]),
+            })
+
+          integrationId = integrationRow.id
+          connectedIntegrationId = integrationRow?.id
+
+          const brandingCtx = await buildContext({
+            workspaceId,
+            integrationType: "messenger",
+            integration: { ...integrationRow, auth },
+          })
+
+          await integrationMessenger.runChannelHandler("bot", "addBranding", {
+            ctx: brandingCtx,
+            title: BRANDING_TITLE,
+            url: getBrandingUrl("messenger", appUrl),
+          })
+
+          return { brandingCtx }
+        })
+
+        await updateWorkspaceLogo({
+          id: workspaceId as string,
+          integration: integrationMessenger,
+          ctx: brandingCtx,
+        })
 
         if (!integrationId) {
           throw new ChatbotXException("Failed to create integration")

--- a/apps/builder/src/features/integration-whatsapp/actions/connect.action.ts
+++ b/apps/builder/src/features/integration-whatsapp/actions/connect.action.ts
@@ -475,35 +475,32 @@ export const connectWhatsappAction = authActionClient
           await registerPhoneNumber({ auth })
         }
 
-        const { workspaceId, createdWorkspace, integrationRow } =
-          await db.transaction((tx) =>
-            persistIntegration({
-              tx,
-              ownerId,
-              userId: ctx.user.id,
-              workspaceId: parsedInput.workspaceId,
-              integrationId,
-              phoneNumber,
-              wabaId: parsedInput.wabaId,
-              businessId,
-              auth,
-              isCoexist,
-              platformType,
-            }),
-          )
+        const { workspaceId, integrationRow } = await db.transaction((tx) =>
+          persistIntegration({
+            tx,
+            ownerId,
+            userId: ctx.user.id,
+            workspaceId: parsedInput.workspaceId,
+            integrationId,
+            phoneNumber,
+            wabaId: parsedInput.wabaId,
+            businessId,
+            auth,
+            isCoexist,
+            platformType,
+          }),
+        )
 
-        if (createdWorkspace) {
-          const whatsappCtx = await buildContext({
-            workspaceId,
-            integrationType: "whatsapp",
-            integration: { ...integrationRow, auth },
-          })
-          await updateWorkspaceLogo({
-            id: workspaceId,
-            integration: integrationWhatsapp,
-            ctx: whatsappCtx,
-          })
-        }
+        const whatsappCtx = await buildContext({
+          workspaceId,
+          integrationType: "whatsapp",
+          integration: { ...integrationRow, auth },
+        })
+        await updateWorkspaceLogo({
+          id: workspaceId,
+          integration: integrationWhatsapp,
+          ctx: whatsappCtx,
+        })
 
         await subscribeWebhook({ auth })
 

--- a/apps/builder/src/features/messages/actions/create-message.action.ts
+++ b/apps/builder/src/features/messages/actions/create-message.action.ts
@@ -85,6 +85,7 @@ export const createMessage = async (props: {
         contactInboxId: contactInbox,
         flowId: parsedInput.flowId,
         nodeId: parsedInput.nodeId,
+        sendFrom: "inbox",
       },
     })
     return null
@@ -176,6 +177,7 @@ export const createMessage = async (props: {
           ...messageWithAttachments,
           clientId: parsedInput.clientId,
         },
+        sendFrom: "inbox",
       },
     }),
   ]

--- a/apps/builder/src/features/messages/components/message-input.tsx
+++ b/apps/builder/src/features/messages/components/message-input.tsx
@@ -9,8 +9,15 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hooks"
 import { PaperclipIcon, SendHorizonalIcon } from "lucide-react"
 import { useTranslations } from "next-intl"
+import { useAction } from "next-safe-action/hooks"
 import { type KeyboardEvent, useCallback, useMemo, useRef } from "react"
 import { Controller, useWatch } from "react-hook-form"
+import { toast } from "sonner"
+import { disableBotAction } from "@/features/conversations/actions/disable-bot.action"
+import {
+  BOT_DISABLE_DURATION_MS,
+  isConversationActive,
+} from "@/features/conversations/utils/bot-state"
 import { InboxIcon } from "@/features/inboxes/components/inbox-icon"
 import { QuickRepliesPopover } from "@/features/saved-replies/quick-replies-popover"
 import { authClient } from "@/lib/auth/auth-client"
@@ -27,14 +34,36 @@ export const MessageInput = () => {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileUploadRef = useRef<HTMLInputElement>(null)
 
-  const { appendMessage, activeConversationId, conversations } = useChatStore(
-    (state) => state,
-  )
+  const {
+    appendMessage,
+    activeConversationId,
+    conversations,
+    updateConversation,
+  } = useChatStore((state) => state)
 
   // Memoize active conversation to prevent unnecessary re-renders
   const conversation = useMemo(
     () => conversations.find((c) => c.id === activeConversationId) ?? null,
     [conversations, activeConversationId],
+  )
+
+  const { execute: disableBot } = useAction(
+    disableBotAction.bind(null, conversation?.workspaceId ?? ""),
+    {
+      onSuccess: () => {
+        if (conversation) {
+          updateConversation(conversation.id, {
+            botEnabled: false,
+            botResumeAt: new Date(Date.now() + BOT_DISABLE_DURATION_MS),
+          })
+        }
+      },
+      onError: ({ error }) => {
+        if (error.serverError) {
+          toast.error(error.serverError)
+        }
+      },
+    },
   )
 
   const { form, handleSubmitWithAction, resetFormAndAction } =
@@ -78,6 +107,9 @@ export const MessageInput = () => {
             textareaRef.current?.focus()
           },
           onSuccess: () => {
+            if (conversation && isConversationActive(conversation)) {
+              disableBot({ ids: [conversation.id] })
+            }
             textareaRef.current?.focus()
             resetFormAndAction()
             form.setValue("clientId", createId())

--- a/apps/builder/src/features/workspaces/actions/upload-logo.ts
+++ b/apps/builder/src/features/workspaces/actions/upload-logo.ts
@@ -5,7 +5,10 @@ import {
   eq,
   isNull,
 } from "@chatbotx.io/database/client"
-import { workspaceModel } from "@chatbotx.io/database/schema"
+import {
+  workspaceMemberModel,
+  workspaceModel,
+} from "@chatbotx.io/database/schema"
 import { uploadFileFromUrl } from "@chatbotx.io/filesystem/node-upload"
 import { invalidateCacheByTags } from "@chatbotx.io/redis"
 import type { AuthValue, Context } from "@chatbotx.io/sdk"
@@ -27,25 +30,37 @@ export async function updateWorkspaceLogo<A extends AuthValue>(props: {
 }): Promise<void> {
   const { id, integration, ctx, tx = db } = props
 
-  const url = await integration.runChannelHandler(
-    "bot",
-    "getProfilePictureUrl",
-    {
-      ctx,
-    },
-  )
-  if (!url) {
+  const workspace = await tx.query.workspaceModel.findFirst({
+    where: { id },
+    columns: { logo: true },
+  })
+  if (!workspace || workspace.logo) {
     return
   }
 
-  let logo: string
+  let logo: string | undefined
   try {
+    const url = await integration.runChannelHandler(
+      "bot",
+      "getProfilePictureUrl",
+      {
+        ctx,
+      },
+    )
+    if (!url) {
+      return
+    }
+
     const uploaded = await uploadFileFromUrl(
       url,
       `public/space/${id}/logos/${createId()}.jpg`,
     )
     logo = uploaded.originPath
   } catch {
+    return
+  }
+
+  if (!logo) {
     return
   }
 
@@ -56,6 +71,17 @@ export async function updateWorkspaceLogo<A extends AuthValue>(props: {
     .returning({ id: workspaceModel.id })
 
   if (updated.length > 0) {
-    await invalidateCacheByTags([`workspaces:${id}`])
+    const workspaceMembers = await tx
+      .select({ userId: workspaceMemberModel.userId })
+      .from(workspaceMemberModel)
+      .where(eq(workspaceMemberModel.workspaceId, id))
+
+    await invalidateCacheByTags([
+      `workspaces:${id}`,
+      ...workspaceMembers.map(
+        (workspaceMember) =>
+          `users:${workspaceMember.userId}:workspace-members`,
+      ),
+    ])
   }
 }

--- a/apps/worker/__tests__/flow.test.ts
+++ b/apps/worker/__tests__/flow.test.ts
@@ -335,6 +335,7 @@ describe("runStepsAndQuickReplies — default edge enqueues a new job (Part 1)",
       ...makeBaseProps(flowVersion),
       details: { steps: [] },
       triggerNextNode: true,
+      sendFrom: "inbox" as const,
     }
 
     await runStepsAndQuickReplies(props)
@@ -342,11 +343,12 @@ describe("runStepsAndQuickReplies — default edge enqueues a new job (Part 1)",
     expect(integrationQueueAdd).toHaveBeenCalledOnce()
     const [action, job] = integrationQueueAdd.mock.calls[0] as unknown as [
       string,
-      { data: { nodeId: string; flowId: string } },
+      { data: { flowId: string; nodeId: string; sendFrom?: string } },
     ]
     expect(action).toBe("sendFlow")
     expect(job.data.nodeId).toBe("node-2")
     expect(job.data.flowId).toBe("flow-1")
+    expect(job.data.sendFrom).toBe("inbox")
   })
 })
 
@@ -599,6 +601,7 @@ describe("runStepsAndQuickReplies — per-step re-dispatch", () => {
       metadata,
       trackingContext,
       targetNodeId: "node-1",
+      sendFrom: "inbox" as const,
     }
 
     await runStepsAndQuickReplies(props)
@@ -606,11 +609,19 @@ describe("runStepsAndQuickReplies — per-step re-dispatch", () => {
     expect(integrationQueueAdd).toHaveBeenCalledOnce()
     const [, job] = integrationQueueAdd.mock.calls[0] as unknown as [
       string,
-      { data: { metadata: unknown; trackingContext: unknown; nodeId: string } },
+      {
+        data: {
+          metadata: unknown
+          nodeId: string
+          sendFrom?: string
+          trackingContext: unknown
+        }
+      },
     ]
     expect(job.data.metadata).toBe(metadata)
     expect(job.data.trackingContext).toBe(trackingContext)
     expect(job.data.nodeId).toBe("node-1")
+    expect(job.data.sendFrom).toBe("inbox")
   })
 
   test("logs a warning and returns early when startFromStepId is set but no matching step exists", async () => {

--- a/apps/worker/__tests__/received-message.test.ts
+++ b/apps/worker/__tests__/received-message.test.ts
@@ -18,8 +18,10 @@ const {
   mockResolvePlatformSettings,
   mockUpdateContactFromMessage,
   mockIntegrationQueueAdd,
+  mockDbSet,
 } = vi.hoisted(() => {
-  const updateChain = { set: vi.fn(), where: vi.fn() }
+  const mockDbSet = vi.fn()
+  const updateChain = { set: mockDbSet, where: vi.fn() }
   updateChain.set.mockReturnValue(updateChain)
   updateChain.where.mockResolvedValue(undefined)
   const mockDbUpdate = vi.fn().mockReturnValue(updateChain)
@@ -50,6 +52,7 @@ const {
     mockResolvePlatformSettings: vi.fn().mockResolvedValue({}),
     mockUpdateContactFromMessage: vi.fn().mockResolvedValue(undefined),
     mockIntegrationQueueAdd: vi.fn().mockResolvedValue(undefined),
+    mockDbSet,
   }
 })
 
@@ -76,7 +79,11 @@ vi.mock("@chatbotx.io/database/client", () => ({
 }))
 
 vi.mock("@chatbotx.io/database/schema", () => ({
-  contactInboxModel: { id: "id" },
+  contactInboxModel: {
+    id: "id",
+    lastMessageAt: "lastMessageAt",
+    lastIncomingMessageAt: "lastIncomingMessageAt",
+  },
   contactModel: { id: "id" },
   conversationModel: { id: "id" },
 }))
@@ -294,7 +301,7 @@ describe("receiveMessage — message repository branch", () => {
     expect(mockCreateOrUpdate).not.toHaveBeenCalled()
   })
 
-  test("updates contactInbox.lastMessageAt when isNew=true", async () => {
+  test("updates contactInbox message timestamps when incoming message is new", async () => {
     mockRunChannelHandler.mockResolvedValue({
       message: { ...baseIncomingMessage, attachments: [] },
       contact: { sourceId: "psid-123", firstName: "Test" },
@@ -310,6 +317,34 @@ describe("receiveMessage — message repository branch", () => {
     await receiveMessage(baseProps)
 
     expect(mockDbUpdate).toHaveBeenCalled()
+    expect(mockDbSet).toHaveBeenCalledWith({
+      lastMessageAt: fakeCreatedMessage.createdAt,
+      lastIncomingMessageAt: fakeCreatedMessage.createdAt,
+    })
+  })
+
+  test("does NOT update lastIncomingMessageAt for outgoing webhook echo", async () => {
+    mockRunChannelHandler.mockResolvedValue({
+      message: {
+        ...baseIncomingMessage,
+        messageType: "outgoing",
+        attachments: [],
+      },
+      contact: { sourceId: "psid-123", firstName: "Test" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+    mockCreateOrUpdate.mockResolvedValue({
+      message: { ...fakeCreatedMessage, messageType: "outgoing" },
+      isNew: true,
+    })
+
+    await receiveMessage(baseProps)
+
+    expect(mockDbSet).toHaveBeenCalledWith({
+      lastMessageAt: fakeCreatedMessage.createdAt,
+    })
   })
 
   test("does NOT update lastMessageAt when isNew=false", async () => {

--- a/apps/worker/__tests__/send-flow-step.test.ts
+++ b/apps/worker/__tests__/send-flow-step.test.ts
@@ -323,7 +323,11 @@ describe("sendFlowStep", () => {
   })
 
   test("calls repository.create() for step without url (sendText)", async () => {
-    await sendFlowStep({ ...baseParams, step: sendTextStep })
+    await sendFlowStep({
+      ...baseParams,
+      sendFrom: "inbox",
+      step: sendTextStep,
+    })
 
     expect(mockRepositoryCreate).toHaveBeenCalledTimes(1)
     expect(mockRepositoryCreateWithAttachments).not.toHaveBeenCalled()
@@ -333,6 +337,11 @@ describe("sendFlowStep", () => {
         senderType: "bot",
         workspaceId: "ws-1",
         conversationId: "conv-1",
+      }),
+    )
+    expect(mockSendFlowStepToChannel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sendFrom: "inbox",
       }),
     )
   })

--- a/apps/worker/__tests__/send-message-handler.test.ts
+++ b/apps/worker/__tests__/send-message-handler.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+  mockEmit,
+  mockResolveIntegrationContextFromContactInbox,
+  mockRunChannelHandler,
+  mockDbUpdate,
+} = vi.hoisted(() => {
+  const updateChain = {
+    set: vi.fn().mockReturnThis(),
+    where: vi.fn().mockResolvedValue(undefined),
+  }
+
+  return {
+    mockEmit: vi.fn().mockResolvedValue(undefined),
+    mockResolveIntegrationContextFromContactInbox: vi.fn(),
+    mockRunChannelHandler: vi.fn().mockResolvedValue({ messageIds: ["mid-1"] }),
+    mockDbUpdate: vi.fn().mockReturnValue(updateChain),
+  }
+})
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    update: mockDbUpdate,
+  },
+  eq: vi.fn((col: unknown, val: unknown) => ({ __eq: [col, val] })),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  messageModel: { id: "id", sourceId: "sourceId" },
+  whatsappFlowModel: { id: "id", sourceId: "sourceId" },
+}))
+
+vi.mock("@chatbotx.io/event-bus", () => ({
+  emit: mockEmit,
+}))
+
+vi.mock("@chatbotx.io/sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@chatbotx.io/sdk")>()
+  return {
+    ...actual,
+    parseSdkError: vi.fn().mockResolvedValue({ message: "sdk error" }),
+  }
+})
+
+vi.mock("../src/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock("../src/services/integrations", () => ({
+  allIntegrations: {},
+  resolveIntegrationContextFromContactInbox:
+    mockResolveIntegrationContextFromContactInbox,
+}))
+
+const { sendFlowStepToChannel, sendMessageToChannel } = await import(
+  "../src/chat/handlers/send-message"
+)
+const { ChannelError, ChannelErrorCategory } = await import("@chatbotx.io/sdk")
+
+const conversation = {
+  id: "conv-1",
+  workspaceId: "ws-1",
+  contactId: "contact-1",
+}
+
+const contactInbox = {
+  id: "ci-1",
+  inboxId: "inbox-1",
+  channel: "messenger",
+  contactId: "contact-1",
+  sourceId: "psid-1",
+  source: "messenger",
+}
+
+describe("chat send-message handlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRunChannelHandler.mockResolvedValue({ messageIds: ["mid-1"] })
+    mockResolveIntegrationContextFromContactInbox.mockResolvedValue({
+      ctx: { workspaceId: "ws-1" },
+      integration: {
+        runChannelHandler: mockRunChannelHandler,
+      },
+    })
+  })
+
+  test("passes sendFrom to sendMessage channel handler", async () => {
+    await sendMessageToChannel({
+      conversation: conversation as never,
+      contactInbox: contactInbox as never,
+      message: {
+        id: "msg-1",
+        workspaceId: "ws-1",
+        conversationId: "conv-1",
+        contactInboxId: "ci-1",
+        contentType: "text",
+        messageType: "outgoing",
+        senderType: "user",
+        text: "hello",
+      } as never,
+      sendFrom: "inbox",
+    })
+
+    expect(mockRunChannelHandler).toHaveBeenCalledWith(
+      "message",
+      "sendMessage",
+      expect.objectContaining({
+        data: expect.objectContaining({
+          sendFrom: "inbox",
+        }),
+      }),
+    )
+  })
+
+  test("passes sendFrom to sendFlowStep channel handler", async () => {
+    await sendFlowStepToChannel({
+      conversation: conversation as never,
+      contactInbox: contactInbox as never,
+      flowId: "flow-1",
+      step: {
+        id: "step-1",
+        nodeId: "node-1",
+        stepType: "sendText",
+        text: "hello",
+      } as never,
+      sendFrom: "inbox",
+    })
+
+    expect(mockRunChannelHandler).toHaveBeenCalledWith(
+      "message",
+      "sendFlowStep",
+      expect.objectContaining({
+        data: expect.objectContaining({
+          sendFrom: "inbox",
+        }),
+      }),
+    )
+  })
+
+  test("does not throw non-retryable ChannelError after emitting failure", async () => {
+    const error = new ChannelError(
+      "expired human agent window",
+      ChannelErrorCategory.PAYLOAD_INVALID,
+      { code: "messenger_human_agent_window_expired" },
+    )
+    mockRunChannelHandler.mockRejectedValueOnce(error)
+
+    await expect(
+      sendMessageToChannel({
+        conversation: conversation as never,
+        contactInbox: contactInbox as never,
+        message: {
+          id: "msg-1",
+          workspaceId: "ws-1",
+          conversationId: "conv-1",
+          contactInboxId: "ci-1",
+          contentType: "text",
+          messageType: "outgoing",
+          senderType: "user",
+          text: "hello",
+        } as never,
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(mockEmit).toHaveBeenCalledWith(
+      "message:failed",
+      expect.objectContaining({
+        action: { messageId: "msg-1" },
+        errorData: { message: "sdk error" },
+      }),
+    )
+  })
+
+  test("throws retryable ChannelError after emitting failure", async () => {
+    const error = new ChannelError(
+      "rate limited",
+      ChannelErrorCategory.RATE_LIMITED,
+      { code: "rate_limited" },
+    )
+    mockRunChannelHandler.mockRejectedValueOnce(error)
+
+    await expect(
+      sendMessageToChannel({
+        conversation: conversation as never,
+        contactInbox: contactInbox as never,
+        message: {
+          id: "msg-1",
+          workspaceId: "ws-1",
+          conversationId: "conv-1",
+          contactInboxId: "ci-1",
+          contentType: "text",
+          messageType: "outgoing",
+          senderType: "user",
+          text: "hello",
+        } as never,
+      }),
+    ).rejects.toBe(error)
+
+    expect(mockEmit).toHaveBeenCalledWith(
+      "message:failed",
+      expect.objectContaining({
+        action: { messageId: "msg-1" },
+        errorData: { message: "sdk error" },
+      }),
+    )
+  })
+
+  test("does not retry missing integration auth resolution errors", async () => {
+    const error = new ChannelError(
+      "Unable to find integration auth for channel: messenger",
+      ChannelErrorCategory.AUTH_FAILED,
+      { code: "integration_auth_missing" },
+    )
+    mockResolveIntegrationContextFromContactInbox.mockRejectedValueOnce(error)
+
+    await expect(
+      sendMessageToChannel({
+        conversation: conversation as never,
+        contactInbox: contactInbox as never,
+        message: {
+          id: "msg-1",
+          workspaceId: "ws-1",
+          conversationId: "conv-1",
+          contactInboxId: "ci-1",
+          contentType: "text",
+          messageType: "outgoing",
+          senderType: "user",
+          text: "hello",
+        } as never,
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(mockRunChannelHandler).not.toHaveBeenCalled()
+    expect(mockEmit).toHaveBeenCalledWith(
+      "message:failed",
+      expect.objectContaining({
+        action: { messageId: "msg-1" },
+        errorData: { message: "sdk error" },
+      }),
+    )
+  })
+})

--- a/apps/worker/src/chat/handlers/send-flow-step.ts
+++ b/apps/worker/src/chat/handlers/send-flow-step.ts
@@ -128,6 +128,7 @@ export async function sendFlowStep({
   step,
   trackingContext,
   metadata,
+  sendFrom,
 }: ChatJobSendFlowStep["data"]) {
   const conversation = await db.query.conversationModel.findFirst({
     where: { id: conversationId },
@@ -351,6 +352,7 @@ export async function sendFlowStep({
         step: resolvedStep as SendFlowStepData,
         metadata,
         messageId: message?.id,
+        sendFrom,
       }),
     ]
 

--- a/apps/worker/src/chat/handlers/send-message.ts
+++ b/apps/worker/src/chat/handlers/send-message.ts
@@ -10,7 +10,11 @@ import {
   messageEventTypeSchema,
   stepTypes,
 } from "@chatbotx.io/flow-config"
-import { parseSdkError, type SendFlowStepData } from "@chatbotx.io/sdk"
+import {
+  ChannelError,
+  parseSdkError,
+  type SendFlowStepData,
+} from "@chatbotx.io/sdk"
 import type {
   ChatJobSendChannelMessage,
   ChatJobSendTyping,
@@ -24,20 +28,22 @@ import {
 export async function sendMessageToChannel(
   data: ChatJobSendChannelMessage["data"],
 ) {
-  const { conversation, contactInbox, message, metadata } = data
-
-  const { integration, ctx } = await resolveIntegrationContextFromContactInbox({
-    workspaceId: conversation.workspaceId,
-    contactInbox,
-  })
+  const { conversation, contactInbox, message, metadata, sendFrom } = data
 
   try {
+    const { integration, ctx } =
+      await resolveIntegrationContextFromContactInbox({
+        workspaceId: conversation.workspaceId,
+        contactInbox,
+      })
+
     await integration.runChannelHandler("message", "sendMessage", {
       ctx,
       data: {
         contact: contactInbox,
         message,
         metadata,
+        sendFrom,
       },
     })
   } catch (error) {
@@ -57,6 +63,9 @@ export async function sendMessageToChannel(
       occurredAt: new Date(),
       metadata,
     })
+    if (error instanceof ChannelError && !error.isRetryable) {
+      return
+    }
     throw error
   }
 }
@@ -108,6 +117,7 @@ export async function sendFlowStepToChannel({
   step,
   metadata,
   messageId,
+  sendFrom,
 }: {
   conversation: ConversationModel
   contactInbox: ContactInboxModel
@@ -116,6 +126,7 @@ export async function sendFlowStepToChannel({
   step: SendFlowStepData
   metadata?: MetadataPayload
   messageId?: string
+  sendFrom?: "inbox"
 }): Promise<{ messageIds: string[] }> {
   const { integration, ctx } = await resolveIntegrationContextFromContactInbox({
     workspaceId: conversation.workspaceId,
@@ -154,6 +165,7 @@ export async function sendFlowStepToChannel({
         flowVersionId,
         step: resolvedStep,
         metadata,
+        sendFrom,
       },
     },
   )

--- a/apps/worker/src/integration/handlers/flow-utils.ts
+++ b/apps/worker/src/integration/handlers/flow-utils.ts
@@ -29,6 +29,7 @@ export type ExecuteMultipleStepsProps = {
   steps: BaseStepSchema[]
   trackingContext?: BotResponseTrackingContext
   metadata?: MetadataPayload
+  sendFrom?: "inbox"
 }
 
 export type ExecuteStepProps<T> = Omit<ExecuteMultipleStepsProps, "steps"> & {
@@ -78,6 +79,7 @@ export async function sendFlow(
         flowId: flowVersion.flowId,
         nodeId: connectedNodeId,
         metadata: props.metadata,
+        sendFrom: props.sendFrom,
       },
     })
   }

--- a/apps/worker/src/integration/handlers/flow.ts
+++ b/apps/worker/src/integration/handlers/flow.ts
@@ -79,6 +79,7 @@ type ExecuteStepsAndQuickRepliesProps = {
   }
   trackingContext?: BotResponseTrackingContext
   metadata?: MetadataPayload
+  sendFrom?: "inbox"
 }
 
 export const runFlowNode = async (props: IntegrationJobRunFlowNode["data"]) => {
@@ -87,7 +88,7 @@ export const runFlowNode = async (props: IntegrationJobRunFlowNode["data"]) => {
     return
   }
 
-  const { trackingContext, metadata } = props
+  const { trackingContext, metadata, sendFrom } = props
   const { conversation, contactInbox } =
     await detectConversationAndContactInbox({
       conversationId: props.conversationId,
@@ -130,6 +131,7 @@ export const runFlowNode = async (props: IntegrationJobRunFlowNode["data"]) => {
       },
       trackingContext,
       metadata,
+      sendFrom,
     })
   } catch (error) {
     if (props.metadata?.type === BROADCAST_PAYLOAD_TYPE) {
@@ -229,6 +231,7 @@ export async function runStepsAndQuickReplies(
           startFromStepId: nextStep.id,
           metadata: props.metadata,
           trackingContext: props.trackingContext,
+          sendFrom: props.sendFrom,
         },
       })
       return
@@ -286,6 +289,7 @@ export async function runStepsAndQuickReplies(
         nodeId: nextNode.id,
         metadata: props.metadata,
         trackingContext: props.trackingContext,
+        sendFrom: props.sendFrom,
       },
     })
   }
@@ -349,6 +353,7 @@ async function* executeMultipleStepsGenerator(
               nodeId: connectedNodeId,
               metadata: props.metadata,
               trackingContext: props.trackingContext,
+              sendFrom: props.sendFrom,
             },
           })
           branched = true

--- a/apps/worker/src/integration/handlers/received-message.ts
+++ b/apps/worker/src/integration/handlers/received-message.ts
@@ -185,11 +185,18 @@ export const receiveMessage = async (
     const newMessage = messageWithAttachments
 
     if (isNewMessage) {
+      const lastMessageUpdate: Partial<typeof contactInboxModel.$inferInsert> =
+        {
+          lastMessageAt: newMessage.createdAt,
+        }
+
+      if (incomingMessage.messageType !== "outgoing") {
+        lastMessageUpdate.lastIncomingMessageAt = newMessage.createdAt
+      }
+
       await db
         .update(contactInboxModel)
-        .set({
-          lastMessageAt: newMessage.createdAt,
-        })
+        .set(lastMessageUpdate)
         .where(eq(contactInboxModel.id, contactInbox.id))
     }
 

--- a/apps/worker/src/integration/handlers/step.ts
+++ b/apps/worker/src/integration/handlers/step.ts
@@ -76,7 +76,14 @@ import {
 export async function sendFlowMessage(
   props: ExecuteStepProps<ChatJobSendFlowStep["data"]["step"]>,
 ) {
-  const { conversation, flowVersion, step, trackingContext, metadata } = props
+  const {
+    conversation,
+    flowVersion,
+    step,
+    trackingContext,
+    metadata,
+    sendFrom,
+  } = props
   await chatQueue.add(ChatJobAction.sendFlowMessage, {
     type: ChatJobAction.sendFlowMessage,
     data: {
@@ -86,6 +93,7 @@ export async function sendFlowMessage(
       step,
       trackingContext,
       metadata,
+      sendFrom,
     },
   })
 }
@@ -97,6 +105,7 @@ async function splitTraffic({
   step,
   targetId,
   useLatestFlowVersion,
+  sendFrom,
 }: ExecuteStepProps<SplitTrafficStepSchema>) {
   if (!(targetId && step.cases.length)) {
     return
@@ -127,6 +136,7 @@ async function splitTraffic({
         flowId: flowVersion.flowId,
         flowVersionId: useLatestFlowVersion ? undefined : flowVersion.id,
         nodeId: connectedEdge.target,
+        sendFrom,
       },
     })
   }
@@ -139,6 +149,7 @@ async function handleWait({
   targetId,
   step,
   useLatestFlowVersion,
+  sendFrom,
 }: ExecuteStepProps<WaitStepSchema>): Promise<ExecuteStepResult> {
   if (!(targetId && step)) {
     return { status: "skip", result: null }
@@ -216,6 +227,7 @@ async function handleWait({
             flowVersionId: useLatestFlowVersion ? undefined : flowVersion.id,
             nodeId: connectedNodeId,
             contactInboxId,
+            sendFrom,
           },
         },
         { delay: Math.max(0, diffMs), jobId: buildJobId(rowId) },
@@ -247,6 +259,7 @@ async function startAnotherNode(
       flowVersionId: props.flowVersion.id,
       nodeId: props.step.nodeId,
       metadata: props.metadata,
+      sendFrom: props.sendFrom,
     },
   })
 }
@@ -256,6 +269,7 @@ async function startExternalFlow({
   contactInbox,
   step,
   metadata,
+  sendFrom,
 }: ExecuteStepProps<StartExternalFlowStepSchema>) {
   await integrationQueue.add(IntegrationJobAction.sendFlow, {
     type: IntegrationJobAction.sendFlow,
@@ -264,6 +278,7 @@ async function startExternalFlow({
       contactInboxId: contactInbox.id,
       flowId: step.flowId,
       metadata,
+      sendFrom,
     },
   })
 }
@@ -273,6 +288,7 @@ async function startExternalNode({
   contactInbox,
   step,
   metadata,
+  sendFrom,
 }: ExecuteStepProps<StartExternalNodeStepSchema>) {
   await integrationQueue.add(IntegrationJobAction.sendFlow, {
     type: IntegrationJobAction.sendFlow,
@@ -282,6 +298,7 @@ async function startExternalNode({
       flowId: step.flowId,
       nodeId: step.nodeId,
       metadata,
+      sendFrom,
     },
   })
 }

--- a/apps/worker/src/services/integrations.ts
+++ b/apps/worker/src/services/integrations.ts
@@ -23,6 +23,8 @@ import { integration as integrationWhatsapp } from "@chatbotx.io/integration-wha
 import { integration as integrationZalo } from "@chatbotx.io/integration-zalo"
 import {
   type AuthValue,
+  ChannelError,
+  ChannelErrorCategory,
   type Integration,
   type IntegrationDefinition,
   SdkException,
@@ -159,8 +161,10 @@ export const integrationService = {
     )
 
     if (!result.rows[0]) {
-      throw new SdkException(
+      throw new ChannelError(
         `Unable to find integration auth for channel: ${contactInbox.channel}`,
+        ChannelErrorCategory.AUTH_FAILED,
+        { code: "integration_auth_missing" },
       )
     }
 

--- a/integrations/messenger/__tests__/outgoing-message-policy.test.ts
+++ b/integrations/messenger/__tests__/outgoing-message-policy.test.ts
@@ -1,0 +1,82 @@
+import { ChannelError } from "@chatbotx.io/sdk"
+import { describe, expect, test } from "vitest"
+import { resolveMessengerMessagingPolicy } from "../src/handlers/message/outgoing-message"
+
+const now = new Date("2026-06-09T00:00:00.000Z")
+
+const makeContact = (lastIncomingMessageAt?: Date | string | null) => ({
+  id: "contact-1",
+  sourceId: "psid-1",
+  lastIncomingMessageAt,
+})
+
+describe("resolveMessengerMessagingPolicy", () => {
+  test("uses RESPONSE for non-inbox sends", () => {
+    expect(
+      resolveMessengerMessagingPolicy({
+        contact: makeContact(null),
+        now,
+      }),
+    ).toEqual({ messagingType: "RESPONSE" })
+  })
+
+  test("uses RESPONSE for inbox sends inside 24 hours", () => {
+    expect(
+      resolveMessengerMessagingPolicy({
+        contact: makeContact(new Date("2026-06-08T01:00:00.000Z")),
+        now,
+        sendFrom: "inbox",
+      }),
+    ).toEqual({ messagingType: "RESPONSE" })
+  })
+
+  test("handles serialized timestamps from BullMQ payloads", () => {
+    expect(
+      resolveMessengerMessagingPolicy({
+        contact: makeContact("2026-06-08T01:00:00.000Z"),
+        now,
+        sendFrom: "inbox",
+      }),
+    ).toEqual({ messagingType: "RESPONSE" })
+  })
+
+  test("uses HUMAN_AGENT between 24 hours and 7 days", () => {
+    expect(
+      resolveMessengerMessagingPolicy({
+        contact: makeContact(new Date("2026-06-07T23:00:00.000Z")),
+        now,
+        sendFrom: "inbox",
+      }),
+    ).toEqual({ messagingType: "MESSAGE_TAG", tag: "HUMAN_AGENT" })
+  })
+
+  test("uses RESPONSE for inbox sends without a valid last incoming timestamp", () => {
+    expect(
+      resolveMessengerMessagingPolicy({
+        contact: makeContact(null),
+        now,
+        sendFrom: "inbox",
+      }),
+    ).toEqual({ messagingType: "RESPONSE" })
+  })
+
+  test("uses RESPONSE for inbox sends with an invalid last incoming timestamp", () => {
+    expect(
+      resolveMessengerMessagingPolicy({
+        contact: makeContact("not-a-date"),
+        now,
+        sendFrom: "inbox",
+      }),
+    ).toEqual({ messagingType: "RESPONSE" })
+  })
+
+  test("throws for inbox sends after the 7-day human-agent window", () => {
+    expect(() =>
+      resolveMessengerMessagingPolicy({
+        contact: makeContact(new Date("2026-06-01T23:59:59.000Z")),
+        now,
+        sendFrom: "inbox",
+      }),
+    ).toThrow(ChannelError)
+  })
+})

--- a/integrations/messenger/__tests__/schema.test.ts
+++ b/integrations/messenger/__tests__/schema.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest"
-import { facebookMessageAttachmentPayloadSchema } from "../src/schema"
+import {
+  facebookMessageAttachmentPayloadSchema,
+  facebookSendMessageRequestSchema,
+} from "../src/schema"
 
 describe("facebookMessageAttachmentPayloadSchema", () => {
   test("rejects template_type 'utility' — utility messages use message.template not attachment", () => {
@@ -13,6 +16,19 @@ describe("facebookMessageAttachmentPayloadSchema", () => {
     const result = facebookMessageAttachmentPayloadSchema.safeParse({
       template_type: "generic",
     })
+    expect(result.success).toBe(true)
+  })
+})
+
+describe("facebookSendMessageRequestSchema", () => {
+  test("accepts HUMAN_AGENT message tag", () => {
+    const result = facebookSendMessageRequestSchema.safeParse({
+      recipient: { id: "psid-1" },
+      message: { text: "hello" },
+      messaging_type: "MESSAGE_TAG",
+      tag: "HUMAN_AGENT",
+    })
+
     expect(result.success).toBe(true)
   })
 })

--- a/integrations/messenger/__tests__/send-messenger-template.test.ts
+++ b/integrations/messenger/__tests__/send-messenger-template.test.ts
@@ -3,16 +3,26 @@ import type {
   SendMessengerTemplateMessageStepSchema,
 } from "@chatbotx.io/flow-config"
 import { decodeButtonPayload } from "@chatbotx.io/flow-config"
-import { describe, expect, test } from "vitest"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import { sendFlowStep } from "../src/handlers/message/outgoing-message"
 import {
   buildMessengerTemplateComponents,
   buildMessengerTemplateSendRequest,
 } from "../src/handlers/message/outgoing-message/send-messenger-template"
 import { MESSENGER_MESSAGE_METADATA } from "../src/schema"
 
+const { mockSendPageMessage } = vi.hoisted(() => ({
+  mockSendPageMessage: vi.fn(),
+}))
+
+vi.mock("../src/apis/message", () => ({
+  sendPageMessage: mockSendPageMessage,
+}))
+
 // Minimal props factory for buildMessengerTemplateSendRequest
 function makeProps(
   overrides: Partial<{
+    lastIncomingMessageAt: Date | string | null
     sourceId: string
     templateName: string
     templateLanguage: string
@@ -23,9 +33,11 @@ function makeProps(
     flowVersionId?: string
     buttons?: ButtonStepProps[]
     metadata?: Record<string, string>
+    sendFrom?: "inbox"
   }> = {},
 ) {
   const {
+    lastIncomingMessageAt,
     sourceId = "user-123",
     templateName = "order_update",
     templateLanguage = "en",
@@ -36,6 +48,7 @@ function makeProps(
     flowVersionId,
     buttons = [],
     metadata,
+    sendFrom,
   } = overrides
 
   return {
@@ -44,10 +57,11 @@ function makeProps(
       integrationDetail: personaId ? { personaId } : undefined,
     },
     data: {
-      contact: { sourceId, id: "contact-1" },
+      contact: { sourceId, id: "contact-1", lastIncomingMessageAt },
       flowId,
       flowVersionId,
       metadata,
+      sendFrom,
       step: {
         id: "step-1",
         nodeId: "node-1",
@@ -64,6 +78,11 @@ function makeProps(
     },
   } as Parameters<typeof buildMessengerTemplateSendRequest>[0]
 }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockSendPageMessage.mockResolvedValue({ recipient_id: "user-123" })
+})
 
 // ─── buildMessengerTemplateComponents ────────────────────────────────────────
 
@@ -315,6 +334,11 @@ describe("buildMessengerTemplateSendRequest", () => {
     expect(req.tag).toBeUndefined()
   })
 
+  test("no message_type field", () => {
+    const req = buildMessengerTemplateSendRequest(makeProps())
+    expect((req as Record<string, unknown>).message_type).toBeUndefined()
+  })
+
   test("persona_id included when integrationDetail.personaId present", () => {
     const req = buildMessengerTemplateSendRequest(
       makeProps({ personaId: "persona-abc" }),
@@ -458,5 +482,23 @@ describe("buildMessengerTemplateSendRequest", () => {
       components[0].parameters[0].payload ?? "",
     )
     expect(decoded).toMatchObject({ broadcastId: "55000" })
+  })
+})
+
+describe("sendFlowStep", () => {
+  test("sends Messenger template as UTILITY even when inbox send is outside the 7-day human-agent window", async () => {
+    await expect(
+      sendFlowStep(
+        makeProps({
+          lastIncomingMessageAt: "2026-06-01T00:00:00.000Z",
+          sendFrom: "inbox",
+        }),
+      ),
+    ).resolves.toEqual({ messageIds: [] })
+
+    expect(mockSendPageMessage).toHaveBeenCalledTimes(1)
+    const [, payload] = mockSendPageMessage.mock.calls[0]
+    expect(payload).toMatchObject({ messaging_type: "UTILITY" })
+    expect(payload).not.toHaveProperty("tag")
   })
 })

--- a/integrations/messenger/src/handlers/message/outgoing-message/index.ts
+++ b/integrations/messenger/src/handlers/message/outgoing-message/index.ts
@@ -166,7 +166,7 @@ const buildMessagePayload = (props: {
   messagingType?: "MESSAGE_TAG" | "RESPONSE"
   personaId?: string
 }): FacebookSendMessageRequest => {
-  const { contact, message, messagingType = "MESSAGE_TAG", personaId } = props
+  const { contact, message, personaId } = props
 
   return {
     recipient: { id: contact.sourceId },
@@ -174,8 +174,8 @@ const buildMessagePayload = (props: {
       ...message,
       metadata: MESSENGER_MESSAGE_METADATA,
     },
-    messaging_type: messagingType,
-    tag: messagingType === "MESSAGE_TAG" ? "ACCOUNT_UPDATE" : undefined,
+    messaging_type: "RESPONSE",
+    // tag: messagingType === "MESSAGE_TAG" ? "ACCOUNT_UPDATE" : undefined,
     persona_id: personaId,
   }
 }

--- a/integrations/messenger/src/handlers/message/outgoing-message/index.ts
+++ b/integrations/messenger/src/handlers/message/outgoing-message/index.ts
@@ -10,6 +10,8 @@ import {
   stepTypes,
 } from "@chatbotx.io/flow-config"
 import {
+  ChannelError,
+  ChannelErrorCategory,
   contentTypes,
   type MessageHandlers,
   type OutgoingContact,
@@ -36,18 +38,28 @@ import { buildMessengerTemplateSendRequest } from "./send-messenger-template"
 import { convertFlowStepQuickReply } from "./send-quick-reply"
 import { convertFlowStepText } from "./send-text"
 
+const RESPONSE_WINDOW_MS = 24 * 60 * 60 * 1000
+const HUMAN_AGENT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
+
+type MessengerMessagingPolicy = {
+  messagingType: "MESSAGE_TAG" | "RESPONSE"
+  tag?: FacebookSendMessageRequest["tag"]
+}
+
 export const sendMessage: MessageHandlers<MessengerAuthValue>["sendMessage"] =
   async (props) => {
     const {
       ctx,
-      data: { contact, message },
+      data: { contact, message, sendFrom },
     } = props
 
     try {
+      const policy = resolveMessengerMessagingPolicy({ contact, sendFrom })
       for (const facebookMessage of convertMessageToFacebookMessage(message)) {
         const payload = buildMessagePayload({
           contact,
           message: facebookMessage,
+          ...policy,
           personaId: (ctx.integrationDetail as MessengerIntegrationDetail)
             .personaId,
         })
@@ -68,7 +80,7 @@ export const sendFlowStep: MessageHandlers<MessengerAuthValue>["sendFlowStep"] =
   async (props: SendFlowStepProps<MessengerAuthValue>) => {
     const {
       ctx,
-      data: { contact, step },
+      data: { contact, sendFrom, step },
     } = props
     try {
       // Messenger utility templates must be sent as a complete Send API request
@@ -86,6 +98,7 @@ export const sendFlowStep: MessageHandlers<MessengerAuthValue>["sendFlowStep"] =
         return { messageIds: [] }
       }
 
+      const policy = resolveMessengerMessagingPolicy({ contact, sendFrom })
       for await (const facebookMessage of convertFlowStepToFacebookMessage(
         props,
       )) {
@@ -94,7 +107,7 @@ export const sendFlowStep: MessageHandlers<MessengerAuthValue>["sendFlowStep"] =
           buildMessagePayload({
             contact,
             message: facebookMessage,
-            messagingType: "RESPONSE",
+            ...policy,
             personaId: (ctx.integrationDetail as MessengerIntegrationDetail)
               .personaId,
           }),
@@ -164,9 +177,10 @@ const buildMessagePayload = (props: {
   contact: OutgoingContact
   message: FacebookMessageAttachmentPayload | FacebookMessage
   messagingType?: "MESSAGE_TAG" | "RESPONSE"
+  tag?: FacebookSendMessageRequest["tag"]
   personaId?: string
 }): FacebookSendMessageRequest => {
-  const { contact, message, personaId } = props
+  const { contact, message, messagingType = "RESPONSE", personaId, tag } = props
 
   return {
     recipient: { id: contact.sourceId },
@@ -174,10 +188,63 @@ const buildMessagePayload = (props: {
       ...message,
       metadata: MESSENGER_MESSAGE_METADATA,
     },
-    messaging_type: "RESPONSE",
-    // tag: messagingType === "MESSAGE_TAG" ? "ACCOUNT_UPDATE" : undefined,
+    messaging_type: messagingType,
+    tag,
     persona_id: personaId,
   }
+}
+
+export function resolveMessengerMessagingPolicy(props: {
+  contact: OutgoingContact
+  now?: Date | number
+  sendFrom?: "inbox"
+}): MessengerMessagingPolicy {
+  const { contact, sendFrom } = props
+
+  if (sendFrom !== "inbox") {
+    return { messagingType: "RESPONSE" }
+  }
+
+  const lastIncomingMessageAt = normalizeLastIncomingMessageAt(
+    contact.lastIncomingMessageAt,
+  )
+
+  if (!lastIncomingMessageAt) {
+    return { messagingType: "RESPONSE" }
+  }
+
+  let nowMs = Date.now()
+  if (props.now instanceof Date) {
+    nowMs = props.now.getTime()
+  } else if (typeof props.now === "number") {
+    nowMs = props.now
+  }
+  const elapsedMs = nowMs - lastIncomingMessageAt.getTime()
+
+  if (elapsedMs <= RESPONSE_WINDOW_MS) {
+    return { messagingType: "RESPONSE" }
+  }
+
+  if (elapsedMs <= HUMAN_AGENT_WINDOW_MS) {
+    return { messagingType: "MESSAGE_TAG", tag: "HUMAN_AGENT" }
+  }
+
+  throw new ChannelError(
+    "Cannot send a Messenger inbox message more than 7 days after the last incoming message",
+    ChannelErrorCategory.PAYLOAD_INVALID,
+    { code: "messenger_human_agent_window_expired" },
+  )
+}
+
+function normalizeLastIncomingMessageAt(
+  value: Date | string | null | undefined,
+) {
+  if (!value) {
+    return null
+  }
+
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
 }
 
 async function* convertFlowStepToFacebookMessage(

--- a/integrations/messenger/src/schema.ts
+++ b/integrations/messenger/src/schema.ts
@@ -275,6 +275,7 @@ export const facebookSendMessageRequestSchema = z.object({
       "TRANSPORTATION_UPDATE",
       "FEATURE_FUNCTIONALITY_UPDATE",
       "TICKET_UPDATE",
+      "HUMAN_AGENT",
     ])
     .optional(),
   notification_type: z.enum(["REGULAR", "SILENT_PUSH", "NO_PUSH"]).optional(),

--- a/packages/sdk/__tests__/channel-error.test.ts
+++ b/packages/sdk/__tests__/channel-error.test.ts
@@ -40,6 +40,30 @@ describe("ChannelError.getErrorData", () => {
     expect(data.isRetryable).toBe(false)
   })
 
+  test("AUTH_FAILED is permanent, not retryable", async () => {
+    const err = new ChannelError(
+      "missing auth",
+      ChannelErrorCategory.AUTH_FAILED,
+      { code: "integration_auth_missing", httpStatusCode: 400 },
+    )
+    const data = await err.getErrorData()
+    expect(data.category).toBe("auth_failed")
+    expect(data.isPermanent).toBe(true)
+    expect(data.isRetryable).toBe(false)
+  })
+
+  test("PAYLOAD_INVALID is permanent, not retryable", async () => {
+    const err = new ChannelError(
+      "invalid payload",
+      ChannelErrorCategory.PAYLOAD_INVALID,
+      { code: "bad_payload", httpStatusCode: 400 },
+    )
+    const data = await err.getErrorData()
+    expect(data.category).toBe("payload_invalid")
+    expect(data.isPermanent).toBe(true)
+    expect(data.isRetryable).toBe(false)
+  })
+
   test("subCode propagates to subcode field", async () => {
     const err = new ChannelError(
       "opted out",

--- a/packages/sdk/src/lib/action.ts
+++ b/packages/sdk/src/lib/action.ts
@@ -5,4 +5,6 @@ import type { ChannelSendFlowStepProps } from "./integration"
 export type SendFlowStepProps<
   TAuth extends AuthValue,
   S extends SendFlowStepData = SendFlowStepData,
-> = ChannelSendFlowStepProps<TAuth> & { data: { step: S } }
+> = Omit<ChannelSendFlowStepProps<TAuth>, "data"> & {
+  data: Omit<ChannelSendFlowStepProps<TAuth>["data"], "step"> & { step: S }
+}

--- a/packages/sdk/src/lib/channel-error-codes.ts
+++ b/packages/sdk/src/lib/channel-error-codes.ts
@@ -19,6 +19,10 @@ export const RETRYABLE_CATEGORIES = new Set<ChannelErrorCategory>([
 ])
 
 export const PERMANENT_CATEGORIES = new Set<ChannelErrorCategory>([
+  ChannelErrorCategory.AUTH_FAILED,
   ChannelErrorCategory.USER_BLOCKED,
   ChannelErrorCategory.INVALID_RECIPIENT,
+  ChannelErrorCategory.PERMISSION_DENIED,
+  ChannelErrorCategory.PAYLOAD_INVALID,
+  ChannelErrorCategory.QUOTA_EXCEEDED,
 ])

--- a/packages/sdk/src/lib/integration.ts
+++ b/packages/sdk/src/lib/integration.ts
@@ -49,6 +49,7 @@ export type ChannelSendFlowStepProps<IAuth extends AuthValue> = {
     flowVersionId?: string
     step: SendFlowStepData
     metadata?: MetadataPayload
+    sendFrom?: "inbox"
   }
 }
 
@@ -63,6 +64,7 @@ export type MessageHandlers<
         contact: OutgoingContact
         message: OutgoingMessage
         metadata?: MetadataPayload
+        sendFrom?: "inbox"
       }
     },
     {
@@ -89,6 +91,7 @@ export type MessageHandlers<
         flowVersionId?: string
         step: TStep
         metadata?: MetadataPayload
+        sendFrom?: "inbox"
       }
     },
     {

--- a/packages/sdk/src/lib/shared/message.ts
+++ b/packages/sdk/src/lib/shared/message.ts
@@ -15,6 +15,7 @@ export type IncomingContact = {
 export type OutgoingContact = {
   sourceId: string
   id: string
+  lastIncomingMessageAt?: Date | string | null
 }
 
 export type OutgoingMessage = {

--- a/packages/worker-config/src/queues/chat/index.ts
+++ b/packages/worker-config/src/queues/chat/index.ts
@@ -46,6 +46,7 @@ export type ChatJobSendChannelMessage = {
     contactInbox: ContactInboxModel
     message: MessageModel & { clientId?: string | undefined }
     metadata?: MetadataPayload
+    sendFrom?: "inbox"
   }
 }
 
@@ -69,6 +70,7 @@ export type ChatJobSendFlowStep = {
       | SendMessengerTemplateMessageStepSchema
     trackingContext?: BotResponseTrackingContext
     metadata?: MetadataPayload
+    sendFrom?: "inbox"
   }
 }
 

--- a/packages/worker-config/src/queues/integration/index.ts
+++ b/packages/worker-config/src/queues/integration/index.ts
@@ -72,6 +72,7 @@ export type IntegrationJobRunFlowNode = {
     startFromStepId?: string
     trackingContext?: BotResponseTrackingContext
     metadata?: MetadataPayload
+    sendFrom?: "inbox"
   }
 }
 


### PR DESCRIPTION
## Summary

- Send Messenger outgoing messages with `messaging_type: "RESPONSE"` and apply a 24-hour window policy for outgoing messages.
- Improve worker message flow (send-message, send-flow-step, received-message) and handle `sendFrom` for flow steps.
- Add channel error codes in the SDK and surface send errors more clearly.
- Refine message sending in the builder (message input, create message) and channel connection actions.
- Add tests for the above changes (worker, messenger, sdk, builder).

## Test plan

- [x] `pnpm lint` (ran via pre-commit hook)
- [x] `pnpm check-types` (ran via pre-commit hook)
- [ ] Verify Messenger send/receive works correctly within the 24-hour window
- [ ] Verify flow send step and `sendFrom` propagation
