### PR TITLE
fix(filesystem): expose uploadFileFromUrl from main entry point

### DIFF
--- a/apps/builder/src/features/workspaces/actions/upload-logo.ts
+++ b/apps/builder/src/features/workspaces/actions/upload-logo.ts
@@ -9,7 +9,7 @@ import {
   workspaceMemberModel,
   workspaceModel,
 } from "@chatbotx.io/database/schema"
-import { uploadFileFromUrl } from "@chatbotx.io/filesystem/node-upload"
+import { uploadFileFromUrl } from "@chatbotx.io/filesystem"
 import { invalidateCacheByTags } from "@chatbotx.io/redis"
 import type { AuthValue, Context } from "@chatbotx.io/sdk"
 import { createId } from "@chatbotx.io/utils"

--- a/apps/worker/src/chat/handlers/send-flow-step.ts
+++ b/apps/worker/src/chat/handlers/send-flow-step.ts
@@ -24,7 +24,7 @@ import {
 } from "@chatbotx.io/database/schema"
 import type { AttachmentModel } from "@chatbotx.io/database/types"
 import { emit } from "@chatbotx.io/event-bus"
-import { uploadFileFromUrl } from "@chatbotx.io/filesystem/node-upload"
+import { uploadFileFromUrl } from "@chatbotx.io/filesystem"
 import type { MetadataPayload } from "@chatbotx.io/flow-config"
 import {
   appendCodeToMagicLink,

--- a/packages/business/src/contact/service.ts
+++ b/packages/business/src/contact/service.ts
@@ -19,7 +19,7 @@ import type {
 } from "@chatbotx.io/database/types"
 import { emit } from "@chatbotx.io/event-bus"
 import { emitContactCreated } from "@chatbotx.io/events"
-import { uploadFileFromUrl } from "@chatbotx.io/filesystem/node-upload"
+import { uploadFileFromUrl } from "@chatbotx.io/filesystem"
 import { invalidateCacheByTags, withCache } from "@chatbotx.io/redis"
 import { createId } from "@chatbotx.io/utils"
 import { BaseService } from "../base.service"

--- a/packages/filesystem/src/lib/upload.ts
+++ b/packages/filesystem/src/lib/upload.ts
@@ -1,7 +1,7 @@
 import type { ObjectCannedACL } from "@aws-sdk/client-s3"
 import { createId } from "@chatbotx.io/utils"
 import { getImageDimensions, pathJoin } from "./helper"
-import type { UploadedFile } from "./schema"
+import { DEFAULT_MIME_TYPE, type UploadedFile } from "./schema"
 import { uploader } from "./uploader"
 
 export async function uploadFile(
@@ -34,4 +34,52 @@ export async function uploadMultipleFiles(
   return await Promise.all(
     files.map((file) => uploadFile(file, pathJoin(prefix, createId()), acl)),
   )
+}
+
+export async function uploadFileFromUrl(
+  url: string,
+  path: string,
+  acl = "public-read",
+): Promise<UploadedFile> {
+  const response = await fetch(url, { redirect: "follow" as const })
+  if (!response.ok) {
+    throw new Error(`Failed to download file: ${response.status}`)
+  }
+
+  const mimeType = (response.headers.get("content-type") || DEFAULT_MIME_TYPE)
+    .split(";")[0]
+    .trim()
+  const headerLength = Number.parseInt(
+    response.headers.get("content-length") ?? "0",
+    10,
+  )
+
+  let name = createId()
+  try {
+    const u = new URL(url)
+    const last = u.pathname.split("/").pop() ?? ""
+    if (last) {
+      name = decodeURIComponent(last)
+    }
+  } catch (error) {
+    console.error("uploadFileFromUrl: invalid URL", error)
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer())
+  const size = headerLength || buffer.byteLength
+
+  await uploader.putObject(path, buffer, {
+    ACL: acl as ObjectCannedACL,
+    ContentType: mimeType,
+    ContentLength: size,
+  })
+
+  const imageDimensions = await getImageDimensions(mimeType, buffer)
+
+  return {
+    name,
+    originPath: path,
+    size,
+    ...imageDimensions,
+  }
 }


### PR DESCRIPTION
  ## Summary
  - Adds uploadFileFromUrl to the main filesystem package (upload.ts) so it is available via @chatbotx.io/filesystem
  - Updates contact service import from the node-upload sub-path to the main entry point 
  - New implementation uses Buffer/arrayBuffer() instead of Node.js streams
  
  ## Changes
  - packages/filesystem/src/lib/upload.ts — added uploadFileFromUrl
  - packages/business/src/contact/service.ts — updated import path
  
  ## Test plan
  - [ ] pnpm lint
  - [ ] pnpm --filter @chatbotx.io/filesystem check-types
  - [ ] pnpm --filter @chatbotx.io/business check-types
  - [ ] Verify contact avatar upload from URL works end-to-end

