### PR TITLE
feat(instagram): migrate to Instagram Business Login API

### DIFF
--- a/apps/builder/src/app/(no-sidebar)/channels/instagram/select/page.tsx
+++ b/apps/builder/src/app/(no-sidebar)/channels/instagram/select/page.tsx
@@ -1,4 +1,4 @@
-import { getUserInstagramAccounts } from "@chatbotx.io/integration-instagram"
+import { getInstagramAccount } from "@chatbotx.io/integration-instagram"
 import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
 import { SelectAccount } from "@/features/integration-instagram/components/select-accounts"
@@ -19,7 +19,11 @@ export default async function InstagramSelectPage() {
     redirect("/channels/create")
   }
 
-  const accounts = await getUserInstagramAccounts(auth.userToken, auth.version)
+  const account = await getInstagramAccount(auth.userToken)
 
-  return <SelectAccount accounts={accounts} workspaceId={auth.workspaceId} />
+  if (!account) {
+    redirect("/channels/create")
+  }
+
+  return <SelectAccount account={account} workspaceId={auth.workspaceId} />
 }

--- a/apps/builder/src/app/integrations/[...integration]/callback.ts
+++ b/apps/builder/src/app/integrations/[...integration]/callback.ts
@@ -167,7 +167,7 @@ export const handleCallback = async (
         safeReferer,
       ).toString()
 
-      const userToken = await exchangeInstagramCode(
+      const { accessToken: userToken } = await exchangeInstagramCode(
         instagramCredential.config,
         code,
         callbackUrl,

--- a/apps/builder/src/features/integration-instagram/actions/refresh-permissions.action.ts
+++ b/apps/builder/src/features/integration-instagram/actions/refresh-permissions.action.ts
@@ -4,7 +4,7 @@ import { ChatbotXException } from "@chatbotx.io/business/errors"
 import { db, eq, findOrFail } from "@chatbotx.io/database/client"
 import { integrationInstagramModel } from "@chatbotx.io/database/schema"
 import type { InstagramAuthValue } from "@chatbotx.io/integration-instagram"
-import { exchangeLongLivedToken } from "@chatbotx.io/integration-instagram"
+import { refreshLongLivedToken } from "@chatbotx.io/integration-instagram"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { logger } from "@/lib/log"
 import { workspaceActionClient } from "@/lib/safe-action"
@@ -32,14 +32,7 @@ const refreshInstagramPermissions = async (ctx: {
   const auth = integrationInstagram.auth as InstagramAuthValue
 
   try {
-    const newAccessToken = await exchangeLongLivedToken(
-      {
-        clientId: auth.clientId,
-        clientSecret: auth.clientSecret,
-        version: auth.metadata.version,
-      },
-      auth.tokens.accessToken,
-    )
+    const newAccessToken = await refreshLongLivedToken(auth.tokens.accessToken)
 
     const updatedAuth: InstagramAuthValue = {
       ...auth,

--- a/apps/builder/src/features/integration-instagram/actions/select-account.action.ts
+++ b/apps/builder/src/features/integration-instagram/actions/select-account.action.ts
@@ -13,7 +13,6 @@ import { integrationInstagramModel } from "@chatbotx.io/database/schema"
 import type { UserModel } from "@chatbotx.io/database/types"
 import type { InstagramAuthValue } from "@chatbotx.io/integration-instagram"
 import {
-  exchangeLongLivedToken,
   integration as integrationInstagram,
   subscribePageToInstagramWebhook,
 } from "@chatbotx.io/integration-instagram"
@@ -63,11 +62,6 @@ export const selectAccountAction = authActionClient
         const instagramSettings = instagramCredential.config
 
         const { brandingCtx } = await db.transaction(async (tx) => {
-          const longLivedToken = await exchangeLongLivedToken(
-            instagramSettings,
-            parsedInput.accessToken,
-          )
-
           if (!workspaceId) {
             const workspace = await workspaceService.create({
               tx,
@@ -87,8 +81,8 @@ export const selectAccountAction = authActionClient
           })
 
           await subscribePageToInstagramWebhook({
-            pageId: parsedInput.pageId,
-            accessToken: longLivedToken,
+            igId: parsedInput.pageId,
+            accessToken: parsedInput.accessToken,
             version: instagramSettings.version,
           })
 
@@ -98,7 +92,7 @@ export const selectAccountAction = authActionClient
             clientSecret: instagramSettings.clientSecret,
             redirectUrl: "",
             tokens: {
-              accessToken: longLivedToken,
+              accessToken: parsedInput.accessToken,
             },
             metadata: {
               igId: parsedInput.igId,

--- a/apps/builder/src/features/integration-instagram/components/instagram-accounts.tsx
+++ b/apps/builder/src/features/integration-instagram/components/instagram-accounts.tsx
@@ -2,28 +2,26 @@
 
 import type { InstagramAccount } from "@chatbotx.io/integration-instagram"
 import { InputField } from "@chatbotx.io/ui/components/form/input-field"
-import { RadioGroupField } from "@chatbotx.io/ui/components/form/radio-group-field"
 import { Button } from "@chatbotx.io/ui/components/ui/button"
 import { Form } from "@chatbotx.io/ui/components/ui/form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hooks"
 import { Loader2Icon } from "lucide-react"
+import Image from "next/image"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
-import { useEffect } from "react"
-import { useWatch } from "react-hook-form"
 import { toast } from "sonner"
 import { selectAccountAction } from "../actions/select-account.action"
 import { selectAccountRequest } from "../schemas/action"
 
 export function InstagramAccounts({
   workspaceId,
-  accounts,
+  account,
   onSuccess,
 }: {
   workspaceId?: string | null
-  accounts: InstagramAccount[]
+  account: InstagramAccount
   onSuccess?: () => void
 }) {
   const t = useTranslations()
@@ -37,11 +35,11 @@ export function InstagramAccounts({
         mode: "onChange",
         defaultValues: {
           workspaceId,
-          igId: "",
-          igName: "",
-          igUsername: "",
-          pageId: "",
-          accessToken: "",
+          igId: account.userId,
+          igName: account.name,
+          igUsername: account.username,
+          pageId: account.id,
+          accessToken: account.accessToken,
         },
       },
       actionProps: {
@@ -65,39 +63,31 @@ export function InstagramAccounts({
     },
   )
 
-  const { control, setValue } = form
-  const watchedIgId = useWatch({ control, name: "igId" })
-  useEffect(() => {
-    const selectedAccount = accounts.find(
-      (account) => account.id === watchedIgId,
-    )
-
-    setValue("accessToken", selectedAccount?.pageAccessToken ?? "")
-    setValue("igName", selectedAccount?.name ?? "")
-    setValue("igUsername", selectedAccount?.username ?? "")
-    setValue("pageId", selectedAccount?.pageId ?? "")
-  }, [watchedIgId, setValue, accounts])
-
   return (
     <Form {...form}>
       <form className="space-y-6" onSubmit={handleSubmitWithAction}>
         <div className="hidden">
+          <InputField name="igId" type="hidden" />
           <InputField name="accessToken" type="hidden" />
           <InputField name="igName" type="hidden" />
           <InputField name="igUsername" type="hidden" />
           <InputField name="pageId" type="hidden" />
         </div>
 
-        <div className="mt-2">
-          <RadioGroupField
-            label={t("instagram.selectInstagramAccount")}
-            name="igId"
-            options={accounts.map((account) => ({
-              value: account.id,
-              label: `${account.name} (@${account.username})`,
-            }))}
-            required
-          />
+        <div className="flex items-center gap-3 rounded-lg border p-4">
+          {account.profile_picture_url && (
+            <Image
+              alt={account.name}
+              className="size-12 rounded-full object-cover"
+              height={48}
+              src={account.profile_picture_url}
+              width={48}
+            />
+          )}
+          <div>
+            <p className="font-medium">{account.name}</p>
+            <p className="text-muted-foreground text-sm">@{account.username}</p>
+          </div>
         </div>
 
         <div className="flex justify-end gap-2">
@@ -108,10 +98,7 @@ export function InstagramAccounts({
               {t("actions.cancel")}
             </Link>
           </Button>
-          <Button
-            disabled={!form.formState.isValid || form.formState.isSubmitting}
-            type="submit"
-          >
+          <Button disabled={form.formState.isSubmitting} type="submit">
             {form.formState.isSubmitting && (
               <Loader2Icon className="animate-spin" />
             )}

--- a/apps/builder/src/features/integration-instagram/components/select-accounts.tsx
+++ b/apps/builder/src/features/integration-instagram/components/select-accounts.tsx
@@ -10,12 +10,12 @@ import {
 import { useTranslations } from "next-intl"
 import { InstagramAccounts } from "@/features/integration-instagram/components/instagram-accounts"
 
-type SelectAccountProps = {
-  accounts: InstagramAccount[]
+export type SelectAccountProps = {
+  account: InstagramAccount
   workspaceId: string
 }
 
-export function SelectAccount({ accounts, workspaceId }: SelectAccountProps) {
+export function SelectAccount({ account, workspaceId }: SelectAccountProps) {
   const t = useTranslations()
 
   return (
@@ -26,7 +26,7 @@ export function SelectAccount({ accounts, workspaceId }: SelectAccountProps) {
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <InstagramAccounts accounts={accounts} workspaceId={workspaceId} />
+        <InstagramAccounts account={account} workspaceId={workspaceId} />
       </CardContent>
     </Card>
   )

--- a/apps/worker/src/integration/handlers/received-message.ts
+++ b/apps/worker/src/integration/handlers/received-message.ts
@@ -449,5 +449,6 @@ const detectContactAndConversation = async (props: {
 
 const canGetUserProfileIfNeeded = (integrationType: string) =>
   integrationType === "messenger" ||
+  integrationType === "instagram" ||
   integrationType === "zalo" ||
   integrationType === "telegram"

--- a/integrations/instagram/src/apis/attachment.ts
+++ b/integrations/instagram/src/apis/attachment.ts
@@ -1,6 +1,6 @@
 import type { FileType } from "@chatbotx.io/sdk"
 import { rescue } from "../exception"
-import { instagramAttachmentClient } from "../lib/http-client"
+import { instagramBusinessClient } from "../lib/http-client"
 import type {
   InstagramAuthValue,
   InstagramMessageAttachment,
@@ -15,7 +15,7 @@ export const uploadAttachment = (
   const endpoint = `${auth.metadata.version}/${auth.metadata.pageId}/message_attachments`
 
   return rescue(endpoint, () =>
-    instagramAttachmentClient.post<InstagramSendMessageResponse>(endpoint, {
+    instagramBusinessClient.post<InstagramSendMessageResponse>(endpoint, {
       headers: {
         Authorization: `Bearer ${auth.tokens.accessToken}`,
       },

--- a/integrations/instagram/src/apis/auth.ts
+++ b/integrations/instagram/src/apis/auth.ts
@@ -1,45 +1,25 @@
-import { DEFAULT_API_VERSION } from "../constants"
-import { rescue } from "../exception"
-import { instagramGraphClient } from "../lib/http-client"
+import { INSTAGRAM_BUSINESS_SCOPES } from "../constants"
+import { InstagramException, rescue } from "../exception"
+import {
+  instagramBusinessClient,
+  instagramOAuthClient,
+} from "../lib/http-client"
+import { logger } from "../lib/logger"
 
-const FACEBOOK_OAUTH_BASE = "https://www.facebook.com"
-
-const INSTAGRAM_SCOPES = [
-  "instagram_basic",
-  "instagram_manage_messages",
-  "pages_manage_metadata",
-  "pages_show_list",
-  "pages_messaging",
-  "pages_read_engagement",
-  "business_management",
-]
+const INSTAGRAM_OAUTH_AUTHORIZE_URL =
+  "https://www.instagram.com/oauth/authorize"
 
 export type InstagramAccount = {
   id: string
   name: string
   username: string
+  userId: string
   profile_picture_url?: string
-  pageId: string
-  pageAccessToken: string
-}
-
-type FacebookPageWithIg = {
-  id: string
-  name: string
-  access_token: string
-  instagram_business_account?: { id: string }
-}
-
-type InstagramUserResponse = {
-  id: string
-  name: string
-  username: string
-  profile_picture_url?: string
+  accessToken: string
 }
 
 export function generateAuthUrl({
   clientId,
-  version = DEFAULT_API_VERSION,
   redirectUrl,
   stateParams,
 }: {
@@ -51,92 +31,111 @@ export function generateAuthUrl({
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUrl,
-    scope: INSTAGRAM_SCOPES.join(","),
     response_type: "code",
     state: Buffer.from(JSON.stringify(stateParams ?? {})).toString("base64"),
+    scope: INSTAGRAM_BUSINESS_SCOPES.join(","),
   })
-  return `${FACEBOOK_OAUTH_BASE}/${version}/dialog/oauth?${params.toString()}`
+  return `${INSTAGRAM_OAUTH_AUTHORIZE_URL}?${params.toString()}`
 }
 
+// Step 1: exchange authorization code → short-lived user access token + user ID
 export function exchangeCodeForToken(
   settings: { clientId: string; clientSecret: string; version?: string },
   code: string,
   redirectUrl: string,
-): Promise<string> {
-  const { version = DEFAULT_API_VERSION } = settings
-  const endpoint = `${version}/oauth/access_token`
+): Promise<{ accessToken: string; userId: string }> {
+  const endpoint = "oauth/access_token"
 
   return rescue(endpoint, async () => {
-    const res: { access_token: string } = await instagramGraphClient.get(
-      endpoint,
-      {
-        searchParams: {
+    const res: { access_token: string; user_id: string | number } =
+      await instagramOAuthClient.post(endpoint, {
+        body: new URLSearchParams({
           client_id: settings.clientId,
           client_secret: settings.clientSecret,
           redirect_uri: redirectUrl,
           code,
-        },
+          grant_type: "authorization_code",
+        }),
+      })
+    const longLivedToken = await exchangeLongLivedToken(
+      {
+        clientId: settings.clientId,
+        clientSecret: settings.clientSecret,
+        version: settings.version,
       },
+      res.access_token,
     )
+    return { accessToken: longLivedToken, userId: String(res.user_id) }
+  })
+}
+
+export const exchangeLongLivedToken = (
+  settings: {
+    clientId: string
+    clientSecret: string
+    version?: string
+  },
+  accessToken: string,
+): Promise<string> => {
+  const endpoint = "access_token"
+
+  return rescue(endpoint, async () => {
+    const res: { access_token: string; expires_in: number } =
+      await instagramBusinessClient.get(endpoint, {
+        searchParams: {
+          grant_type: "ig_exchange_token",
+          client_secret: settings.clientSecret,
+          access_token: accessToken,
+        },
+      })
+
     return res.access_token
   })
 }
 
-export async function getUserInstagramAccounts(
+export async function getInstagramAccount(
   userAccessToken: string,
-  version: string = DEFAULT_API_VERSION,
-): Promise<InstagramAccount[]> {
-  const pagesEndpoint = `${version}/me/accounts`
+): Promise<InstagramAccount | null> {
+  const endpoint = "me"
 
-  const pagesRes = await rescue(pagesEndpoint, async () => {
-    const res: { data: FacebookPageWithIg[] } = await instagramGraphClient.get(
-      pagesEndpoint,
-      {
+  try {
+    const res = await rescue(endpoint, async () =>
+      instagramBusinessClient.get<{
+        id: string
+        username: string
+        user_id: string
+        name?: string
+        profile_picture_url?: string
+        account_type?: string
+      }>(endpoint, {
         searchParams: {
-          fields: "id,name,access_token,instagram_business_account",
+          fields: "id,user_id,username,name,profile_picture_url,account_type",
           access_token: userAccessToken,
         },
-      },
+      }),
     )
-    return res.data
-  })
 
-  const pagesWithIg = pagesRes.filter((page) => page.instagram_business_account)
+    if (res.account_type !== "BUSINESS" && res.account_type !== "CREATOR") {
+      logger.warn(
+        { account_type: res.account_type },
+        "Instagram account is not a Business or Creator account",
+      )
+      return null
+    }
 
-  const accounts: (InstagramAccount | null)[] = await Promise.all(
-    pagesWithIg.map(async (page): Promise<InstagramAccount | null> => {
-      const igId = page.instagram_business_account?.id
-      if (!igId) {
-        return null
-      }
-
-      const igEndpoint = `${version}/${igId}`
-      try {
-        const igRes: InstagramUserResponse = await rescue(
-          igEndpoint,
-          async () =>
-            instagramGraphClient.get<InstagramUserResponse>(igEndpoint, {
-              searchParams: {
-                fields: "id,name,username,profile_picture_url",
-                access_token: page.access_token,
-              },
-            }),
-        )
-        return {
-          id: igRes.id,
-          name: igRes.name,
-          username: igRes.username,
-          profile_picture_url: igRes.profile_picture_url,
-          pageId: page.id,
-          pageAccessToken: page.access_token,
-        }
-      } catch {
-        return null
-      }
-    }),
-  )
-
-  return accounts.filter(
-    (account): account is InstagramAccount => account !== null,
-  )
+    return {
+      id: res.id,
+      name: res.name ?? res.username,
+      username: res.username,
+      profile_picture_url: res.profile_picture_url,
+      userId: res.user_id,
+      accessToken: userAccessToken,
+    }
+  } catch (error) {
+    if (error instanceof InstagramException) {
+      logger.warn(error, "Failed to fetch Instagram account during connect")
+      return null
+    }
+    throw error
+  }
 }

--- a/integrations/instagram/src/apis/contact-profile.ts
+++ b/integrations/instagram/src/apis/contact-profile.ts
@@ -1,18 +1,11 @@
 import { DEFAULT_API_VERSION } from "../constants"
 import { rescue } from "../exception"
-import { instagramGraphClient } from "../lib/http-client"
-
-export type InstagramContactProfile = {
-  followersCount: number | null
-  isVerified: boolean | null
-  followsBusiness: boolean | null
-  businessFollowUser: boolean | null
-}
+import { instagramBusinessClient } from "../lib/http-client"
+import type { InstagramContactProfile } from "../schemas"
 
 type RawContactProfileResponse = {
   id: string
   follower_count?: number
-  is_verified?: boolean
   is_user_follow_business?: boolean
   is_business_follow_user?: boolean
 }
@@ -27,18 +20,17 @@ export const fetchInstagramContactProfile = (props: {
 
   return rescue(endpoint, async () => {
     const queries = new URLSearchParams({
-      fields:
-        "follower_count,is_verified,is_user_follow_business,is_business_follow_user",
+      fields: "follower_count,is_user_follow_business,is_business_follow_user",
       access_token: accessToken,
     })
 
-    const response = await instagramGraphClient.get<RawContactProfileResponse>(
-      `${endpoint}?${queries.toString()}`,
-    )
+    const response =
+      await instagramBusinessClient.get<RawContactProfileResponse>(
+        `${endpoint}?${queries.toString()}`,
+      )
 
     return {
       followersCount: response.follower_count ?? null,
-      isVerified: response.is_verified ?? null,
       followsBusiness: response.is_user_follow_business ?? null,
       businessFollowUser: response.is_business_follow_user ?? null,
     }

--- a/integrations/instagram/src/apis/page.ts
+++ b/integrations/instagram/src/apis/page.ts
@@ -8,7 +8,7 @@ import fetch from "cross-fetch"
 import imageSize from "image-size"
 import { DEFAULT_API_VERSION } from "../constants"
 import { rescue } from "../exception"
-import { instagramGraphClient } from "../lib/http-client"
+import { instagramBusinessClient } from "../lib/http-client"
 import type {
   InstagramAuthValue,
   InstagramMessageAttachment,
@@ -21,31 +21,20 @@ export const INSTAGRAM_SUBSCRIBE_FIELDS = [
   "messages",
   "messaging_postbacks",
   "messaging_optins",
-  "message_reads",
-  "messaging_referrals",
-  "message_echoes",
+  "messaging_seen",
+  "messaging_referral",
 ]
 
-export const exchangeLongLivedToken = (
-  settings: {
-    clientId: string
-    clientSecret: string
-    version?: string
-  },
-  accessToken: string,
-): Promise<string> => {
-  const { version = DEFAULT_API_VERSION } = settings
-  const endpoint = `${version}/oauth/access_token`
+export const refreshLongLivedToken = (accessToken: string): Promise<string> => {
+  const endpoint = "refresh_access_token"
 
   return rescue(endpoint, async () => {
-    const res: { access_token: string } = await instagramGraphClient.get(
+    const res: { access_token: string } = await instagramBusinessClient.get(
       endpoint,
       {
         searchParams: {
-          grant_type: "fb_exchange_token",
-          client_id: settings.clientId as string,
-          client_secret: settings.clientSecret as string,
-          fb_exchange_token: accessToken,
+          grant_type: "ig_refresh_token",
+          access_token: accessToken,
         },
       },
     )
@@ -58,15 +47,14 @@ export const getInstagramProfilePictureUrl = async (props: {
   ctx: Context<InstagramAuthValue>
 }): Promise<string | undefined> => {
   const { ctx } = props
-  const { version = DEFAULT_API_VERSION } = ctx.auth
-  const igId = ctx.auth.metadata.igId
+  const version = ctx.auth.metadata.version ?? DEFAULT_API_VERSION
   const accessToken = ctx.auth.tokens.accessToken
-  const endpoint = `${version}/${igId}`
+  const endpoint = `${version}/me`
 
   try {
     return await rescue(endpoint, async () => {
       const res: { profile_picture_url?: string } =
-        await instagramGraphClient.get(endpoint, {
+        await instagramBusinessClient.get(endpoint, {
           searchParams: {
             fields: "profile_picture_url",
             access_token: accessToken,
@@ -80,15 +68,15 @@ export const getInstagramProfilePictureUrl = async (props: {
 }
 
 export const subscribePageToInstagramWebhook = (props: {
-  pageId: string
+  igId: string
   accessToken: string
   version?: string
 }): Promise<void> => {
   const { version = DEFAULT_API_VERSION } = props
-  const endpoint = `${version}/${props.pageId}/subscribed_apps`
+  const endpoint = `${version}/${props.igId}/subscribed_apps`
 
   return rescue(endpoint, () =>
-    instagramGraphClient.post(endpoint, {
+    instagramBusinessClient.post(endpoint, {
       headers: {
         Authorization: `Bearer ${props.accessToken}`,
       },
@@ -102,11 +90,11 @@ export const subscribePageToInstagramWebhook = (props: {
 export const unsubscribePageFromInstagramWebhook = (props: {
   auth: InstagramAuthValue
 }): Promise<void> => {
-  const { version = DEFAULT_API_VERSION } = props.auth
+  const version = props.auth.metadata.version ?? DEFAULT_API_VERSION
   const endpoint = `${version}/${props.auth.metadata.pageId}/subscribed_apps`
 
   return rescue(endpoint, () =>
-    instagramGraphClient.delete(endpoint, {
+    instagramBusinessClient.delete(endpoint, {
       headers: {
         Authorization: `Bearer ${props.auth.tokens.accessToken}`,
       },
@@ -118,11 +106,11 @@ export const sendInstagramMessage = (
   auth: InstagramAuthValue,
   payload: InstagramSendMessageRequest,
 ): Promise<InstagramSendMessageResponse> => {
-  const { version = DEFAULT_API_VERSION } = auth
+  const version = auth.metadata.version ?? DEFAULT_API_VERSION
   const endpoint = `${version}/me/messages`
 
   return rescue(endpoint, () =>
-    instagramGraphClient.post<InstagramSendMessageResponse>(endpoint, {
+    instagramBusinessClient.post<InstagramSendMessageResponse>(endpoint, {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${auth.tokens.accessToken}`,
@@ -186,11 +174,11 @@ export const deleteInstagramProfileFields = (props: {
   fields: string[]
 }): Promise<void> => {
   const { ctx, fields } = props
-  const { version = DEFAULT_API_VERSION } = ctx.auth
+  const version = ctx.auth.metadata.version ?? DEFAULT_API_VERSION
   const endpoint = `${version}/me/messenger_profile`
 
   return rescue(endpoint, () =>
-    instagramGraphClient.delete(endpoint, {
+    instagramBusinessClient.delete(endpoint, {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${ctx.auth.tokens.accessToken}`,
@@ -208,7 +196,7 @@ export const updateInstagramProfile = (props: {
   params: InstagramProfileRequest
 }): Promise<void> => {
   const { ctx, params } = props
-  const { version = DEFAULT_API_VERSION } = ctx.auth
+  const version = ctx.auth.metadata.version ?? DEFAULT_API_VERSION
   const endpoint = `${version}/me/messenger_profile`
 
   return rescue(endpoint, () => {
@@ -217,7 +205,7 @@ export const updateInstagramProfile = (props: {
       access_token: ctx.auth.tokens.accessToken,
     }).toString()
 
-    return instagramGraphClient.post(`${endpoint}?${queries}`, {
+    return instagramBusinessClient.post(`${endpoint}?${queries}`, {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${ctx.auth.tokens.accessToken}`,
@@ -236,7 +224,7 @@ export const getInstagramPersistentMenu = (props: {
   persistentMenu?: InstagramProfileRequest["persistent_menu"]
 }> => {
   const { ctx } = props
-  const { version = DEFAULT_API_VERSION } = ctx.auth
+  const version = ctx.auth.metadata.version ?? DEFAULT_API_VERSION
   const endpoint = `${version}/me/messenger_profile`
 
   return rescue(endpoint, async () => {
@@ -248,7 +236,7 @@ export const getInstagramPersistentMenu = (props: {
 
     const response: {
       persistent_menu?: InstagramProfileRequest["persistent_menu"]
-    } = await instagramGraphClient.get(`${endpoint}?${queries}`, {
+    } = await instagramBusinessClient.get(`${endpoint}?${queries}`, {
       headers: {
         Authorization: `Bearer ${ctx.auth.tokens.accessToken}`,
       },
@@ -264,7 +252,7 @@ export const addBranding = async (props: {
   url: string
 }): Promise<void> => {
   const { ctx } = props
-  const { version = DEFAULT_API_VERSION } = ctx.auth
+  const version = ctx.auth.metadata.version ?? DEFAULT_API_VERSION
 
   const { persistentMenu } = await getInstagramPersistentMenu({ ctx })
 
@@ -283,7 +271,7 @@ export const addBranding = async (props: {
 
   if (!persistentMenu || persistentMenu.length === 0) {
     await rescue(endpoint, () =>
-      instagramGraphClient.post(`${endpoint}?${queries}`, {
+      instagramBusinessClient.post(`${endpoint}?${queries}`, {
         headers: { "Content-Type": "application/json" },
         json: {
           platform: "instagram",
@@ -323,7 +311,7 @@ export const addBranding = async (props: {
   })
 
   await rescue(endpoint, () =>
-    instagramGraphClient.post(`${endpoint}?${queries}`, {
+    instagramBusinessClient.post(`${endpoint}?${queries}`, {
       headers: { "Content-Type": "application/json" },
       json: {
         platform: "instagram",

--- a/integrations/instagram/src/apis/user.ts
+++ b/integrations/instagram/src/apis/user.ts
@@ -1,8 +1,7 @@
 import type { Context, IncomingContact } from "@chatbotx.io/sdk"
 import { createId } from "@chatbotx.io/utils"
-import { API_URL } from "../constants"
 import { rescue } from "../exception"
-import { instagramGraphClient } from "../lib/http-client"
+import { instagramBusinessClient } from "../lib/http-client"
 import { logger } from "../lib/logger"
 import type { InstagramAuthValue, InstagramUserProfile } from "../schemas"
 
@@ -13,14 +12,14 @@ export const getUserProfile = ({
   ctx: Context<InstagramAuthValue>
   psid: string
 }): Promise<IncomingContact> => {
-  const endpoint = `${API_URL}/${ctx.auth.metadata.version}/${psid}`
+  const endpoint = `${ctx.auth.metadata.version}/${psid}`
 
   return rescue(endpoint, async () => {
     const queries = new URLSearchParams({
-      fields: "name,username,profile_pic",
+      fields: "id,name,username,profile_pic",
       access_token: ctx.auth.tokens.accessToken,
     })
-    const response = await instagramGraphClient.get<InstagramUserProfile>(
+    const response = await instagramBusinessClient.get<InstagramUserProfile>(
       `${ctx.auth.metadata.version}/${psid}?${queries.toString()}`,
     )
 

--- a/integrations/instagram/src/constants.ts
+++ b/integrations/instagram/src/constants.ts
@@ -1,5 +1,12 @@
 export const MAX_BUTTONS = 3
 
-export const API_URL = "https://graph.facebook.com"
+export const INSTAGRAM_API_URL = "https://graph.instagram.com"
 
-export const DEFAULT_API_VERSION = "v23.0"
+export const INSTAGRAM_OAUTH_URL = "https://api.instagram.com"
+
+export const DEFAULT_API_VERSION = "v22.0"
+
+export const INSTAGRAM_BUSINESS_SCOPES = [
+  "instagram_business_basic",
+  "instagram_business_manage_messages",
+]

--- a/integrations/instagram/src/handlers/message/outgoing-message/index.ts
+++ b/integrations/instagram/src/handlers/message/outgoing-message/index.ts
@@ -141,12 +141,12 @@ export async function* convertFlowStepToInstagramMessage(
       break
     case stepTypes.enum.sendImage:
     case stepTypes.enum.sendVideo:
-      await (yield* convertFlowStepMedia(
+      yield* convertFlowStepMedia(
         props as SendFlowStepProps<
           InstagramAuthValue,
           SendImageStepSchema | SendVideoStepSchema
         >,
-      ))
+      )
       break
     case stepTypes.enum.sendAudio:
     case stepTypes.enum.sendFile:

--- a/integrations/instagram/src/handlers/message/outgoing-message/send-media.ts
+++ b/integrations/instagram/src/handlers/message/outgoing-message/send-media.ts
@@ -3,44 +3,31 @@ import type {
   SendVideoStepSchema,
 } from "@chatbotx.io/flow-config"
 import type { SendFlowStepProps } from "@chatbotx.io/sdk"
-import { uploadAttachment } from "../../../apis/attachment"
 import { logger } from "../../../lib/logger"
 import type { InstagramAuthValue } from "../../../schemas"
 import { convertMediaType } from "./send-attachment"
-import { convertInstagramButtons } from "./send-button"
 
-export async function* convertFlowStepMedia(
+export function* convertFlowStepMedia(
   props: SendFlowStepProps<
     InstagramAuthValue,
     SendImageStepSchema | SendVideoStepSchema
   >,
 ) {
   const {
-    ctx,
-    data: { flowId, flowVersionId, step },
+    data: { step },
   } = props
   try {
     const media_type = convertMediaType(step.stepType)
-    const attachment = await uploadAttachment(ctx.auth, step.url, media_type)
-    const buttons = convertInstagramButtons({
-      flowId,
-      flowVersionId,
-      buttons: step.buttons,
-    })
+
     yield {
-      attachment: {
-        type: "template" as const,
-        payload: {
-          template_type: "media" as const,
-          elements: [
-            {
-              media_type,
-              attachment_id: attachment.attachment_id,
-              buttons,
-            },
-          ],
+      attachments: [
+        {
+          type: media_type,
+          payload: {
+            url: step.url,
+          },
         },
-      },
+      ],
     }
   } catch (error) {
     logger.error(error, "Error uploading media")

--- a/integrations/instagram/src/handlers/webhook.ts
+++ b/integrations/instagram/src/handlers/webhook.ts
@@ -26,7 +26,10 @@ const verifyWebhookSignature = (
       .update(payload)
       .digest("hex")
 
-    return signatureHash === expectedHash
+    return crypto.timingSafeEqual(
+      Buffer.from(signatureHash, "utf8"),
+      Buffer.from(expectedHash, "utf8"),
+    )
   } catch {
     return false
   }

--- a/integrations/instagram/src/lib/error-mapper.ts
+++ b/integrations/instagram/src/lib/error-mapper.ts
@@ -162,13 +162,6 @@ function mapApiFields(fields: ChannelErrorSource): ChannelError {
   })
 }
 
-// === Revoked / invalidated access token detection ===
-// Instagram messaging does not surface a deterministic revoked-token signal —
-// reconnect flow is driven by upstream FB Page disconnect. Always returns false.
-export function isRevokedTokenError(_error: unknown): boolean {
-  return false
-}
-
 export function mapToChannelError(rawError: unknown): ChannelError {
   if (rawError instanceof ChannelError) {
     return rawError
@@ -179,4 +172,30 @@ export function mapToChannelError(rawError: unknown): ChannelError {
   }
 
   return mapApiFields(parseOriginError(rawError))
+}
+
+// === Revoked / invalidated access token detection ===
+// Instagram Business API signals revoked/expired tokens via OAuthException + code 190.
+// Sub-codes: 458 = app not installed, 460 = password changed,
+//   463 = access token expired, 467 = invalid access token.
+// Code 190 with no subcode is ambiguous and is NOT treated as revoked
+// to avoid false-positive channel disconnects.
+const REVOKED_TOKEN_SUBCODES = new Set([458, 460, 463, 467])
+
+export function isRevokedTokenError(error: unknown): boolean {
+  if (!(error instanceof InstagramException)) {
+    return false
+  }
+
+  const mappedError = mapToChannelError(error)
+  if (mappedError.subCode === null || mappedError.subCode === undefined) {
+    return false
+  }
+  const subCode = Number(mappedError.subCode)
+
+  return (
+    mappedError.category === ChannelErrorCategory.AUTH_FAILED &&
+    mappedError.code === 190 &&
+    REVOKED_TOKEN_SUBCODES.has(subCode)
+  )
 }

--- a/integrations/instagram/src/lib/http-client.ts
+++ b/integrations/instagram/src/lib/http-client.ts
@@ -1,5 +1,6 @@
 import { UNKNOWN_ERROR } from "@chatbotx.io/sdk"
 import ky, { isHTTPError, type KyInstance } from "ky"
+import { INSTAGRAM_API_URL, INSTAGRAM_OAUTH_URL } from "../constants"
 import { InstagramAPIException, parseOriginError } from "../exception"
 import { logger } from "./logger"
 
@@ -94,16 +95,16 @@ class InstagramHttpClient {
   }
 }
 
-export const instagramGraphClient = new InstagramHttpClient({
-  baseUrl: "https://graph.facebook.com",
+export const instagramBusinessClient = new InstagramHttpClient({
+  baseUrl: INSTAGRAM_API_URL,
   timeout: 30_000,
   retries: 3,
   retryDelay: 1000,
 })
 
-export const instagramAttachmentClient = new InstagramHttpClient({
-  baseUrl: "https://graph.facebook.com",
-  timeout: 60_000,
+export const instagramOAuthClient = new InstagramHttpClient({
+  baseUrl: INSTAGRAM_OAUTH_URL,
+  timeout: 30_000,
   retries: 2,
-  retryDelay: 2000,
+  retryDelay: 1000,
 })

--- a/integrations/instagram/src/schemas.ts
+++ b/integrations/instagram/src/schemas.ts
@@ -56,7 +56,7 @@ export const instagramMessageSchema = z.object({
 export type InstagramMessage = z.infer<typeof instagramMessageSchema>
 
 export const instagramReadSchema = z.object({
-  watermark: z.number(),
+  watermark: z.number().optional(),
 })
 
 export const instagramPostbackSchema = z.object({
@@ -152,6 +152,7 @@ export type InstagramMessageAttachment = z.infer<
 export const instagramSendMessageSchema = z.object({
   text: z.string().optional(),
   attachment: instagramMessageAttachmentSchema.optional(),
+  attachments: z.array(instagramMessageAttachmentSchema).optional(),
   quick_replies: z.array(instagramQuickReplySchema).max(13).optional(),
   metadata: z.string().optional(),
 })
@@ -231,6 +232,7 @@ export const instagramAccessTokenResponseSchema = z.object({
   access_token: z.string(),
   token_type: z.literal("bearer"),
   expires_in: z.number().optional(),
+  user_id: z.coerce.string().optional(),
 })
 export type InstagramAccessTokenResponse = z.infer<
   typeof instagramAccessTokenResponseSchema
@@ -268,3 +270,9 @@ export const instagramProfileRequest = z.object({
   persistent_menu: z.array(persistentMenuSchema),
 })
 export type InstagramProfileRequest = z.infer<typeof instagramProfileRequest>
+
+export type InstagramContactProfile = {
+  followersCount: number | null
+  followsBusiness: boolean | null
+  businessFollowUser: boolean | null
+}

--- a/packages/variables/src/helpers/integration-fields.ts
+++ b/packages/variables/src/helpers/integration-fields.ts
@@ -33,7 +33,6 @@ const IG_PROFILE_CACHE_TTL = 300
 
 const EMPTY_IG_PROFILE: InstagramContactProfile = {
   followersCount: null,
-  isVerified: null,
   followsBusiness: null,
   businessFollowUser: null,
 }
@@ -146,7 +145,6 @@ export const getIntegrationField = async (
       return contactInbox.sourceId ?? null
 
     case "ig_followers":
-    case "ig_verified":
     case "ig_follow_business":
     case "ig_business_follow_user": {
       if (!inbox.integrationInstagram) {
@@ -162,8 +160,6 @@ export const getIntegrationField = async (
           return profile.followersCount == null
             ? null
             : String(profile.followersCount)
-        case "ig_verified":
-          return profile.isVerified == null ? null : String(profile.isVerified)
         case "ig_follow_business":
           return profile.followsBusiness == null
             ? null


### PR DESCRIPTION
## Summary

  Migrates the Instagram integration from the old **Facebook Graph API** approach
  (OAuth via Facebook) to the new **Instagram Business Login API** (OAuth directly
  via Instagram). This is required because Meta is deprecating the old method for
  new integrations.

  ## What changed

  ### API endpoints
  - Replaced `https://graph.facebook.com` with `https://graph.instagram.com` (Instagram Business API)
  - Added `https://api.instagram.com` as a separate OAuth client
  - Renamed `instagramGraphClient` → `instagramBusinessClient`, `instagramAttachmentClient` → `instagramOAuthClient`

  ### OAuth flow
  - Old: Facebook OAuth dialog (`facebook.com/{version}/dialog/oauth`) with 7 scopes
  - New: Instagram OAuth dialog (`instagram.com/oauth/authorize`) with 2 scopes:
    `instagram_business_basic`, `instagram_business_manage_messages`
  - Token exchange now goes through Instagram's own OAuth endpoints

  ### Account selection
  - Old: fetched Facebook Pages → filtered those with linked IG Business accounts →
    queried each account individually
  - New: directly calls `/me` on Instagram Business API — single request returns
    account info including `user_id`

  ### Token refresh
  - Simplified: `exchangeLongLivedToken(settings, token)` → `refreshLongLivedToken(token)`
  - No longer requires `clientId`/`clientSecret` to refresh; uses `ig_refresh_token` grant

  ### Webhook subscriptions
  - Removed: `message_reads`, `messaging_referrals`, `message_echoes`
  - Added: `messaging_seen`, `messaging_referral`
  - Changed subscription target from `pageId` to `igId`

  ### Security
  - Webhook signature verification now uses `crypto.timingSafeEqual` (prevents timing attacks)

  ### Revoked token detection
  - Previously always returned `false` (no signal available via FB approach)
  - Now properly detects expired/revoked tokens via OAuthException code 190 +
    sub-codes (458, 460, 463, 467)

  ## Test plan
  - [ ] Connect a new Instagram Business account via the updated OAuth flow
  - [ ] Verify webhook events are received (incoming messages, seen receipts)
  - [ ] Send an outgoing message to an Instagram contact
  - [ ] Refresh permissions on an existing integration — token refreshes without error
  - [ ] Revoke app access from Instagram settings — channel is flagged as disconnected
  - [ ] Verify old integrations connected via Facebook flow still function correctly
