### PR TITLE
fix(auth,mail): fix email link hostnames and enable subject template substitution

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -94,6 +94,9 @@ export function createAuth(_config: AuthConfig) {
           getPlatformSettings(request),
         ])
 
+        const resetPasswordUrl = new URL(url)
+        resetPasswordUrl.hostname = new URL(originUrl).hostname
+
         const {
           name: brandName,
           logoLightUrl,
@@ -106,7 +109,7 @@ export function createAuth(_config: AuthConfig) {
           brandUrl: new URL("/", originUrl).toString(),
           subject: DEFAULT_FORGOT_PASSWORD_SUBJECT,
           userName: user.name ?? user.email,
-          resetPasswordUrl: url,
+          resetPasswordUrl: resetPasswordUrl.toString(),
           customTemplate: forgotPasswordEmailTemplate,
         })
       },
@@ -123,6 +126,10 @@ export function createAuth(_config: AuthConfig) {
           getPublicOriginFromRequest(request as unknown as Request),
           getPlatformSettings(request),
         ])
+
+        const verificationUrl = new URL(url)
+        verificationUrl.hostname = new URL(originUrl).hostname
+
         const {
           name: brandName,
           logoLightUrl,
@@ -135,7 +142,7 @@ export function createAuth(_config: AuthConfig) {
           brandUrl: new URL("/", originUrl).toString(),
           subject: DEFAULT_SIGNUP_SUBJECT,
           userName: user.name ?? user.email,
-          verificationUrl: url,
+          verificationUrl: verificationUrl.toString(),
           customTemplate: signupEmailTemplate,
         })
       },
@@ -153,6 +160,10 @@ export function createAuth(_config: AuthConfig) {
             getPublicOriginFromRequest(request as unknown as Request),
             getPlatformSettings(request as unknown as Request),
           ])
+
+          const magicUrl = new URL(url)
+          magicUrl.hostname = new URL(originUrl).hostname
+
           const {
             name: brandName,
             logoLightUrl,
@@ -172,7 +183,7 @@ export function createAuth(_config: AuthConfig) {
             brandUrl: new URL("/", originUrl).toString(),
             subject: DEFAULT_MAGIC_LINK_SUBJECT,
             userName: user.name ?? email,
-            magicUrl: url,
+            magicUrl: magicUrl.toString(),
             customTemplate: magicLinkEmailTemplate,
           })
         },
@@ -198,7 +209,7 @@ export function createAuth(_config: AuthConfig) {
     trustedOrigins: async () => {
       const domains = await db.query.customDomainModel.findMany({
         where: {
-          status: "verified",
+          status: "active",
         },
         columns: {
           domain: true,

--- a/packages/mail/src/index.ts
+++ b/packages/mail/src/index.ts
@@ -25,13 +25,15 @@ export {
   DEFAULT_SIGNUP_TEMPLATE,
 } from "./emails/default-templates"
 
+function substituteVars(text: string, vars: Record<string, string>): string {
+  return text.replace(/\{\{(\w+)\}\}/g, (_, key) => esc(vars[key] ?? ""))
+}
+
 async function renderCustomTemplate(
   body: string,
   vars: Record<string, string>,
 ): Promise<string> {
-  const substituted = body.replace(/\{\{(\w+)\}\}/g, (_, key) =>
-    esc(vars[key] ?? ""),
-  )
+  const substituted = substituteVars(body, vars)
   if (substituted.trimStart().startsWith("<mjml")) {
     return await compileMjml(substituted)
   }
@@ -70,11 +72,10 @@ async function sendEmailWithTemplate(
   templateVars: Record<string, string>,
 ): Promise<void> {
   const customBody = customTemplate?.body?.trim()
-  const subject =
-    (customBody && customTemplate?.subject?.trim()) || defaultSubject
-  const html = customBody
-    ? await renderCustomTemplate(customBody, templateVars)
-    : await buildDefaultHtml()
+  const customSubject = customBody && customTemplate?.subject?.trim()
+  const subject = substituteVars(customSubject ?? defaultSubject, templateVars)
+  const body = customBody ?? (await buildDefaultHtml())
+  const html = await renderCustomTemplate(body, templateVars)
   await sendMail(email, subject, html)
 }
 


### PR DESCRIPTION
## Summary

- Auth email links (reset-password, verify-email, magic-link) had their hostname taken directly from the internal `url` parameter, which could point to an internal host. This replaces the hostname with the one from `originUrl` (the public-facing origin) so links in emails resolve correctly for end-users.
- The trusted-origins domain query was filtering by `status: "verified"`, which never matched — the correct enum value is `"active"`.
- Email subjects were not processed through the `{{var}}` template substitution system, so custom subject templates with variables were sent verbatim. Subjects now go through the same substitution as the body.

## Changes

- `packages/auth/src/server.ts` — rewrite URL hostname to `originUrl` hostname for reset-password, verify-email, and magic-link callbacks; fix trusted-origins filter `"verified"` → `"active"`
- `packages/mail/src/index.ts` — extract `substituteVars` helper; apply it to both subject and body in `sendEmailWithTemplate`; simplify `renderCustomTemplate` to always process the body (default or custom)

## Test plan

- [ ] `pnpm lint` — passes
- [ ] `pnpm check-types` (all packages) — passes
- [ ] Trigger a forgot-password email and verify the reset link hostname matches the public origin
- [ ] Trigger a signup verification email and verify the verification link hostname is correct
- [ ] Trigger a magic-link email and verify the link hostname is correct
- [ ] Configure a custom email template with a `{{var}}` in the subject; confirm the subject is substituted in the delivered email
- [ ] Verify workspace with an `active` custom domain appears in trusted origins (previously broken by `"verified"` filter)