### PR TITLE
fix: clone messenger template

### DIFF
--- a/apps/builder/__tests__/messenger-build-template-components.test.ts
+++ b/apps/builder/__tests__/messenger-build-template-components.test.ts
@@ -30,6 +30,21 @@ describe("buildMessengerMessageTemplateComponents", () => {
     ])
   })
 
+  test("omits body example when body has no variables", () => {
+    expect(
+      buildMessengerMessageTemplateComponents({
+        ...baseInput,
+        body: "Plain body text",
+        bodyVariables: [],
+      }),
+    ).toEqual([
+      {
+        type: "BODY",
+        text: "Plain body text",
+      },
+    ])
+  })
+
   test("builds text header with header_text example", () => {
     expect(
       buildMessengerMessageTemplateComponents({
@@ -46,6 +61,30 @@ describe("buildMessengerMessageTemplateComponents", () => {
         example: {
           header_text: ["Customer"],
         },
+      },
+      {
+        type: "BODY",
+        text: "Hello {{1}}",
+        example: {
+          body_text: [["Hung"]],
+        },
+      },
+    ])
+  })
+
+  test("omits text header example when header has no variables", () => {
+    expect(
+      buildMessengerMessageTemplateComponents({
+        ...baseInput,
+        headerType: "text",
+        headerText: "PAMAOI XIN THONG BAO",
+        headerVariables: [],
+      }),
+    ).toEqual([
+      {
+        type: "HEADER",
+        format: "TEXT",
+        text: "PAMAOI XIN THONG BAO",
       },
       {
         type: "BODY",
@@ -76,6 +115,37 @@ describe("buildMessengerMessageTemplateComponents", () => {
         text: "Hi {{1}}",
         example: {
           header_text: ["Customer"],
+          header_handle: ["header-handle"],
+        },
+      },
+      {
+        type: "BODY",
+        text: "Hello {{1}}",
+        example: {
+          body_text: [["Hung"]],
+        },
+      },
+    ])
+  })
+
+  test("omits image header text example when header has no variables", () => {
+    expect(
+      buildMessengerMessageTemplateComponents(
+        {
+          ...baseInput,
+          headerType: "text_and_image",
+          headerText: "PAMAOI XIN THONG BAO",
+          headerVariables: [],
+          headerImageUrl: "https://example.com/header.jpg",
+        },
+        "header-handle",
+      ),
+    ).toEqual([
+      {
+        type: "HEADER",
+        format: "IMAGE",
+        text: "PAMAOI XIN THONG BAO",
+        example: {
           header_handle: ["header-handle"],
         },
       },
@@ -133,7 +203,9 @@ describe("buildMessengerMessageTemplateComponents", () => {
             type: "URL",
             text: "Open",
             url: "https://example.com/{{1}}",
-            example: ["abc"],
+            example: {
+              url_suffix_example: "https://example.com/abc",
+            },
           },
         ],
       },
@@ -234,6 +306,22 @@ describe("createMessengerMessageTemplateRequest", () => {
             title: "Open",
             url: "https://example.com/{{1}}",
             variables: [],
+          },
+        ],
+      }).success,
+    ).toBe(false)
+  })
+
+  test("rejects more than one URL variable", () => {
+    expect(
+      createMessengerMessageTemplateRequest.safeParse({
+        ...baseInput,
+        buttons: [
+          {
+            type: "URL",
+            title: "Open",
+            url: "https://example.com/{{1}}/{{2}}",
+            variables: ["one", "two"],
           },
         ],
       }).success,

--- a/apps/builder/__tests__/messenger-clone-template-components.test.ts
+++ b/apps/builder/__tests__/messenger-clone-template-components.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const resumableUploadImage = vi.fn(async () => "new-handle")
+
+vi.mock("@chatbotx.io/integration-messenger/apis/upload", () => ({
+  resumableUploadImage,
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {},
+  inArray: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  integrationMessengerModel: {},
+  messengerMessageTemplateModel: {},
+}))
+
+vi.mock("@chatbotx.io/integration-messenger/apis/message-templates", () => ({
+  createPageMessageTemplate: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/redis", () => ({
+  invalidateCacheByTags: vi.fn(),
+}))
+
+vi.mock(
+  "@/features/integration-messenger/message-templates/actions/sync-message-templates",
+  () => ({
+    syncMessengerMessageTemplatesForIntegration: vi.fn(),
+  }),
+)
+
+vi.mock("@/features/workspace-members/queries", () => ({
+  getAllWorkspaceMembers: vi.fn(),
+}))
+
+vi.mock("@/lib/safe-action", () => ({
+  workspaceActionClient: {
+    bindArgsSchemas: vi.fn(() => ({
+      schema: vi.fn(() => ({
+        action: vi.fn(),
+      })),
+    })),
+  },
+}))
+
+const { prepareComponentsForClone } = await import(
+  "@/features/integration-messenger/message-templates/actions/clone-message-templates"
+)
+
+describe("prepareComponentsForClone", () => {
+  beforeEach(() => {
+    resumableUploadImage.mockClear()
+  })
+
+  test("rejects opaque Meta image handles", async () => {
+    const components = [
+      {
+        type: "HEADER",
+        format: "IMAGE",
+        example: {
+          header_handle: ["4:opaque-meta-handle"],
+        },
+      },
+    ]
+
+    await expect(
+      prepareComponentsForClone(components, {} as never),
+    ).rejects.toThrow("Image header cannot be cloned")
+    expect(resumableUploadImage).not.toHaveBeenCalled()
+  })
+
+  test("re-uploads stored public image URLs without bearer auth", async () => {
+    const components = [
+      {
+        type: "HEADER",
+        format: "IMAGE",
+        example: {
+          header_handle: ["https://storage.test/header.jpg"],
+        },
+      },
+    ]
+
+    const result = await prepareComponentsForClone(components, {} as never)
+
+    expect(resumableUploadImage).toHaveBeenCalledWith(
+      {},
+      "https://storage.test/header.jpg",
+      { authenticatedDownload: false },
+    )
+    expect(result[0].example.header_handle).toEqual(["new-handle"])
+  })
+
+  test("re-uploads Meta image URLs with bearer auth", async () => {
+    const components = [
+      {
+        type: "HEADER",
+        format: "IMAGE",
+        example: {
+          header_handle: ["https://lookaside.facebook.com/header.jpg"],
+        },
+      },
+    ]
+
+    const result = await prepareComponentsForClone(components, {} as never)
+
+    expect(resumableUploadImage).toHaveBeenCalledWith(
+      {},
+      "https://lookaside.facebook.com/header.jpg",
+      { authenticatedDownload: true },
+    )
+    expect(result[0].example.header_handle).toEqual(["new-handle"])
+  })
+
+  test("re-uploads legacy opaque Meta handles from stored public image URL", async () => {
+    const components = [
+      {
+        type: "HEADER",
+        format: "IMAGE",
+        example: {
+          header_handle: ["4:opaque-meta-handle"],
+          header_image_url: "https://storage.test/header.jpg",
+        },
+      },
+    ]
+
+    const result = await prepareComponentsForClone(components, {} as never)
+
+    expect(resumableUploadImage).toHaveBeenCalledWith(
+      {},
+      "https://storage.test/header.jpg",
+      { authenticatedDownload: false },
+    )
+    expect(result[0].example).toEqual({
+      header_handle: ["new-handle"],
+    })
+  })
+})

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -1774,6 +1774,7 @@
         "postbackPayloadPlaceholder": "Enter payload (optional)"
       },
       "create": {
+        "trigger": "Create new template",
         "header": "Header",
         "headerType": "Header Type",
         "none": "None",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -1785,6 +1785,7 @@
         "postbackPayloadPlaceholder": "Nhập payload (tùy chọn)"
       },
       "create": {
+        "trigger": "Tạo mẫu mới",
         "header": "Đầu mẫu",
         "headerType": "Loại đầu mẫu",
         "none": "Không có",

--- a/apps/builder/src/app/space/[workspaceId]/messengers/[id]/message-templates/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/messengers/[id]/message-templates/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation"
 import { Suspense } from "react"
 import { MessengerMessageTemplatesTable } from "@/features/integration-messenger/message-templates/message-templates-table"
 import { messengerMessageTemplateService } from "@/features/integration-messenger/message-templates/queries"
+import { listMessengerMessageTemplatesSearchParamsCache } from "@/features/integration-messenger/message-templates/schema/query"
 import { findIntegrationMessenger } from "@/features/integration-messenger/queries"
 import { getAllWorkspaceMembers } from "@/features/workspace-members/queries"
 import { withWorkspaceIdAndIdSchema } from "@/features/workspaces/schema/resource"
@@ -11,6 +12,7 @@ import { getCurrentUserId } from "@/lib/auth/utils"
 
 export default async function MessengerMessageTemplatesPage(props: {
   params: Promise<{ workspaceId: string; id: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
 }) {
   const { data } = withWorkspaceIdAndIdSchema.safeParse(await props.params)
   if (!data) {
@@ -18,6 +20,9 @@ export default async function MessengerMessageTemplatesPage(props: {
   }
 
   const { workspaceId, id } = data
+  const search = listMessengerMessageTemplatesSearchParamsCache.parse(
+    await props.searchParams,
+  )
 
   let integrationMessenger: Awaited<ReturnType<typeof findIntegrationMessenger>>
   try {
@@ -58,11 +63,14 @@ export default async function MessengerMessageTemplatesPage(props: {
     }
   }
 
-  const promises = messengerMessageTemplateService.list({
+  const promises = messengerMessageTemplateService.listPaginated({
     where: {
       workspaceId,
       integrationMessengerId: id,
+      name: search.name,
     },
+    page: search.page,
+    perPage: search.perPage,
   })
 
   return (

--- a/apps/builder/src/features/flows/react-flow/steps/send-messenger-template-message/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-messenger-template-message/editor.tsx
@@ -1,16 +1,18 @@
 "use client"
 
 import {
+  type ButtonStepProps,
   extractMessengerFlowButtons,
   extractMessengerParameterInfos,
   extractMessengerTemplateParams,
   type MessengerTemplateComponent,
+  mergeMessengerFlowButtonsWithExisting,
   type ParameterInfo,
 } from "@chatbotx.io/flow-config"
 import { ComboboxField } from "@chatbotx.io/ui/components/form/combobox-field"
 import { SelectField } from "@chatbotx.io/ui/components/form/select-field"
 import { useTranslations } from "next-intl"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useFormContext } from "react-hook-form"
 import { useMessengerInboxOptions } from "@/features/inboxes/provider/inbox-hook"
 import { MessengerTemplateParamsForm } from "@/features/integration-messenger/message-templates/components/template-params-form"
@@ -29,11 +31,12 @@ function SendMessengerTemplateMessageStepEditor(
 ) {
   const { parentName } = props
   const t = useTranslations()
-  const { setValue, watch } = useFormContext()
+  const { getValues, setValue, unregister, watch } = useFormContext()
   const [selectedTemplate, setSelectedTemplate] =
     useState<FlowMessengerTemplateResource | null>(null)
   const [parameters, setParameters] = useState<ParameterInfo[]>([])
   const prevInboxIdRef = useRef<string | undefined>(undefined)
+  const prevTemplateIdRef = useRef<string | undefined>(undefined)
 
   const messengerInboxOptions = useMessengerInboxOptions()
   const messengerTemplates = useFlowTemplate((s) => s.messengerTemplates)
@@ -46,6 +49,40 @@ function SendMessengerTemplateMessageStepEditor(
       | "POSITIONAL"
       | "NAMED") || "POSITIONAL"
   const flowButtons = (watch(`${parentName}.buttons`) as unknown[]) || []
+  const resetTemplateParams = useCallback(
+    (
+      template: FlowMessengerTemplateResource,
+      format: "POSITIONAL" | "NAMED",
+    ) => {
+      unregister(`${parentName}.template.params`)
+      setValue(
+        `${parentName}.template.params`,
+        extractMessengerTemplateParams(
+          template.components as MessengerTemplateComponent[],
+          format,
+        ),
+        { shouldDirty: true, shouldValidate: true },
+      )
+    },
+    [parentName, setValue, unregister],
+  )
+  const resetFlowButtons = useCallback(
+    (template: FlowMessengerTemplateResource) => {
+      const templateButtons = extractMessengerFlowButtons(
+        template.components as MessengerTemplateComponent[],
+      )
+      const existingButtons =
+        (getValues(`${parentName}.buttons`) as ButtonStepProps[] | undefined) ??
+        []
+
+      setValue(
+        `${parentName}.buttons`,
+        mergeMessengerFlowButtonsWithExisting(templateButtons, existingButtons),
+        { shouldDirty: true, shouldValidate: true },
+      )
+    },
+    [getValues, parentName, setValue],
+  )
 
   useEffect(() => {
     if (
@@ -56,17 +93,21 @@ function SendMessengerTemplateMessageStepEditor(
       setValue(`${parentName}.template.name`, "")
       setValue(`${parentName}.template.language`, "")
       setValue(`${parentName}.template.parameterFormat`, "POSITIONAL")
+      unregister(`${parentName}.template.params`)
       setValue(`${parentName}.template.params`, {})
       setSelectedTemplate(null)
       setParameters([])
     }
     prevInboxIdRef.current = integrationInboxId
-  }, [integrationInboxId, parentName, setValue])
+  }, [integrationInboxId, parentName, setValue, unregister])
 
   useEffect(() => {
     if (templateId && messengerTemplates.length > 0) {
       const template = messengerTemplates.find((t) => t.id === templateId)
       if (template) {
+        const hasTemplateChanged =
+          prevTemplateIdRef.current !== undefined &&
+          prevTemplateIdRef.current !== templateId
         setSelectedTemplate(template)
         setValue(`${parentName}.template.name`, template.name)
         setValue(`${parentName}.template.language`, template.language)
@@ -77,25 +118,36 @@ function SendMessengerTemplateMessageStepEditor(
         const format = (template.parameterFormat ?? "POSITIONAL") as
           | "POSITIONAL"
           | "NAMED"
+        if (hasTemplateChanged) {
+          resetTemplateParams(template, format)
+        }
         const params = extractMessengerParameterInfos(
           template.components as MessengerTemplateComponent[],
           format,
         )
         setParameters(params)
 
-        // Seed flow buttons only when not yet configured (preserve persisted buttons)
-        const existingButtons = watch(`${parentName}.buttons`)
-        if (!existingButtons || (existingButtons as unknown[]).length === 0) {
-          setValue(
-            `${parentName}.buttons`,
-            extractMessengerFlowButtons(
-              template.components as MessengerTemplateComponent[],
-            ),
-          )
+        if (hasTemplateChanged) {
+          resetFlowButtons(template)
+        } else {
+          // Seed flow buttons only when not yet configured (preserve persisted buttons)
+          const existingButtons = watch(`${parentName}.buttons`)
+          if (!existingButtons || (existingButtons as unknown[]).length === 0) {
+            resetFlowButtons(template)
+          }
         }
       }
     }
-  }, [templateId, messengerTemplates, parentName, setValue, watch])
+    prevTemplateIdRef.current = templateId
+  }, [
+    templateId,
+    messengerTemplates,
+    parentName,
+    resetFlowButtons,
+    resetTemplateParams,
+    setValue,
+    watch,
+  ])
 
   const filteredTemplates = useMemo(
     () =>
@@ -129,17 +181,8 @@ function SendMessengerTemplateMessageStepEditor(
       setValue(`${parentName}.template.name`, template.name)
       setValue(`${parentName}.template.language`, template.language)
       setValue(`${parentName}.template.parameterFormat`, format)
-      const initialParams = extractMessengerTemplateParams(
-        template.components as MessengerTemplateComponent[],
-        format,
-      )
-      setValue(`${parentName}.template.params`, initialParams)
-      setValue(
-        `${parentName}.buttons`,
-        extractMessengerFlowButtons(
-          template.components as MessengerTemplateComponent[],
-        ),
-      )
+      resetTemplateParams(template, format)
+      resetFlowButtons(template)
       setSelectedTemplate(template)
       const params = extractMessengerParameterInfos(
         template.components as MessengerTemplateComponent[],
@@ -170,6 +213,7 @@ function SendMessengerTemplateMessageStepEditor(
             components={
               selectedTemplate?.components as MessengerTemplateComponent[]
             }
+            key={templateId}
             parameterFormat={parameterFormat}
             parentName={`${parentName}.template.params`}
           />

--- a/apps/builder/src/features/flows/react-flow/steps/send-wa-template-message/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-wa-template-message/editor.tsx
@@ -9,7 +9,7 @@ import {
 import { ComboboxField } from "@chatbotx.io/ui/components/form/combobox-field"
 import { SelectField } from "@chatbotx.io/ui/components/form/select-field"
 import { useTranslations } from "next-intl"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useFormContext } from "react-hook-form"
 import { useWhatsappInboxOptions } from "@/features/inboxes/provider/inbox-hook"
 import { TemplateParamsForm } from "@/features/integration-whatsapp/message-templates/components/template-params-form"
@@ -27,11 +27,12 @@ function SendWaTemplateMessageStepEditor(
 ) {
   const { parentName } = props
   const t = useTranslations()
-  const { setValue, watch } = useFormContext()
+  const { setValue, unregister, watch } = useFormContext()
   const [selectedTemplate, setSelectedTemplate] =
     useState<FlowTemplateResource | null>(null)
   const [parameters, setParameters] = useState<ParameterInfo[]>([])
   const prevInboxIdRef = useRef<string | undefined>(undefined)
+  const prevTemplateIdRef = useRef<string | undefined>(undefined)
 
   const whatsappInboxOptions = useWhatsappInboxOptions()
   const whatsappTemplates = useFlowTemplate((s) => s.whatsappTemplates)
@@ -39,6 +40,17 @@ function SendWaTemplateMessageStepEditor(
   const integrationInboxId = watch(`${parentName}.template.inboxId`)
   const templateId = watch(`${parentName}.template.id`)
   const templateParams = watch(`${parentName}.template.params`) || {}
+  const resetTemplateParams = useCallback(
+    (template: FlowTemplateResource) => {
+      unregister(`${parentName}.template.params`)
+      setValue(
+        `${parentName}.template.params`,
+        extractTemplateParams(template.components as TemplateComponent[]),
+        { shouldDirty: true, shouldValidate: true },
+      )
+    },
+    [parentName, setValue, unregister],
+  )
 
   useEffect(() => {
     if (
@@ -48,27 +60,35 @@ function SendWaTemplateMessageStepEditor(
       setValue(`${parentName}.template.id`, "")
       setValue(`${parentName}.template.name`, "")
       setValue(`${parentName}.template.language`, "")
+      unregister(`${parentName}.template.params`)
       setValue(`${parentName}.template.params`, {})
       setSelectedTemplate(null)
       setParameters([])
     }
     prevInboxIdRef.current = integrationInboxId
-  }, [integrationInboxId, parentName, setValue])
+  }, [integrationInboxId, parentName, setValue, unregister])
 
   useEffect(() => {
     if (templateId && whatsappTemplates.length > 0) {
       const template = whatsappTemplates.find((t) => t.id === templateId)
       if (template) {
+        const hasTemplateChanged =
+          prevTemplateIdRef.current !== undefined &&
+          prevTemplateIdRef.current !== templateId
         setSelectedTemplate(template)
         setValue(`${parentName}.template.name`, template.name)
         setValue(`${parentName}.template.language`, template.language)
+        if (hasTemplateChanged) {
+          resetTemplateParams(template)
+        }
         const params = extractParameterInfos(
           template.components as TemplateComponent[],
         )
         setParameters(params)
       }
     }
-  }, [templateId, whatsappTemplates, parentName, setValue])
+    prevTemplateIdRef.current = templateId
+  }, [templateId, whatsappTemplates, parentName, resetTemplateParams, setValue])
 
   const filteredTemplates = useMemo(
     () =>
@@ -98,10 +118,7 @@ function SendWaTemplateMessageStepEditor(
       setValue(`${parentName}.template.id`, template.id)
       setValue(`${parentName}.template.name`, template.name)
       setValue(`${parentName}.template.language`, template.language)
-      const initialParams = extractTemplateParams(
-        template.components as TemplateComponent[],
-      )
-      setValue(`${parentName}.template.params`, initialParams)
+      resetTemplateParams(template)
       setSelectedTemplate(template)
       const params = extractParameterInfos(
         template.components as TemplateComponent[],
@@ -129,6 +146,7 @@ function SendWaTemplateMessageStepEditor(
         {parameters.length > 0 && (
           <TemplateParamsForm
             components={selectedTemplate?.components as TemplateComponent[]}
+            key={templateId}
             parentName={`${parentName}.template.params`}
           />
         )}

--- a/apps/builder/src/features/integration-messenger/message-templates/actions/clone-message-templates.ts
+++ b/apps/builder/src/features/integration-messenger/message-templates/actions/clone-message-templates.ts
@@ -1,25 +1,90 @@
 "use server"
 
 import { db, inArray } from "@chatbotx.io/database/client"
-import {
-  integrationMessengerModel,
-  messengerMessageTemplateModel,
-} from "@chatbotx.io/database/schema"
+import { integrationMessengerModel } from "@chatbotx.io/database/schema"
 import { createPageMessageTemplate } from "@chatbotx.io/integration-messenger/apis/message-templates"
 import { resumableUploadImage } from "@chatbotx.io/integration-messenger/apis/upload"
 import type { MessengerAuthValue } from "@chatbotx.io/integration-messenger/schema"
 import { invalidateCacheByTags } from "@chatbotx.io/redis"
 import { SdkException } from "@chatbotx.io/sdk"
-import { createId, zodBigintAsString } from "@chatbotx.io/utils"
+import { zodBigintAsString } from "@chatbotx.io/utils"
 import { chunk } from "remeda"
 import { z } from "zod"
 import { getAllWorkspaceMembers } from "@/features/workspace-members/queries"
 import { workspaceActionClient } from "@/lib/safe-action"
+import { syncMessengerMessageTemplatesForIntegration } from "./sync-message-templates"
 
-// IMAGE header handles are page-scoped — re-upload each one to the target page
-// to get a fresh handle. Other components pass through unchanged.
-// PHP ref: UtilityMessageTemplateService::copyMessageTemplates + reuploadHeaderImage
-async function prepareComponentsForClone(
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return url.protocol === "http:" || url.protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+function isMetaImageUrl(value: string): boolean {
+  try {
+    const hostname = new URL(value).hostname
+    return (
+      hostname === "facebook.com" ||
+      hostname.endsWith(".facebook.com") ||
+      hostname.endsWith(".fbcdn.net") ||
+      hostname.endsWith(".fbsbx.com")
+    )
+  } catch {
+    return false
+  }
+}
+
+function stripLegacyInternalHeaderImageUrl(
+  // biome-ignore lint/suspicious/noExplicitAny: Meta component example shape varies
+  example: any,
+) {
+  if (!example || typeof example !== "object") {
+    return example
+  }
+
+  const { header_image_url: _headerImageUrl, ...rest } = example
+  return rest
+}
+
+function getStoredHeaderImageUrl(
+  // biome-ignore lint/suspicious/noExplicitAny: Meta component shape varies
+  component: any,
+): string | undefined {
+  const headerHandle: string | undefined = component.example?.header_handle?.[0]
+  if (headerHandle && isHttpUrl(headerHandle)) {
+    return headerHandle
+  }
+
+  const legacyInternalImageUrl: string | undefined =
+    component.example?.header_image_url
+  if (legacyInternalImageUrl && isHttpUrl(legacyInternalImageUrl)) {
+    return legacyInternalImageUrl
+  }
+
+  return
+}
+
+function withHeaderHandle(
+  // biome-ignore lint/suspicious/noExplicitAny: Meta component shape varies
+  component: any,
+  headerHandle: string,
+) {
+  return {
+    ...component,
+    example: {
+      ...stripLegacyInternalHeaderImageUrl(component.example),
+      header_handle: [headerHandle],
+    },
+  }
+}
+
+// IMAGE header handles are page-scoped. The DB stores Meta's listed image URL in
+// example.header_handle[0], while the create-template request needs a freshly
+// uploaded handle for each target Page.
+export async function prepareComponentsForClone(
   // biome-ignore lint/suspicious/noExplicitAny: Meta API component shape varies
   components: any[],
   auth: MessengerAuthValue,
@@ -34,18 +99,19 @@ async function prepareComponentsForClone(
       ) {
         return c
       }
-      const existingHandle: string | undefined = c.example?.header_handle?.[0]
-      if (!existingHandle) {
-        return c
+      const storedHeaderImageUrl = getStoredHeaderImageUrl(c)
+
+      if (!storedHeaderImageUrl) {
+        throw new Error(
+          "Image header cannot be cloned because Meta returned a page-owned file handle instead of a downloadable image URL. Recreate the template on the target channel with the original image.",
+        )
       }
-      const newHandle = await resumableUploadImage(auth, existingHandle)
-      return {
-        ...c,
-        example: {
-          ...c.example,
-          header_handle: [newHandle],
-        },
-      }
+
+      const newHandle = await resumableUploadImage(auth, storedHeaderImageUrl, {
+        authenticatedDownload: isMetaImageUrl(storedHeaderImageUrl),
+      })
+
+      return withHeaderHandle(c, newHandle)
     }),
   )
 }
@@ -150,34 +216,13 @@ export const cloneMessengerMessageTemplateAction = workspaceActionClient
         })
 
         if (resp.status === "APPROVED") {
-          await db
-            .insert(messengerMessageTemplateModel)
-            .values({
-              id: createId(),
-              sourceId: resp.id,
-              status: resp.status,
-              name: sourceTemplate.name,
-              language: sourceTemplate.language,
-              category: sourceTemplate.category,
-              parameterFormat: sourceTemplate.parameterFormat,
-              components: sourceTemplate.components,
-              integrationMessengerId: target.id,
-            })
-            .onConflictDoUpdate({
-              target: [
-                messengerMessageTemplateModel.integrationMessengerId,
-                messengerMessageTemplateModel.sourceId,
-              ],
-              set: {
-                sourceId: resp.id,
-                status: resp.status,
-                name: sourceTemplate.name,
-                language: sourceTemplate.language,
-                category: sourceTemplate.category,
-                parameterFormat: sourceTemplate.parameterFormat,
-                components: sourceTemplate.components,
-              },
-            })
+          await syncMessengerMessageTemplatesForIntegration({
+            workspaceId: target.workspaceId,
+            integrationMessenger: target,
+            templateId: resp.id,
+            templateName: sourceTemplate.name,
+            templateLanguage: sourceTemplate.language,
+          })
           succeeded.push({ channel: target.name })
         } else {
           failed.push({

--- a/apps/builder/src/features/integration-messenger/message-templates/actions/create-message-template.ts
+++ b/apps/builder/src/features/integration-messenger/message-templates/actions/create-message-template.ts
@@ -1,15 +1,29 @@
 "use server"
 
 import { db } from "@chatbotx.io/database/client"
-import { messengerMessageTemplateModel } from "@chatbotx.io/database/schema"
 import { createPageMessageTemplate } from "@chatbotx.io/integration-messenger/apis/message-templates"
 import { resumableUploadImage } from "@chatbotx.io/integration-messenger/apis/upload"
 import type { MessengerAuthValue } from "@chatbotx.io/integration-messenger/schema"
 import { invalidateCacheByTags } from "@chatbotx.io/redis"
-import { createId, zodBigintAsString } from "@chatbotx.io/utils"
+import { SdkException } from "@chatbotx.io/sdk"
+import { zodBigintAsString } from "@chatbotx.io/utils"
 import { workspaceActionClient } from "@/lib/safe-action"
 import { buildMessengerMessageTemplateComponents } from "../lib/build-template-components"
 import { createMessengerMessageTemplateRequest } from "../schema/mutation"
+import { syncMessengerMessageTemplatesForIntegration } from "./sync-message-templates"
+
+function formatTemplateRejectionMessage({
+  rejectionReason,
+  specificRejectionReason,
+}: {
+  rejectionReason?: string
+  specificRejectionReason?: string
+}) {
+  const reasons = [rejectionReason, specificRejectionReason].filter(Boolean)
+  return reasons.length > 0
+    ? `Meta rejected this template: ${reasons.join(" / ")}`
+    : "Meta rejected this template"
+}
 
 export const createMessengerMessageTemplateAction = workspaceActionClient
   .bindArgsSchemas([zodBigintAsString(), zodBigintAsString()])
@@ -35,8 +49,11 @@ export const createMessengerMessageTemplateAction = workspaceActionClient
     const auth = integrationMessenger.auth as MessengerAuthValue
     const headerHandle =
       parsedInput.headerType === "text_and_image" && parsedInput.headerImageUrl
-        ? await resumableUploadImage(auth, parsedInput.headerImageUrl)
+        ? await resumableUploadImage(auth, parsedInput.headerImageUrl, {
+            authenticatedDownload: false,
+          })
         : undefined
+
     const components = buildMessengerMessageTemplateComponents(
       parsedInput,
       headerHandle,
@@ -49,38 +66,26 @@ export const createMessengerMessageTemplateAction = workspaceActionClient
       components,
     })
 
-    await db
-      .insert(messengerMessageTemplateModel)
-      .values({
-        id: createId(),
-        sourceId: resp.id,
-        status: resp.status,
-        name: parsedInput.name,
-        language: parsedInput.language,
-        category: "UTILITY",
-        parameterFormat: resp.parameter_format ?? "POSITIONAL",
-        components,
-        integrationMessengerId: integrationMessenger.id,
-      })
-      .onConflictDoUpdate({
-        target: [
-          messengerMessageTemplateModel.integrationMessengerId,
-          messengerMessageTemplateModel.sourceId,
-        ],
-        set: {
-          sourceId: resp.id,
-          status: resp.status,
-          name: parsedInput.name,
-          language: parsedInput.language,
-          category: "UTILITY",
-          parameterFormat: resp.parameter_format ?? "POSITIONAL",
-          components,
-        },
-      })
+    await syncMessengerMessageTemplatesForIntegration({
+      workspaceId,
+      integrationMessenger,
+      templateId: resp.id,
+      templateName: parsedInput.name,
+      templateLanguage: parsedInput.language,
+    })
 
     await invalidateCacheByTags([
       `workspaces:${workspaceId}#messenger#messageTemplates`,
     ])
+
+    if (resp.status === "REJECTED") {
+      throw new SdkException(
+        formatTemplateRejectionMessage({
+          rejectionReason: resp.rejection_reason,
+          specificRejectionReason: resp.specific_rejection_reason,
+        }),
+      )
+    }
 
     return { status: resp.status }
   })

--- a/apps/builder/src/features/integration-messenger/message-templates/actions/sync-message-templates.ts
+++ b/apps/builder/src/features/integration-messenger/message-templates/actions/sync-message-templates.ts
@@ -6,12 +6,130 @@ import {
   integrationMessengerModel,
   messengerMessageTemplateModel,
 } from "@chatbotx.io/database/schema"
+import type { IntegrationMessengerModel } from "@chatbotx.io/database/types"
 import type { MessengerAuthValue } from "@chatbotx.io/integration-messenger/schema"
 import { invalidateCacheByTags } from "@chatbotx.io/redis"
 import { SdkException } from "@chatbotx.io/sdk"
 import { createId, zodBigintAsString } from "@chatbotx.io/utils"
 import { integrations } from "@/integration"
 import { workspaceActionClient } from "@/lib/safe-action"
+
+export async function syncMessengerMessageTemplatesForIntegration({
+  workspaceId,
+  integrationMessenger,
+  templateId,
+  templateName,
+  templateLanguage,
+}: {
+  workspaceId: string
+  integrationMessenger: IntegrationMessengerModel
+  templateId?: string
+  templateName?: string
+  templateLanguage?: string
+}) {
+  const isPartialSync = Boolean(templateId || templateName || templateLanguage)
+  const ctx = await buildContext({
+    workspaceId,
+    integrationType: "messenger",
+    integration: {
+      ...integrationMessenger,
+      auth: integrationMessenger.auth as MessengerAuthValue,
+    },
+  })
+  let res: Awaited<
+    ReturnType<typeof integrations.messenger.runAction<"listMessageTemplates">>
+  >
+  try {
+    res = await integrations.messenger.runAction("listMessageTemplates", {
+      ctx,
+      input: templateName ? { name: templateName } : undefined,
+    })
+  } catch (error) {
+    throw new SdkException(
+      `Failed to fetch Messenger templates from Facebook API: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+
+  const templates = res.data.filter((template) => {
+    if (templateId && template.id !== templateId) {
+      return false
+    }
+
+    if (templateName && template.name !== templateName) {
+      return false
+    }
+
+    if (templateLanguage && template.language !== templateLanguage) {
+      return false
+    }
+
+    return true
+  })
+
+  await db.transaction(async (tx) => {
+    if (!isPartialSync) {
+      const existingTemplates = await tx
+        .select({
+          id: messengerMessageTemplateModel.id,
+          sourceId: messengerMessageTemplateModel.sourceId,
+        })
+        .from(messengerMessageTemplateModel)
+        .where(
+          eq(
+            messengerMessageTemplateModel.integrationMessengerId,
+            integrationMessenger.id,
+          ),
+        )
+
+      const incomingSourceIds = new Set(templates.map((t) => t.id))
+
+      const templatesToDelete = existingTemplates.filter(
+        (t) => !incomingSourceIds.has(t.sourceId),
+      )
+
+      if (templatesToDelete.length > 0) {
+        await tx.delete(messengerMessageTemplateModel).where(
+          inArray(
+            messengerMessageTemplateModel.id,
+            templatesToDelete.map((t) => t.id),
+          ),
+        )
+      }
+    }
+
+    for (const template of templates) {
+      await tx
+        .insert(messengerMessageTemplateModel)
+        .values([
+          {
+            id: createId(),
+            name: template.name,
+            integrationMessengerId: integrationMessenger.id,
+            language: template.language,
+            category: template.category,
+            status: template.status,
+            parameterFormat: template.parameter_format ?? "POSITIONAL",
+            sourceId: template.id,
+            components: template.components,
+          },
+        ])
+        .onConflictDoUpdate({
+          target: [
+            messengerMessageTemplateModel.integrationMessengerId,
+            messengerMessageTemplateModel.sourceId,
+          ],
+          set: {
+            name: template.name,
+            language: template.language,
+            category: template.category,
+            status: template.status,
+            parameterFormat: template.parameter_format ?? "POSITIONAL",
+            components: template.components,
+          },
+        })
+    }
+  })
+}
 
 export const syncMessengerMessageTemplateAction = workspaceActionClient
   .bindArgsSchemas([zodBigintAsString(), zodBigintAsString()])
@@ -29,89 +147,9 @@ export const syncMessengerMessageTemplateAction = workspaceActionClient
       message: "Messenger integration not found",
     })
 
-    const ctx = await buildContext({
+    await syncMessengerMessageTemplatesForIntegration({
       workspaceId,
-      integrationType: "messenger",
-      integration: {
-        ...integrationMessenger,
-        auth: integrationMessenger.auth as MessengerAuthValue,
-      },
-    })
-    let res: Awaited<
-      ReturnType<
-        typeof integrations.messenger.runAction<"listMessageTemplates">
-      >
-    >
-    try {
-      res = await integrations.messenger.runAction("listMessageTemplates", {
-        ctx,
-      })
-    } catch (error) {
-      throw new SdkException(
-        `Failed to fetch Messenger templates from Facebook API: ${error instanceof Error ? error.message : String(error)}`,
-      )
-    }
-
-    await db.transaction(async (tx) => {
-      const existingTemplates = await tx
-        .select({
-          id: messengerMessageTemplateModel.id,
-          sourceId: messengerMessageTemplateModel.sourceId,
-        })
-        .from(messengerMessageTemplateModel)
-        .where(
-          eq(
-            messengerMessageTemplateModel.integrationMessengerId,
-            integrationMessenger.id,
-          ),
-        )
-
-      const incomingSourceIds = new Set(res.data.map((t) => t.id))
-
-      const templatesToDelete = existingTemplates.filter(
-        (t) => !incomingSourceIds.has(t.sourceId),
-      )
-
-      if (templatesToDelete.length > 0) {
-        await tx.delete(messengerMessageTemplateModel).where(
-          inArray(
-            messengerMessageTemplateModel.id,
-            templatesToDelete.map((t) => t.id),
-          ),
-        )
-      }
-
-      for (const template of res.data) {
-        await tx
-          .insert(messengerMessageTemplateModel)
-          .values([
-            {
-              id: createId(),
-              name: template.name,
-              integrationMessengerId: integrationMessenger.id,
-              language: template.language,
-              category: template.category,
-              status: template.status,
-              parameterFormat: template.parameter_format ?? "POSITIONAL",
-              sourceId: template.id,
-              components: template.components,
-            },
-          ])
-          .onConflictDoUpdate({
-            target: [
-              messengerMessageTemplateModel.integrationMessengerId,
-              messengerMessageTemplateModel.sourceId,
-            ],
-            set: {
-              name: template.name,
-              language: template.language,
-              category: template.category,
-              status: template.status,
-              parameterFormat: template.parameter_format ?? "POSITIONAL",
-              components: template.components,
-            },
-          })
-      }
+      integrationMessenger,
     })
 
     await invalidateCacheByTags([

--- a/apps/builder/src/features/integration-messenger/message-templates/components/template-preview.tsx
+++ b/apps/builder/src/features/integration-messenger/message-templates/components/template-preview.tsx
@@ -11,7 +11,51 @@ type MessengerTemplatePreviewProps = {
     image?: { link: string }
   }>
   bodyParams: Array<{ text?: string }>
-  buttonParams: Array<{ text?: string; payload?: string }>
+  buttonParams: Array<{
+    sub_type?: string
+    index?: number
+    text?: string
+    payload?: string
+  }>
+}
+
+const NAMED_PARAMETER_PATTERN = /\{\{[a-zA-Z_]+\}\}/
+
+function renderTemplateText(
+  templateText: string,
+  params: Array<{ text?: string }>,
+) {
+  let text = templateText
+  const textParams = params.filter((param) => param.text)
+
+  for (const [i, param] of textParams.entries()) {
+    if (param.text) {
+      text = text.replaceAll(`{{${i + 1}}}`, param.text)
+    }
+  }
+
+  for (const param of textParams) {
+    if (param.text) {
+      text = text.replace(NAMED_PARAMETER_PATTERN, param.text)
+    }
+  }
+
+  return text
+}
+
+function getButtonParam(
+  buttonParams: MessengerTemplatePreviewProps["buttonParams"],
+  buttonType: string,
+  buttonIndex: number,
+) {
+  const subType = buttonType.toLowerCase()
+  return (
+    buttonParams.find(
+      (param) => param.index === buttonIndex && param.sub_type === subType,
+    ) ??
+    buttonParams.find((param) => param.index === buttonIndex) ??
+    buttonParams.find((param) => param.sub_type === subType)
+  )
 }
 
 export function MessengerTemplatePreview({
@@ -27,27 +71,15 @@ export function MessengerTemplatePreview({
   return (
     <div className="space-y-2 rounded-lg bg-muted p-3">
       {components.map((component) => {
-        if (component.type === "HEADER") {
-          if (component.format === "TEXT" && component.text) {
-            let text = component.text
-            if (headerParams && headerParams.length > 0) {
-              for (const [i, param] of headerParams.entries()) {
-                if (param?.text) {
-                  text = text.replace(`{{${i + 1}}}`, param.text)
-                  text = text.replace(/\{\{[a-zA-Z_]+\}\}/g, param.text)
-                }
-              }
-            }
-            return (
-              <div
-                className="font-bold text-sm"
-                key={`header-text-${component.type}`}
-              >
-                {text}
-              </div>
-            )
-          }
-          if (component.format === "IMAGE" && headerParams?.[0]?.image?.link) {
+        const componentType = component.type?.toUpperCase()
+        const componentFormat = component.format?.toUpperCase()
+
+        if (componentType === "HEADER") {
+          const headerText = component.text
+            ? renderTemplateText(component.text, headerParams)
+            : null
+
+          if (componentFormat === "IMAGE" && headerParams?.[0]?.image?.link) {
             let imageUrl: URL | null = null
             try {
               imageUrl = new URL(headerParams[0].image.link)
@@ -56,7 +88,7 @@ export function MessengerTemplatePreview({
             }
 
             return (
-              <div className="mb-2" key={`header-image-${component.type}`}>
+              <div className="space-y-2" key={`header-image-${component.type}`}>
                 {imageUrl ? (
                   <div className="relative h-32 w-full">
                     <Image
@@ -71,20 +103,26 @@ export function MessengerTemplatePreview({
                     {headerParams[0].image.link}
                   </div>
                 )}
+                {headerText && (
+                  <div className="font-bold text-sm">{headerText}</div>
+                )}
+              </div>
+            )
+          }
+
+          if (headerText) {
+            return (
+              <div
+                className="font-bold text-sm"
+                key={`header-text-${component.type}`}
+              >
+                {headerText}
               </div>
             )
           }
         }
-        if (component.type === "BODY" && component.text) {
-          let text = component.text
-          if (bodyParams && bodyParams.length > 0) {
-            for (const [i, param] of bodyParams.entries()) {
-              if (param?.text) {
-                text = text.replace(`{{${i + 1}}}`, param.text)
-                text = text.replace(/\{\{[a-zA-Z_]+\}\}/g, param.text)
-              }
-            }
-          }
+        if (componentType === "BODY" && component.text) {
+          const text = renderTemplateText(component.text, bodyParams)
           return (
             <div
               className="whitespace-pre-wrap text-sm"
@@ -94,7 +132,7 @@ export function MessengerTemplatePreview({
             </div>
           )
         }
-        if (component.type === "FOOTER" && component.text) {
+        if (componentType === "FOOTER" && component.text) {
           return (
             <div
               className="mt-2 text-muted-foreground text-xs"
@@ -104,33 +142,43 @@ export function MessengerTemplatePreview({
             </div>
           )
         }
-        if (component.type === "BUTTONS" && component.buttons) {
-          // POSTBACK / QUICK_REPLY buttons render separately as flow buttons —
-          // only URL buttons belong in the template preview.
-          const urlButtons = component.buttons.filter(
-            (button) => button.type?.toUpperCase() === "URL",
-          )
-          if (urlButtons.length === 0) {
-            return null
-          }
+        if (componentType === "BUTTONS" && component.buttons) {
           return (
             <div className="mt-2 space-y-1" key={`buttons-${component.type}`}>
-              {urlButtons.map((button, btnIdx) => {
-                let url = button.url ?? ""
-                if (
-                  button.type === "URL" &&
-                  url.includes("{{1}}") &&
-                  buttonParams?.[btnIdx]?.text
-                ) {
-                  url = url.replace("{{1}}", buttonParams[btnIdx].text ?? "")
+              {component.buttons.map((button, btnIdx) => {
+                const buttonType = button.type?.toUpperCase()
+                const buttonParam = getButtonParam(
+                  buttonParams,
+                  button.type,
+                  btnIdx,
+                )
+                let detail = ""
+
+                if (buttonType === "URL") {
+                  detail = button.url ?? ""
+                  const value = buttonParam?.text
+                  if (detail.includes("{{1}}") && value) {
+                    detail = detail.replace("{{1}}", value)
+                  } else if (!detail && value) {
+                    detail = value
+                  }
                 }
+
+                if (
+                  buttonType === "PHONE_NUMBER" &&
+                  "phone_number" in button &&
+                  button.phone_number
+                ) {
+                  detail = button.phone_number
+                }
+
                 return (
                   <div
                     className="rounded border bg-gray-300 px-2 py-1 text-center text-blue-600 text-xs"
                     // biome-ignore lint/suspicious/noArrayIndexKey: safe index
                     key={`button-${component.type}-${btnIdx}-${button.text}`}
                   >
-                    {button.text} {url && `→ ${url}`}
+                    {button.text} {detail && `→ ${detail}`}
                   </div>
                 )
               })}

--- a/apps/builder/src/features/integration-messenger/message-templates/components/text-with-variables-field.tsx
+++ b/apps/builder/src/features/integration-messenger/message-templates/components/text-with-variables-field.tsx
@@ -28,6 +28,7 @@ type TextWithVariablesFieldProps = {
   variablesName: FieldPath<FieldValues>
   label: string
   maxVariables?: number
+  variablesLayout?: "grid" | "stack"
 }
 
 const VARIABLE_PATTERN = /{{\d}}/g
@@ -46,6 +47,7 @@ export function TextWithVariablesField({
   variablesName,
   label,
   maxVariables = 9,
+  variablesLayout = "grid",
 }: TextWithVariablesFieldProps) {
   const t = useTranslations()
   const form = useFormContext<FieldValues>()
@@ -112,7 +114,13 @@ export function TextWithVariablesField({
         </Button>
       )}
       {variableKeys.length > 0 && (
-        <div className="grid gap-3 sm:grid-cols-2">
+        <div
+          className={
+            variablesLayout === "stack"
+              ? "grid gap-3"
+              : "grid gap-3 sm:grid-cols-2"
+          }
+        >
           {variableKeys.map((key, index) => (
             <InputField
               key={key}

--- a/apps/builder/src/features/integration-messenger/message-templates/create-message-template-dialog.tsx
+++ b/apps/builder/src/features/integration-messenger/message-templates/create-message-template-dialog.tsx
@@ -266,6 +266,7 @@ export function CreateMessageTemplateDialog({
                 duration: 5000,
               })
             }
+            router.refresh()
           },
         },
         formProps: {

--- a/apps/builder/src/features/integration-messenger/message-templates/create-message-template-dialog.tsx
+++ b/apps/builder/src/features/integration-messenger/message-templates/create-message-template-dialog.tsx
@@ -38,7 +38,7 @@ import {
   Trash2Icon,
 } from "lucide-react"
 import { useRouter } from "next/navigation"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form"
 import { toast } from "sonner"
@@ -223,9 +223,15 @@ export function CreateMessageTemplateDialog({
   integrationMessengerId,
 }: CreateMessageTemplateDialogProps) {
   const t = useTranslations()
+  const locale = useLocale()
   const router = useRouter()
   const [open, setOpen] = useState(false)
   const [uploadedImage, setUploadedImage] = useState<UploadedImage | null>(null)
+  const defaultLanguage = locale.startsWith("en") ? "en" : "vi"
+  const formDefaultValues = useMemo(
+    () => ({ ...defaultValues, language: defaultLanguage }),
+    [defaultLanguage],
+  )
 
   const boundAction = useMemo(
     () =>
@@ -256,13 +262,15 @@ export function CreateMessageTemplateDialog({
           },
           onError: ({ error }) => {
             if (error.serverError) {
-              toast.error(error.serverError)
+              toast.error(error.serverError, {
+                duration: 5000,
+              })
             }
           },
         },
         formProps: {
           mode: "onChange",
-          defaultValues,
+          defaultValues: formDefaultValues,
         },
         errorMapProps: {},
       },
@@ -281,16 +289,19 @@ export function CreateMessageTemplateDialog({
   const resetDialog = useCallback(() => {
     setUploadedImage(null)
     resetFormAndAction()
-  }, [resetFormAndAction])
+    form.reset(formDefaultValues)
+  }, [form, formDefaultValues, resetFormAndAction])
 
   const handleOpenChange = useCallback(
     (isOpen: boolean) => {
       setOpen(isOpen)
-      if (!isOpen) {
+      if (isOpen) {
+        form.reset(formDefaultValues)
+      } else {
         resetDialog()
       }
     },
-    [resetDialog],
+    [form, formDefaultValues, resetDialog],
   )
 
   const headerOptions = useMemo(
@@ -307,12 +318,13 @@ export function CreateMessageTemplateDialog({
       <DialogTrigger asChild>
         <Button size="sm">
           <PlusIcon className="size-4" />
-          {t("actions.createFeature", {
-            feature: t("fields.messageTemplate.label"),
-          })}
+          {t("messenger.messageTemplate.create.trigger")}
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-h-screen overflow-y-auto sm:max-w-2xl">
+      <DialogContent
+        className="max-h-screen overflow-y-auto sm:max-w-2xl"
+        onInteractOutside={(event) => event.preventDefault()}
+      >
         <DialogHeader className="mb-2">
           <DialogTitle>
             {t("actions.createFeature", {
@@ -323,7 +335,7 @@ export function CreateMessageTemplateDialog({
 
         <Form {...form}>
           <form className="space-y-6" onSubmit={handleSubmitWithAction}>
-            <div className="grid gap-4 sm:grid-cols-2">
+            <div className="grid gap-4">
               <InputField label={t("fields.name.label")} name="name" required />
               <SelectField
                 label={t("fields.language.label")}
@@ -417,6 +429,7 @@ export function CreateMessageTemplateDialog({
               label={t("messenger.messageTemplate.create.body")}
               maxVariables={9}
               name="body"
+              variablesLayout="stack"
               variablesName="bodyVariables"
             />
 

--- a/apps/builder/src/features/integration-messenger/message-templates/lib/build-template-components.ts
+++ b/apps/builder/src/features/integration-messenger/message-templates/lib/build-template-components.ts
@@ -12,18 +12,18 @@ export type MessengerTemplateComponent =
       type: "HEADER"
       format: "TEXT"
       text: string
-      example: { header_text: string[] }
+      example?: { header_text: string[] }
     }
   | {
       type: "HEADER"
       format: "IMAGE"
       text: string
-      example: { header_text: string[]; header_handle: string[] }
+      example: { header_text?: string[]; header_handle: string[] }
     }
   | {
       type: "BODY"
       text: string
-      example: { body_text: string[][] }
+      example?: { body_text: string[][] }
     }
   | {
       type: "BUTTONS"
@@ -35,7 +35,9 @@ export type MessengerTemplateButtonComponent =
       type: "URL"
       text: string
       url: string
-      example?: string[]
+      example?: {
+        url_suffix_example: string
+      }
     }
   | {
       type: "PHONE_NUMBER"
@@ -52,13 +54,48 @@ function buildHeaderTextExample(variables: TemplateVariable[]) {
   return variables.map((variable) => variable.example)
 }
 
+function buildHeaderTextExampleParam(variables: TemplateVariable[]):
+  | {
+      header_text: string[]
+    }
+  | undefined {
+  const headerText = buildHeaderTextExample(variables)
+  return headerText.length > 0 ? { header_text: headerText } : undefined
+}
+
+function buildBodyExampleParam(variables: TemplateVariable[]):
+  | {
+      body_text: string[][]
+    }
+  | undefined {
+  const bodyText = variables.map((variable) => variable.example)
+  return bodyText.length > 0 ? { body_text: [bodyText] } : undefined
+}
+
+function buildUrlSuffixExample(url: string, variables: string[]) {
+  return variables.reduce(
+    (result, variable, index) =>
+      result.replaceAll(`{{${index + 1}}}`, variable),
+    url,
+  )
+}
+
 function buildButton(button: TemplateButton): MessengerTemplateButtonComponent {
   if (button.type === "URL") {
     return {
       type: "URL",
       text: button.title,
       url: button.url,
-      ...(button.variables.length > 0 ? { example: button.variables } : {}),
+      ...(button.variables.length > 0
+        ? {
+            example: {
+              url_suffix_example: buildUrlSuffixExample(
+                button.url,
+                button.variables,
+              ),
+            },
+          }
+        : {}),
     }
   }
 
@@ -84,14 +121,16 @@ export function buildMessengerMessageTemplateComponents(
   const components: MessengerTemplateComponent[] = []
 
   if (input.headerType === "text") {
-    components.push({
+    const headerTextExample = buildHeaderTextExample(input.headerVariables)
+    const headerComponent: MessengerTemplateComponent = {
       type: "HEADER",
       format: "TEXT",
       text: input.headerText,
-      example: {
-        header_text: buildHeaderTextExample(input.headerVariables),
-      },
-    })
+      ...(headerTextExample.length > 0
+        ? { example: { header_text: headerTextExample } }
+        : {}),
+    }
+    components.push(headerComponent)
   }
 
   if (input.headerType === "text_and_image") {
@@ -100,18 +139,17 @@ export function buildMessengerMessageTemplateComponents(
       format: "IMAGE",
       text: input.headerText,
       example: {
-        header_text: buildHeaderTextExample(input.headerVariables),
+        ...(buildHeaderTextExampleParam(input.headerVariables) ?? {}),
         header_handle: headerHandle ? [headerHandle] : [],
       },
     })
   }
 
+  const bodyExample = buildBodyExampleParam(input.bodyVariables)
   components.push({
     type: "BODY",
     text: input.body,
-    example: {
-      body_text: [input.bodyVariables.map((variable) => variable.example)],
-    },
+    ...(bodyExample ? { example: bodyExample } : {}),
   })
 
   if (input.buttons.length > 0) {

--- a/apps/builder/src/features/integration-messenger/message-templates/message-templates-table.tsx
+++ b/apps/builder/src/features/integration-messenger/message-templates/message-templates-table.tsx
@@ -1,6 +1,9 @@
 "use client"
 
 import type { IntegrationMessengerModel } from "@chatbotx.io/database/types"
+import { DataTable } from "@chatbotx.io/ui/components/data-table/data-table"
+import { DataTableColumnHeader } from "@chatbotx.io/ui/components/data-table/data-table-column-header"
+import { DataTableToolbar } from "@chatbotx.io/ui/components/data-table/data-table-toolbar"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -13,21 +16,33 @@ import {
 } from "@chatbotx.io/ui/components/ui/alert-dialog"
 import { Button } from "@chatbotx.io/ui/components/ui/button"
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@chatbotx.io/ui/components/ui/table"
-import { CopyIcon, Trash2Icon } from "lucide-react"
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@chatbotx.io/ui/components/ui/dialog"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@chatbotx.io/ui/components/ui/dropdown-menu"
+import { useDataTable } from "@chatbotx.io/ui/hooks/use-data-table"
+import type { ColumnDef } from "@tanstack/react-table"
+import {
+  CopyIcon,
+  EllipsisVerticalIcon,
+  EyeIcon,
+  Trash2Icon,
+} from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { useAction } from "next-safe-action/hooks"
-import React, { useState } from "react"
+import React, { useMemo, useState } from "react"
 import { toast } from "sonner"
 import { deleteMessengerMessageTemplateAction } from "./actions/delete-message-template"
 import { CloneMessageTemplateDialog } from "./clone-message-template-dialog"
+import { MessengerTemplatePreview } from "./components/template-preview"
 import { MessengerMessageTemplatesTableToolbarActions } from "./message-templates-table-toolbar-actions"
 import type { MessengerMessageTemplateResource } from "./schema/resource"
 
@@ -38,29 +53,33 @@ type Channel = {
 
 type MessengerMessageTemplatesTableProps = {
   integrationMessenger: IntegrationMessengerModel
-  promises: Promise<MessengerMessageTemplateResource[]>
+  promises: Promise<{
+    data: MessengerMessageTemplateResource[]
+    pageCount: number
+  }>
   channels: Channel[]
 }
 
-function DeleteTemplateButton({
+function DeleteTemplateDialog({
   workspaceId,
   integrationMessengerId,
-  templateId,
+  template,
+  onClose,
 }: {
   workspaceId: string
   integrationMessengerId: string
-  templateId: string
+  template: MessengerMessageTemplateResource | null
+  onClose: () => void
 }) {
   const t = useTranslations()
   const router = useRouter()
-  const [confirmOpen, setConfirmOpen] = useState(false)
 
   const { execute, isPending } = useAction(
     deleteMessengerMessageTemplateAction.bind(
       null,
       workspaceId,
       integrationMessengerId,
-      templateId,
+      template?.id ?? "",
     ),
     {
       onSuccess() {
@@ -69,6 +88,7 @@ function DeleteTemplateButton({
             feature: t("fields.messageTemplate.label"),
           }),
         )
+        onClose()
         router.refresh()
       },
       onError({ error }) {
@@ -80,48 +100,206 @@ function DeleteTemplateButton({
   )
 
   return (
-    <>
-      <Button
-        disabled={isPending}
-        onClick={() => setConfirmOpen(true)}
-        size="sm"
-        title={t("actions.remove")}
-        variant="destructive"
-      >
-        <Trash2Icon className="size-4" />
-        <span className="sr-only">{t("actions.remove")}</span>
-      </Button>
+    <AlertDialog onOpenChange={(open) => !open && onClose()} open={!!template}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {t("messages.deleteFeature", {
+              feature: t("fields.messageTemplate.label"),
+            })}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("messages.deleteConfirmation", {
+              feature: t("fields.messageTemplate.label"),
+            })}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{t("actions.cancel")}</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive hover:bg-destructive/90"
+            disabled={isPending}
+            onClick={() => execute()}
+          >
+            {t("actions.delete")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
 
-      <AlertDialog onOpenChange={setConfirmOpen} open={confirmOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {t("messages.deleteFeature", {
-                feature: t("fields.messageTemplate.label"),
-              })}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {t("messages.deleteConfirmation", {
-                feature: t("fields.messageTemplate.label"),
-              })}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t("actions.cancel")}</AlertDialogCancel>
-            <AlertDialogAction
-              className="bg-destructive hover:bg-destructive/90"
-              disabled={isPending}
-              onClick={() => {
-                setConfirmOpen(false)
-                execute()
-              }}
-            >
-              {t("actions.delete")}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
+type TemplateComponent = {
+  type?: string
+  format?: string
+  text?: string
+  example?: {
+    header_handle?: string[]
+    header_text?: string[]
+    header_text_named_params?: Array<{ example?: string }>
+    body_text?: string[][]
+    body_text_named_params?: Array<{ example?: string }>
+    url_suffix_example?: string
+  }
+  buttons?: Array<{
+    type?: string
+    text?: string
+    url?: string
+    phone_number?: string
+    payload?: string
+    example?: string[]
+  }>
+}
+
+function buildPreviewParams(components: TemplateComponent[]) {
+  const headerParams: Array<{
+    type?: string
+    text?: string
+    image?: { link: string }
+  }> = []
+  const bodyParams: Array<{ text?: string }> = []
+  const buttonParams: Array<{
+    sub_type?: string
+    index?: number
+    text?: string
+    payload?: string
+  }> = []
+
+  for (const component of components) {
+    const componentType = component.type?.toUpperCase()
+    const componentFormat = component.format?.toUpperCase()
+
+    if (componentType === "HEADER") {
+      if (componentFormat === "IMAGE") {
+        const imageUrl = component.example?.header_handle?.[0]
+        if (imageUrl) {
+          headerParams.push({ type: "image", image: { link: imageUrl } })
+        }
+      }
+      for (const text of component.example?.header_text ?? []) {
+        headerParams.push({ type: "text", text })
+      }
+      for (const param of component.example?.header_text_named_params ?? []) {
+        if (param.example) {
+          headerParams.push({ type: "text", text: param.example })
+        }
+      }
+    }
+    if (componentType === "BODY") {
+      for (const text of component.example?.body_text?.[0] ?? []) {
+        bodyParams.push({ text })
+      }
+      for (const param of component.example?.body_text_named_params ?? []) {
+        if (param.example) {
+          bodyParams.push({ text: param.example })
+        }
+      }
+    }
+    if (componentType === "BUTTONS") {
+      for (const [index, button] of (component.buttons ?? []).entries()) {
+        const buttonType = button.type?.toUpperCase()
+        if (buttonType === "URL") {
+          buttonParams.push({
+            sub_type: "url",
+            index,
+            text: button.example?.[0] ?? button.url,
+          })
+        }
+        if (buttonType === "PHONE_NUMBER") {
+          buttonParams.push({
+            sub_type: "phone_number",
+            index,
+          })
+        }
+      }
+    }
+  }
+
+  return { headerParams, bodyParams, buttonParams }
+}
+
+function ViewTemplateDialog({
+  template,
+  onClose,
+}: {
+  template: MessengerMessageTemplateResource | null
+  onClose: () => void
+}) {
+  const t = useTranslations()
+  const components = (template?.components ?? []) as TemplateComponent[]
+  const previewParams = buildPreviewParams(components)
+  const buttons = components.flatMap((component) => component.buttons ?? [])
+
+  return (
+    <Dialog onOpenChange={(open) => !open && onClose()} open={!!template}>
+      <DialogContent className="max-h-screen overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>
+            {t("actions.view")} {t("fields.messageTemplate.label")}
+          </DialogTitle>
+        </DialogHeader>
+
+        {template && (
+          <div className="space-y-4">
+            <div className="grid gap-3 text-sm sm:grid-cols-2">
+              <div>
+                <div className="text-muted-foreground">
+                  {t("fields.name.label")}
+                </div>
+                <div className="font-medium">{template.name}</div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">
+                  {t("fields.language.label")}
+                </div>
+                <div className="font-medium">{template.language}</div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">
+                  {t("fields.category.label")}
+                </div>
+                <div className="font-medium">{template.category}</div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">
+                  {t("fields.status.label")}
+                </div>
+                <div className="font-medium">{template.status}</div>
+              </div>
+            </div>
+
+            <MessengerTemplatePreview
+              bodyParams={previewParams.bodyParams}
+              buttonParams={previewParams.buttonParams}
+              components={components as never}
+              headerParams={previewParams.headerParams}
+            />
+
+            {buttons.length > 0 && (
+              <div className="space-y-2">
+                <div className="font-medium text-sm">
+                  {t("messenger.messageTemplate.create.buttons")}
+                </div>
+                <div className="space-y-2">
+                  {buttons.map((button, index) => (
+                    <div
+                      className="rounded border px-3 py-2 text-sm"
+                      // biome-ignore lint/suspicious/noArrayIndexKey: template buttons do not expose stable ids
+                      key={`${button.type}-${button.text}-${index}`}
+                    >
+                      <div className="font-medium">{button.text}</div>
+                      <div className="text-muted-foreground text-xs">
+                        {button.type}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
   )
 }
 
@@ -131,64 +309,131 @@ export function MessengerMessageTemplatesTable({
   channels,
 }: MessengerMessageTemplatesTableProps) {
   const t = useTranslations()
-  const data = React.use(promises)
+  const { data, pageCount } = React.use(promises)
 
   const [cloneTarget, setCloneTarget] =
     useState<MessengerMessageTemplateResource | null>(null)
+  const [viewTarget, setViewTarget] =
+    useState<MessengerMessageTemplateResource | null>(null)
+  const [deleteTarget, setDeleteTarget] =
+    useState<MessengerMessageTemplateResource | null>(null)
+
+  const columns = useMemo<ColumnDef<MessengerMessageTemplateResource>[]>(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={t("fields.name.label")}
+          />
+        ),
+        cell: ({ row }) => row.original.name,
+        meta: {
+          label: t("fields.name.label"),
+          placeholder: t("fields.name.searchPlaceholder"),
+          variant: "text",
+        },
+        enableColumnFilter: true,
+        enableSorting: false,
+      },
+      {
+        id: "language",
+        accessorKey: "language",
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={t("fields.language.label")}
+          />
+        ),
+        cell: ({ row }) => row.original.language,
+        enableSorting: false,
+      },
+      {
+        id: "category",
+        accessorKey: "category",
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={t("fields.category.label")}
+          />
+        ),
+        cell: ({ row }) => row.original.category,
+        enableSorting: false,
+      },
+      {
+        id: "status",
+        accessorKey: "status",
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={t("fields.status.label")}
+          />
+        ),
+        cell: ({ row }) => row.original.status,
+        enableSorting: false,
+      },
+      {
+        id: "actions",
+        header: t("actions.actions"),
+        cell: ({ row }) => (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                aria-label={t("actions.openMenu")}
+                className="flex size-8 p-0 data-[state=open]:bg-muted"
+                variant="ghost"
+              >
+                <EllipsisVerticalIcon aria-hidden="true" className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-40">
+              {row.original.status === "APPROVED" && (
+                <DropdownMenuItem onSelect={() => setCloneTarget(row.original)}>
+                  <CopyIcon />
+                  {t("actions.clone")}
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuItem onSelect={() => setViewTarget(row.original)}>
+                <EyeIcon />
+                {t("actions.view")}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={() => setDeleteTarget(row.original)}
+                variant="destructive"
+              >
+                <Trash2Icon />
+                {t("actions.delete")}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ),
+        enableSorting: false,
+        enableHiding: false,
+      },
+    ],
+    [t],
+  )
+
+  const { table } = useDataTable({
+    data,
+    columns,
+    pageCount,
+    initialState: {
+      pagination: { pageIndex: 0, pageSize: 10 },
+      columnPinning: { right: ["actions"] },
+    },
+    getRowId: (originalRow) => originalRow.id,
+    shallow: false,
+    clearOnDefault: true,
+  })
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="rounded border">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>{t("fields.name.label")}</TableHead>
-              <TableHead>{t("fields.language.label")}</TableHead>
-              <TableHead>{t("fields.category.label")}</TableHead>
-              <TableHead>{t("fields.status.label")}</TableHead>
-              <TableHead>{t("actions.actions")}</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {data.map((mt) => (
-              <TableRow key={mt.id}>
-                <TableCell>{mt.name}</TableCell>
-                <TableCell>{mt.language}</TableCell>
-                <TableCell>{mt.category}</TableCell>
-                <TableCell>{mt.status}</TableCell>
-                <TableCell>
-                  <div className="flex items-center gap-2">
-                    {mt.status === "APPROVED" && (
-                      <Button
-                        onClick={() => setCloneTarget(mt)}
-                        size="sm"
-                        title={t("actions.clone")}
-                        variant="outline"
-                      >
-                        <CopyIcon className="size-4" />
-                        <span className="sr-only">{t("actions.clone")}</span>
-                      </Button>
-                    )}
-                    {mt.status !== "APPROVED" && <div className="size-9" />}
-                    <DeleteTemplateButton
-                      integrationMessengerId={integrationMessenger.id}
-                      templateId={mt.id}
-                      workspaceId={integrationMessenger.workspaceId}
-                    />
-                  </div>
-                </TableCell>
-              </TableRow>
-            ))}
-            {data.length === 0 && (
-              <TableRow>
-                <TableCell className="text-center" colSpan={5}>
-                  {t("messages.noData")}
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      </div>
+      <DataTable table={table}>
+        <DataTableToolbar table={table} />
+      </DataTable>
       <div className="flex flex-col items-center justify-center p-4">
         <MessengerMessageTemplatesTableToolbarActions
           integrationMessengerId={integrationMessenger.id}
@@ -202,6 +447,16 @@ export function MessengerMessageTemplatesTable({
         key={cloneTarget?.id ?? ""}
         onClose={() => setCloneTarget(null)}
         sourceIntegrationMessengerId={integrationMessenger.id}
+        workspaceId={integrationMessenger.workspaceId}
+      />
+      <ViewTemplateDialog
+        onClose={() => setViewTarget(null)}
+        template={viewTarget}
+      />
+      <DeleteTemplateDialog
+        integrationMessengerId={integrationMessenger.id}
+        onClose={() => setDeleteTarget(null)}
+        template={deleteTarget}
         workspaceId={integrationMessenger.workspaceId}
       />
     </div>

--- a/apps/builder/src/features/integration-messenger/message-templates/queries/index.ts
+++ b/apps/builder/src/features/integration-messenger/message-templates/queries/index.ts
@@ -1,16 +1,50 @@
-import { type DatabaseClient, db } from "@chatbotx.io/database/client"
+import {
+  and,
+  type DatabaseClient,
+  db,
+  eq,
+  ilike,
+} from "@chatbotx.io/database/client"
 import type { MessengerTemplateStatus } from "@chatbotx.io/database/partials"
+import { messengerMessageTemplateModel } from "@chatbotx.io/database/schema"
+import { getPaginationWithDefaults } from "@chatbotx.io/database/utils"
 import type { ListMessengerMessageTemplatesResponse } from "@/features/integration-messenger/message-templates/schema/query"
+
+type MessengerMessageTemplateListWhere = {
+  workspaceId: string
+  inboxId?: string
+  integrationMessengerId?: string
+  status?: MessengerTemplateStatus
+  name?: string
+}
+
+async function resolveIntegrationMessengerId({
+  tx,
+  where,
+}: {
+  tx: DatabaseClient
+  where: MessengerMessageTemplateListWhere
+}) {
+  let resolvedIntegrationMessengerId = where.integrationMessengerId
+
+  if (!resolvedIntegrationMessengerId && where.inboxId) {
+    const integration = await tx.query.integrationMessengerModel.findFirst({
+      where: {
+        workspaceId: where.workspaceId,
+        inboxId: where.inboxId,
+      },
+      columns: { id: true },
+    })
+    resolvedIntegrationMessengerId = integration?.id
+  }
+
+  return resolvedIntegrationMessengerId
+}
 
 export const messengerMessageTemplateService = {
   list: async (props: {
     tx?: DatabaseClient
-    where: {
-      workspaceId: string
-      inboxId?: string
-      integrationMessengerId?: string
-      status?: MessengerTemplateStatus
-    }
+    where: MessengerMessageTemplateListWhere
   }): Promise<ListMessengerMessageTemplatesResponse> => {
     const { tx = db, where } = props
 
@@ -18,18 +52,10 @@ export const messengerMessageTemplateService = {
     // Relying on nested relational filtering for inboxId is fragile and ORM-
     // version-sensitive because messengerMessageTemplateModel has no direct
     // inboxId column.
-    let resolvedIntegrationMessengerId = where.integrationMessengerId
-
-    if (!resolvedIntegrationMessengerId && where.inboxId) {
-      const integration = await tx.query.integrationMessengerModel.findFirst({
-        where: {
-          workspaceId: where.workspaceId,
-          inboxId: where.inboxId,
-        },
-        columns: { id: true },
-      })
-      resolvedIntegrationMessengerId = integration?.id
-    }
+    const resolvedIntegrationMessengerId = await resolveIntegrationMessengerId({
+      tx,
+      where,
+    })
 
     return tx.query.messengerMessageTemplateModel.findMany({
       where: {
@@ -42,7 +68,65 @@ export const messengerMessageTemplateService = {
       with: {
         integrationMessenger: true,
       },
-      orderBy: { createdAt: "asc" },
+      orderBy: { id: "desc" },
     })
+  },
+  listPaginated: async (props: {
+    tx?: DatabaseClient
+    where: MessengerMessageTemplateListWhere
+    page?: number
+    perPage?: number
+  }) => {
+    const { tx = db, where } = props
+    const resolvedIntegrationMessengerId = await resolveIntegrationMessengerId({
+      tx,
+      where,
+    })
+    const queryWhere = {
+      name: where.name ? { ilike: `%${where.name}%` } : undefined,
+      status: where.status,
+      integrationMessengerId: resolvedIntegrationMessengerId,
+      integrationMessenger: {
+        workspaceId: where.workspaceId,
+      },
+    }
+    const pagination = getPaginationWithDefaults({
+      page: props.page,
+      perPage: props.perPage,
+    })
+
+    const [data, total] = await Promise.all([
+      tx.query.messengerMessageTemplateModel.findMany({
+        where: queryWhere,
+        with: {
+          integrationMessenger: true,
+        },
+        orderBy: { id: "desc" },
+        limit: pagination.limit,
+        offset: pagination.offset,
+      }),
+      tx.$count(
+        messengerMessageTemplateModel,
+        and(
+          where.name
+            ? ilike(messengerMessageTemplateModel.name, `%${where.name}%`)
+            : undefined,
+          where.status
+            ? eq(messengerMessageTemplateModel.status, where.status)
+            : undefined,
+          resolvedIntegrationMessengerId
+            ? eq(
+                messengerMessageTemplateModel.integrationMessengerId,
+                resolvedIntegrationMessengerId,
+              )
+            : undefined,
+        ),
+      ),
+    ])
+
+    return {
+      data,
+      pageCount: Math.max(1, Math.ceil(total / pagination.limit)),
+    }
   },
 }

--- a/apps/builder/src/features/integration-messenger/message-templates/schema/mutation.ts
+++ b/apps/builder/src/features/integration-messenger/message-templates/schema/mutation.ts
@@ -22,7 +22,7 @@ const templateButtonSchema = z.discriminatedUnion("type", [
     type: z.literal("URL"),
     title: z.string().min(1).max(20),
     url: z.string().min(1),
-    variables: z.array(z.string().min(1)).default([]),
+    variables: z.array(z.string().min(1)).max(1).default([]),
   }),
 ])
 
@@ -151,6 +151,15 @@ export const createMessengerMessageTemplateRequest = z
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: "Only variables from {{1}} to {{9}} are supported",
+          path: ["buttons", index, "url"],
+        })
+        return
+      }
+
+      if (placeholders.length > 1) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "URL buttons support only one variable",
           path: ["buttons", index, "url"],
         })
         return

--- a/apps/builder/src/features/integration-messenger/message-templates/schema/query.ts
+++ b/apps/builder/src/features/integration-messenger/message-templates/schema/query.ts
@@ -1,5 +1,10 @@
 import { messengerTemplateStatusSchema } from "@chatbotx.io/database/partials"
 import { zodBigintAsString } from "@chatbotx.io/utils"
+import {
+  createSearchParamsCache,
+  parseAsInteger,
+  parseAsString,
+} from "nuqs/server"
 import z from "zod"
 import { integrationMessengerResource } from "../../schema/resource"
 import { messengerMessageTemplateResource } from "./resource"
@@ -9,6 +14,9 @@ export const listMessengerMessageTemplatesRequest = z.object({
   inboxId: zodBigintAsString().optional(),
   integrationMessengerId: zodBigintAsString().optional(),
   status: messengerTemplateStatusSchema.optional(),
+  page: z.coerce.number().int().positive().optional(),
+  perPage: z.coerce.number().int().positive().optional(),
+  name: z.string().optional(),
 })
 export type ListMessengerMessageTemplatesRequest = z.infer<
   typeof listMessengerMessageTemplatesRequest
@@ -22,3 +30,10 @@ export const listMessengerMessageTemplatesResponse = z.array(
 export type ListMessengerMessageTemplatesResponse = z.infer<
   typeof listMessengerMessageTemplatesResponse
 >
+
+export const listMessengerMessageTemplatesSearchParamsCache =
+  createSearchParamsCache({
+    page: parseAsInteger.withDefault(1),
+    perPage: parseAsInteger.withDefault(10),
+    name: parseAsString.withDefault(""),
+  })

--- a/apps/worker/src/chat/handlers/send-messenger-template.ts
+++ b/apps/worker/src/chat/handlers/send-messenger-template.ts
@@ -55,6 +55,40 @@ export interface ProcessMessengerTemplateResult {
   providerMessageId?: string
 }
 
+function mergeMessengerTemplateButtonParams(
+  params: MessengerTemplateParams,
+  components: MessengerTemplateComponent[],
+  parameterFormat: "POSITIONAL" | "NAMED",
+): MessengerTemplateParams {
+  const templateButtonParams = extractMessengerTemplateParams(
+    components,
+    parameterFormat,
+  ).button
+
+  if (!templateButtonParams || templateButtonParams.length === 0) {
+    return params
+  }
+
+  const currentButtons = params.button ?? []
+  const currentKeys = new Set(
+    currentButtons.map((button) => `${button.sub_type}:${button.index ?? ""}`),
+  )
+  const missingButtons = templateButtonParams.filter(
+    (button) => !currentKeys.has(`${button.sub_type}:${button.index ?? ""}`),
+  )
+
+  if (missingButtons.length === 0) {
+    return params
+  }
+
+  return {
+    ...params,
+    button: [...currentButtons, ...missingButtons].sort(
+      (left, right) => (left.index ?? 0) - (right.index ?? 0),
+    ),
+  }
+}
+
 export async function processMessengerTemplate(
   params: ProcessMessengerTemplateParams,
 ): Promise<ProcessMessengerTemplateResult> {
@@ -104,8 +138,13 @@ export async function processMessengerTemplate(
     const variables = await contactVariableService.getAll(
       conversation.contactId,
     )
+    const completeParams = mergeMessengerTemplateButtonParams(
+      template.params,
+      (validated.template.components as MessengerTemplateComponent[]) || [],
+      template.parameterFormat,
+    )
     const replacedParams = await replaceMessengerTemplateVariables({
-      templateParams: template.params,
+      templateParams: completeParams,
       variables,
       parameterFormat: template.parameterFormat,
     })

--- a/integrations/messenger/__tests__/message-templates-api.test.ts
+++ b/integrations/messenger/__tests__/message-templates-api.test.ts
@@ -178,6 +178,33 @@ describe("listPageMessageTemplates", () => {
     expect(url).toContain("fields=")
   })
 
+  test("adds name filter when listing one template", async () => {
+    mockGet.mockResolvedValueOnce({ data: [] })
+
+    await listPageMessageTemplates(AUTH, { name: "delivery_confirmation" })
+
+    const [url] = mockGet.mock.calls[0]
+    expect(url).toContain("name=delivery_confirmation")
+  })
+
+  test("keeps name filter on paginated requests", async () => {
+    mockGet
+      .mockResolvedValueOnce({
+        data: [],
+        paging: {
+          cursors: { before: "abc", after: "cursor_abc" },
+          next: "https://graph.facebook.com/v23.0/PAGE123/message_templates?after=cursor_abc",
+        },
+      })
+      .mockResolvedValueOnce({ data: [] })
+
+    await listPageMessageTemplates(AUTH, { name: "delivery_confirmation" })
+
+    const secondCallUrl = mockGet.mock.calls[1][0] as string
+    expect(secondCallUrl).toContain("name=delivery_confirmation")
+    expect(secondCallUrl).toContain("after=cursor_abc")
+  })
+
   test("auth without version uses DEFAULT_API_VERSION (v23.0)", async () => {
     const authNoVersion = {
       ...AUTH,

--- a/integrations/messenger/__tests__/send-messenger-template.test.ts
+++ b/integrations/messenger/__tests__/send-messenger-template.test.ts
@@ -193,7 +193,7 @@ describe("buildMessengerTemplateComponents", () => {
       })
     })
 
-    test("two url buttons in params → two URL components", () => {
+    test("two url buttons in params → one buttons component with two URL parameters", () => {
       const components = buildMessengerTemplateComponents(
         {
           button: [
@@ -203,15 +203,28 @@ describe("buildMessengerTemplateComponents", () => {
         },
         "POSITIONAL",
       )
-      expect(components).toHaveLength(2)
+      expect(components).toHaveLength(1)
       expect(components[0].parameters[0]).toMatchObject({
         type: "URL",
         url: "suffix1",
       })
-      expect(components[1].parameters[0]).toMatchObject({
+      expect(components[0].parameters[1]).toMatchObject({
         type: "URL",
         url: "suffix2",
       })
+    })
+
+    test("phone_number param → PHONE_NUMBER parameter", () => {
+      const components = buildMessengerTemplateComponents(
+        { button: [{ sub_type: "phone_number", index: 0 }] },
+        "POSITIONAL",
+      )
+      expect(components).toEqual([
+        {
+          type: "buttons",
+          parameters: [{ type: "PHONE_NUMBER" }],
+        },
+      ])
     })
 
     test("POSTBACK from flowContext.flowButtons → POSTBACK type with encoded payload", () => {
@@ -240,7 +253,7 @@ describe("buildMessengerTemplateComponents", () => {
       })
     })
 
-    test("two flow buttons → two POSTBACK components", () => {
+    test("two flow buttons → one buttons component with two POSTBACK parameters", () => {
       const buttons: ButtonStepProps[] = [
         { id: "2001", label: "Yes", buttonType: null },
         { id: "2002", label: "No", buttonType: null },
@@ -249,11 +262,10 @@ describe("buildMessengerTemplateComponents", () => {
         flowId: "333",
         flowButtons: buttons,
       })
-      expect(components).toHaveLength(2)
-      for (const comp of components) {
-        const param = comp.parameters[0] as { type: string }
-        expect(param.type).toBe("POSTBACK")
-      }
+      expect(components).toHaveLength(1)
+      expect(components[0].parameters).toHaveLength(2)
+      expect(components[0].parameters[0]).toMatchObject({ type: "POSTBACK" })
+      expect(components[0].parameters[1]).toMatchObject({ type: "POSTBACK" })
     })
 
     test("broadcastId and sequenceStepId encoded into flow button payload", () => {
@@ -291,7 +303,7 @@ describe("buildMessengerTemplateComponents", () => {
     expect(components[2].type).toBe("buttons")
   })
 
-  test("URL params then POSTBACK flow buttons → URL components before POSTBACK components", () => {
+  test("URL params then POSTBACK flow buttons → button parameters ordered by index", () => {
     const flowButton: ButtonStepProps = {
       id: "9001",
       label: "Confirm",
@@ -306,11 +318,35 @@ describe("buildMessengerTemplateComponents", () => {
       "POSITIONAL",
       { flowId: "777", flowVersionId: "888", flowButtons: [flowButton] },
     )
-    expect(components).toHaveLength(4)
+    expect(components).toHaveLength(3)
     expect(components[0].type).toBe("header")
     expect(components[1].type).toBe("body")
     expect(components[2].parameters[0]).toMatchObject({ type: "URL" })
-    expect(components[3].parameters[0]).toMatchObject({ type: "POSTBACK" })
+    expect(components[2].parameters[1]).toMatchObject({ type: "POSTBACK" })
+  })
+
+  test("POSTBACK + PHONE_NUMBER + URL keeps template button order", () => {
+    const button: ButtonStepProps = {
+      id: "9002",
+      label: "Details",
+      buttonType: null,
+    }
+    const components = buildMessengerTemplateComponents(
+      {
+        button: [
+          { sub_type: "phone_number", index: 1 },
+          { sub_type: "url", index: 2, text: "https://ahachat.com/" },
+        ],
+      },
+      "POSITIONAL",
+      { flowId: "777", flowVersionId: "888", flowButtons: [button] },
+    )
+    expect(components).toHaveLength(1)
+    expect(components[0].parameters).toEqual([
+      expect.objectContaining({ type: "POSTBACK" }),
+      { type: "PHONE_NUMBER" },
+      { type: "URL", url: "https://ahachat.com/" },
+    ])
   })
 })
 
@@ -437,7 +473,7 @@ describe("buildMessengerTemplateSendRequest", () => {
     })
   })
 
-  test("URL params and step.buttons → URL then POSTBACK components", () => {
+  test("URL params and step.buttons → one buttons component with URL then POSTBACK parameters", () => {
     const button: ButtonStepProps = {
       id: "20001",
       label: "Start",
@@ -455,9 +491,9 @@ describe("buildMessengerTemplateSendRequest", () => {
       type: string
       parameters: Array<{ type: string }>
     }>
-    expect(components).toHaveLength(2)
+    expect(components).toHaveLength(1)
     expect(components[0].parameters[0].type).toBe("URL")
-    expect(components[1].parameters[0].type).toBe("POSTBACK")
+    expect(components[0].parameters[1].type).toBe("POSTBACK")
   })
 
   test("metadata broadcastId propagates into POSTBACK payload", () => {

--- a/integrations/messenger/__tests__/upload.test.ts
+++ b/integrations/messenger/__tests__/upload.test.ts
@@ -1,0 +1,57 @@
+import { HttpResponse, http, server } from "@chatbotx.io/vitest-config/msw"
+import { beforeEach, describe, expect, test } from "vitest"
+import { resumableUploadImage } from "../src/apis/upload"
+
+const AUTH = {
+  clientId: "app-123",
+  tokens: { accessToken: "page-token" },
+  metadata: {
+    pageId: "page-123",
+    version: "v23.0",
+  },
+} as never
+
+function imageResponse() {
+  return new HttpResponse(new Uint8Array([1, 2, 3]), {
+    headers: { "content-type": "image/png" },
+    status: 200,
+  })
+}
+
+describe("resumableUploadImage", () => {
+  let imageRequestHeaders: Headers | undefined
+
+  beforeEach(() => {
+    imageRequestHeaders = undefined
+    server.use(
+      http.get("https://graph.facebook.com/header.png", ({ request }) => {
+        imageRequestHeaders = request.headers
+        return imageResponse()
+      }),
+      http.get("https://storage.test/header.png", ({ request }) => {
+        imageRequestHeaders = request.headers
+        return imageResponse()
+      }),
+      http.post("https://graph.facebook.com/:version/:appId/uploads", () =>
+        HttpResponse.json({ id: "upload-session" }),
+      ),
+      http.post("https://graph.facebook.com/:version/upload-session", () =>
+        HttpResponse.json({ h: "header-handle" }),
+      ),
+    )
+  })
+
+  test("downloads template handles with bearer auth by default", async () => {
+    await resumableUploadImage(AUTH, "https://graph.facebook.com/header.png")
+
+    expect(imageRequestHeaders?.get("authorization")).toBe("Bearer page-token")
+  })
+
+  test("downloads public create-template images without bearer auth", async () => {
+    await resumableUploadImage(AUTH, "https://storage.test/header.png", {
+      authenticatedDownload: false,
+    })
+
+    expect(imageRequestHeaders?.get("authorization")).toBeNull()
+  })
+})

--- a/integrations/messenger/src/apis/message-templates.ts
+++ b/integrations/messenger/src/apis/message-templates.ts
@@ -10,6 +10,8 @@ export type MessengerMessageTemplateEntity = {
   language: string
   category: "AUTHENTICATION" | "MARKETING" | "UTILITY"
   parameter_format?: string
+  rejection_reason?: string
+  specific_rejection_reason?: string
   // biome-ignore lint/suspicious/noExplicitAny: Meta API shape varies
   components: any[]
 }
@@ -25,6 +27,10 @@ export type ListMessengerMessageTemplatesResponse = {
   }
 }
 
+export type ListMessengerMessageTemplatesProps = {
+  name?: string
+}
+
 export type CreateMessengerTemplateProps = {
   name: string
   language: string
@@ -36,12 +42,19 @@ export type CreateMessengerTemplateProps = {
 
 export const listPageMessageTemplates = (
   auth: MessengerAuthValue,
+  props: ListMessengerMessageTemplatesProps = {},
 ): Promise<ListMessengerMessageTemplatesResponse> => {
   const version = auth.metadata.version ?? DEFAULT_API_VERSION
   const pageId = auth.metadata.pageId
   const accessToken = auth.tokens.accessToken
 
-  const BASE_PATH = `/${version}/${pageId}/message_templates?fields=name,status,language,category,parameter_format,components`
+  const searchParams = new URLSearchParams({
+    fields: "name,status,language,category,parameter_format,components",
+  })
+  if (props.name) {
+    searchParams.set("name", props.name)
+  }
+  const BASE_PATH = `/${version}/${pageId}/message_templates?${searchParams.toString()}`
   const MAX_PAGES = 50
 
   return rescue("message_templates", async () => {

--- a/integrations/messenger/src/apis/upload.ts
+++ b/integrations/messenger/src/apis/upload.ts
@@ -1,6 +1,10 @@
 import { DEFAULT_API_VERSION } from "../constants"
 import type { MessengerAuthValue } from "../schema"
 
+type ResumableUploadImageOptions = {
+  authenticatedDownload?: boolean
+}
+
 /**
  * Upload an image to Meta's Resumable Upload API for a specific Page.
  *
@@ -13,15 +17,22 @@ import type { MessengerAuthValue } from "../schema"
 export async function resumableUploadImage(
   auth: MessengerAuthValue,
   imageUrl: string,
+  options: ResumableUploadImageOptions = {},
 ): Promise<string> {
   const version = auth.metadata.version ?? DEFAULT_API_VERSION
   const appId = auth.clientId
   const accessToken = auth.tokens.accessToken
+  const authenticatedDownload = options.authenticatedDownload ?? true
 
   // 1. Download image bytes from the stored handle URL
-  const imgRes = await fetch(imageUrl, {
-    headers: { Authorization: `Bearer ${accessToken}` },
-  })
+  const imgRes = await fetch(
+    imageUrl,
+    authenticatedDownload
+      ? {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        }
+      : undefined,
+  )
   if (!imgRes.ok) {
     throw new Error(`Template image download failed: HTTP ${imgRes.status}`)
   }

--- a/integrations/messenger/src/handlers/message/outgoing-message/send-messenger-template.ts
+++ b/integrations/messenger/src/handlers/message/outgoing-message/send-messenger-template.ts
@@ -1,6 +1,5 @@
 import type {
   ButtonStepProps,
-  MessengerTemplateButtonParam,
   MessengerTemplateParams,
   MetadataPayload,
   SendMessengerTemplateMessageStepSchema,
@@ -22,6 +21,7 @@ type MessengerTemplateComponentParameter =
   | { type: "image"; image: { link: string } }
   | { type: "POSTBACK"; payload: string }
   | { type: "URL"; url: string }
+  | { type: "PHONE_NUMBER" }
 
 type MessengerTemplateComponent = {
   type: "header" | "body" | "buttons"
@@ -37,8 +37,8 @@ type MessengerTemplateComponent = {
  *
  * NOT message.attachment.payload — that is the old generic-template shape.
  *
- * Button components come from two sources:
- *   - URL buttons: built from template.params.button (sub_type "url")
+ * Button parameters come from two sources and are merged in template order:
+ *   - URL / PHONE_NUMBER buttons: built from template.params.button
  *   - POSTBACK buttons: built from step.buttons[] with encoded flow payloads
  */
 export function buildMessengerTemplateSendRequest(
@@ -134,68 +134,82 @@ export function buildMessengerTemplateComponents(
     components.push({ type: "body", parameters: bodyParameters })
   }
 
-  // URL button components — built from params.button (sub_type "url" only)
-  if (params.button && params.button.length > 0) {
-    for (const btn of params.button) {
-      if (btn.sub_type === "url") {
-        components.push(buildUrlButtonComponent(btn))
-      }
-    }
-  }
-
-  // POSTBACK button components — built from flow buttons with encoded payloads
-  const flowButtons = flowContext?.flowButtons ?? []
-  if (flowButtons.length > 0) {
-    const { flowId = "", flowVersionId, metadata } = flowContext ?? {}
-    const broadcastId = extractMetadata("broadcastId", metadata)
-    const sequenceStepId = extractMetadata("sequenceStepId", metadata)
-    for (const button of flowButtons) {
-      // startExternalFlow: encode the button's own target flowId without a
-      // buttonId so runFlowPostback takes the direct-start path instead of
-      // the node-lookup path (which requires a live flow context).
-      if (button.buttonType === buttonTypes.enum.startExternalFlow) {
-        components.push({
-          type: "buttons",
-          parameters: [
-            {
-              type: "POSTBACK",
-              payload: encodeButtonPayload({
-                flowId: button.beforeStep.flowId,
-                broadcastId,
-                sequenceStepId,
-              }),
-            },
-          ],
-        })
-        continue
-      }
-
-      components.push({
-        type: "buttons",
-        parameters: [
-          {
-            type: "POSTBACK",
-            payload: encodeButtonPayload({
-              flowId,
-              flowVersionId,
-              buttonId: button.id,
-              broadcastId,
-              sequenceStepId,
-            }),
-          },
-        ],
-      })
-    }
+  const buttonParameters = buildButtonParameters(params, flowContext)
+  if (buttonParameters.length > 0) {
+    components.push({ type: "buttons", parameters: buttonParameters })
   }
 
   return components
 }
 
-function buildUrlButtonComponent(
-  param: MessengerTemplateButtonParam,
-): MessengerTemplateComponent {
-  return {
-    type: "buttons",
-    parameters: [{ type: "URL", url: param.text ?? "" }],
+function buildButtonParameters(
+  params: MessengerTemplateParams,
+  flowContext?: {
+    flowId?: string
+    flowVersionId?: string
+    metadata?: MetadataPayload
+    flowButtons?: ButtonStepProps[]
+  },
+): MessengerTemplateComponentParameter[] {
+  const indexedParameters: Array<{
+    index: number
+    parameter: MessengerTemplateComponentParameter
+  }> = []
+
+  for (const [fallbackIndex, button] of (params.button ?? []).entries()) {
+    const index = button.index ?? fallbackIndex
+
+    if (button.sub_type === "url") {
+      indexedParameters.push({
+        index,
+        parameter: { type: "URL", url: button.text ?? "" },
+      })
+    }
+
+    if (button.sub_type === "phone_number") {
+      indexedParameters.push({
+        index,
+        parameter: { type: "PHONE_NUMBER" },
+      })
+    }
   }
+
+  const usedIndexes = new Set(
+    indexedParameters.map((indexedParameter) => indexedParameter.index),
+  )
+  let nextPostbackIndex = 0
+  const { flowId = "", flowVersionId, metadata } = flowContext ?? {}
+  const broadcastId = extractMetadata("broadcastId", metadata)
+  const sequenceStepId = extractMetadata("sequenceStepId", metadata)
+
+  for (const button of flowContext?.flowButtons ?? []) {
+    while (usedIndexes.has(nextPostbackIndex)) {
+      nextPostbackIndex += 1
+    }
+
+    const payload =
+      button.buttonType === buttonTypes.enum.startExternalFlow
+        ? encodeButtonPayload({
+            flowId: button.beforeStep.flowId,
+            broadcastId,
+            sequenceStepId,
+          })
+        : encodeButtonPayload({
+            flowId,
+            flowVersionId,
+            buttonId: button.id,
+            broadcastId,
+            sequenceStepId,
+          })
+
+    indexedParameters.push({
+      index: nextPostbackIndex,
+      parameter: { type: "POSTBACK", payload },
+    })
+    usedIndexes.add(nextPostbackIndex)
+  }
+
+  return indexedParameters
+    .sort((left, right) => left.index - right.index)
+    .map((indexedParameter) => indexedParameter.parameter)
 }

--- a/integrations/messenger/src/integration.ts
+++ b/integrations/messenger/src/integration.ts
@@ -37,7 +37,8 @@ const config: IntegrationDefinition<
   },
   actions: {
     updatePersona,
-    listMessageTemplates: async ({ ctx }) => listPageMessageTemplates(ctx.auth),
+    listMessageTemplates: async ({ ctx, input }) =>
+      listPageMessageTemplates(ctx.auth, input),
     cloneMessageTemplate: async ({
       ctx,
       input,

--- a/integrations/messenger/src/schema.ts
+++ b/integrations/messenger/src/schema.ts
@@ -7,6 +7,7 @@ import type {
 import { z } from "zod"
 import type {
   CloneMessengerTemplateProps,
+  ListMessengerMessageTemplatesProps,
   ListMessengerMessageTemplatesResponse,
   MessengerMessageTemplateEntity,
 } from "./apis/message-templates"
@@ -41,7 +42,7 @@ export type MessengerActions<
     persona: PersonaRequest
   }) => Promise<{ personaId?: string }>
   listMessageTemplates: Handler<
-    { ctx: Context<IAuth> },
+    { ctx: Context<IAuth>; input?: ListMessengerMessageTemplatesProps },
     ListMessengerMessageTemplatesResponse
   >
   cloneMessageTemplate: Handler<

--- a/packages/flow-config/__tests__/messenger-template.test.ts
+++ b/packages/flow-config/__tests__/messenger-template.test.ts
@@ -4,6 +4,7 @@ import {
   extractMessengerParameterInfos,
   extractMessengerTemplateParams,
   type MessengerTemplateComponent,
+  mergeMessengerFlowButtonsWithExisting,
   messengerTemplateButtonParamSchema,
   sendMessengerTemplateMessageStepDefaultFn,
   sendMessengerTemplateMessageStepSchema,
@@ -111,7 +112,7 @@ describe("extractMessengerTemplateParams", () => {
       expect(result.button).toEqual([{ sub_type: "url", index: 0, text: "" }])
     })
 
-    test("URL button WITHOUT {{1}} in url — not added", () => {
+    test("URL button WITHOUT {{1}} in url — uses fixed url as send param", () => {
       const component: MessengerTemplateComponent = {
         type: "BUTTONS",
         buttons: [
@@ -119,7 +120,9 @@ describe("extractMessengerTemplateParams", () => {
         ],
       }
       const result = extractMessengerTemplateParams([component], "POSITIONAL")
-      expect(result.button).toBeUndefined()
+      expect(result.button).toEqual([
+        { sub_type: "url", index: 0, text: "https://example.com/fixed" },
+      ])
     })
 
     test("POSTBACK with fixed payload (no {{) — not added", () => {
@@ -167,6 +170,26 @@ describe("extractMessengerTemplateParams", () => {
       expect(result.button).toHaveLength(1)
       expect(result.button?.[0].sub_type).toBe("url")
       expect(result.button?.[0].index).toBe(1)
+    })
+
+    test("POSTBACK + PHONE_NUMBER + static URL — phone and URL produce send params", () => {
+      const component: MessengerTemplateComponent = {
+        type: "BUTTONS",
+        buttons: [
+          { type: "POSTBACK", text: "Detail", payload: "{{1}}" },
+          {
+            type: "PHONE_NUMBER",
+            text: "Phone",
+            phone_number: "+84349566551",
+          },
+          { type: "URL", text: "Visit website", url: "https://ahachat.com/" },
+        ],
+      }
+      const result = extractMessengerTemplateParams([component], "POSITIONAL")
+      expect(result.button).toEqual([
+        { sub_type: "phone_number", index: 1 },
+        { sub_type: "url", index: 2, text: "https://ahachat.com/" },
+      ])
     })
   })
 })
@@ -566,5 +589,68 @@ describe("sendMessengerTemplateMessageStepSchema — inboxId/integrationMessenge
       sub_type: "quick_reply",
     })
     expect(result.success).toBe(false)
+  })
+})
+
+describe("mergeMessengerFlowButtonsWithExisting", () => {
+  test("keeps existing button id and routing config by index while updating label", () => {
+    const result = mergeMessengerFlowButtonsWithExisting(
+      [
+        {
+          id: "new-button",
+          label: "New template label",
+          buttonType: null,
+          beforeStep: null,
+          steps: [],
+        },
+      ],
+      [
+        {
+          id: "connected-button",
+          label: "Old template label",
+          buttonType: "startAnotherNode",
+          beforeStep: {
+            id: "before-step",
+            stepType: "startAnotherNode",
+            nodeId: "target-node",
+            viewOnly: true,
+          },
+          steps: [],
+        },
+      ],
+    )
+
+    expect(result).toEqual([
+      {
+        id: "connected-button",
+        label: "New template label",
+        buttonType: "startAnotherNode",
+        beforeStep: {
+          id: "before-step",
+          stepType: "startAnotherNode",
+          nodeId: "target-node",
+          viewOnly: true,
+        },
+        steps: [],
+      },
+    ])
+  })
+
+  test("uses new template button when there is no existing button at that index", () => {
+    const result = mergeMessengerFlowButtonsWithExisting([
+      {
+        id: "new-button",
+        label: "New template label",
+        buttonType: null,
+        beforeStep: null,
+        steps: [],
+      },
+    ])
+
+    expect(result[0]).toMatchObject({
+      id: "new-button",
+      label: "New template label",
+      buttonType: null,
+    })
   })
 })

--- a/packages/flow-config/src/steps/send-messenger-message-template.ts
+++ b/packages/flow-config/src/steps/send-messenger-message-template.ts
@@ -7,9 +7,7 @@ import { stepTypes } from "./step-action"
 import type { ParameterInfo } from "./wa-template-utils"
 
 export const messengerTemplateButtonParamSchema = z.object({
-  // "quick_reply" has no handler in buildMessengerTemplateComponents — silently dropped.
-  // extractMessengerTemplateParams only creates sub_type "url".
-  sub_type: z.literal("url"),
+  sub_type: z.enum(["url", "phone_number"]),
   index: z.number().optional(),
   text: z.string().optional(),
   payload: z.string().optional(),
@@ -56,6 +54,7 @@ export type MessengerTemplateComponentButton = {
   text: string
   url?: string
   payload?: string
+  phone_number?: string
   example?: string[]
 }
 
@@ -156,11 +155,17 @@ export function extractMessengerTemplateParams(
       for (const [idx, button] of component.buttons.entries()) {
         const buttonType = button.type.toUpperCase()
 
-        if (buttonType === "URL" && button.url?.includes("{{1}}")) {
+        if (buttonType === "URL" && button.url) {
           buttonParams.push({
             sub_type: "url",
             index: idx,
-            text: "",
+            text: button.url.includes("{{1}}") ? "" : button.url,
+          })
+        }
+        if (buttonType === "PHONE_NUMBER") {
+          buttonParams.push({
+            sub_type: "phone_number",
+            index: idx,
           })
         }
         // POSTBACK/QUICK_REPLY buttons are handled as flow buttons (step.buttons[]),
@@ -265,4 +270,22 @@ export function extractMessengerFlowButtons(
   }
 
   return buttons
+}
+
+export function mergeMessengerFlowButtonsWithExisting(
+  templateButtons: ButtonStepProps[],
+  existingButtons: ButtonStepProps[] = [],
+): ButtonStepProps[] {
+  return templateButtons.map((templateButton, index) => {
+    const existingButton = existingButtons[index]
+
+    if (!existingButton) {
+      return templateButton
+    }
+
+    return {
+      ...existingButton,
+      label: templateButton.label,
+    }
+  })
 }

--- a/packages/ui/src/components/uploader/direct-upload-button.tsx
+++ b/packages/ui/src/components/uploader/direct-upload-button.tsx
@@ -154,6 +154,7 @@ export function DirectUploadButton({
         })
       } finally {
         setIsUploading(false)
+        setFiles([])
       }
     },
     [workspaceId, uploadPath, uploadHandlerUrl, onUploadSuccess, onUploadError],


### PR DESCRIPTION
## Summary

Fixes issues with **cloning Messenger message templates** to other channels, and improves the template experience overall:

- Cloning a template to another Facebook page now works reliably, including templates with header images
- After creating or cloning a template, the template list refreshes automatically so the new template shows up right away
- Template messages sent from flows now display more accurately

## Test plan

- [x] Automated tests for template cloning and creation
- [ ] Clone an approved template to another channel → it appears on the target channel
- [ ] Create a new template → the list updates immediately without a manual refresh