### PR TITLE
fix: refresh template list after creating

### DIFF
--- a/apps/builder/src/features/integration-messenger/message-templates/create-message-template-dialog.tsx
+++ b/apps/builder/src/features/integration-messenger/message-templates/create-message-template-dialog.tsx
@@ -266,6 +266,7 @@ export function CreateMessageTemplateDialog({
                 duration: 5000,
               })
             }
+            router.refresh()
           },
         },
         formProps: {


### PR DESCRIPTION
## Summary

After creating a new Messenger message template, the template list now refreshes automatically — the new template shows up right away without needing a manual page reload.

## Test plan

- [ ] Create a new template → it appears in the list immediately