### PR TITLE
fix(tiktok): store and use conversation_id as recipient for outgoing messages

### DIFF
--- a/apps/worker/src/integration/handlers/received-message.ts
+++ b/apps/worker/src/integration/handlers/received-message.ts
@@ -383,6 +383,7 @@ const detectContactAndConversation = async (props: {
             contactId: newContact.id,
             originalContactId: newContact.id,
             source: inbox.channel,
+            sourceConversationId: incomingContact.sourceConversationId,
             sourceId: incomingContact.sourceId,
             channel: inbox.channel,
           })

--- a/integrations/tiktok/src/handlers/message/incoming-message.ts
+++ b/integrations/tiktok/src/handlers/message/incoming-message.ts
@@ -87,6 +87,7 @@ export const receiveMessage = async ({
 
   const contact: IncomingContact = {
     sourceId: customerOpenId,
+    sourceConversationId: content.conversation_id,
     firstName: isEcho
       ? (content.to ?? content.to_user?.id ?? content.from_user.id)
       : (content.from ?? content.from_user.id),

--- a/integrations/tiktok/src/handlers/message/outgoing-message/index.ts
+++ b/integrations/tiktok/src/handlers/message/outgoing-message/index.ts
@@ -19,7 +19,7 @@ export const sendMessage: MessageHandlers<TiktokAuthValue>["sendMessage"] =
     } = props
 
     const businessId = ctx.auth.metadata.openId
-    const conversationId = contact.sourceId
+    const conversationId = contact.sourceConversationId ?? contact.sourceId
     const messageIds: string[] = []
 
     try {
@@ -69,7 +69,7 @@ export const sendFlowStep: MessageHandlers<TiktokAuthValue>["sendFlowStep"] =
     } = props
 
     const businessId = ctx.auth.metadata.openId
-    const conversationId = contact.sourceId
+    const conversationId = contact.sourceConversationId ?? contact.sourceId
     const messageIds: string[] = []
 
     try {

--- a/integrations/tiktok/src/handlers/message/outgoing-message/send-text.ts
+++ b/integrations/tiktok/src/handlers/message/outgoing-message/send-text.ts
@@ -15,7 +15,7 @@ export function* convertFlowStepText(
     yield {
       business_id: businessId,
       recipient_type: "CONVERSATION",
-      recipient: contact.sourceId,
+      recipient: contact.sourceConversationId ?? contact.sourceId,
       message_type: "TEXT",
       text: { body: step.text },
     }
@@ -33,7 +33,7 @@ export function* convertFlowStepText(
     yield {
       business_id: businessId,
       recipient_type: "CONVERSATION",
-      recipient: contact.sourceId,
+      recipient: contact.sourceConversationId ?? contact.sourceId,
       message_type: "TEMPLATE",
       template,
     }

--- a/packages/database/drizzle/20260610051033_nullable_file_workspace_id/snapshot.json
+++ b/packages/database/drizzle/20260610051033_nullable_file_workspace_id/snapshot.json
@@ -2,7 +2,7 @@
   "version": "8",
   "dialect": "postgres",
   "id": "42a183eb-a770-4d7e-912b-81ce54d3aa5e",
-  "prevIds": ["c744036c-a1a7-46d5-9952-109e12fc83a3"],
+  "prevIds": ["00ec001e-ef94-4702-afde-69c8fba361c5"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],

--- a/packages/database/drizzle/20260610084543_drop_contact_last_activity_at/snapshot.json
+++ b/packages/database/drizzle/20260610084543_drop_contact_last_activity_at/snapshot.json
@@ -2,11 +2,7 @@
   "version": "8",
   "dialect": "postgres",
   "id": "42b9360b-d40a-4c49-b18f-df5ec19f9e88",
-  "prevIds": [
-    "2837a2eb-228b-4d67-9094-c00454c0ed1b",
-    "351fc50a-eea1-42ef-b92f-193cf6838d66",
-    "c3f29eb6-e631-4178-8eaf-342854b85a0e"
-  ],
+  "prevIds": ["42a183eb-a770-4d7e-912b-81ce54d3aa5e"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],

--- a/packages/database/drizzle/20260611080913_add_source_conversation_id/migration.sql
+++ b/packages/database/drizzle/20260611080913_add_source_conversation_id/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "ContactInbox" ADD COLUMN "sourceConversationId" text;--> statement-breakpoint

--- a/packages/database/drizzle/20260611080913_add_source_conversation_id/snapshot.json
+++ b/packages/database/drizzle/20260611080913_add_source_conversation_id/snapshot.json
@@ -1,8 +1,8 @@
 {
   "version": "8",
   "dialect": "postgres",
-  "id": "00ec001e-ef94-4702-afde-69c8fba361c5",
-  "prevIds": ["c744036c-a1a7-46d5-9952-109e12fc83a3"],
+  "id": "60161194-dbfc-49df-8635-0e8db1a0f547",
+  "prevIds": ["42b9360b-d40a-4c49-b18f-df5ec19f9e88"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],
@@ -5282,19 +5282,6 @@
       "table": "Contact"
     },
     {
-      "type": "timestamp(6) with time zone",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": "now()",
-      "generated": null,
-      "identity": null,
-      "name": "lastActivityAt",
-      "entityType": "columns",
-      "schema": "public",
-      "table": "Contact"
-    },
-    {
       "type": "bigint",
       "typeSchema": null,
       "notNull": true,
@@ -5563,6 +5550,32 @@
       "generated": null,
       "identity": null,
       "name": "sourceId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ContactInbox"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "sourceConversationId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ContactInbox"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "contactLastReadAt",
       "entityType": "columns",
       "schema": "public",
       "table": "ContactInbox"
@@ -7066,6 +7079,45 @@
       "table": "CustomDomain"
     },
     {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cfHostnameId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "CustomDomain"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cfOwnershipValue",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "CustomDomain"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cfAcmeValue",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "CustomDomain"
+    },
+    {
       "type": "bigint",
       "typeSchema": null,
       "notNull": true,
@@ -7718,7 +7770,7 @@
     {
       "type": "bigint",
       "typeSchema": null,
-      "notNull": true,
+      "notNull": false,
       "dimensions": 0,
       "default": null,
       "generated": null,
@@ -16363,6 +16415,34 @@
           "asc": true,
           "nullsFirst": false,
           "opclass": null
+        },
+        {
+          "value": "lastIncomingMessageAt",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ContactInbox_contactId_lastIncomingMessageAt_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "ContactInbox"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "contactId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
         }
       ],
       "isUnique": false,
@@ -16707,6 +16787,41 @@
       "method": "btree",
       "concurrently": false,
       "name": "Conversation_aiContextLastMessageId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "Conversation"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspaceId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "lastActivityAt",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "Conversation_workspaceId_lastActivityAt_id_idx",
       "entityType": "indexes",
       "schema": "public",
       "table": "Conversation"
@@ -17638,6 +17753,27 @@
       "method": "btree",
       "concurrently": false,
       "name": "IntegrationMailchimp_integrationId_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "IntegrationMailchimp"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspaceId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "IntegrationMailchimp_workspaceId_idx",
       "entityType": "indexes",
       "schema": "public",
       "table": "IntegrationMailchimp"

--- a/packages/database/src/schema/contact-inbox.ts
+++ b/packages/database/src/schema/contact-inbox.ts
@@ -33,6 +33,7 @@ export const contactInboxModel = pgTable(
     channel: text().notNull(),
     source: text().notNull(),
     sourceId: text().notNull(),
+    sourceConversationId: text(),
     contactLastReadAt: timestamp(timestampConfig),
     lastMessageAt: timestamp(timestampConfig),
     lastIncomingMessageAt: timestamp(timestampConfig),

--- a/packages/sdk/src/lib/shared/message.ts
+++ b/packages/sdk/src/lib/shared/message.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 
 export type IncomingContact = {
   sourceId: string
+  sourceConversationId?: string
   phoneNumber?: string
   phoneNumberId?: string
   firstName?: string
@@ -15,6 +16,7 @@ export type IncomingContact = {
 export type OutgoingContact = {
   sourceId: string
   id: string
+  sourceConversationId?: string | null
   lastIncomingMessageAt?: Date | string | null
 }
 


### PR DESCRIPTION
  Summary

  TikTok Business API distinguishes between two identifiers:

  - sourceId (customerOpenId) — the unique identifier of the TikTok user, used to look up and store the contact.
  - conversation_id — the conversation identifier, which is required as the recipient when calling the message-send API.

  Before this fix, both outgoing handlers (sendMessage, sendFlowStep) were passing sourceId as the recipient, causing every outbound message to be rejected by TikTok due to an incorrect recipient identifier.

  Root Cause
  
  IncomingContact and OutgoingContact in the SDK had no dedicated field for conversation_id. When a TikTok webhook arrived, conversation_id was present in the payload but never persisted to ContactInbox, so it was
   unavailable at send time.

  Solution

  1. SDK — add optional sourceConversationId?: string to both IncomingContact and OutgoingContact (non-breaking for all other integrations).
  2. Database — add a nullable sourceConversationId column to the ContactInbox table with migration 20260611080913.
  3. TikTok incoming — populate sourceConversationId from content.conversation_id when processing an inbound webhook.
  4. Worker — forward sourceConversationId from IncomingContact when creating a new ContactInbox record.
  5. TikTok outgoing — use contact.sourceConversationId ?? contact.sourceId as the conversationId / recipient in all three send paths: sendMessage, sendFlowStep, and convertFlowStepText. The fallback to sourceId
  ensures backward compatibility with existing records that predate this column.