### PR TITLE
fix(tiktok): throw ChannelError when sourceConversationId is missing

### DIFF
--- a/integrations/tiktok/src/handlers/message/outgoing-message/index.ts
+++ b/integrations/tiktok/src/handlers/message/outgoing-message/index.ts
@@ -3,13 +3,30 @@ import {
   type SendTextStepSchema,
   stepTypes,
 } from "@chatbotx.io/flow-config"
-import type { MessageHandlers } from "@chatbotx.io/sdk"
+import {
+  ChannelError,
+  ChannelErrorCategory,
+  type MessageHandlers,
+} from "@chatbotx.io/sdk"
 import { sendTiktokMessage } from "../../../apis/message"
 import { mapToChannelError } from "../../../lib/error-mapper"
 import { logger } from "../../../lib/logger"
 import type { TiktokAuthValue } from "../../../schema"
 import { uploadAndBuildImagePayload } from "./send-media"
 import { convertFlowStepText } from "./send-text"
+
+function requireConversationId(
+  sourceConversationId: string | null | undefined,
+): string {
+  if (!sourceConversationId) {
+    throw new ChannelError(
+      "TikTok requires a conversation_id to send messages (recipient_type: CONVERSATION). This contact has no sourceConversationId — wait for an inbound message or backfill the column.",
+      ChannelErrorCategory.INVALID_RECIPIENT,
+      { code: "tiktok_missing_conversation_id" },
+    )
+  }
+  return sourceConversationId
+}
 
 export const sendMessage: MessageHandlers<TiktokAuthValue>["sendMessage"] =
   async (props) => {
@@ -19,10 +36,11 @@ export const sendMessage: MessageHandlers<TiktokAuthValue>["sendMessage"] =
     } = props
 
     const businessId = ctx.auth.metadata.openId
-    const conversationId = contact.sourceConversationId ?? contact.sourceId
     const messageIds: string[] = []
 
     try {
+      const conversationId = requireConversationId(contact.sourceConversationId)
+
       if (message.text) {
         const messageId = await sendTiktokMessage(ctx.auth.tokens.accessToken, {
           business_id: businessId,
@@ -69,10 +87,11 @@ export const sendFlowStep: MessageHandlers<TiktokAuthValue>["sendFlowStep"] =
     } = props
 
     const businessId = ctx.auth.metadata.openId
-    const conversationId = contact.sourceConversationId ?? contact.sourceId
     const messageIds: string[] = []
 
     try {
+      const conversationId = requireConversationId(contact.sourceConversationId)
+
       switch (step.stepType) {
         case stepTypes.enum.sendText: {
           for (const payload of convertFlowStepText(


### PR DESCRIPTION
  ## Summary
  - Replaces the silent `?? contact.sourceId` fallback with an explicit `requireConversationId` guard that throws a `ChannelError` when `sourceConversationId` is absent
  - TikTok's API requires `recipient_type: CONVERSATION`, so falling back to `sourceId` silently produces an invalid request; this surfaces the problem with a clear, actionable error message
  - Applies to both `sendMessage` and `sendFlowStep` paths

  ## Changes
  - `integrations/tiktok/src/handlers/message/outgoing-message/index.ts` — added `requireConversationId` helper; replaced `?? contact.sourceId` fallback in two places

  ## Test plan
  - [ ] `pnpm lint`
  - [ ] `pnpm --filter @chatbotx.io/integration-tiktok check-types`
  - [ ] Send a message to a TikTok contact that has `sourceConversationId` set — should succeed
  - [ ] Send a message to a TikTok contact with no `sourceConversationId` — should receive `ChannelError` with `INVALID_RECIPIENT` category
