### PR TITLE
fix: keep messages loading reliably when database has issues

### DIFF
--- a/packages/database/__tests__/connection-manager.test.ts
+++ b/packages/database/__tests__/connection-manager.test.ts
@@ -57,13 +57,18 @@ function makePool(id: string, query = vi.fn().mockResolvedValue([{ ok: 1 }])) {
 
 function makeManager(
   registryOverrides: Record<string, unknown> = {},
+  options: { readReplicasEnabled?: boolean } = {},
 ): MessageShardConnectionManager {
   const registry = {
     countActiveShards: vi.fn().mockResolvedValue(1),
     findShardForWrite: vi.fn().mockResolvedValue(shardRecord),
     ...registryOverrides,
   }
-  return new MessageShardConnectionManager({} as never, registry as never)
+  return new MessageShardConnectionManager(
+    {} as never,
+    registry as never,
+    options,
+  )
 }
 
 describe("MessageShardConnectionManager.getWriteShardInfo", () => {
@@ -114,7 +119,7 @@ describe("MessageShardConnectionManager.getWriteShardInfo", () => {
   })
 })
 
-describe("MessageShardConnectionManager.getShardClientForRead", () => {
+describe("MessageShardConnectionManager.withShardClientForRead", () => {
   beforeEach(() => {
     shardMocks.createMessageShardClient.mockReset()
     shardMocks.createReadShardPool.mockReset()
@@ -125,45 +130,138 @@ describe("MessageShardConnectionManager.getShardClientForRead", () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
+    vi.unstubAllEnvs()
   })
 
-  test("retries an unhealthy read replica after the retry TTL", async () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"))
+  const readShard = {
+    ...shardRecord,
+    readHost: "replica",
+    readPort: 5432,
+  } satisfies ShardConfig
 
-    const shard = {
-      ...shardRecord,
-      readHost: "replica",
-      readPort: 5432,
-    } satisfies ShardConfig
-    const primaryPool = makePool("primary")
+  async function flushBackgroundRetry() {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+
+  test("uses primary even when a read replica is configured while read replicas are disabled by default", async () => {
+    const manager = makeManager()
+    shardMocks.createShardPool.mockReturnValue(makePool("primary"))
+
+    const usedClient = await manager.withShardClientForRead(
+      readShard,
+      (client) => Promise.resolve(client),
+    )
+
+    expect(usedClient).toEqual({ clientId: "primary" })
+    expect(shardMocks.createReadShardPool).not.toHaveBeenCalled()
+  })
+
+  test("uses the replica when read replicas are enabled and the health check passes", async () => {
+    const manager = makeManager({}, { readReplicasEnabled: true })
+    shardMocks.createShardPool.mockReturnValue(makePool("primary"))
+    shardMocks.createReadShardPool.mockReturnValue(makePool("read-ok"))
+
+    const usedClient = await manager.withShardClientForRead(
+      readShard,
+      (client) => Promise.resolve(client),
+    )
+
+    expect(usedClient).toEqual({ clientId: "read-ok" })
+  })
+
+  test("falls back to primary when enabled replica fails its initial health check", async () => {
+    const manager = makeManager({}, { readReplicasEnabled: true })
+    shardMocks.createShardPool.mockReturnValue(makePool("primary"))
+    const failingReadPool = makePool(
+      "read-fail",
+      vi.fn().mockRejectedValue(new Error("replica down")),
+    )
+    shardMocks.createReadShardPool.mockReturnValue(failingReadPool)
+
+    const usedClient = await manager.withShardClientForRead(
+      readShard,
+      (client) => Promise.resolve(client),
+    )
+
+    expect(usedClient).toEqual({ clientId: "primary" })
+    expect(failingReadPool.end).toHaveBeenCalled()
+  })
+
+  test("reconnects the enabled replica in the background after the retry TTL without blocking the read", async () => {
+    vi.stubEnv("SHARD_READ_REPLICA_RETRY_TTL_MS", "0")
+    const manager = makeManager({}, { readReplicasEnabled: true })
+    shardMocks.createShardPool.mockReturnValue(makePool("primary"))
     const failingReadPool = makePool(
       "read-fail",
       vi.fn().mockRejectedValue(new Error("replica down")),
     )
     const recoveredReadPool = makePool("read-ok")
-    const manager = makeManager()
-
-    shardMocks.createShardPool.mockReturnValue(primaryPool)
     shardMocks.createReadShardPool
       .mockReturnValueOnce(failingReadPool)
       .mockReturnValueOnce(recoveredReadPool)
 
-    const writeClient = await manager.getShardClient(shard)
-    const readClientBeforeTtl = await manager.getShardClientForRead(shard)
+    const first = await manager.withShardClientForRead(readShard, (client) =>
+      Promise.resolve(client),
+    )
+    expect(first).toEqual({ clientId: "primary" })
 
-    expect(writeClient).toEqual({ clientId: "primary" })
-    expect(readClientBeforeTtl).toEqual({ clientId: "primary" })
-    expect(shardMocks.createReadShardPool).toHaveBeenCalledTimes(1)
-    expect(failingReadPool.end).toHaveBeenCalled()
+    await flushBackgroundRetry()
 
-    vi.setSystemTime(new Date("2026-01-01T00:01:01.000Z"))
-
-    const readClientAfterTtl = await manager.getShardClientForRead(shard)
-
-    expect(readClientAfterTtl).toEqual({ clientId: "read-ok" })
-    expect(shardMocks.createReadShardPool).toHaveBeenCalledTimes(2)
+    const second = await manager.withShardClientForRead(readShard, (client) =>
+      Promise.resolve(client),
+    )
+    expect(second).toEqual({ clientId: "read-ok" })
     expect(recoveredReadPool.query).toHaveBeenCalledWith("SELECT 1")
+  })
+
+  test("marks the enabled replica unhealthy on a runtime connection error and retries the query on primary", async () => {
+    const manager = makeManager({}, { readReplicasEnabled: true })
+    shardMocks.createShardPool.mockReturnValue(makePool("primary"))
+    const readPool = makePool("read-ok")
+    shardMocks.createReadShardPool.mockReturnValue(readPool)
+
+    const seenClients: string[] = []
+    const result = await manager.withShardClientForRead(readShard, (client) => {
+      const { clientId } = client as unknown as { clientId: string }
+      seenClients.push(clientId)
+      if (clientId === "read-ok") {
+        return Promise.reject(
+          Object.assign(new Error("Connection terminated unexpectedly"), {
+            code: "ECONNRESET",
+          }),
+        )
+      }
+      return Promise.resolve("primary-result")
+    })
+
+    expect(result).toBe("primary-result")
+    expect(seenClients).toEqual(["read-ok", "primary"])
+    expect(readPool.end).toHaveBeenCalled()
+
+    const next = await manager.withShardClientForRead(readShard, (client) =>
+      Promise.resolve(client),
+    )
+    expect(next).toEqual({ clientId: "primary" })
+  })
+
+  test("rethrows non-connection errors and keeps the enabled replica healthy", async () => {
+    const manager = makeManager({}, { readReplicasEnabled: true })
+    shardMocks.createShardPool.mockReturnValue(makePool("primary"))
+    const readPool = makePool("read-ok")
+    shardMocks.createReadShardPool.mockReturnValue(readPool)
+
+    const sqlError = Object.assign(new Error('column "nope" does not exist'), {
+      code: "42703",
+    })
+    await expect(
+      manager.withShardClientForRead(readShard, () => Promise.reject(sqlError)),
+    ).rejects.toThrow('column "nope" does not exist')
+
+    expect(readPool.end).not.toHaveBeenCalled()
+
+    const next = await manager.withShardClientForRead(readShard, (client) =>
+      Promise.resolve(client),
+    )
+    expect(next).toEqual({ clientId: "read-ok" })
   })
 })

--- a/packages/database/__tests__/connection-manager.test.ts
+++ b/packages/database/__tests__/connection-manager.test.ts
@@ -81,10 +81,6 @@ describe("MessageShardConnectionManager.getWriteShardInfo", () => {
     )
   })
 
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
   test("maps the workspace write shard to an all-time time-range info", async () => {
     const manager = makeManager()
 
@@ -242,6 +238,50 @@ describe("MessageShardConnectionManager.withShardClientForRead", () => {
       Promise.resolve(client),
     )
     expect(next).toEqual({ clientId: "primary" })
+  })
+
+  test("recreates the primary before retrying when the shard entry was evicted mid-read", async () => {
+    const manager = makeManager({}, { readReplicasEnabled: true })
+    const readPool = makePool("read-ok")
+    const evictedPrimaryPool = makePool("primary-evicted")
+    const replacementPrimaryPool = makePool("primary-replacement")
+    let mainShardPoolCreated = false
+    shardMocks.createShardPool.mockImplementation((shard: ShardConfig) => {
+      if (shard.id !== readShard.id) {
+        return makePool(`primary-${shard.id}`)
+      }
+      if (mainShardPoolCreated) {
+        return replacementPrimaryPool
+      }
+      mainShardPoolCreated = true
+      return evictedPrimaryPool
+    })
+    shardMocks.createReadShardPool.mockReturnValue(readPool)
+
+    const seenClients: string[] = []
+    const result = await manager.withShardClientForRead(readShard, (client) => {
+      const { clientId } = client as unknown as { clientId: string }
+      seenClients.push(clientId)
+      if (clientId === "read-ok") {
+        return (async () => {
+          for (let index = 0; index < 10; index++) {
+            await manager.getShardClient({
+              ...readShard,
+              id: `other-${index}`,
+              readHost: null,
+            })
+          }
+          throw Object.assign(new Error("Connection terminated unexpectedly"), {
+            code: "ECONNRESET",
+          })
+        })()
+      }
+      return Promise.resolve("primary-result")
+    })
+
+    expect(result).toBe("primary-result")
+    expect(seenClients).toEqual(["read-ok", "primary-replacement"])
+    expect(evictedPrimaryPool.end).toHaveBeenCalled()
   })
 
   test("rethrows non-connection errors and keeps the enabled replica healthy", async () => {

--- a/packages/database/__tests__/connection-manager.test.ts
+++ b/packages/database/__tests__/connection-manager.test.ts
@@ -1,4 +1,25 @@
-import { beforeEach, describe, expect, test, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import type { ShardConfig } from "../src/sharding/shared"
+
+const shardMocks = vi.hoisted(() => ({
+  createMessageShardClient: vi.fn(),
+  createReadShardPool: vi.fn(),
+  createShardPool: vi.fn(),
+}))
+
+vi.mock("../src/sharding/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/sharding/shared")>()
+  return {
+    ...actual,
+    createReadShardPool: shardMocks.createReadShardPool,
+    createShardPool: shardMocks.createShardPool,
+  }
+})
+
+vi.mock("../src/sharding/message/client", () => ({
+  createMessageShardClient: shardMocks.createMessageShardClient,
+}))
+
 import { MessageShardConnectionManager } from "../src/sharding/message/connection-manager"
 
 // ---------------------------------------------------------------------------
@@ -23,6 +44,17 @@ const shardRecord = {
   readPort: null,
 }
 
+function makePool(id: string, query = vi.fn().mockResolvedValue([{ ok: 1 }])) {
+  return {
+    end: vi.fn().mockResolvedValue(undefined),
+    idleCount: 0,
+    id,
+    query,
+    totalCount: 0,
+    waitingCount: 0,
+  }
+}
+
 function makeManager(
   registryOverrides: Record<string, unknown> = {},
 ): MessageShardConnectionManager {
@@ -36,7 +68,16 @@ function makeManager(
 
 describe("MessageShardConnectionManager.getWriteShardInfo", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    shardMocks.createMessageShardClient.mockReset()
+    shardMocks.createReadShardPool.mockReset()
+    shardMocks.createShardPool.mockReset()
+    shardMocks.createMessageShardClient.mockImplementation(
+      (pool: { id: string }) => ({ clientId: pool.id }),
+    )
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   test("maps the workspace write shard to an all-time time-range info", async () => {
@@ -70,5 +111,59 @@ describe("MessageShardConnectionManager.getWriteShardInfo", () => {
     const info = await manager.getWriteShardInfo("ws-1")
 
     expect(info).toBeNull()
+  })
+})
+
+describe("MessageShardConnectionManager.getShardClientForRead", () => {
+  beforeEach(() => {
+    shardMocks.createMessageShardClient.mockReset()
+    shardMocks.createReadShardPool.mockReset()
+    shardMocks.createShardPool.mockReset()
+    shardMocks.createMessageShardClient.mockImplementation(
+      (pool: { id: string }) => ({ clientId: pool.id }),
+    )
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test("retries an unhealthy read replica after the retry TTL", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"))
+
+    const shard = {
+      ...shardRecord,
+      readHost: "replica",
+      readPort: 5432,
+    } satisfies ShardConfig
+    const primaryPool = makePool("primary")
+    const failingReadPool = makePool(
+      "read-fail",
+      vi.fn().mockRejectedValue(new Error("replica down")),
+    )
+    const recoveredReadPool = makePool("read-ok")
+    const manager = makeManager()
+
+    shardMocks.createShardPool.mockReturnValue(primaryPool)
+    shardMocks.createReadShardPool
+      .mockReturnValueOnce(failingReadPool)
+      .mockReturnValueOnce(recoveredReadPool)
+
+    const writeClient = await manager.getShardClient(shard)
+    const readClientBeforeTtl = await manager.getShardClientForRead(shard)
+
+    expect(writeClient).toEqual({ clientId: "primary" })
+    expect(readClientBeforeTtl).toEqual({ clientId: "primary" })
+    expect(shardMocks.createReadShardPool).toHaveBeenCalledTimes(1)
+    expect(failingReadPool.end).toHaveBeenCalled()
+
+    vi.setSystemTime(new Date("2026-01-01T00:01:01.000Z"))
+
+    const readClientAfterTtl = await manager.getShardClientForRead(shard)
+
+    expect(readClientAfterTtl).toEqual({ clientId: "read-ok" })
+    expect(shardMocks.createReadShardPool).toHaveBeenCalledTimes(2)
+    expect(recoveredReadPool.query).toHaveBeenCalledWith("SELECT 1")
   })
 })

--- a/packages/database/__tests__/sharded-message-repository.test.ts
+++ b/packages/database/__tests__/sharded-message-repository.test.ts
@@ -323,7 +323,10 @@ describe("ShardedMessageRepository.listByConversation — write-shard union", ()
       // Time-range registry excludes the shard: query window predates activation.
       getShardsForTimeRange: vi.fn().mockResolvedValue([]),
       getWriteShardInfo: vi.fn().mockResolvedValue(writeShard),
-      getShardClientForRead: vi.fn().mockResolvedValue(shardClient),
+      withShardClientForRead: vi.fn(
+        (_shard: unknown, fn: (client: unknown) => Promise<unknown>) =>
+          fn(shardClient),
+      ),
     }
     const localRepo = new ShardedMessageRepository(shardManager as never)
 
@@ -338,7 +341,7 @@ describe("ShardedMessageRepository.listByConversation — write-shard union", ()
     })
 
     expect(shardManager.getWriteShardInfo).toHaveBeenCalledWith("ws-1")
-    expect(shardManager.getShardClientForRead).toHaveBeenCalledTimes(1)
+    expect(shardManager.withShardClientForRead).toHaveBeenCalledTimes(1)
     expect(result.data).toHaveLength(1)
     expect(result.data[0].id).toBe("msg-hist-1")
   })
@@ -359,7 +362,10 @@ describe("ShardedMessageRepository.listByConversation — write-shard union", ()
     const shardManager = {
       getShardsForTimeRange: vi.fn().mockResolvedValue([timeRangeShard]),
       getWriteShardInfo: vi.fn().mockResolvedValue(writeShard),
-      getShardClientForRead: vi.fn().mockResolvedValue(shardClient),
+      withShardClientForRead: vi.fn(
+        (_shard: unknown, fn: (client: unknown) => Promise<unknown>) =>
+          fn(shardClient),
+      ),
     }
     const localRepo = new ShardedMessageRepository(shardManager as never)
 
@@ -374,7 +380,7 @@ describe("ShardedMessageRepository.listByConversation — write-shard union", ()
     })
 
     // Deduped by shard id → the single shard is queried exactly once.
-    expect(shardManager.getShardClientForRead).toHaveBeenCalledTimes(1)
+    expect(shardManager.withShardClientForRead).toHaveBeenCalledTimes(1)
     expect(result.data).toHaveLength(1)
   })
 
@@ -382,7 +388,7 @@ describe("ShardedMessageRepository.listByConversation — write-shard union", ()
     const shardManager = {
       getShardsForTimeRange: vi.fn().mockResolvedValue([]),
       getWriteShardInfo: vi.fn().mockResolvedValue(null),
-      getShardClientForRead: vi.fn(),
+      withShardClientForRead: vi.fn(),
     }
     const localRepo = new ShardedMessageRepository(shardManager as never)
 
@@ -397,6 +403,6 @@ describe("ShardedMessageRepository.listByConversation — write-shard union", ()
     })
 
     expect(result).toEqual({ data: [], nextCursor: null })
-    expect(shardManager.getShardClientForRead).not.toHaveBeenCalled()
+    expect(shardManager.withShardClientForRead).not.toHaveBeenCalled()
   })
 })

--- a/packages/database/__tests__/sharding-shared.test.ts
+++ b/packages/database/__tests__/sharding-shared.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test, vi } from "vitest"
+
+vi.mock("../src/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}))
+
+import { envInt } from "../src/sharding/shared/env"
+
+describe("envInt", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  test("returns the parsed value for a valid integer", () => {
+    vi.stubEnv("TEST_SHARD_ENV", "1500")
+    expect(envInt("TEST_SHARD_ENV", 60_000)).toBe(1500)
+  })
+
+  test("returns the fallback when the variable is unset", () => {
+    expect(envInt("TEST_SHARD_ENV_UNSET", 60_000)).toBe(60_000)
+  })
+
+  test("returns the fallback for a non-numeric value (NaN guard)", () => {
+    vi.stubEnv("TEST_SHARD_ENV", "abc")
+    expect(envInt("TEST_SHARD_ENV", 60_000)).toBe(60_000)
+  })
+
+  test("returns the fallback for a negative value", () => {
+    vi.stubEnv("TEST_SHARD_ENV", "-5")
+    expect(envInt("TEST_SHARD_ENV", 60_000)).toBe(60_000)
+  })
+
+  test("returns the fallback for a non-integer value", () => {
+    vi.stubEnv("TEST_SHARD_ENV", "1.5")
+    expect(envInt("TEST_SHARD_ENV", 60_000)).toBe(60_000)
+  })
+
+  test("accepts zero by default", () => {
+    vi.stubEnv("TEST_SHARD_ENV", "0")
+    expect(envInt("TEST_SHARD_ENV", 60_000)).toBe(0)
+  })
+
+  test("returns the fallback when the value is below min (pool max must be positive)", () => {
+    vi.stubEnv("TEST_SHARD_ENV", "0")
+    expect(envInt("TEST_SHARD_ENV", 10, { min: 1 })).toBe(10)
+  })
+
+  test("accepts values at or above min", () => {
+    vi.stubEnv("TEST_SHARD_ENV", "25")
+    expect(envInt("TEST_SHARD_ENV", 10, { min: 1 })).toBe(25)
+  })
+})

--- a/packages/database/__tests__/sharding-shared.test.ts
+++ b/packages/database/__tests__/sharding-shared.test.ts
@@ -5,6 +5,11 @@ vi.mock("../src/logger", () => ({
 }))
 
 import { envInt } from "../src/sharding/shared/env"
+import { isConnectionError } from "../src/sharding/shared/errors"
+
+function errWithCode(code: string): Error {
+  return Object.assign(new Error(`fail: ${code}`), { code })
+}
 
 describe("envInt", () => {
   afterEach(() => {
@@ -48,5 +53,64 @@ describe("envInt", () => {
   test("accepts values at or above min", () => {
     vi.stubEnv("TEST_SHARD_ENV", "25")
     expect(envInt("TEST_SHARD_ENV", 10, { min: 1 })).toBe(25)
+  })
+})
+
+describe("isConnectionError", () => {
+  test.each([
+    "ECONNREFUSED",
+    "ECONNRESET",
+    "ETIMEDOUT",
+    "EPIPE",
+    "ENOTFOUND",
+    "EHOSTUNREACH",
+    "EAI_AGAIN",
+  ])("detects Node socket error code %s", (code) => {
+    expect(isConnectionError(errWithCode(code))).toBe(true)
+  })
+
+  test.each([
+    "57P01",
+    "57P02",
+    "57P03",
+  ])("detects PostgreSQL operator-intervention SQLSTATE %s", (code) => {
+    expect(isConnectionError(errWithCode(code))).toBe(true)
+  })
+
+  test("detects SQLSTATE class 08 (connection exception)", () => {
+    expect(isConnectionError(errWithCode("08006"))).toBe(true)
+  })
+
+  test("detects pg 'Connection terminated unexpectedly' by message", () => {
+    expect(
+      isConnectionError(new Error("Connection terminated unexpectedly")),
+    ).toBe(true)
+  })
+
+  test("detects pg connect timeout by message", () => {
+    expect(
+      isConnectionError(new Error("timeout exceeded when trying to connect")),
+    ).toBe(true)
+  })
+
+  test("walks the cause chain", () => {
+    const wrapped = new Error("Shard s1:read health check failed", {
+      cause: errWithCode("ECONNREFUSED"),
+    })
+    expect(isConnectionError(wrapped)).toBe(true)
+  })
+
+  test("rejects SQL logic errors (undefined_column 42703)", () => {
+    expect(isConnectionError(errWithCode("42703"))).toBe(false)
+  })
+
+  test("rejects unique violations (23505)", () => {
+    expect(isConnectionError(errWithCode("23505"))).toBe(false)
+  })
+
+  test("rejects plain errors and non-errors", () => {
+    expect(isConnectionError(new Error("syntax error at or near"))).toBe(false)
+    expect(isConnectionError(null)).toBe(false)
+    expect(isConnectionError("ECONNREFUSED")).toBe(false)
   })
 })

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -8,6 +8,7 @@ import type { PgTable } from "drizzle-orm/pg-core"
 import { Pool } from "pg"
 import { ModelNotfoundException } from "./errors"
 import { keys } from "./keys"
+import { logger } from "./logger"
 import { relations } from "./relations"
 
 // biome-ignore lint/performance/noNamespaceImport: drizzle schema
@@ -20,6 +21,10 @@ const pool = new Pool({
   max: 10,
   idleTimeoutMillis: 30_000,
   connectionTimeoutMillis: 5000,
+})
+
+pool.on("error", (error) => {
+  logger.error({ err: error }, "Unexpected idle database pool error")
 })
 
 export const db = drizzle({

--- a/packages/database/src/sharding/message/connection-manager.ts
+++ b/packages/database/src/sharding/message/connection-manager.ts
@@ -4,6 +4,8 @@ import { logger } from "../../logger"
 import {
   createReadShardPool,
   createShardPool,
+  envInt,
+  isConnectionError,
   type ShardConfig,
   ShardNotActiveError,
   ShardUnreachableError,
@@ -33,22 +35,36 @@ interface ActiveShardsCache {
   shards: ShardConfig[]
 }
 
+const READ_REPLICAS_ENABLED: boolean = false
+
+interface MessageShardConnectionManagerOptions {
+  readReplicasEnabled?: boolean
+}
+
 export class MessageShardConnectionManager {
   private readonly pools: Map<string, PoolEntry> = new Map()
   private shardingEnabled: boolean | null = null
   private activeShardsCache: ActiveShardsCache | null = null
   private lastEvictedAt: Date | null = null
   private readonly registry: MessageShardRegistry
+  private readonly readReplicaRetryTtlMs: number
+  private readonly readReplicasEnabled: boolean
 
   private static readonly MAX_POOLS = 10
   private static readonly ACTIVE_SHARD_TTL_MS = 30_000
-  private static readonly READ_REPLICA_RETRY_TTL_MS = process.env
-    .SHARD_READ_REPLICA_RETRY_TTL_MS
-    ? Number(process.env.SHARD_READ_REPLICA_RETRY_TTL_MS)
-    : 60_000
 
-  constructor(mainDb: DatabaseClient, registry?: MessageShardRegistry) {
+  constructor(
+    mainDb: DatabaseClient,
+    registry?: MessageShardRegistry,
+    options: MessageShardConnectionManagerOptions = {},
+  ) {
     this.registry = registry ?? new MessageShardRegistry(mainDb)
+    this.readReplicaRetryTtlMs = envInt(
+      "SHARD_READ_REPLICA_RETRY_TTL_MS",
+      60_000,
+    )
+    this.readReplicasEnabled =
+      options.readReplicasEnabled ?? READ_REPLICAS_ENABLED
   }
 
   async isShardingEnabled(): Promise<boolean> {
@@ -157,10 +173,14 @@ export class MessageShardConnectionManager {
   async getShardClient(
     shard: ShardConfig,
   ): Promise<MessageShardDatabaseClient> {
+    return (await this.ensureEntry(shard)).client
+  }
+
+  private async ensureEntry(shard: ShardConfig): Promise<PoolEntry> {
     const existing = this.pools.get(shard.id)
     if (existing) {
       existing.lastUsed = new Date()
-      return existing.client
+      return existing
     }
 
     if (this.pools.size >= MessageShardConnectionManager.MAX_POOLS) {
@@ -170,7 +190,9 @@ export class MessageShardConnectionManager {
     const pool = createShardPool(shard)
     await this.healthCheck(pool, shard.id)
 
-    const readPool = createReadShardPool(shard)
+    const readPool = this.readReplicasEnabled
+      ? createReadShardPool(shard)
+      : null
     let readClient: MessageShardDatabaseClient | null = null
     let readFailedAt: Date | null = null
     if (readPool) {
@@ -187,44 +209,70 @@ export class MessageShardConnectionManager {
       }
     }
 
-    const client = createMessageShardClient(pool)
-    this.pools.set(shard.id, {
+    const entry: PoolEntry = {
       pool,
-      client,
+      client: createMessageShardClient(pool),
       readPool: readClient ? readPool : null,
       readClient,
       readFailedAt,
       readRetryPromise: null,
       lastUsed: new Date(),
-    })
-
-    return client
+    }
+    this.pools.set(shard.id, entry)
+    return entry
   }
 
-  async getShardClientForRead(
+  async withShardClientForRead<T>(
     shard: ShardConfig,
-  ): Promise<MessageShardDatabaseClient> {
-    const entry = this.pools.get(shard.id)
-    if (entry?.readClient) {
-      entry.lastUsed = new Date()
-      return entry.readClient
-    }
-    if (!entry) {
-      return this.getShardClient(shard)
+    fn: (client: MessageShardDatabaseClient) => Promise<T>,
+  ): Promise<T> {
+    const entry = await this.ensureEntry(shard)
+
+    if (!this.readReplicasEnabled) {
+      return fn(entry.client)
     }
 
-    entry.lastUsed = new Date()
-    if (this.shouldRetryReadReplica(shard, entry)) {
-      await this.retryReadReplica(shard, entry)
+    if (!entry.readClient && this.shouldRetryReadReplica(shard, entry)) {
+      this.scheduleReadReplicaRetry(shard, entry)
     }
-    return entry.readClient ?? entry.client
+
+    const readClient = entry.readClient
+    if (!readClient) {
+      return fn(entry.client)
+    }
+
+    try {
+      return await fn(readClient)
+    } catch (error) {
+      if (!isConnectionError(error)) {
+        throw error
+      }
+      logger.warn(
+        { err: error, shardId: shard.id },
+        "Read replica query failed with connection error, retrying on primary",
+      )
+      this.markReadReplicaUnhealthy(shard.id)
+      return fn(entry.client)
+    }
+  }
+
+  markReadReplicaUnhealthy(shardId: string): void {
+    const entry = this.pools.get(shardId)
+    if (!entry?.readClient) {
+      return
+    }
+    const readPool = entry.readPool
+    entry.readClient = null
+    entry.readPool = null
+    entry.readFailedAt = new Date()
+    readPool?.end().catch((_e) => undefined)
   }
 
   private shouldRetryReadReplica(
     shard: ShardConfig,
     entry: PoolEntry,
   ): boolean {
-    if (!shard.readHost || entry.readClient) {
+    if (!(this.readReplicasEnabled && shard.readHost) || entry.readClient) {
       return false
     }
 
@@ -233,37 +281,44 @@ export class MessageShardConnectionManager {
     }
 
     const elapsedMs = Date.now() - entry.readFailedAt.getTime()
-    return elapsedMs >= MessageShardConnectionManager.READ_REPLICA_RETRY_TTL_MS
+    return elapsedMs >= this.readReplicaRetryTtlMs
   }
 
-  private async retryReadReplica(
-    shard: ShardConfig,
-    entry: PoolEntry,
-  ): Promise<void> {
+  private scheduleReadReplicaRetry(shard: ShardConfig, entry: PoolEntry): void {
     if (entry.readRetryPromise) {
-      await entry.readRetryPromise
       return
     }
 
-    entry.readRetryPromise = this.connectReadReplica(shard, entry).finally(
-      () => {
+    entry.readRetryPromise = this.connectReadReplica(shard, entry)
+      .catch((error) => {
+        logger.warn(
+          { err: error, shardId: shard.id },
+          "Unexpected error during read replica reconnect",
+        )
+      })
+      .finally(() => {
         entry.readRetryPromise = null
-      },
-    )
-    await entry.readRetryPromise
+      })
   }
 
   private async connectReadReplica(
     shard: ShardConfig,
     entry: PoolEntry,
   ): Promise<void> {
-    const readPool = createReadShardPool(shard)
-    if (!readPool) {
-      return
-    }
-
+    let readPool: Pool | null = null
     try {
+      if (!this.readReplicasEnabled) {
+        return
+      }
+      readPool = createReadShardPool(shard)
+      if (!readPool) {
+        return
+      }
       await this.healthCheck(readPool, `${shard.id}:read`)
+      if (this.pools.get(shard.id) !== entry) {
+        await readPool.end().catch((_e) => undefined)
+        return
+      }
       entry.readPool = readPool
       entry.readClient = createMessageShardClient(readPool)
       entry.readFailedAt = null
@@ -274,7 +329,7 @@ export class MessageShardConnectionManager {
         { err: error, shardId: shard.id },
         "Read replica still unhealthy, continuing primary fallback for reads",
       )
-      await readPool.end().catch((_e) => undefined)
+      await readPool?.end().catch((_e) => undefined)
     }
   }
 

--- a/packages/database/src/sharding/message/connection-manager.ts
+++ b/packages/database/src/sharding/message/connection-manager.ts
@@ -252,7 +252,11 @@ export class MessageShardConnectionManager {
         "Read replica query failed with connection error, retrying on primary",
       )
       this.markReadReplicaUnhealthy(shard.id)
-      return fn(entry.client)
+      const retryEntry =
+        this.pools.get(shard.id) === entry
+          ? entry
+          : await this.ensureEntry(shard)
+      return fn(retryEntry.client)
     }
   }
 
@@ -289,6 +293,9 @@ export class MessageShardConnectionManager {
       return
     }
 
+    // .catch is mandatory: nothing awaits this promise. connectReadReplica
+    // catches expected failures internally, but this remains the final guard
+    // against future unexpected throws becoming unhandled rejections.
     entry.readRetryPromise = this.connectReadReplica(shard, entry)
       .catch((error) => {
         logger.warn(

--- a/packages/database/src/sharding/message/connection-manager.ts
+++ b/packages/database/src/sharding/message/connection-manager.ts
@@ -23,7 +23,9 @@ interface PoolEntry {
   lastUsed: Date
   pool: Pool
   readClient: MessageShardDatabaseClient | null
+  readFailedAt: Date | null
   readPool: Pool | null
+  readRetryPromise: Promise<void> | null
 }
 
 interface ActiveShardsCache {
@@ -40,6 +42,10 @@ export class MessageShardConnectionManager {
 
   private static readonly MAX_POOLS = 10
   private static readonly ACTIVE_SHARD_TTL_MS = 30_000
+  private static readonly READ_REPLICA_RETRY_TTL_MS = process.env
+    .SHARD_READ_REPLICA_RETRY_TTL_MS
+    ? Number(process.env.SHARD_READ_REPLICA_RETRY_TTL_MS)
+    : 60_000
 
   constructor(mainDb: DatabaseClient, registry?: MessageShardRegistry) {
     this.registry = registry ?? new MessageShardRegistry(mainDb)
@@ -166,6 +172,7 @@ export class MessageShardConnectionManager {
 
     const readPool = createReadShardPool(shard)
     let readClient: MessageShardDatabaseClient | null = null
+    let readFailedAt: Date | null = null
     if (readPool) {
       try {
         await this.healthCheck(readPool, `${shard.id}:read`)
@@ -175,6 +182,7 @@ export class MessageShardConnectionManager {
           { err: error, shardId: shard.id },
           "Read replica unhealthy, falling back to primary for reads",
         )
+        readFailedAt = new Date()
         await readPool.end().catch((_e) => undefined)
       }
     }
@@ -185,21 +193,89 @@ export class MessageShardConnectionManager {
       client,
       readPool: readClient ? readPool : null,
       readClient,
+      readFailedAt,
+      readRetryPromise: null,
       lastUsed: new Date(),
     })
 
     return client
   }
 
-  getShardClientForRead(
+  async getShardClientForRead(
     shard: ShardConfig,
   ): Promise<MessageShardDatabaseClient> {
     const entry = this.pools.get(shard.id)
     if (entry?.readClient) {
       entry.lastUsed = new Date()
-      return Promise.resolve(entry.readClient)
+      return entry.readClient
     }
-    return this.getShardClient(shard)
+    if (!entry) {
+      return this.getShardClient(shard)
+    }
+
+    entry.lastUsed = new Date()
+    if (this.shouldRetryReadReplica(shard, entry)) {
+      await this.retryReadReplica(shard, entry)
+    }
+    return entry.readClient ?? entry.client
+  }
+
+  private shouldRetryReadReplica(
+    shard: ShardConfig,
+    entry: PoolEntry,
+  ): boolean {
+    if (!shard.readHost || entry.readClient) {
+      return false
+    }
+
+    if (!entry.readFailedAt) {
+      return true
+    }
+
+    const elapsedMs = Date.now() - entry.readFailedAt.getTime()
+    return elapsedMs >= MessageShardConnectionManager.READ_REPLICA_RETRY_TTL_MS
+  }
+
+  private async retryReadReplica(
+    shard: ShardConfig,
+    entry: PoolEntry,
+  ): Promise<void> {
+    if (entry.readRetryPromise) {
+      await entry.readRetryPromise
+      return
+    }
+
+    entry.readRetryPromise = this.connectReadReplica(shard, entry).finally(
+      () => {
+        entry.readRetryPromise = null
+      },
+    )
+    await entry.readRetryPromise
+  }
+
+  private async connectReadReplica(
+    shard: ShardConfig,
+    entry: PoolEntry,
+  ): Promise<void> {
+    const readPool = createReadShardPool(shard)
+    if (!readPool) {
+      return
+    }
+
+    try {
+      await this.healthCheck(readPool, `${shard.id}:read`)
+      entry.readPool = readPool
+      entry.readClient = createMessageShardClient(readPool)
+      entry.readFailedAt = null
+      logger.info({ shardId: shard.id }, "Read replica recovered")
+    } catch (error) {
+      entry.readFailedAt = new Date()
+      logger.warn(
+        { err: error, shardId: shard.id },
+        "Read replica still unhealthy, continuing primary fallback for reads",
+      )
+      await readPool.end().catch((_e) => undefined)
+    }
   }
 
   private async healthCheck(pool: Pool, shardId: string): Promise<void> {

--- a/packages/database/src/sharding/message/repository/sharded-message-repository.ts
+++ b/packages/database/src/sharding/message/repository/sharded-message-repository.ts
@@ -438,24 +438,34 @@ export class ShardedMessageRepository implements IMessageRepository {
 
     for (const shardInfo of shards) {
       try {
-        const shardClient = await this.shardManager.getShardClientForRead(
+        const found = await this.shardManager.withShardClientForRead(
           shardInfo.shard,
-        )
-        const [message] = await shardClient
-          .select()
-          .from(messageModel)
-          .where(
-            and(eq(messageModel.id, id), eq(messageModel.createdAt, createdAt)),
-          )
-          .limit(1)
+          async (shardClient) => {
+            const [message] = await shardClient
+              .select()
+              .from(messageModel)
+              .where(
+                and(
+                  eq(messageModel.id, id),
+                  eq(messageModel.createdAt, createdAt),
+                ),
+              )
+              .limit(1)
 
-        if (message) {
-          const attachments = await this.queryAttachmentsForMessages(
-            shardClient,
-            [id],
-            [message.createdAt],
-          )
-          return { ...message, attachments } as MessageWithAttachments
+            if (!message) {
+              return null
+            }
+
+            const attachments = await this.queryAttachmentsForMessages(
+              shardClient,
+              [id],
+              [message.createdAt],
+            )
+            return { ...message, attachments } as MessageWithAttachments
+          },
+        )
+        if (found) {
+          return found
         }
       } catch (error) {
         logger.warn(
@@ -488,22 +498,24 @@ export class ShardedMessageRepository implements IMessageRepository {
     const results = await Promise.all(
       shards.map(async (shardInfo): Promise<MessageModel | null> => {
         try {
-          const shardClient = await this.shardManager.getShardClientForRead(
+          return await this.shardManager.withShardClientForRead(
             shardInfo.shard,
+            async (shardClient) => {
+              const [message] = await shardClient
+                .select()
+                .from(messageModel)
+                .where(
+                  and(
+                    eq(messageModel.sourceId, sourceId),
+                    eq(messageModel.conversationId, conversationId),
+                    eq(messageModel.workspaceId, workspaceId),
+                    gte(messageModel.createdAt, sinceTime),
+                  ),
+                )
+                .limit(1)
+              return (message as MessageModel) ?? null
+            },
           )
-          const [message] = await shardClient
-            .select()
-            .from(messageModel)
-            .where(
-              and(
-                eq(messageModel.sourceId, sourceId),
-                eq(messageModel.conversationId, conversationId),
-                eq(messageModel.workspaceId, workspaceId),
-                gte(messageModel.createdAt, sinceTime),
-              ),
-            )
-            .limit(1)
-          return (message as MessageModel) ?? null
         } catch (error) {
           logger.warn(
             { err: error, shardId: shardInfo.shard.id },
@@ -545,42 +557,44 @@ export class ShardedMessageRepository implements IMessageRepository {
     const shardResults = await Promise.all(
       shards.map(async (shardInfo): Promise<MessageWithAttachments[]> => {
         try {
-          const shardClient = await this.shardManager.getShardClientForRead(
+          return await this.shardManager.withShardClientForRead(
             shardInfo.shard,
-          )
-          const whereConditions = [
-            eq(messageModel.conversationId, conversationId),
-            gte(messageModel.createdAt, sinceTime),
-          ]
+            async (shardClient) => {
+              const whereConditions = [
+                eq(messageModel.conversationId, conversationId),
+                gte(messageModel.createdAt, sinceTime),
+              ]
 
-          if (options?.messageTypes && options.messageTypes.length > 0) {
-            whereConditions.push(
-              inArray(messageModel.messageType, options.messageTypes),
-            )
-          }
+              if (options?.messageTypes && options.messageTypes.length > 0) {
+                whereConditions.push(
+                  inArray(messageModel.messageType, options.messageTypes),
+                )
+              }
 
-          const messages = await shardClient
-            .select()
-            .from(messageModel)
-            .where(and(...whereConditions))
-            .orderBy(desc(messageModel.createdAt))
-            .limit(limit)
+              const messages = await shardClient
+                .select()
+                .from(messageModel)
+                .where(and(...whereConditions))
+                .orderBy(desc(messageModel.createdAt))
+                .limit(limit)
 
-          if (messages.length === 0) {
-            return []
-          }
+              if (messages.length === 0) {
+                return []
+              }
 
-          let attachmentsByMessageId: Record<string, AttachmentModel[]> = {}
-          if (options?.withAttachments) {
-            attachmentsByMessageId = await this.fetchAndGroupAttachments(
-              shardClient,
-              messages,
-            )
-          }
+              let attachmentsByMessageId: Record<string, AttachmentModel[]> = {}
+              if (options?.withAttachments) {
+                attachmentsByMessageId = await this.fetchAndGroupAttachments(
+                  shardClient,
+                  messages,
+                )
+              }
 
-          return this.mapMessagesToWithAttachments(
-            messages as MessageModel[],
-            attachmentsByMessageId,
+              return this.mapMessagesToWithAttachments(
+                messages as MessageModel[],
+                attachmentsByMessageId,
+              )
+            },
           )
         } catch (error) {
           logger.warn(
@@ -619,32 +633,34 @@ export class ShardedMessageRepository implements IMessageRepository {
     const shardResults = await Promise.all(
       shards.map(async (shardInfo): Promise<MessageModel[]> => {
         try {
-          const shardClient = await this.shardManager.getShardClientForRead(
+          return await this.shardManager.withShardClientForRead(
             shardInfo.shard,
+            async (shardClient) => {
+              const whereConditions = [
+                eq(messageModel.conversationId, conversationId),
+                gte(messageModel.createdAt, sinceTime),
+              ]
+
+              if (options.messageTypes && options.messageTypes.length > 0) {
+                whereConditions.push(
+                  inArray(messageModel.messageType, options.messageTypes),
+                )
+              }
+
+              if (options.textNotNull) {
+                whereConditions.push(isNotNull(messageModel.text))
+              }
+
+              const messages = await shardClient
+                .select()
+                .from(messageModel)
+                .where(and(...whereConditions))
+                .orderBy(desc(messageModel.createdAt))
+                .limit(options.limit)
+
+              return messages as MessageModel[]
+            },
           )
-          const whereConditions = [
-            eq(messageModel.conversationId, conversationId),
-            gte(messageModel.createdAt, sinceTime),
-          ]
-
-          if (options.messageTypes && options.messageTypes.length > 0) {
-            whereConditions.push(
-              inArray(messageModel.messageType, options.messageTypes),
-            )
-          }
-
-          if (options.textNotNull) {
-            whereConditions.push(isNotNull(messageModel.text))
-          }
-
-          const messages = await shardClient
-            .select()
-            .from(messageModel)
-            .where(and(...whereConditions))
-            .orderBy(desc(messageModel.createdAt))
-            .limit(options.limit)
-
-          return messages as MessageModel[]
         } catch (error) {
           logger.warn(
             { err: error, shardId: shardInfo.shard.id },
@@ -686,20 +702,22 @@ export class ShardedMessageRepository implements IMessageRepository {
       shards.map(
         async (shardInfo): Promise<Pick<MessageModel, "id" | "text">[]> => {
           try {
-            const shardClient = await this.shardManager.getShardClientForRead(
+            return await this.shardManager.withShardClientForRead(
               shardInfo.shard,
+              async (shardClient) => {
+                const messages = await shardClient
+                  .select({ id: messageModel.id, text: messageModel.text })
+                  .from(messageModel)
+                  .where(
+                    and(
+                      eq(messageModel.contactInboxId, contactInboxId),
+                      inArray(messageModel.id, ids),
+                      gte(messageModel.createdAt, sinceTime),
+                    ),
+                  )
+                return messages as Pick<MessageModel, "id" | "text">[]
+              },
             )
-            const messages = await shardClient
-              .select({ id: messageModel.id, text: messageModel.text })
-              .from(messageModel)
-              .where(
-                and(
-                  eq(messageModel.contactInboxId, contactInboxId),
-                  inArray(messageModel.id, ids),
-                  gte(messageModel.createdAt, sinceTime),
-                ),
-              )
-            return messages as Pick<MessageModel, "id" | "text">[]
           } catch (error) {
             logger.warn(
               { err: error, shardId: shardInfo.shard.id },
@@ -827,70 +845,71 @@ export class ShardedMessageRepository implements IMessageRepository {
     }
   }
 
-  private async queryShardForMessages(
+  private queryShardForMessages(
     shardInfo: MessageShardTimeRangeInfo,
     query: ListMessagesQuery,
     limit: number,
     cursor?: PaginationCursor,
   ): Promise<PaginatedMessages> {
     const { workspaceId, conversationId } = query
-    const shardClient = await this.shardManager.getShardClientForRead(
+    return this.shardManager.withShardClientForRead(
       shardInfo.shard,
+      async (shardClient) => {
+        const whereConditions = [eq(messageModel.workspaceId, workspaceId)]
+
+        if (conversationId) {
+          whereConditions.push(eq(messageModel.conversationId, conversationId))
+        }
+
+        if (cursor) {
+          const cursorCondition = cursor.id
+            ? or(
+                lt(messageModel.createdAt, cursor.createdAt),
+                and(
+                  eq(messageModel.createdAt, cursor.createdAt),
+                  lt(messageModel.id, cursor.id),
+                ),
+              )
+            : lt(messageModel.createdAt, cursor.createdAt)
+          if (cursorCondition) {
+            whereConditions.push(cursorCondition)
+          }
+        }
+
+        const messages = await shardClient
+          .select()
+          .from(messageModel)
+          .where(and(...whereConditions))
+          .limit(limit + 1)
+          .orderBy(desc(messageModel.createdAt), desc(messageModel.id))
+
+        const hasMore = messages.length > limit
+        const resultMessages = hasMore ? messages.slice(0, limit) : messages
+
+        if (resultMessages.length === 0) {
+          return { data: [], nextCursor: null }
+        }
+
+        const attachmentsByMessageId = await this.fetchAndGroupAttachments(
+          shardClient,
+          resultMessages,
+        )
+
+        const messagesWithAttachments = this.mapMessagesToWithAttachments(
+          resultMessages as MessageModel[],
+          attachmentsByMessageId,
+        )
+
+        let nextCursor: PaginationCursor | null = null
+        if (hasMore) {
+          const lastMessage = resultMessages.at(-1)
+          if (lastMessage) {
+            nextCursor = this.buildNextCursor(lastMessage, shardInfo.shard.id)
+          }
+        }
+
+        return { data: messagesWithAttachments, nextCursor }
+      },
     )
-
-    const whereConditions = [eq(messageModel.workspaceId, workspaceId)]
-
-    if (conversationId) {
-      whereConditions.push(eq(messageModel.conversationId, conversationId))
-    }
-
-    if (cursor) {
-      const cursorCondition = cursor.id
-        ? or(
-            lt(messageModel.createdAt, cursor.createdAt),
-            and(
-              eq(messageModel.createdAt, cursor.createdAt),
-              lt(messageModel.id, cursor.id),
-            ),
-          )
-        : lt(messageModel.createdAt, cursor.createdAt)
-      if (cursorCondition) {
-        whereConditions.push(cursorCondition)
-      }
-    }
-
-    const messages = await shardClient
-      .select()
-      .from(messageModel)
-      .where(and(...whereConditions))
-      .limit(limit + 1)
-      .orderBy(desc(messageModel.createdAt), desc(messageModel.id))
-
-    const hasMore = messages.length > limit
-    const resultMessages = hasMore ? messages.slice(0, limit) : messages
-
-    if (resultMessages.length === 0) {
-      return { data: [], nextCursor: null }
-    }
-
-    const attachmentsByMessageId = await this.fetchAndGroupAttachments(
-      shardClient,
-      resultMessages,
-    )
-
-    const messagesWithAttachments = this.mapMessagesToWithAttachments(
-      resultMessages as MessageModel[],
-      attachmentsByMessageId,
-    )
-
-    let nextCursor: PaginationCursor | null = null
-    if (hasMore) {
-      const lastMessage = resultMessages.at(-1)
-      if (lastMessage) {
-        nextCursor = this.buildNextCursor(lastMessage, shardInfo.shard.id)
-      }
-    }
-
-    return { data: messagesWithAttachments, nextCursor }
   }
 }

--- a/packages/database/src/sharding/shared/env.ts
+++ b/packages/database/src/sharding/shared/env.ts
@@ -1,0 +1,28 @@
+import { logger } from "../../logger"
+
+/**
+ * Read an integer from process.env with a safe fallback. Anything that is
+ * not an integer >= min (default 0) logs a warning and returns the fallback.
+ */
+export function envInt(
+  name: string,
+  fallback: number,
+  options: { min?: number } = {},
+): number {
+  const min = options.min ?? 0
+  const raw = process.env[name]
+  if (raw === undefined || raw === "") {
+    return fallback
+  }
+
+  const value = Number(raw)
+  if (!Number.isInteger(value) || value < min) {
+    logger.warn(
+      { name, value: raw, min, fallback },
+      "Invalid numeric environment value, using fallback",
+    )
+    return fallback
+  }
+
+  return value
+}

--- a/packages/database/src/sharding/shared/errors.ts
+++ b/packages/database/src/sharding/shared/errors.ts
@@ -13,3 +13,49 @@ export class ShardUnreachableError extends Error {
     this.name = "ShardUnreachableError"
   }
 }
+
+const CONNECTION_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENOTFOUND",
+  "EPIPE",
+  "ETIMEDOUT",
+  "57P01",
+  "57P02",
+  "57P03",
+])
+
+const CONNECTION_ERROR_MESSAGE_PATTERN =
+  /connection terminated|connection refused|connection ended|timeout exceeded when trying to connect/i
+
+const MAX_CAUSE_DEPTH = 5
+
+export function isConnectionError(error: unknown): boolean {
+  let current: unknown = error
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH && current; depth++) {
+    if (typeof current !== "object") {
+      return false
+    }
+
+    const { code, message } = current as { code?: unknown; message?: unknown }
+    if (
+      typeof code === "string" &&
+      (CONNECTION_ERROR_CODES.has(code) || code.startsWith("08"))
+    ) {
+      return true
+    }
+
+    if (
+      typeof message === "string" &&
+      CONNECTION_ERROR_MESSAGE_PATTERN.test(message)
+    ) {
+      return true
+    }
+
+    current = (current as { cause?: unknown }).cause
+  }
+
+  return false
+}

--- a/packages/database/src/sharding/shared/index.ts
+++ b/packages/database/src/sharding/shared/index.ts
@@ -1,4 +1,5 @@
 export * from "./credentials"
+export * from "./env"
 export * from "./errors"
 export * from "./hash"
 export * from "./pool"

--- a/packages/database/src/sharding/shared/pool.ts
+++ b/packages/database/src/sharding/shared/pool.ts
@@ -1,4 +1,5 @@
 import { Pool } from "pg"
+import { logger } from "../../logger"
 import { resolveShardCredentials } from "./credentials"
 import type { ShardConfig } from "./types"
 
@@ -27,6 +28,19 @@ function buildSslConfig(sslMode: string) {
   return { rejectUnauthorized: sslMode !== "require" }
 }
 
+function attachPoolErrorHandler(
+  pool: Pool,
+  props: { role: "primary" | "read"; shardId: string },
+): Pool {
+  pool.on("error", (error) => {
+    logger.error(
+      { err: error, role: props.role, shardId: props.shardId },
+      "Unexpected idle shard pool error",
+    )
+  })
+  return pool
+}
+
 export function createShardPool(
   shard: ShardConfig,
   options: CreateShardPoolOptions = {},
@@ -38,18 +52,21 @@ export function createShardPool(
 
   const merged = { ...ENV_DEFAULTS, ...options }
 
-  return new Pool({
-    host: shard.host,
-    port: shard.port ?? 5432,
-    database: shard.database,
-    user: shard.user,
-    password,
-    ssl: buildSslConfig(sslMode),
-    max: merged.max,
-    min: merged.min,
-    idleTimeoutMillis: merged.idleTimeoutMillis,
-    connectionTimeoutMillis: merged.connectionTimeoutMillis,
-  })
+  return attachPoolErrorHandler(
+    new Pool({
+      host: shard.host,
+      port: shard.port ?? 5432,
+      database: shard.database,
+      user: shard.user,
+      password,
+      ssl: buildSslConfig(sslMode),
+      max: merged.max,
+      min: merged.min,
+      idleTimeoutMillis: merged.idleTimeoutMillis,
+      connectionTimeoutMillis: merged.connectionTimeoutMillis,
+    }),
+    { role: "primary", shardId: shard.id },
+  )
 }
 
 export function createReadShardPool(
@@ -67,16 +84,19 @@ export function createReadShardPool(
 
   const merged = { ...ENV_DEFAULTS, ...options }
 
-  return new Pool({
-    host: shard.readHost,
-    port: shard.readPort ?? shard.port ?? 5432,
-    database: shard.database,
-    user: shard.user,
-    password,
-    ssl: buildSslConfig(sslMode),
-    max: merged.max,
-    min: merged.min,
-    idleTimeoutMillis: merged.idleTimeoutMillis,
-    connectionTimeoutMillis: merged.connectionTimeoutMillis,
-  })
+  return attachPoolErrorHandler(
+    new Pool({
+      host: shard.readHost,
+      port: shard.readPort ?? shard.port ?? 5432,
+      database: shard.database,
+      user: shard.user,
+      password,
+      ssl: buildSslConfig(sslMode),
+      max: merged.max,
+      min: merged.min,
+      idleTimeoutMillis: merged.idleTimeoutMillis,
+      connectionTimeoutMillis: merged.connectionTimeoutMillis,
+    }),
+    { role: "read", shardId: shard.id },
+  )
 }

--- a/packages/database/src/sharding/shared/pool.ts
+++ b/packages/database/src/sharding/shared/pool.ts
@@ -1,6 +1,7 @@
 import { Pool } from "pg"
 import { logger } from "../../logger"
 import { resolveShardCredentials } from "./credentials"
+import { envInt } from "./env"
 import type { ShardConfig } from "./types"
 
 export interface CreateShardPoolOptions {
@@ -11,14 +12,10 @@ export interface CreateShardPoolOptions {
 }
 
 const ENV_DEFAULTS = {
-  max: process.env.SHARD_POOL_MAX ? Number(process.env.SHARD_POOL_MAX) : 10,
-  min: process.env.SHARD_POOL_MIN ? Number(process.env.SHARD_POOL_MIN) : 2,
-  idleTimeoutMillis: process.env.SHARD_POOL_IDLE_TIMEOUT_MS
-    ? Number(process.env.SHARD_POOL_IDLE_TIMEOUT_MS)
-    : 30_000,
-  connectionTimeoutMillis: process.env.SHARD_POOL_CONNECT_TIMEOUT_MS
-    ? Number(process.env.SHARD_POOL_CONNECT_TIMEOUT_MS)
-    : 5000,
+  max: envInt("SHARD_POOL_MAX", 10, { min: 1 }),
+  min: envInt("SHARD_POOL_MIN", 2),
+  idleTimeoutMillis: envInt("SHARD_POOL_IDLE_TIMEOUT_MS", 30_000),
+  connectionTimeoutMillis: envInt("SHARD_POOL_CONNECT_TIMEOUT_MS", 5000),
 }
 
 function buildSslConfig(sslMode: string) {


### PR DESCRIPTION
## What

Makes message loading more stable. If part of the message database has a problem, the app now keeps showing messages instead of silently losing them.

## Why

Before this, a database hiccup could make some conversations look empty until a restart. Now the system recovers on its own.

## Testing

- All database tests pass (66/66)
- Verified messages still load normally when the backup database connection is unavailable