### PR TITLE
feat: add project AI agents, skills, and commands

### DIFF
--- a/.agents/rules/git.md
+++ b/.agents/rules/git.md
@@ -8,7 +8,7 @@ Enforced by `lefthook.yml` commit-msg hook. Pattern:
 <type>(<scope>): <subject>
 ```
 
-**Types:** `feat`, `fix`, `bugfix`, `refactor`, `docs`, `style`, `test`, `chore`, `ci`, `perf`, `build`, `revert`
+**Types:** `feat`, `fix`, `refactor`, `docs`, `style`, `test`, `chore`, `ci`, `perf`, `build`, `revert` (Conventional Commits; non-standard types like `bugfix` are dropped by release-note tooling)
 
 **Examples:**
 ```

--- a/.agents/skills/builder-ui-i18n/SKILL.md
+++ b/.agents/skills/builder-ui-i18n/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: builder-ui-i18n
+description: >-
+  Build or modify ChatbotX builder UI components, forms, tables, dialogs,
+  shared UI usage, and translations. Use for user-facing React/Next.js UI in
+  apps/builder, especially when labels, placeholders, menus, or validation
+  messages are added or changed.
+---
+
+# Builder UI and i18n
+
+Use for `apps/builder` UI work. Pair with `feature-scaffold` for new feature
+modules and pages.
+
+## UI Stack
+
+- React 19 + Next.js app router.
+- Shared components come from `@chatbotx.io/ui/*`.
+- Builder also has local components under `apps/builder/src/components`.
+- Forms use React Hook Form, Zod, and next-safe-action adapter.
+- URL state commonly uses `nuqs`.
+- Icons should use the project icon library when available.
+
+## i18n Rule
+
+All user-facing strings must use translations. Do not hardcode labels,
+placeholders, button text, empty states, tab names, toasts, or dialog copy in
+builder UI.
+
+Primary files:
+
+- `apps/builder/messages/en.json`
+- `apps/builder/messages/vi.json`
+
+Before adding keys, check existing `fields.*`, common actions, table labels, and
+feature namespaces. Add both English and Vietnamese values for new keys.
+
+Typical component pattern:
+
+```typescript
+"use client"
+
+import { useTranslations } from "next-intl"
+
+export const ExampleButton = () => {
+  const t = useTranslations("features.examples")
+  return <Button>{t("create")}</Button>
+}
+```
+
+## Form Pattern
+
+- Server actions with `bindArgsSchemas` must be bound before passing to hooks:
+  `createThingAction.bind(null, workspaceId)`.
+- No-input delete actions call `execute()` with no arguments, not `execute({})`.
+- Validation schemas live near the feature, usually `schema/action.ts`.
+- Prefer shared form components from `@chatbotx.io/ui`.
+
+## Layout and Components
+
+- Mirror sibling features for tables, dialogs, toolbar actions, and columns.
+- Keep server components responsible for data promises and client components
+  responsible for interaction.
+- Pages receive Promise `params` / `searchParams`.
+- Client components unwrap server promises with `use(promises)` where this repo
+  already follows that pattern.
+- Public routes need `apps/builder/src/proxy.ts` public route registration.
+
+## Styling Guidance
+
+- Keep operational UI dense, scan-friendly, and consistent with existing builder
+  screens.
+- Do not create landing-page style layouts for product workflows.
+- Avoid nested cards and oversized hero typography inside tools.
+- Ensure button and table text fits at mobile and desktop sizes.
+
+## Verification
+
+Run targeted checks for touched UI:
+
+```bash
+pnpm --filter builder check-types
+pnpm --filter builder test
+pnpm lint
+```
+
+If visual layout risk is high, start the builder dev server and inspect the page.

--- a/.agents/skills/business-data-access/SKILL.md
+++ b/.agents/skills/business-data-access/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: business-data-access
+description: >-
+  Implement or modify ChatbotX business services, repositories, cache
+  invalidation, event emission, and data-access boundaries. Use when app,
+  worker, or integration code needs database-backed reads or mutations without
+  importing db directly.
+---
+
+# Business Data Access
+
+Use this skill whenever code outside `packages/business` or
+`packages/database/src/repositories` needs database-backed behavior.
+
+## Boundary Rule
+
+Do not add direct database imports in:
+
+- `apps/builder`
+- `apps/worker`
+- `integrations`
+
+These layers call services from `@chatbotx.io/business` or repositories from
+`@chatbotx.io/database/repositories`. Legacy direct `db` imports are exceptions,
+not examples to copy.
+
+Allowed direct `db` usage:
+
+- `packages/business/src/**`
+- `packages/database/src/repositories/**`
+
+## Choosing Service vs Repository
+
+Use a business service when the method has business semantics, authorization
+adjacent constraints, cache invalidation, event emission, composition across
+tables, or is reused by app and worker code.
+
+Use a repository when the method is a low-level persistence concern such as
+shard routing, specialized pagination, or reusable raw query mechanics.
+
+## Service Pattern
+
+Services live in `packages/business/src/<domain>/`.
+
+```
+<domain>/
+  service.ts
+  index.ts
+```
+
+Typical shape:
+
+```typescript
+import { type DatabaseClient, db } from "@chatbotx.io/database/client"
+import { BaseService } from "../base.service"
+
+class ExampleService extends BaseService {
+  async doThing(props: {
+    workspaceId: string
+    tx?: DatabaseClient
+  }) {
+    const { workspaceId, tx = db } = props
+    // query/mutate with tx
+    await this.invalidateCacheTags([`examples:${workspaceId}`])
+  }
+}
+
+export const exampleService = new ExampleService()
+```
+
+Also export from:
+
+- `packages/business/src/<domain>/index.ts`
+- `packages/business/src/index.ts`
+
+## Transaction Pattern
+
+- Accept `tx?: DatabaseClient` in service methods that may compose with other operations.
+- Default to `db` inside the service: `const { tx = db } = props`.
+- Pass `tx` through nested service/repository calls.
+
+## Cache and Events
+
+- Extend `BaseService` to use `invalidateCacheTags()`.
+- Use `withCache` from `@chatbotx.io/redis` only around stable reads with clear keys.
+- Emit domain events from services when mutations affect downstream workflows.
+- Fire-and-forget events should handle `.catch(() => {})` if the local pattern does.
+
+## Repository Pattern
+
+Repositories live in `packages/database/src/repositories/<domain>/`.
+
+```
+repositories/<domain>/
+  repository.ts
+  index.ts
+```
+
+Export new repositories from `packages/database/src/repositories/index.ts`.
+Use the `drizzle-database` skill for schema, relation, and migration work.
+
+## App Layer Usage
+
+Builder feature queries/actions should call services:
+
+```typescript
+import { tagService } from "@chatbotx.io/business"
+
+export const listTags = async (params: { workspaceId: string }) => {
+  return tagService.list({ workspaceId: params.workspaceId })
+}
+```
+
+Workers and integrations follow the same boundary.
+
+## Verification
+
+Before finishing:
+
+- Search changed app/worker/integration files for new direct `db` imports.
+- Add or update focused service/repository tests when behavior is non-trivial.
+- Run the smallest relevant test/typecheck script from the touched workspace.

--- a/.agents/skills/chatbotx-basecode/SKILL.md
+++ b/.agents/skills/chatbotx-basecode/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: chatbotx-basecode
+description: >-
+  Understand and audit the ChatbotX base code before making changes. Use when
+  asked to scan the project, check architecture, locate ownership boundaries,
+  onboard to the repository, or decide which project-specific skill should
+  handle a task.
+---
+
+# ChatbotX Basecode
+
+Use this skill as the first pass for broad or ambiguous requests. It is a map,
+not a replacement for reading adjacent code.
+
+## Project Shape
+
+ChatbotX is a pnpm workspace + Turborepo monorepo.
+
+```
+apps/
+  builder/     Next.js app: product UI, oRPC/OpenAPI, route handlers
+  worker/      BullMQ/Kafka background jobs
+  realtime/    PartyKit realtime server
+  cli/         chatbotx-cli
+  mcp-server/  MCP tools generated from OpenAPI
+
+packages/
+  business/       service layer and business orchestration
+  database/       Drizzle schema, relations, repositories, migrations
+  ui/             shared UI components
+  public-apis/    typed public API client
+  sdk/            integration contracts and shared schemas
+  worker-config/  queue names, job payloads, BullMQ queues
+  flow-config/    flow/node/step config schemas
+  ai, events, redis, kafka, filesystem, mail, imports, analytics, ...
+
+integrations/
+  messenger, whatsapp, zalo, telegram, webchat, smtp, openai, google-sheets, ...
+```
+
+## Skill Router
+
+- Builder feature, page, action, query, or public route: use `feature-scaffold`.
+- oRPC or OpenAPI endpoint: use `orpc-api`.
+- Database schema, relations, migration, repository: use `drizzle-database`.
+- Service layer, app data-access boundary: use `business-data-access`.
+- UI component work, forms, tables, translations: use `builder-ui-i18n`.
+- Worker, BullMQ, Kafka, scheduled job: use `worker-development`.
+- Channel integration or webhook behavior: use `integration-channel`.
+- Flow step or state-based routing: use `flow-step-development`.
+- CLI, MCP server, generated public client: use `public-api-tooling`.
+- Dev server, build, lint, package management: use `turborepo-workflow`.
+
+## Basecode Scan Checklist
+
+1. Read the nearest `package.json`, route/module files, and sibling features.
+2. Identify the owning layer before editing:
+   - UI/app orchestration: `apps/builder`
+   - business rules: `packages/business`
+   - raw database queries: `packages/database/src/repositories`
+   - schema/migrations: `packages/database`
+   - async processing: `apps/worker` + `packages/worker-config`
+   - external channel protocol: `integrations/<channel>`
+3. Search for a similar feature and mirror naming, imports, error handling, and tests.
+4. Check `.agents/rules/*` for local invariants, especially data access and git.
+5. Keep changes scoped to the user request; do not refactor legacy exceptions unless required.
+
+## Non-Negotiable Invariants
+
+- New app/integration code must not import `db` from `@chatbotx.io/database/client`.
+- User-facing builder strings must use `useTranslations()` and message JSON keys.
+- Next.js app pages use Promise `params` / `searchParams`.
+- Public unauthenticated builder routes must be registered in `apps/builder/src/proxy.ts`.
+- Middleware names intentionally contain three `d`s:
+  `workspaceAuthorizedMidddleware` and `workspaceTokenAuthMidddleware`.
+- Adding database tables requires schema, migration, relation import, and relation spread.
+- Adding `ChannelType` values requires fixing every `Record<ChannelType, ...>` use.
+
+## Validation
+
+Prefer targeted checks first, then broader checks when the blast radius grows:
+
+```bash
+pnpm --filter builder check-types
+pnpm --filter @chatbotx.io/database check-types
+pnpm --filter worker test
+pnpm lint
+pnpm build
+```
+
+If the exact script is unclear, inspect the relevant workspace `package.json`.

--- a/.agents/skills/implement-plan/SKILL.md
+++ b/.agents/skills/implement-plan/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: implement-plan
+description: Implement an already-approved technical plan from a plan path, executing the next unfinished task without replanning or expanding scope.
+---
+
+# Implement Approved Plan
+
+Use this skill when the user gives an approved implementation plan and asks to implement it, continue it, or run implementation mode.
+
+## Operating Mode
+
+- The plan is already approved; execute it instead of creating a new plan.
+- Keep changes minimal and scoped to the approved task.
+- Reuse existing architecture, APIs, schema, and local patterns.
+- Do not redesign, expand scope, or perform unrelated refactors.
+- Work on one independently deliverable unfinished task at a time.
+
+## Starting Workflow
+
+When given a plan path:
+
+1. Read the plan completely.
+2. Check completed items (`- [x]`).
+3. Read the original ticket only if it is referenced or provided.
+4. Read all files referenced by the plan.
+5. Read the surrounding implementation before editing.
+6. Create an internal task list.
+7. Implement the highest-priority unfinished task.
+
+If no plan path is provided, ask for one.
+
+Your first action must be reading the plan and relevant files. Your first code-changing action should be implementation, not replanning.
+
+## Execution Rules
+
+- Do not create a new implementation plan.
+- Do not rewrite plan content.
+- You may update only task checkboxes/status after the task is implemented and verified.
+- Do not ask for approval before coding unless there is ambiguity, a plan mismatch, or an unsafe/destructive operation.
+- Do not pause to summarize before implementation.
+- Stop after the selected task is complete unless the user explicitly asks to continue.
+
+Prefer the smallest independently deliverable unfinished task.
+
+## Plan Mismatch
+
+If reality differs from the plan, stop and report:
+
+```text
+Issue in Phase [N]
+
+Expected:
+[what the plan specifies]
+
+Found:
+[actual implementation reality]
+
+Why this matters:
+[technical impact]
+
+Recommended path:
+[best option]
+```
+
+Wait for guidance before proceeding.
+
+## Verification
+
+After implementation:
+
+- Run relevant tests.
+- Run lint or targeted formatter/check commands.
+- Run typecheck for touched app/package when available.
+- Fix issues introduced by your changes.
+- Verify plan success criteria.
+
+Run full build only when the task scope or plan requires it.
+
+## Manual Verification
+
+Pause for manual verification only when:
+
+- The plan explicitly requires manual testing.
+- The implementation cannot be fully validated automatically.
+- User interaction is required.
+
+Do not mark manual verification items complete until the user confirms.
+
+## Resuming Work
+
+- Trust completed checkboxes unless they block the current task, conflict with current code, or verification fails.
+- Resume from the first unfinished item by priority.
+- Revisit completed work only when necessary for the current task.
+
+## Final Output
+
+Report:
+
+- Task implemented and why.
+- Files changed and why.
+- Validation commands and results.
+- Remaining unfinished tasks from the plan.

--- a/.agents/skills/integration-channel/SKILL.md
+++ b/.agents/skills/integration-channel/SKILL.md
@@ -283,7 +283,7 @@ After editing, immediately read back each file to verify both import AND spread 
 
 **CRITICAL — `ChannelType` cascade:** Adding a value to the `channelTypes` enum causes compile errors in every `Record<ChannelType, ...>` that doesn't include the new key. Grep for `Record<ChannelType` and `Record<\n\s*ChannelType` (multiline) to find and fix ALL hits.
 
-**Phase 3 checkpoint:** Run `ReadLints` on all modified files. Fix any undeclared variable or missing import errors before continuing.
+**Phase 3 checkpoint:** Run `pnpm lint` and `pnpm --filter <touched-workspace> check-types` on the modified files. Fix any undeclared-variable or missing-import errors before continuing.
 
 ### Phase 4: Builder Feature + Settings Page
 

--- a/.agents/skills/public-api-tooling/SKILL.md
+++ b/.agents/skills/public-api-tooling/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: public-api-tooling
+description: >-
+  Work on ChatbotX public API clients, generated OpenAPI types, CLI commands,
+  and MCP server tools. Use when changing packages/public-apis, apps/cli,
+  apps/mcp-server, OpenAPI-derived tooling, workspace-token API behavior, or
+  command-line access to ChatbotX APIs.
+---
+
+# Public API Tooling
+
+Use this skill for the client/tooling surface around the public API. Pair with
+`orpc-api` when adding or changing the builder endpoint that produces OpenAPI.
+
+## Surfaces
+
+```
+packages/public-apis/
+  src/generated/chatbotx.ts  OpenAPI-generated types
+  src/apis/*.ts             Typed client methods + Zod input schemas
+  src/lib/*                 API client, config, request helpers
+
+apps/cli/
+  src/index.ts              CLI entry
+  src/openapi-loader.ts     OpenAPI tool discovery
+  src/dynamic-executor.ts   Runtime endpoint execution
+  src/commands/*            Static commands and config helpers
+
+apps/mcp-server/
+  src/openapi-loader.ts
+  src/server/create-mcp-server.ts
+  src/server/stdio-server.ts
+  src/server/sse-server.ts
+```
+
+## Public API Client Pattern
+
+Client modules in `packages/public-apis/src/apis/<domain>.ts` generally:
+
+- Import `paths` from `../generated/chatbotx`.
+- Derive input and output types from OpenAPI paths.
+- Define Zod input schemas for CLI/MCP validation.
+- Implement functions using `api.getClient().get/post/delete(...).json()`.
+- Export domain APIs through `src/apis/index.ts` and package entrypoints.
+
+When changing endpoint paths or response shapes, regenerate or update generated
+OpenAPI types before adjusting typed clients.
+
+## CLI and MCP Pattern
+
+- CLI and MCP load OpenAPI metadata and execute operations dynamically.
+- MCP registers raw JSON Schema tools through low-level MCP handlers so OpenAPI
+  schemas can pass through.
+- Workspace token auth uses `Authorization: Bearer <token>`.
+- MCP API key comes from `CHATBOTX_API_KEY` or the provided runtime getter.
+- Do not add ad-hoc duplicated endpoint definitions if OpenAPI can provide them.
+
+## Adding or Changing an API Operation
+
+1. Use `orpc-api` to add/update the builder oRPC procedure and OpenAPI metadata.
+2. Make sure the procedure uses the correct auth stack:
+   - session APIs: `authorizedAPI`
+   - workspace token APIs: `workspaceTokenAuthAPI`
+3. Refresh generated OpenAPI types if the workflow requires it.
+4. Update `packages/public-apis/src/apis/<domain>.ts` schemas and functions.
+5. Update CLI/MCP tests or smoke tests if dynamic discovery/args changed.
+
+## Validation
+
+Inspect scripts in each workspace `package.json`, then run the narrow checks:
+
+```bash
+pnpm --filter @chatbotx.io/public-apis test
+pnpm --filter chatbotx-cli test
+pnpm --filter chatbotx-mcp-server test
+pnpm --filter builder check-types
+```
+
+Run broader lint/build if endpoint shape or generated types changed across
+multiple packages.

--- a/.agents/skills/reliability-concurrency/SKILL.md
+++ b/.agents/skills/reliability-concurrency/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: reliability-concurrency
+description: Use when writing code that runs concurrently in ChatbotX — BullMQ worker consumers, sharded DB migrations, embedding replace-writes, or any multi-step operation that could be retried or run by two workers at once. Covers advisory locks, idempotency, transactions, and safe-retry patterns. Read before adding a worker job, migration runner, or replace-style write.
+---
+
+# Reliability & Concurrency (ChatbotX)
+
+Production runs multiple worker instances and re-tries failed jobs. Code that is correct single-threaded can corrupt data when two workers race or a job re-runs. Apply these patterns.
+
+## 1. Guard schema/DDL changes with an advisory lock
+
+Migration runners (e.g. `packages/database/src/sharding/message/shard-migration-runner.ts`) must not let two workers apply the same DDL concurrently. Wrap the apply loop:
+
+- Take a `pg_advisory_lock` (or `pg_try_advisory_lock`) keyed on the shard before reading the current version.
+- Do the version check and each migration apply inside a transaction so a crash mid-step rolls back.
+- Make "read version → apply → write version" atomic; never read-then-write across two unguarded statements.
+
+## 2. Make replace-writes atomic AND race-safe
+
+Delete-then-insert (e.g. embedding `replaceForSource`) must be:
+
+- **Atomic** — inside a single `transaction()` so there is no zero-row window within one worker (this is already done in the embedding repo).
+- **Race-safe** — add an advisory lock or optimistic-concurrency guard keyed on the `sourceId`, so two workers processing the same source don't delete each other's fresh rows. A transaction alone does not prevent the cross-worker race.
+
+## 3. Idempotent job consumers
+
+- A BullMQ job can run more than once (retry, redelivery). Design the handler so re-running produces the same end state.
+- Guard the status transition: `UPDATE … SET status='processing' WHERE id=? AND status='pending'` and check the affected-row count, instead of read-`pending`-then-write-`processing` (two workers both pass the read).
+- Use a natural idempotency key (source id + content hash) before re-inserting derived data.
+
+## 4. Fail loudly, degrade safely
+
+- If a dependency (RAG store, Redis, downstream channel) is down, surface the error and let BullMQ retry — do not write partial/corrupt state and return success.
+- Never swallow errors in a worker handler; an unlogged failure in a background job is invisible until data is wrong.
+
+## 5. Parallel agents / git
+
+- Multiple agents editing the same working tree corrupt each other's git index. For parallel work use separate git worktrees.
+- Stage specific files only — never `git add -A`/`.` (`.agents/rules/git.md`).
+
+## Stop condition
+
+Before shipping concurrent code, confirm: locked DDL? atomic + race-safe replace? idempotent re-run? loud failure? If any answer is no, fix it — the failure mode is silent data corruption, which lint and types will not catch.

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: security-review
+description: Use before committing changes to auth, workspace scoping, channel webhooks, AI tools/MCP, permission settings, or anything handling untrusted channel content in ChatbotX. A repo-specific security checklist covering tenant isolation, prompt injection via channel content, the Bash permission allowlist, and secret handling. Read before security-sensitive work; pair with the global security-reviewer agent for deep dives.
+---
+
+# Security Review (ChatbotX)
+
+A focused, repo-specific checklist. For OWASP-depth analysis dispatch the global `security-reviewer` agent; this skill is the ChatbotX-specific surface map and the things that bite here.
+
+## 1. Tenant isolation (the #1 risk in a multi-workspace product)
+
+- Every query that returns workspace data MUST be scoped by `workspaceId`, OR by an id that is provably workspace-bound by construction (trace it).
+- Builder APIs go through `workspaceAuthorizedMidddleware` / `workspaceTokenAuthMidddleware` (triple-d — preserved typo). Confirm new oRPC routes use the authorized stack, not an unauthenticated handler.
+- RAG/embedding queries: see the `rag-eval` agent. A `sourceId`-only filter with no `workspaceId` predicate is a defense-in-depth gap.
+- Repositories/services are the boundary — app/integration code must not reach `db` directly (`.agents/rules/data-access.md`).
+
+## 2. Prompt injection (untrusted channel content → agent context)
+
+- Customer messages (WhatsApp/Messenger/webchat), uploaded documents, and fetched URLs are **untrusted**. When their content reaches an AI prompt or RAG context, it must be framed as data, not instructions (clear delimiters, "the following is user-provided content").
+- Flag raw `content: row.content` passthrough from a context-source adapter into a model prompt (`apps/worker/.../context-sources/`, `packages/ai/`).
+
+## 3. Tool / permission allowlist (`.claude/settings.local.json`)
+
+- This file is git-ignored and local — but it is live in every agent session.
+- **Never** put credential literals (`PGPASSWORD`, `DATABASE_URL` with a real password) inside `Bash(...)` allow-patterns. Use env indirection.
+- **Never** grant wildcard exec: `Bash(pnpm *)`, `Bash(node *)`, `Bash(python3 *)`, `Bash(git *)`. Grant the specific commands you need (`Bash(pnpm lint)`, `Bash(pnpm --filter <x> test)`).
+- **Never** auto-approve `cp` of any `.env`, or reads of `~`/`/etc`. Scope filesystem grants to the repo.
+- Paths must be relative/repo-local, not machine-absolute, and must match this repo (`ChatbotX01`).
+
+## 4. Secret handling
+
+- No secrets in tracked files. `.env*` is never committed (`.agents/rules/git.md`, `/commit` guardrails).
+- If a real credential is found in any file (even gitignored), **rotate it out-of-band** and remove it — being un-committed is not the same as being safe when it's live in agent context.
+- MCP server: restrict CORS origins; accept tokens via `Authorization` header, never URL query params (they get logged).
+
+## Stop condition
+
+Produce a findings list (`file:line | risk | severity | fix`) ranked by severity. If a CRITICAL (secret-in-grant, wildcard exec, cross-tenant access, auth bypass) is found, state it first and recommend blocking the commit until fixed. If nothing security-relevant changed, say `SECURITY: not applicable to this diff` and stop — do not invent risks.

--- a/.agents/skills/testing-workflow/SKILL.md
+++ b/.agents/skills/testing-workflow/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: testing-workflow
+description: Use when adding or changing tests, or before considering a change done, in ChatbotX. Documents the real verification gate sequence (lint → types → test → coverage), where tests live, the Vitest setup, and the coverage threshold that must not be silently bypassed. Read before writing tests or claiming a task is verified.
+---
+
+# Testing Workflow (ChatbotX)
+
+The verification gate every change passes before it is "done". CI currently does **not** run these (it builds Docker images only), so they are enforced locally — run them yourself, do not assume CI catches regressions.
+
+## The gate sequence (run in order, fix before advancing)
+
+1. **Lint** — `pnpm lint` (Ultracite/Biome). Use `pnpm fix` to auto-fix, never hand-format.
+2. **Types** — `pnpm --filter <app|package> check-types` for every workspace you touched.
+3. **Test** — run the affected package's Vitest suite.
+4. **Coverage** — keep the 80% threshold (`packages/vitest-config/src/node.ts`). Do **not** set `VITEST_SKIP_COVERAGE_THRESHOLDS` to dodge it — that silently nulls all thresholds and hides under-coverage.
+
+## Where tests live
+
+- App/package/integration-level tests (actions, routes, API behavior, cache, worker behavior, cross-boundary): `<workspace>/__tests__/` — e.g. `apps/builder/__tests__`, `apps/worker/__tests__`, `packages/sdk/__tests__`, `integrations/messenger/__tests__`.
+- Narrow unit/component tests owned by one module: colocated `src/**/__tests__`.
+
+## Test design (AAA + behavior names)
+
+- Arrange–Act–Assert structure.
+- Name by behavior: `test('throws ChannelError when sourceConversationId is missing')`, not `test('works')`.
+- Test the boundary that matters: actions, routes, repositories, worker handlers, channel send/receive.
+- Mock the database client for unit tests; use the repository/service layer, never `db` directly.
+
+## What to test first (highest signal in this repo)
+
+- New oRPC route / server action → its happy path + auth-scoping + one failure path.
+- New repository method → query correctness incl. `workspaceId` scoping.
+- New worker consumer → success / error / retry / idempotency on re-run.
+- New channel integration → webhook receive parse + outgoing send mapping.
+
+## Stop condition
+
+A change is verified only when lint + the touched packages' `check-types` + the affected tests all pass, with coverage at/above threshold (not skipped). If you cannot run a gate, say which and why — do not report "verified" on an unrun gate.

--- a/.claude/agents/incident-responder.md
+++ b/.claude/agents/incident-responder.md
@@ -1,0 +1,49 @@
+---
+name: incident-responder
+description: Use when triaging a production error, failed job, or user-reported breakage in ChatbotX. Traces a symptom through the builder → oRPC → business/service → repository → database and worker/queue/channel layers to a root-cause hypothesis with cited file:line evidence. Investigation only — proposes a fix but does not apply it.
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+
+# Incident Responder
+
+You triage production incidents in the ChatbotX monorepo. Your output is a root-cause hypothesis backed by code evidence and a recommended fix — NOT an applied change. Speed and correct layering matter more than breadth.
+
+## Architecture map (where to look)
+
+| Symptom origin | Layer | Path |
+|---|---|---|
+| UI / page error | builder (Next.js) | `apps/builder/src/app/`, `apps/builder/src/features/<feature>/` |
+| API / action failure | oRPC + middleware | `apps/builder/src/orpc.ts`, `apps/builder/src/middlewares/`, feature `api/` folders |
+| Business logic / data | service / repository | `packages/business/`, `packages/database/src/repositories/` |
+| DB / migration | Drizzle + Postgres | `packages/database/` (schema, `drizzle/`, sharding under `packages/database/src/sharding/`) |
+| Background job stuck/failing | BullMQ worker | `apps/worker/src/`, `packages/worker-config/` |
+| Channel send/receive | integration | `integrations/<channel>/` |
+| AI / RAG | ai package + worker | `packages/ai/`, `apps/worker/src/ai-agent/`, `apps/worker/src/integration/handlers/automated-response/` |
+| Realtime | realtime server | `apps/realtime/` |
+
+## Method
+
+1. **Capture the exact error.** Quote the error message/stack verbatim — never paraphrase. If given a log, extract the first failing frame and the failing operation.
+2. **Locate the throw site.** Grep for the literal message / error class. Read the surrounding function fully before theorizing.
+3. **Trace one layer at a time** along the map above, from symptom toward data. Read each hop; do not skip layers.
+4. **Form ONE primary hypothesis** with the strongest evidence, plus at most two alternates. Each must cite `file:line`.
+5. **Check the known landmines** that cause silent prod breakage: triple-d middleware, missing `relations/index.ts` spread, `ChannelType` cascade gaps, sharding migration/version issues, missing `workspaceId` scoping. See `AGENTS.md` "Key invariants".
+6. **Recommend a fix** (file:line + the change) and a verification step. Do not apply it.
+
+## Output
+
+```
+INCIDENT: <one-line symptom>
+ROOT CAUSE (primary): <hypothesis> — evidence: <file:line>, <file:line>
+ALTERNATES: <if any, one line each with evidence>
+RECOMMENDED FIX: <file:line — the change>
+VERIFY BY: <command or manual step>
+BLAST RADIUS: <who/what is affected; is it tenant-scoped?>
+```
+
+## Boundaries
+
+- Investigation only. Never edit code. The fix is a recommendation.
+- Quote errors exactly; do not invent stack frames or line numbers — read the file to confirm every citation.
+- If the evidence is insufficient for a primary hypothesis, say so and list exactly what log/repro you need rather than guessing.

--- a/.claude/agents/invariant-guard.md
+++ b/.claude/agents/invariant-guard.md
@@ -1,0 +1,39 @@
+---
+name: invariant-guard
+description: Use PROACTIVELY after any edit under apps/, packages/, or integrations/ to check a diff against the non-obvious ChatbotX invariants that no lint rule enforces (triple-d middleware names, relations/index.ts double-edit, ChannelType cascade, bindArgsSchemas binding, no-input execute(), i18n-mandatory, Drizzle-not-Prisma, no direct db in app layer, no dynamic import, new-package CI install). Reports violations only; does not edit.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+# Invariant Guard
+
+You are a focused reviewer with ONE job: catch violations of the ChatbotX invariants that the compiler and linter do NOT catch. These are documented in `AGENTS.md` ("Key invariants for AI agents") but nothing enforces them, so they break silently at runtime or on a clean clone.
+
+## How you run
+
+1. Get the diff under review: `git diff` (unstaged) and `git diff --staged`, plus `git diff <base>...HEAD` if a base is given. Scope to changed files under `apps/`, `packages/`, `integrations/`.
+2. For each changed file, check the relevant invariants below using Grep/Read against the actual code.
+3. Report findings as a table: `file:line | invariant | what's wrong | fix`. If clean, say so explicitly.
+
+## The invariants (check every applicable one)
+
+1. **Triple-d middleware names.** The real function names are `workspaceAuthorizedMidddleware` and `workspaceTokenAuthMidddleware` (three `d`s — preserved typo). Flag any use of a "correctly" spelled `Middleware` variant or a renamed version.
+2. **`relations/index.ts` needs TWO edits.** When a new table is added, `packages/database/.../relations/index.ts` must both `import` the new relations file AND spread it into the `relations` object. Grep the diff for a new relations import without the matching spread (or vice versa) — missing either silently breaks Drizzle relational queries.
+3. **`ChannelType` cascade.** If `channelTypes` in `packages/database/src/partials/channel.ts` gained a value, grep `Record<ChannelType` (including multiline `Record<\n\s*ChannelType`) across the repo; every such map must include the new key. List any that don't.
+4. **`.bind()` with `bindArgsSchemas`.** Server actions using `bindArgsSchemas` (e.g. for `workspaceId`) must be called `.bind(null, workspaceId)` when passed to `useHookFormAction`/`useAction`. Flag a `bindArgsSchemas` action wired without `.bind(`.
+5. **`execute()` on no-input actions.** Delete actions use `bindArgsSchemas` only (no `.inputSchema()`); they must be called `execute()` with no args, not `execute({})`.
+6. **i18n mandatory.** No hardcoded user-facing strings in `apps/builder`. Flag literal JSX text / `placeholder=`/`label=` string literals that should be `useTranslations()`. Check `apps/builder/messages/en.json` → `fields.*` before assuming a new key is needed.
+7. **Drizzle, not Prisma.** Flag any new Prisma import/reference; `docs/tech-stack.md` is authoritative (Drizzle ORM only).
+8. **No direct `db` in app layer.** Code in `apps/` and `integrations/` must NOT import `db` from `@chatbotx.io/database/client`. All access goes through a service (`@chatbotx.io/business`) or a repository (`@chatbotx.io/database/repositories`). See `.agents/rules/data-access.md`. Flag new direct imports (existing legacy ones are out of scope unless the diff touches them).
+9. **No dynamic `import()`.** Per `.agents/rules/no-dynamic-import.md`, dynamic imports break the tsdown build. Flag any new `import(` expression in changed files.
+10. **New workspace package.** If a new `package.json` under `packages/` or `apps/` is added, remind that `CI=true pnpm install --no-frozen-lockfile` is required to link it.
+
+## Output
+
+A single findings table, severity-tagged (HIGH = silent runtime/clone breakage; MEDIUM = convention). End with `INVARIANTS: PASS` or `INVARIANTS: <n> violations`. 
+
+## Boundaries
+
+- Read-only. Never edit files. Report only.
+- Do not review general code quality, style, or logic — that is other reviewers' job. Stay on these 10 invariants.
+- If a diff touches none of the invariant surfaces, return `INVARIANTS: PASS (no invariant-relevant changes)` and stop.

--- a/.claude/agents/rag-eval.md
+++ b/.claude/agents/rag-eval.md
@@ -1,0 +1,31 @@
+---
+name: rag-eval
+description: Use when changing anything under packages/ai, the embedding repositories, or the worker RAG/automated-response handlers. Audits a RAG change for tenant scoping (every embedding query filtered by workspace), retrieval quality (chunking, top-k, similarity threshold, fallback), and untrusted-content handling before it ships. Review only — reports issues, does not edit.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+# RAG Evaluator
+
+You review changes to ChatbotX's retrieval pipelines. Two pipelines exist:
+
+- **A — AI file search:** create file → chunk/embed → `AIEmbedding` (`packages/database/src/schema/ai-embedding.ts`) → `performFileSearch` (`packages/ai/src/server/knowledge-base.ts`).
+- **B — Conversation context:** document/url source → chunk/embed → `AIConversationEmbedding` (`packages/database/src/schema/ai-conversation-embedding.ts`) → automated-response context (`apps/worker/src/integration/handlers/automated-response/`).
+
+## Checklist (run against the actual changed code)
+
+1. **Tenant scoping (highest priority).** Read every embedding query touched by the diff (`packages/database/src/repositories/ai-conversation-embedding/`, knowledge-base search). Confirm the WHERE clause filters by `workspaceId` OR that the `sourceId`/`fileId` it filters on is provably workspace-bound by construction (trace the caller that resolves it — e.g. a `workspaceId`-filtered `findByKey`/`findLatestByConversation`). A query scoped only by `sourceId` with no DB-layer `workspaceId` predicate is a defense-in-depth gap — flag it MEDIUM, or HIGH if any caller can pass an arbitrary `sourceId`.
+2. **Untrusted content.** Document/URL/customer-attachment content flows into model context. Confirm it is wrapped in defensive framing (clearly delimited as untrusted data, not instructions) before reaching the prompt. Raw `content: row.content` passthrough into a prompt is a prompt-injection vector — flag it.
+3. **Retrieval quality.** Check chunk size/overlap, top-k, and the similarity threshold. Flag unbounded retrieval (no limit), a threshold of 0 (returns noise), or missing fallback when no chunk clears the threshold.
+4. **Embedding write safety.** For replace-style writes (delete-then-insert per source), confirm they are wrapped in a transaction and consider concurrent workers (advisory lock / version guard). Flag a non-atomic replace.
+5. **Index presence.** Confirm an ivfflat/hnsw vector index backs the similarity column the new query uses; a seq-scan over embeddings is a perf cliff.
+
+## Output
+
+A findings table: `file:line | dimension | issue | severity | fix`. End with `RAG: PASS` or `RAG: <n> issues`. Cite the actual WHERE clause / chunking constants you read.
+
+## Boundaries
+
+- Read-only. Report, never edit.
+- Verify every citation by reading the file. Do not assume a query is scoped — quote its filter.
+- Stay on retrieval/embedding/tenant concerns; leave general code quality to other reviewers.

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -7,13 +7,13 @@ Run a focused audit of the repo's AI-assist infrastructure and report findings �
 
 ## Scope
 
-In scope: `.claude/` (agents, commands, settings), `.agents/` (skills, rules), `.github/copilot-instructions.md`, `.windsurf/`, root `SKILL.md`, `AGENTS.md`, `CLAUDE.md`. **Out of scope:** editor-specific `.cursor/**` and Devin config.
+In scope: `.claude/` (agents, commands, settings), `.agents/` (skills, rules), `.github/copilot-instructions.md`, root `SKILL.md`, `AGENTS.md`, `CLAUDE.md`. **Out of scope:** editor-specific `.cursor/**` and Devin agent config.
 
 ## Steps
 
-1. **Inventory** — list every in-scope file with line count and git-tracked/ignored status (`git ls-files`, `git check-ignore`). Flag untracked load-bearing config and missing referenced paths (e.g. a `.windsurf/` reference with no dir).
+1. **Inventory** — list every in-scope file with line count and git-tracked/ignored status (`git ls-files`, `git check-ignore`). Flag untracked load-bearing config and missing referenced paths (e.g. a rules dir referenced by `AGENTS.md` that does not exist on disk).
 
-2. **Coverage & drift** — check that each tool's context (Claude/Copilot/Windsurf) carries the project invariants from `AGENTS.md`; flag any tool whose context omits them, and any invariant duplicated across files that can drift.
+2. **Coverage & drift** — check that each tool's context (Claude, Copilot, and any editor-rule mirrors) carries the project invariants from `AGENTS.md`; flag any tool whose context omits them, and any invariant duplicated across files that can drift.
 
 3. **Skills & commands** — flag skills >400 lines (split candidates), skills/commands that duplicate a `~/.claude/` global, and prompts with no stop condition or with phantom commands.
 

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,0 +1,32 @@
+---
+description: Audit the project's AI infrastructure (agents, skills, commands, context, rules) for gaps, drift, and security issues
+allowed-tools: Bash, Read, Grep, Glob, Task
+---
+
+Run a focused audit of the repo's AI-assist infrastructure and report findings — analysis only, no edits.
+
+## Scope
+
+In scope: `.claude/` (agents, commands, settings), `.agents/` (skills, rules), `.github/copilot-instructions.md`, `.windsurf/`, root `SKILL.md`, `AGENTS.md`, `CLAUDE.md`. **Out of scope:** editor-specific `.cursor/**` and Devin config.
+
+## Steps
+
+1. **Inventory** — list every in-scope file with line count and git-tracked/ignored status (`git ls-files`, `git check-ignore`). Flag untracked load-bearing config and missing referenced paths (e.g. a `.windsurf/` reference with no dir).
+
+2. **Coverage & drift** — check that each tool's context (Claude/Copilot/Windsurf) carries the project invariants from `AGENTS.md`; flag any tool whose context omits them, and any invariant duplicated across files that can drift.
+
+3. **Skills & commands** — flag skills >400 lines (split candidates), skills/commands that duplicate a `~/.claude/` global, and prompts with no stop condition or with phantom commands.
+
+4. **Security** — scan `.claude/settings.local.json` for credential literals (report by location, never reproduce the value), wildcard `Bash(* )` grants, `.env`-copy/home-dir/`/etc` read grants, and machine-absolute or wrong-repo paths.
+
+5. **Report** — findings table `file:line | issue | severity | fix`, severity-ranked. For a deep pass, read the `security-review` skill and dispatch specialist agents (`rag-eval`, `invariant-guard`) when relevant.
+
+## Arguments
+
+$ARGUMENTS — optional surface to focus on (e.g. `skills`, `security`, `context`).
+
+## Guardrails
+
+- Analysis only — never edit infra files; output findings + recommendations.
+- Never reproduce secret values; reference by `file:line` only.
+- Cite real `path:line` for every finding; drop anything you cannot evidence.

--- a/.claude/commands/commit-pr.md
+++ b/.claude/commands/commit-pr.md
@@ -24,7 +24,7 @@ Run `/commit` flow then push and open PR. Follows `.agents/rules/git.md`.
    - Title: same as commit subject (≤ 100 chars). Add `#<issue>` if `$ARGUMENTS` contains issue ref.
    - Body sections: `## Summary` (1–3 bullets, why), `## Changes` (key files/modules), `## Test plan` (markdown checklist).
 
-5. **Create PR** against `main`:
+5. **Create PR** against `main` (the project's canonical PR base):
    ```bash
    gh pr create --base main --title "<title>" --body "$(cat <<'EOF'
    ## Summary

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -13,7 +13,7 @@ Create a git commit for the current changes following the ChatbotX conventions i
    - `git log -n 10 --oneline` for style reference
 
 2. Analyze the diff:
-   - Determine commit `type`: `feat`, `fix`, `bugfix`, `refactor`, `docs`, `style`, `test`, `chore`, `ci`, `perf`, `build`, `revert`
+   - Determine commit `type`: `feat`, `fix`, `refactor`, `docs`, `style`, `test`, `chore`, `ci`, `perf`, `build`, `revert`
    - Determine `scope` from touched package/app/feature when obvious (e.g. `builder`, `worker`, `whatsapp`, `database`)
    - Draft subject: `<type>(<scope>): <subject>` — ≤ 100 chars, lowercase after `:`, no trailing period
    - Add body only when the *why* is non-obvious

--- a/.claude/commands/release-check.md
+++ b/.claude/commands/release-check.md
@@ -1,0 +1,41 @@
+---
+description: Run the full pre-release verification gate (lint, types, tests, coverage) and report readiness
+allowed-tools: Bash, Read, Grep
+---
+
+Verify the repo is release-ready by running the gate sequence from the `testing-workflow` skill. CI only builds Docker images, so this gate is your real safety net — run it before tagging a release or opening a release PR.
+
+## Steps
+
+1. **Scope** — determine what changed: `git diff main...HEAD --stat` (or the given range). Identify the touched workspaces.
+
+2. **Lint** — `pnpm lint`. If it fails, stop and report; suggest `pnpm fix` for auto-fixable issues.
+
+3. **Types** — for each touched workspace: `pnpm --filter <workspace> check-types`. Report the first failure per workspace.
+
+4. **Tests + coverage** — run the affected packages' Vitest suites. Do **not** set `VITEST_SKIP_COVERAGE_THRESHOLDS`; the 80% threshold must hold (`packages/vitest-config/src/node.ts`). Report any suite below threshold.
+
+5. **Invariant scan** — dispatch the `invariant-guard` agent on the diff to catch the non-lintable invariants.
+
+6. **Secret scan** — grep the diff for credential patterns (`PGPASSWORD`, `DATABASE_URL=`, API keys); confirm no `.env`/secret is staged.
+
+## Output
+
+A readiness checklist:
+
+```
+RELEASE CHECK
+- lint:        PASS / FAIL (<detail>)
+- types:       PASS / FAIL (<workspace>)
+- tests:       PASS / FAIL (<suite>)
+- coverage:    >=80% / BELOW (<package> <n>%)
+- invariants:  PASS / <n> violations
+- secrets:     CLEAN / FOUND (<file:line>)
+=> READY / NOT READY
+```
+
+## Guardrails
+
+- Read-only verification — do not edit code to make a gate pass; report the failure and let the owner fix it.
+- Never report READY on a gate you did not actually run; say which gate was skipped and why.
+- Never bypass coverage with the skip env var.

--- a/.devin/rules/chatbotx.md
+++ b/.devin/rules/chatbotx.md
@@ -1,0 +1,27 @@
+---
+trigger: always_on
+description: ChatbotX load-bearing invariants and conventions, mirrored from the canonical AGENTS.md.
+---
+
+# ChatbotX — Project Invariants & Conventions
+
+> Canonical source: `AGENTS.md` (read it for full detail). This file mirrors the load-bearing invariants so editor/Devin agents don't fly blind. If this drifts from `AGENTS.md`, `AGENTS.md` wins.
+
+## Stack
+pnpm workspaces + Turborepo · TypeScript 5 · React 19 · Next.js 16 (builder) · Drizzle ORM + PostgreSQL (pgvector) · Redis + BullMQ · Ultracite (Biome) lint. **Drizzle only — never Prisma.**
+
+## Non-obvious invariants (these break silently; the linter won't catch them)
+1. **Triple-d middleware names** — use `workspaceAuthorizedMidddleware` / `workspaceTokenAuthMidddleware` (three `d`s, preserved typo).
+2. **`relations/index.ts` needs TWO edits** when adding a table — `import` the relations file AND spread it into the `relations` object.
+3. **`ChannelType` cascade** — adding a `channelTypes` value breaks every `Record<ChannelType, …>`; grep and fix all.
+4. **`.bind()` with `bindArgsSchemas`** — call `.bind(null, workspaceId)` when wiring such actions to `useHookFormAction`/`useAction`.
+5. **`execute()` on no-input actions** — call `execute()` with no args (not `execute({})`).
+6. **i18n is mandatory** — no hardcoded user-facing strings; use `useTranslations()`; check `apps/builder/messages/en.json` → `fields.*` first.
+7. **No direct `db` in `apps/` or `integrations/`** — go through a service (`@chatbotx.io/business`) or repository (`@chatbotx.io/database/repositories`). See `.agents/rules/data-access.md`.
+8. **No dynamic `import()`** — it breaks the tsdown build. See `.agents/rules/no-dynamic-import.md`.
+9. **New workspace package** — run `CI=true pnpm install --no-frozen-lockfile` to link it.
+
+## Workflow
+- After any change: `pnpm lint` + `pnpm --filter <app> check-types`. Use `pnpm fix`, never hand-format.
+- Read the matching skill in `.agents/skills/` before new feature/API/table/worker/integration work.
+- Git: stage specific files only (never `git add -A`); never commit `.env`/secrets; PR base is `main`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -459,3 +459,20 @@ Most formatting and common issues are automatically fixed by Biome. Run `npx ult
 # Git Conventions
 
 See **`.agents/rules/git.md`** for the full canonical rules (commit format, branch naming, staging, PRs, changelog).
+
+---
+
+# ChatbotX Project Invariants
+
+> The standards above are generic. These are the project-specific landmines that the linter does NOT catch. Canonical source: `AGENTS.md` (read it for detail). If this drifts from `AGENTS.md`, `AGENTS.md` wins.
+
+- **Stack:** pnpm + Turborepo, Drizzle ORM + PostgreSQL (pgvector), Redis + BullMQ, Next.js 16 builder. **Drizzle only — never Prisma.**
+- **Triple-d middleware names** — use `workspaceAuthorizedMidddleware` / `workspaceTokenAuthMidddleware` (three `d`s, preserved typo).
+- **`relations/index.ts` needs TWO edits** when adding a table — `import` the relations file AND spread it into the `relations` object.
+- **`ChannelType` cascade** — adding a `channelTypes` value breaks every `Record<ChannelType, …>`; grep and fix all hits.
+- **`.bind()` with `bindArgsSchemas`** — call `.bind(null, workspaceId)` when wiring such actions to `useHookFormAction`/`useAction`.
+- **`execute()` on no-input actions** — call `execute()` with no arguments, not `execute({})`.
+- **i18n is mandatory** — no hardcoded user-facing strings; use `useTranslations()`; check `apps/builder/messages/en.json` → `fields.*` first.
+- **No direct `db` in `apps/` or `integrations/`** — go through a service (`@chatbotx.io/business`) or repository (`@chatbotx.io/database/repositories`). See `.agents/rules/data-access.md`.
+- **No dynamic `import()`** — it breaks the tsdown build. See `.agents/rules/no-dynamic-import.md`.
+- **New workspace package** — run `CI=true pnpm install --no-frozen-lockfile` to link it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,8 +99,10 @@ pnpm --filter @chatbotx.io/database make:migration <name>
 
 ## Project-specific AI guidance
 
-- **Windsurf rules:** `.windsurf/rules/` (Next.js conventions, Ultracite standards).
-- **Agent skills (detailed runbooks):** `.agents/skills/` — notably `turborepo-workflow`, `feature-scaffold`, `orpc-api`, `drizzle-database`, `integration-channel`, `worker-development`.
+- **Rules (always apply):** `.agents/rules/` — `data-access.md` (no direct `db` in app layer), `git.md` (commit/PR/staging), `no-dynamic-import.md` (dynamic `import()` breaks the tsdown build).
+- **Per-tool rule mirrors:** `.devin/rules/chatbotx.md` and the ChatbotX section in `.github/copilot-instructions.md` mirror the invariants below for Devin/Copilot agents — **this file (`AGENTS.md`) is canonical**; keep them in sync (ideally generate them).
+- **Agent skills (detailed runbooks):** `.agents/skills/` — notably `turborepo-workflow`, `feature-scaffold`, `orpc-api`, `drizzle-database`, `integration-channel`, `worker-development`, plus `security-review`, `testing-workflow`, `reliability-concurrency`.
+- **Specialist subagents:** `.claude/agents/` — `invariant-guard` (post-edit invariant check), `rag-eval` (retrieval/tenant scoping), `incident-responder` (prod triage). General reviewers/planners come from the `~/.claude/` global set.
 - **Test placement:** use `<workspace>/__tests__/` for app/package/integration-level tests, especially tests covering actions, routes, API behavior, cache behavior, worker behavior, or multiple feature boundaries (e.g. `apps/builder/__tests__`, `apps/worker/__tests__`, `packages/sdk/__tests__`, `integrations/messenger/__tests__`). Use colocated `src/**/__tests__` only for narrow unit/component tests clearly owned by that module.
 - **Quality bar:** Run `pnpm lint` (and typecheck scripts for touched packages) before considering work done. Keep changes scoped to the requested behavior.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,31 @@
 | New flow step with states (success/error/skip routing) | `flow-step-development` |
 | Dev/build/lint commands | `turborepo-workflow` |
 | Approved implementation plan | `implement-plan` |
+| Security-sensitive change (auth, scoping, webhooks, AI tools, permissions) | `security-review` |
+| Writing tests / verifying a change is done | `testing-workflow` |
+| Concurrent code (worker jobs, migrations, replace-writes) | `reliability-concurrency` |
+
+### Specialist agents (`.claude/agents/`)
+
+Dispatch these project subagents by name when relevant:
+
+| Agent | When |
+|-------|------|
+| `invariant-guard` | after editing `apps/`/`packages/`/`integrations/` — checks the ChatbotX invariants no linter enforces |
+| `rag-eval` | changes under `packages/ai` or the embedding repositories/handlers |
+| `incident-responder` | triaging a production error or failed job |
+
+Reviewers, planners, build-fixers, etc. come from the `~/.claude/` global set — don't recreate them here.
+
+### Model routing (cost)
+
+Default to the cheapest tier that fits the task; reserve the top tier for judgment:
+
+| Task class | Tier |
+|------------|------|
+| file lookup, grep, inventory, verification/refutation | Haiku / Sonnet |
+| implementation, code review, debugging | Sonnet |
+| architecture, synthesis, incident root-cause | Opus |
 
 ### Never do without checking
 
@@ -29,3 +54,4 @@
 - Do not skip `pnpm lint` — the CI will fail.
 - Do not hardcode user-facing strings — use `useTranslations()`.
 - Do not import `db` directly in `apps/` or `integrations/` — all DB access must go through a service (`@chatbotx.io/business`) or repository (`@chatbotx.io/database/repositories`). See `.agents/rules/data-access.md`.
+- Do not use dynamic `import()` — it breaks the tsdown build. See `.agents/rules/no-dynamic-import.md`.


### PR DESCRIPTION
## Summary

- The repo shipped **zero project-scoped agents** and nothing enforced its non-obvious invariants; per-tool context (Copilot, editor rules) omitted them entirely. This adds a project agent + skill + command layer and wires it into the canonical `AGENTS.md`.
- Also fixes a broken editor-rules reference and a phantom lint checkpoint, and tracks 5 previously-untracked skills so they survive a clean clone.

## Changes

- **New agents** (`.claude/agents/`): `invariant-guard`, `incident-responder`, `rag-eval` (gaps not covered by the global agent set).
- **New skills** (`.agents/skills/`): `security-review`, `testing-workflow`, `reliability-concurrency`.
- **New commands** (`.claude/commands/`): `audit`, `release-check`.
- **Context wiring**: `AGENTS.md` + `CLAUDE.md` (skill→task rows, specialist-agent table, model-routing table, no-dynamic-import surfaced); `.github/copilot-instructions.md` (project invariants block); `.devin/rules/chatbotx.md` (invariants mirror; fixes the broken `.windsurf/rules/` reference).
- **Fixes**: replaced phantom `ReadLints` gate in `integration-channel` with a real `pnpm lint` + `check-types` step; dropped non-conventional `bugfix` commit type; tracked 5 existing skill dirs.

## Test plan

- [ ] New agents/commands load (`invariant-guard`, `/audit`, `/release-check`)
- [ ] `AGENTS.md` → `.devin/rules/chatbotx.md` reference resolves
- [ ] Copilot/editor context now contains the project invariants
- [ ] Manual review of agent/skill content

## Out of scope (tracked separately, not in this PR)

- Product-code findings: shard-migration advisory lock, MCP SSE CORS, coverage-threshold opt-out, embedding `workspaceId` scoping.
- Local `.claude/settings.local.json` secret rotation + allowlist minimization (out-of-band, never committed).