### PR TITLE
test(broadcast,sequence): add unit coverage + fix surfaced bugs

### DIFF
--- a/apps/builder/__tests__/create-broadcast.action.test.ts
+++ b/apps/builder/__tests__/create-broadcast.action.test.ts
@@ -1,0 +1,353 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+  mockDbInsert,
+  mockInsertReturning,
+  mockInsertValues,
+  mockFlowFindFirst,
+  mockMessengerTemplateFindFirst,
+  mockWhatsappTemplateFindFirst,
+  mockReturnValidationErrors,
+} = vi.hoisted(() => {
+  const mockInsertReturning = vi.fn()
+  const mockInsertValues = vi.fn()
+  mockInsertValues.mockReturnValue({ returning: mockInsertReturning })
+  const mockDbInsert = vi.fn()
+  mockDbInsert.mockReturnValue({ values: mockInsertValues })
+
+  const mockReturnValidationErrors = vi.fn(
+    (_schema: unknown, errs: unknown) => ({ __validationError: errs }),
+  )
+
+  return {
+    mockDbInsert,
+    mockInsertReturning,
+    mockInsertValues,
+    mockFlowFindFirst: vi.fn(),
+    mockMessengerTemplateFindFirst: vi.fn(),
+    mockWhatsappTemplateFindFirst: vi.fn(),
+    mockReturnValidationErrors,
+  }
+})
+
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, unknown> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.inputSchema = () => chain
+  chain.action = (fn: unknown) => fn
+  return { workspaceActionClient: chain }
+})
+
+vi.mock("next-safe-action", () => ({
+  returnValidationErrors: mockReturnValidationErrors,
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      flowModel: { findFirst: mockFlowFindFirst },
+      messengerMessageTemplateModel: {
+        findFirst: mockMessengerTemplateFindFirst,
+      },
+      whatsappMessageTemplateModel: {
+        findFirst: mockWhatsappTemplateFindFirst,
+      },
+    },
+    insert: mockDbInsert,
+  },
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  broadcastModel: { _: "broadcastModel" },
+}))
+
+const { createBroadcastAction } = await import(
+  "../src/features/broadcasts/actions/create-broadcast.action"
+)
+
+const WORKSPACE_ID = "ws-1"
+
+const baseInput = {
+  channel: "whatsapp" as const,
+  subaction: "flow" as const,
+  schedulesType: "now" as const,
+  schedulesAt: null,
+  contactFilter: null,
+}
+
+describe("createBroadcastAction — flowId validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInsertValues.mockReturnValue({ returning: mockInsertReturning })
+    mockDbInsert.mockReturnValue({ values: mockInsertValues })
+  })
+
+  test("returns validation error when flowId provided but flow not found", async () => {
+    mockFlowFindFirst.mockResolvedValue(undefined)
+
+    const result = await (
+      createBroadcastAction as (props: unknown) => Promise<unknown>
+    )({
+      bindArgsParsedInputs: [WORKSPACE_ID],
+      parsedInput: { ...baseInput, flowId: "flow-123" },
+    })
+
+    expect(mockReturnValidationErrors).toHaveBeenCalledOnce()
+    const [, errors] = mockReturnValidationErrors.mock.calls[0] as [
+      unknown,
+      { flowId: { _errors: string[] } },
+    ]
+    expect(errors.flowId._errors).toContain("Flow not found")
+    expect(result).toMatchObject({ __validationError: expect.anything() })
+  })
+
+  test("sets broadcastName to flow.name when flow is found", async () => {
+    const mockFlow = { id: "flow-123", name: "My Flow" }
+    mockFlowFindFirst.mockResolvedValue(mockFlow)
+    const mockBroadcast = { id: "bc-1", name: "My Flow" }
+    mockInsertReturning.mockResolvedValue([mockBroadcast])
+
+    await (createBroadcastAction as (props: unknown) => Promise<unknown>)({
+      bindArgsParsedInputs: [WORKSPACE_ID],
+      parsedInput: { ...baseInput, flowId: "flow-123" },
+    })
+
+    const insertedValues = mockInsertValues.mock.calls[0]?.[0] as {
+      name: string
+    }
+    expect(insertedValues.name).toBe("My Flow")
+  })
+})
+
+describe("createBroadcastAction — messenger template validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInsertValues.mockReturnValue({ returning: mockInsertReturning })
+    mockDbInsert.mockReturnValue({ values: mockInsertValues })
+  })
+
+  test("returns validation error when messenger template not found", async () => {
+    mockMessengerTemplateFindFirst.mockResolvedValue(undefined)
+
+    const result = await (
+      createBroadcastAction as (props: unknown) => Promise<unknown>
+    )({
+      bindArgsParsedInputs: [WORKSPACE_ID],
+      parsedInput: {
+        ...baseInput,
+        channel: "messenger",
+        templateId: "tpl-1",
+        integrationMessengerId: "int-1",
+      },
+    })
+
+    expect(mockReturnValidationErrors).toHaveBeenCalledOnce()
+    const [, errors] = mockReturnValidationErrors.mock.calls[0] as [
+      unknown,
+      { templateId: { _errors: string[] } },
+    ]
+    expect(errors.templateId._errors).toContain("Template not found")
+    expect(result).toMatchObject({ __validationError: expect.anything() })
+  })
+
+  test("sets broadcastName to template.name when messenger template found", async () => {
+    const mockTemplate = { id: "tpl-1", name: "Promo Template" }
+    mockMessengerTemplateFindFirst.mockResolvedValue(mockTemplate)
+    const mockBroadcast = { id: "bc-2", name: "Promo Template" }
+    mockInsertReturning.mockResolvedValue([mockBroadcast])
+
+    await (createBroadcastAction as (props: unknown) => Promise<unknown>)({
+      bindArgsParsedInputs: [WORKSPACE_ID],
+      parsedInput: {
+        ...baseInput,
+        channel: "messenger",
+        templateId: "tpl-1",
+        integrationMessengerId: "int-1",
+      },
+    })
+
+    const insertedValues = mockInsertValues.mock.calls[0]?.[0] as {
+      name: string
+    }
+    expect(insertedValues.name).toBe("Promo Template")
+  })
+})
+
+describe("createBroadcastAction — whatsapp template validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInsertValues.mockReturnValue({ returning: mockInsertReturning })
+    mockDbInsert.mockReturnValue({ values: mockInsertValues })
+  })
+
+  test("returns validation error when whatsapp template not found", async () => {
+    mockWhatsappTemplateFindFirst.mockResolvedValue(undefined)
+
+    const result = await (
+      createBroadcastAction as (props: unknown) => Promise<unknown>
+    )({
+      bindArgsParsedInputs: [WORKSPACE_ID],
+      parsedInput: {
+        ...baseInput,
+        channel: "whatsapp",
+        templateId: "tpl-2",
+        integrationWhatsappId: "wa-int-1",
+      },
+    })
+
+    expect(mockReturnValidationErrors).toHaveBeenCalledOnce()
+    const [, errors] = mockReturnValidationErrors.mock.calls[0] as [
+      unknown,
+      { templateId: { _errors: string[] } },
+    ]
+    expect(errors.templateId._errors).toContain("Template not found")
+    expect(result).toMatchObject({ __validationError: expect.anything() })
+  })
+
+  test("sets broadcastName to template.name when whatsapp template found", async () => {
+    const mockTemplate = { id: "tpl-2", name: "WA Promo" }
+    mockWhatsappTemplateFindFirst.mockResolvedValue(mockTemplate)
+    const mockBroadcast = { id: "bc-3", name: "WA Promo" }
+    mockInsertReturning.mockResolvedValue([mockBroadcast])
+
+    await (createBroadcastAction as (props: unknown) => Promise<unknown>)({
+      bindArgsParsedInputs: [WORKSPACE_ID],
+      parsedInput: {
+        ...baseInput,
+        channel: "whatsapp",
+        templateId: "tpl-2",
+        integrationWhatsappId: "wa-int-1",
+      },
+    })
+
+    const insertedValues = mockInsertValues.mock.calls[0]?.[0] as {
+      name: string
+    }
+    expect(insertedValues.name).toBe("WA Promo")
+  })
+})
+
+describe("createBroadcastAction — happy path insert", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInsertValues.mockReturnValue({ returning: mockInsertReturning })
+    mockDbInsert.mockReturnValue({ values: mockInsertValues })
+  })
+
+  test("inserts with status 'scheduled' and returns the broadcast", async () => {
+    const mockBroadcast = { id: "bc-4", name: "Broadcast", status: "scheduled" }
+    mockInsertReturning.mockResolvedValue([mockBroadcast])
+
+    const result = await (
+      createBroadcastAction as (props: unknown) => Promise<unknown>
+    )({
+      bindArgsParsedInputs: [WORKSPACE_ID],
+      parsedInput: { ...baseInput, flowId: undefined, templateId: undefined },
+    })
+
+    const insertedValues = mockInsertValues.mock.calls[0]?.[0] as {
+      status: string
+      workspaceId: string
+    }
+    expect(insertedValues.status).toBe("scheduled")
+    expect(insertedValues.workspaceId).toBe(WORKSPACE_ID)
+    expect(result).toBe(mockBroadcast)
+  })
+
+  test("strips integrationMessengerId from insert values", async () => {
+    const mockBroadcast = { id: "bc-5", name: "Broadcast" }
+    mockInsertReturning.mockResolvedValue([mockBroadcast])
+
+    await (createBroadcastAction as (props: unknown) => Promise<unknown>)({
+      bindArgsParsedInputs: [WORKSPACE_ID],
+      parsedInput: {
+        ...baseInput,
+        channel: "messenger",
+        integrationMessengerId: "int-999",
+      },
+    })
+
+    const insertedValues = mockInsertValues.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >
+    expect(insertedValues).not.toHaveProperty("integrationMessengerId")
+  })
+
+  test("merges templateData with buttons when templateData is provided", async () => {
+    const mockBroadcast = { id: "bc-6", name: "Broadcast" }
+    mockInsertReturning.mockResolvedValue([mockBroadcast])
+
+    const templateData = { language: "en", components: [] }
+    const buttons = [{ id: "btn-1", label: "Click me" }]
+
+    await (createBroadcastAction as (props: unknown) => Promise<unknown>)({
+      bindArgsParsedInputs: [WORKSPACE_ID],
+      parsedInput: {
+        ...baseInput,
+        templateData,
+        buttons,
+      },
+    })
+
+    const insertedValues = mockInsertValues.mock.calls[0]?.[0] as {
+      templateData: Record<string, unknown>
+    }
+    expect(insertedValues.templateData).toMatchObject({
+      language: "en",
+      components: [],
+      buttons: [{ id: "btn-1", label: "Click me" }],
+    })
+  })
+
+  test("sets templateData to null when no templateData is provided", async () => {
+    const mockBroadcast = { id: "bc-7", name: "Broadcast" }
+    mockInsertReturning.mockResolvedValue([mockBroadcast])
+
+    await (createBroadcastAction as (props: unknown) => Promise<unknown>)({
+      bindArgsParsedInputs: [WORKSPACE_ID],
+      parsedInput: { ...baseInput },
+    })
+
+    const insertedValues = mockInsertValues.mock.calls[0]?.[0] as {
+      templateData: null
+    }
+    expect(insertedValues.templateData).toBeNull()
+  })
+
+  test("schedulesAt is set to startOfMinute of the provided date string", async () => {
+    const mockBroadcast = { id: "bc-8" }
+    mockInsertReturning.mockResolvedValue([mockBroadcast])
+
+    const schedulesAt = "2030-06-01T12:34:56.789Z"
+
+    await (createBroadcastAction as (props: unknown) => Promise<unknown>)({
+      bindArgsParsedInputs: [WORKSPACE_ID],
+      parsedInput: { ...baseInput, schedulesAt },
+    })
+
+    const insertedValues = mockInsertValues.mock.calls[0]?.[0] as {
+      schedulesAt: Date
+    }
+    expect(insertedValues.schedulesAt.getSeconds()).toBe(0)
+    expect(insertedValues.schedulesAt.getMilliseconds()).toBe(0)
+    expect(insertedValues.schedulesAt.getMinutes()).toBe(34)
+  })
+
+  test("uses default name 'Broadcast' when no flowId or templateId", async () => {
+    const mockBroadcast = { id: "bc-9" }
+    mockInsertReturning.mockResolvedValue([mockBroadcast])
+
+    await (createBroadcastAction as (props: unknown) => Promise<unknown>)({
+      bindArgsParsedInputs: [WORKSPACE_ID],
+      parsedInput: { ...baseInput },
+    })
+
+    const insertedValues = mockInsertValues.mock.calls[0]?.[0] as {
+      name: string
+    }
+    expect(insertedValues.name).toBe("Broadcast")
+  })
+})

--- a/apps/builder/__tests__/create-sequence.action.test.ts
+++ b/apps/builder/__tests__/create-sequence.action.test.ts
@@ -1,0 +1,244 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+  mockInsertValues,
+  mockInsert,
+  mockIsDatabaseError,
+  mockReturnValidationErrors,
+  mockGetTranslations,
+  mockCreateId,
+  mockCreateSequenceRequest,
+} = vi.hoisted(() => {
+  const mockInsertValues = vi.fn().mockResolvedValue(undefined)
+  const mockInsert = vi.fn().mockReturnValue({ values: mockInsertValues })
+
+  return {
+    mockInsertValues,
+    mockInsert,
+    mockIsDatabaseError: vi.fn().mockReturnValue(false),
+    mockReturnValidationErrors: vi
+      .fn()
+      .mockReturnValue({ __validationError: true }),
+    mockGetTranslations: vi.fn().mockResolvedValue((k: string) => k),
+    mockCreateId: vi.fn().mockReturnValue("test-id"),
+    mockCreateSequenceRequest: { __schema: "createSequenceRequest" },
+  }
+})
+
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, unknown> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.inputSchema = () => chain
+  chain.action = (fn: unknown) => fn
+  return { workspaceActionClient: chain }
+})
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: { insert: mockInsert },
+  isDatabaseError: mockIsDatabaseError,
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  sequenceModel: { id: "id", name: "name", workspaceId: "workspaceId" },
+}))
+
+vi.mock("@chatbotx.io/utils", () => ({
+  createId: mockCreateId,
+}))
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: mockGetTranslations,
+}))
+
+vi.mock("next-safe-action", () => ({
+  returnValidationErrors: mockReturnValidationErrors,
+}))
+
+vi.mock("@/features/common/schemas", () => ({
+  workspaceIdrequestParams: [],
+}))
+
+vi.mock("@/features/sequences/schema/action", () => ({
+  createSequenceRequest: mockCreateSequenceRequest,
+}))
+
+const { createSequenceAction } = await import(
+  "../src/features/sequences/actions/create-sequence.action"
+)
+
+// With the safe-action chain mock, the exported action IS the raw handler.
+type Handler = (args: {
+  bindArgsParsedInputs: [string]
+  parsedInput: { name: string; folderId?: string | null }
+}) => Promise<unknown>
+
+const callAction = createSequenceAction as unknown as Handler
+
+const WS = "ws-1"
+
+describe("createSequenceAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInsert.mockReturnValue({ values: mockInsertValues })
+    mockInsertValues.mockResolvedValue(undefined)
+    mockIsDatabaseError.mockReturnValue(false)
+    mockGetTranslations.mockResolvedValue((k: string) => k)
+    mockCreateId.mockReturnValue("test-id")
+    mockReturnValidationErrors.mockReturnValue({ __validationError: true })
+  })
+
+  describe("happy path", () => {
+    test("inserts sequence with correct fields and returns sequenceId", async () => {
+      // Arrange
+      const parsedInput = { name: "My Sequence", folderId: null }
+
+      // Act
+      const result = await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput,
+      })
+
+      // Assert
+      expect(mockInsert).toHaveBeenCalledTimes(1)
+      expect(mockInsertValues).toHaveBeenCalledWith({
+        id: "test-id",
+        workspaceId: WS,
+        name: "My Sequence",
+        folderId: null,
+      })
+      expect(result).toEqual({ sequenceId: "test-id" })
+    })
+
+    test("uses createId result as the new sequence id", async () => {
+      // Arrange
+      mockCreateId.mockReturnValue("custom-id")
+
+      // Act
+      const result = await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { name: "Seq" },
+      })
+
+      // Assert
+      expect(mockCreateId).toHaveBeenCalledTimes(1)
+      expect((result as { sequenceId: string }).sequenceId).toBe("custom-id")
+    })
+
+    test("stores folderId as null when parsedInput.folderId is undefined", async () => {
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { name: "Seq" },
+      })
+
+      // Assert
+      const arg = mockInsertValues.mock.calls[0]?.[0] as { folderId: unknown }
+      expect(arg.folderId).toBeNull()
+    })
+
+    test("stores folderId as null when parsedInput.folderId is explicitly null", async () => {
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { name: "Seq", folderId: null },
+      })
+
+      // Assert
+      const arg = mockInsertValues.mock.calls[0]?.[0] as { folderId: unknown }
+      expect(arg.folderId).toBeNull()
+    })
+
+    test("passes folderId through when a non-null value is provided", async () => {
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { name: "Seq", folderId: "folder-99" },
+      })
+
+      // Assert
+      const arg = mockInsertValues.mock.calls[0]?.[0] as { folderId: unknown }
+      expect(arg.folderId).toBe("folder-99")
+    })
+  })
+
+  describe("unique violation (23505)", () => {
+    test("returns returnValidationErrors result on duplicate name", async () => {
+      // Arrange
+      const dbError = Object.assign(new Error("unique violation"), {
+        cause: { code: "23505" },
+      })
+      mockInsertValues.mockRejectedValue(dbError)
+      mockIsDatabaseError.mockReturnValue(true)
+
+      // Act
+      const result = await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { name: "Duplicate", folderId: null },
+      })
+
+      // Assert
+      expect(mockReturnValidationErrors).toHaveBeenCalledTimes(1)
+      expect(result).toEqual({ __validationError: true })
+    })
+
+    test("calls returnValidationErrors with the createSequenceRequest schema", async () => {
+      // Arrange
+      const dbError = Object.assign(new Error("unique violation"), {
+        cause: { code: "23505" },
+      })
+      mockInsertValues.mockRejectedValue(dbError)
+      mockIsDatabaseError.mockReturnValue(true)
+
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { name: "Duplicate" },
+      })
+
+      // Assert — first argument is the schema, second is the errors object
+      const [schema, errors] = mockReturnValidationErrors.mock.calls[0] as [
+        unknown,
+        Record<string, unknown>,
+      ]
+      expect(schema).toBe(mockCreateSequenceRequest)
+      expect(errors).toHaveProperty("_errors")
+      expect(errors).toHaveProperty("name._errors")
+    })
+  })
+
+  describe("non-23505 DB errors", () => {
+    test("throws 'Failed to create sequence' for non-23505 DB errors", async () => {
+      // Arrange
+      const dbError = Object.assign(new Error("other db"), {
+        cause: { code: "XXXXX" },
+      })
+      mockInsertValues.mockRejectedValue(dbError)
+      mockIsDatabaseError.mockReturnValue(true)
+
+      // Act & Assert
+      await expect(
+        callAction({
+          bindArgsParsedInputs: [WS],
+          parsedInput: { name: "Seq", folderId: null },
+        }),
+      ).rejects.toThrow("Failed to create sequence")
+      expect(mockReturnValidationErrors).not.toHaveBeenCalled()
+    })
+
+    test("throws 'Failed to create sequence' for non-DB errors", async () => {
+      // Arrange
+      mockInsertValues.mockRejectedValue(new Error("network error"))
+      mockIsDatabaseError.mockReturnValue(false)
+
+      // Act & Assert
+      await expect(
+        callAction({
+          bindArgsParsedInputs: [WS],
+          parsedInput: { name: "Seq", folderId: null },
+        }),
+      ).rejects.toThrow("Failed to create sequence")
+    })
+  })
+})

--- a/apps/builder/__tests__/delete-sequence-step.action.test.ts
+++ b/apps/builder/__tests__/delete-sequence-step.action.test.ts
@@ -1,0 +1,216 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+  mockDeleteWhere,
+  mockDelete,
+  mockFindOrFail,
+  mockFindFirst,
+  mockRecalculateAllContactsInSequence,
+} = vi.hoisted(() => {
+  const mockDeleteWhere = vi.fn().mockResolvedValue(undefined)
+  const mockDelete = vi.fn().mockReturnValue({ where: mockDeleteWhere })
+  const mockFindFirst = vi.fn()
+
+  return {
+    mockDeleteWhere,
+    mockDelete,
+    mockFindOrFail: vi.fn().mockResolvedValue(undefined),
+    mockFindFirst,
+    mockRecalculateAllContactsInSequence: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, unknown> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.inputSchema = () => chain
+  chain.action = (fn: unknown) => fn
+  return { workspaceActionClient: chain }
+})
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      sequenceStepModel: { findFirst: mockFindFirst },
+    },
+    delete: mockDelete,
+  },
+  eq: (a: unknown, b: unknown) => ({ eq: [a, b] }),
+  findOrFail: mockFindOrFail,
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  sequenceModel: { id: "id", workspaceId: "workspaceId" },
+  sequenceStepModel: { id: "id" },
+}))
+
+vi.mock("@/features/common/schemas", () => ({
+  workspaceIdrequestParams: [],
+}))
+
+vi.mock("@/features/contact-sequences/utils/calculate-next-run-at", () => ({
+  recalculateAllContactsInSequence: mockRecalculateAllContactsInSequence,
+}))
+
+const { deleteSequenceStepAction } = await import(
+  "../src/features/sequences/actions/delete-sequence-step.action"
+)
+
+// With the safe-action chain mock, the exported action IS the raw handler.
+type ActionHandler = (args: {
+  bindArgsParsedInputs: [string]
+  parsedInput: { stepId: string; sequenceId: string }
+}) => Promise<unknown>
+
+const callAction = deleteSequenceStepAction as unknown as ActionHandler
+
+const WS = "ws-1"
+const SEQ_ID = "seq-1"
+const STEP_ID = "step-1"
+
+/** Helper to produce a step object with the given workspace on its parent sequence */
+const makeStep = (workspaceId = WS) => ({
+  id: STEP_ID,
+  sequence: { workspaceId },
+})
+
+describe("deleteSequenceStepAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDelete.mockReturnValue({ where: mockDeleteWhere })
+    mockDeleteWhere.mockResolvedValue(undefined)
+    mockFindOrFail.mockResolvedValue(undefined)
+    mockFindFirst.mockResolvedValue(makeStep())
+    mockRecalculateAllContactsInSequence.mockResolvedValue(undefined)
+  })
+
+  describe("happy path", () => {
+    test("validates sequence ownership, deletes step, and recalculates contacts", async () => {
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { stepId: STEP_ID, sequenceId: SEQ_ID },
+      })
+
+      // Assert
+      expect(mockFindOrFail).toHaveBeenCalledTimes(1)
+      expect(mockFindFirst).toHaveBeenCalledTimes(1)
+      expect(mockDelete).toHaveBeenCalledTimes(1)
+      expect(mockRecalculateAllContactsInSequence).toHaveBeenCalledTimes(1)
+    })
+
+    test("returns { success: true }", async () => {
+      // Act
+      const result = await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { stepId: STEP_ID, sequenceId: SEQ_ID },
+      })
+
+      // Assert
+      expect(result).toEqual({ success: true })
+    })
+
+    test("calls findOrFail with sequenceId and workspaceId for ownership validation", async () => {
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { stepId: STEP_ID, sequenceId: SEQ_ID },
+      })
+
+      // Assert
+      const args = mockFindOrFail.mock.calls[0]?.[0] as {
+        where: { id: string; workspaceId: string }
+        message: string
+      }
+      expect(args.where.id).toBe(SEQ_ID)
+      expect(args.where.workspaceId).toBe(WS)
+      expect(args.message).toBe("Sequence not found")
+    })
+
+    test("calls recalculateAllContactsInSequence with sequenceId and workspaceId", async () => {
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { stepId: STEP_ID, sequenceId: SEQ_ID },
+      })
+
+      // Assert
+      expect(mockRecalculateAllContactsInSequence).toHaveBeenCalledWith(
+        SEQ_ID,
+        WS,
+      )
+    })
+
+    test("queries step with the provided stepId", async () => {
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { stepId: STEP_ID, sequenceId: SEQ_ID },
+      })
+
+      // Assert
+      const findArgs = mockFindFirst.mock.calls[0]?.[0] as {
+        where: { id: string }
+        with: { sequence: boolean }
+      }
+      expect(findArgs.where.id).toBe(STEP_ID)
+      expect(findArgs.with.sequence).toBe(true)
+    })
+  })
+
+  describe("sequence not found", () => {
+    test("throws when findOrFail rejects and does not delete or recalculate", async () => {
+      // Arrange
+      mockFindOrFail.mockRejectedValue(new Error("Sequence not found"))
+
+      // Act & Assert
+      await expect(
+        callAction({
+          bindArgsParsedInputs: [WS],
+          parsedInput: { stepId: STEP_ID, sequenceId: SEQ_ID },
+        }),
+      ).rejects.toThrow("Sequence not found")
+
+      expect(mockDelete).not.toHaveBeenCalled()
+      expect(mockRecalculateAllContactsInSequence).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("step not found", () => {
+    test("throws 'Step not found' when db query returns null", async () => {
+      // Arrange
+      mockFindFirst.mockResolvedValue(null)
+
+      // Act & Assert
+      await expect(
+        callAction({
+          bindArgsParsedInputs: [WS],
+          parsedInput: { stepId: STEP_ID, sequenceId: SEQ_ID },
+        }),
+      ).rejects.toThrow("Step not found")
+
+      expect(mockDelete).not.toHaveBeenCalled()
+      expect(mockRecalculateAllContactsInSequence).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("workspace mismatch", () => {
+    test("throws unauthorized error when step belongs to a different workspace", async () => {
+      // Arrange
+      mockFindFirst.mockResolvedValue(makeStep("other-workspace"))
+
+      // Act & Assert
+      await expect(
+        callAction({
+          bindArgsParsedInputs: [WS],
+          parsedInput: { stepId: STEP_ID, sequenceId: SEQ_ID },
+        }),
+      ).rejects.toThrow("Unauthorized: Step does not belong to this workspace")
+
+      expect(mockDelete).not.toHaveBeenCalled()
+      expect(mockRecalculateAllContactsInSequence).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/builder/__tests__/delete-sequence.action.test.ts
+++ b/apps/builder/__tests__/delete-sequence.action.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockDeleteWhere, mockDelete, mockFindOrFail } = vi.hoisted(() => {
+  const mockDeleteWhere = vi.fn().mockResolvedValue(undefined)
+  const mockDelete = vi.fn().mockReturnValue({ where: mockDeleteWhere })
+
+  return {
+    mockDeleteWhere,
+    mockDelete,
+    mockFindOrFail: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, unknown> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.inputSchema = () => chain
+  chain.action = (fn: unknown) => fn
+  return { workspaceActionClient: chain }
+})
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  and: (...args: unknown[]) => ({ and: args }),
+  db: { delete: mockDelete },
+  eq: (a: unknown, b: unknown) => ({ eq: [a, b] }),
+  findOrFail: mockFindOrFail,
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  sequenceModel: { id: "id", workspaceId: "workspaceId" },
+}))
+
+const { deleteSequenceAction, deleteSequence } = await import(
+  "../src/features/sequences/actions/delete-sequence.action"
+)
+
+// deleteSequenceAction uses bindArgsSchemas ONLY (no inputSchema).
+// With the safe-action chain mock the exported value is the raw handler.
+type ActionHandler = (args: {
+  bindArgsParsedInputs: [string, string]
+}) => Promise<unknown>
+
+const callAction = deleteSequenceAction as unknown as ActionHandler
+
+const WS = "ws-1"
+const SEQ_ID = "seq-1"
+
+describe("deleteSequenceAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDelete.mockReturnValue({ where: mockDeleteWhere })
+    mockDeleteWhere.mockResolvedValue(undefined)
+    mockFindOrFail.mockResolvedValue(undefined)
+  })
+
+  describe("happy path", () => {
+    test("calls findOrFail and db.delete for a valid sequence", async () => {
+      // Act
+      await callAction({ bindArgsParsedInputs: [WS, SEQ_ID] })
+
+      // Assert
+      expect(mockFindOrFail).toHaveBeenCalledTimes(1)
+      expect(mockDelete).toHaveBeenCalledTimes(1)
+    })
+
+    test("calls findOrFail with workspace-scoped where clause", async () => {
+      // Act
+      await callAction({ bindArgsParsedInputs: [WS, SEQ_ID] })
+
+      // Assert
+      const args = mockFindOrFail.mock.calls[0]?.[0] as {
+        where: { id: string; workspaceId: string }
+        message: string
+      }
+      expect(args.where.id).toBe(SEQ_ID)
+      expect(args.where.workspaceId).toBe(WS)
+      expect(args.message).toBe("Sequence not found")
+    })
+
+    test("calls db.delete after successful findOrFail", async () => {
+      // Act
+      await callAction({ bindArgsParsedInputs: [WS, SEQ_ID] })
+
+      // Assert – order: findOrFail is invoked before delete
+      const findOrFailOrder = mockFindOrFail.mock.invocationCallOrder[0] ?? -1
+      const deleteOrder = mockDelete.mock.invocationCallOrder[0] ?? -2
+      expect(findOrFailOrder).toBeLessThan(deleteOrder)
+    })
+  })
+
+  describe("sequence not found", () => {
+    test("propagates findOrFail error and does not call db.delete", async () => {
+      // Arrange
+      mockFindOrFail.mockRejectedValue(new Error("Sequence not found"))
+
+      // Act & Assert
+      await expect(
+        callAction({ bindArgsParsedInputs: [WS, SEQ_ID] }),
+      ).rejects.toThrow("Sequence not found")
+      expect(mockDelete).not.toHaveBeenCalled()
+    })
+
+    test("does not call db.delete.where when findOrFail throws", async () => {
+      // Arrange
+      mockFindOrFail.mockRejectedValue(new Error("not found"))
+
+      // Act
+      await callAction({ bindArgsParsedInputs: [WS, SEQ_ID] }).catch(() => {
+        // intentionally swallow
+      })
+
+      // Assert
+      expect(mockDeleteWhere).not.toHaveBeenCalled()
+    })
+  })
+})
+
+describe("deleteSequence (exported helper)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDelete.mockReturnValue({ where: mockDeleteWhere })
+    mockDeleteWhere.mockResolvedValue(undefined)
+    mockFindOrFail.mockResolvedValue(undefined)
+  })
+
+  test("is directly callable with ctx object", async () => {
+    // Act
+    await deleteSequence({ workspaceId: WS, id: SEQ_ID })
+
+    // Assert
+    expect(mockFindOrFail).toHaveBeenCalledTimes(1)
+    expect(mockDelete).toHaveBeenCalledTimes(1)
+  })
+
+  test("scopes findOrFail to the provided workspaceId", async () => {
+    // Act
+    await deleteSequence({ workspaceId: "alt-ws", id: SEQ_ID })
+
+    // Assert
+    const args = mockFindOrFail.mock.calls[0]?.[0] as {
+      where: { workspaceId: string }
+    }
+    expect(args.where.workspaceId).toBe("alt-ws")
+  })
+
+  test("does not delete when findOrFail rejects", async () => {
+    // Arrange
+    mockFindOrFail.mockRejectedValue(new Error("Sequence not found"))
+
+    // Act & Assert
+    await expect(
+      deleteSequence({ workspaceId: WS, id: SEQ_ID }),
+    ).rejects.toThrow("Sequence not found")
+    expect(mockDelete).not.toHaveBeenCalled()
+  })
+})

--- a/apps/builder/__tests__/resend-broadcast.action.test.ts
+++ b/apps/builder/__tests__/resend-broadcast.action.test.ts
@@ -1,0 +1,196 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+  mockFindOrFail,
+  mockDbTransaction,
+  mockTxInsert,
+  mockTxInsertValues,
+  mockTxInsertReturning,
+  mockCreateId,
+  MockChatbotXException,
+} = vi.hoisted(() => {
+  const mockTxInsertReturning = vi.fn()
+  const mockTxInsertValues = vi.fn()
+  mockTxInsertValues.mockReturnValue({ returning: mockTxInsertReturning })
+  const mockTxInsert = vi.fn()
+  mockTxInsert.mockReturnValue({ values: mockTxInsertValues })
+
+  class MockChatbotXException extends Error {
+    constructor(message: string) {
+      super(message)
+      this.name = "ChatbotXException"
+    }
+  }
+
+  return {
+    mockFindOrFail: vi.fn(),
+    mockDbTransaction: vi.fn(),
+    mockTxInsert,
+    mockTxInsertValues,
+    mockTxInsertReturning,
+    mockCreateId: vi.fn().mockReturnValue("new-bc-id"),
+    MockChatbotXException,
+  }
+})
+
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, unknown> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.inputSchema = () => chain
+  chain.action = (fn: unknown) => fn
+  return { workspaceActionClient: chain }
+})
+
+vi.mock("@chatbotx.io/business/errors", () => ({
+  ChatbotXException: MockChatbotXException,
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    transaction: mockDbTransaction,
+  },
+  findOrFail: mockFindOrFail,
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  broadcastModel: { _: "broadcastModel" },
+}))
+
+vi.mock("@chatbotx.io/utils", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...original,
+    createId: mockCreateId,
+  }
+})
+
+const { resendBroadcast } = await import(
+  "../src/features/broadcasts/actions/resend-broadcast.action"
+)
+
+const WORKSPACE_ID = "ws-1"
+const BROADCAST_ID = "bc-1"
+
+const baseBroadcast = {
+  id: BROADCAST_ID,
+  workspaceId: WORKSPACE_ID,
+  name: "Summer Sale",
+  status: "sent" as const,
+  channel: "whatsapp" as const,
+  flowId: "flow-1",
+  integrationWhatsappId: "wa-1",
+  subaction: "flow" as const,
+  templateId: null,
+  templateData: null,
+  schedulesType: "now" as const,
+  contactFilter: null,
+}
+
+describe("resendBroadcast", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockTxInsertValues.mockReturnValue({ returning: mockTxInsertReturning })
+    mockTxInsert.mockReturnValue({ values: mockTxInsertValues })
+    mockTxInsertReturning.mockResolvedValue([{ id: "new-bc-id" }])
+    mockDbTransaction.mockImplementation(
+      async (fn: (tx: { insert: typeof mockTxInsert }) => Promise<unknown>) =>
+        fn({ insert: mockTxInsert }),
+    )
+    mockCreateId.mockReturnValue("new-bc-id")
+  })
+
+  test("throws ChatbotXException when broadcast status is not 'sent'", async () => {
+    const draftBroadcast = { ...baseBroadcast, status: "scheduled" as const }
+    mockFindOrFail.mockResolvedValue(draftBroadcast)
+
+    await expect(
+      resendBroadcast({ workspaceId: WORKSPACE_ID, id: BROADCAST_ID }),
+    ).rejects.toThrow("Broadcast is not sent")
+  })
+
+  test("throws ChatbotXException (not a generic Error) for non-sent status", async () => {
+    const draftBroadcast = { ...baseBroadcast, status: "failed" as const }
+    mockFindOrFail.mockResolvedValue(draftBroadcast)
+
+    await expect(
+      resendBroadcast({ workspaceId: WORKSPACE_ID, id: BROADCAST_ID }),
+    ).rejects.toBeInstanceOf(MockChatbotXException)
+  })
+
+  test("propagates error when findOrFail throws (broadcast not found)", async () => {
+    mockFindOrFail.mockRejectedValue(new Error("Record not found"))
+
+    await expect(
+      resendBroadcast({ workspaceId: WORKSPACE_ID, id: BROADCAST_ID }),
+    ).rejects.toThrow("Record not found")
+  })
+
+  test("inserts new broadcast with '(Resend)' suffix in name via transaction", async () => {
+    mockFindOrFail.mockResolvedValue(baseBroadcast)
+
+    await resendBroadcast({ workspaceId: WORKSPACE_ID, id: BROADCAST_ID })
+
+    expect(mockDbTransaction).toHaveBeenCalledOnce()
+    const insertedValues = mockTxInsertValues.mock.calls[0]?.[0] as {
+      name: string
+      status: string
+    }
+    expect(insertedValues.name).toBe("Summer Sale (Resend)")
+    expect(insertedValues.status).toBe("scheduled")
+  })
+
+  test("new broadcast copies key fields from original", async () => {
+    mockFindOrFail.mockResolvedValue(baseBroadcast)
+
+    await resendBroadcast({ workspaceId: WORKSPACE_ID, id: BROADCAST_ID })
+
+    const insertedValues = mockTxInsertValues.mock.calls[0]?.[0] as {
+      workspaceId: string
+      flowId: string
+      channel: string
+      schedulesType: string
+    }
+    expect(insertedValues.workspaceId).toBe(WORKSPACE_ID)
+    expect(insertedValues.flowId).toBe("flow-1")
+    expect(insertedValues.channel).toBe("whatsapp")
+    expect(insertedValues.schedulesType).toBe("now")
+  })
+
+  test("new broadcast uses a new id from createId", async () => {
+    mockFindOrFail.mockResolvedValue(baseBroadcast)
+    mockCreateId.mockReturnValue("generated-id-42")
+
+    await resendBroadcast({ workspaceId: WORKSPACE_ID, id: BROADCAST_ID })
+
+    const insertedValues = mockTxInsertValues.mock.calls[0]?.[0] as {
+      id: string
+    }
+    expect(insertedValues.id).toBe("generated-id-42")
+  })
+
+  test("returns the new broadcast copy", async () => {
+    const newBroadcast = { id: "new-bc-id", name: "Summer Sale (Resend)" }
+    mockFindOrFail.mockResolvedValue(baseBroadcast)
+    mockTxInsertReturning.mockResolvedValue([newBroadcast])
+
+    const result = await resendBroadcast({
+      workspaceId: WORKSPACE_ID,
+      id: BROADCAST_ID,
+    })
+
+    expect(result).toBe(newBroadcast)
+  })
+
+  test("scopes findOrFail by workspaceId", async () => {
+    mockFindOrFail.mockResolvedValue(baseBroadcast)
+
+    await resendBroadcast({ workspaceId: "other-ws", id: BROADCAST_ID })
+
+    const findArgs = mockFindOrFail.mock.calls[0]?.[0] as {
+      where: { workspaceId: string }
+    }
+    expect(findArgs.where.workspaceId).toBe("other-ws")
+  })
+})

--- a/apps/builder/__tests__/update-broadcast.action.test.ts
+++ b/apps/builder/__tests__/update-broadcast.action.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockDbUpdate, mockUpdateSet, mockUpdateWhere, mockFindOrFail, mockEq } =
+  vi.hoisted(() => {
+    const mockUpdateWhere = vi.fn().mockResolvedValue(undefined)
+    const mockUpdateSet = vi.fn()
+    mockUpdateSet.mockReturnValue({ where: mockUpdateWhere })
+    const mockDbUpdate = vi.fn()
+    mockDbUpdate.mockReturnValue({ set: mockUpdateSet })
+
+    return {
+      mockDbUpdate,
+      mockUpdateSet,
+      mockUpdateWhere,
+      mockFindOrFail: vi.fn(),
+      mockEq: vi.fn((col: unknown, val: unknown) => ({ __eq: [col, val] })),
+    }
+  })
+
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, unknown> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.inputSchema = () => chain
+  chain.action = (fn: unknown) => fn
+  return { workspaceActionClient: chain }
+})
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    update: mockDbUpdate,
+  },
+  eq: mockEq,
+  findOrFail: mockFindOrFail,
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  broadcastModel: { id: "broadcastModelId" },
+}))
+
+const { updateBroadcast } = await import(
+  "../src/features/broadcasts/actions/update-broadcast.action"
+)
+
+const WORKSPACE_ID = "ws-1"
+const BROADCAST_ID = "bc-1"
+
+describe("updateBroadcast", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUpdateSet.mockReturnValue({ where: mockUpdateWhere })
+    mockDbUpdate.mockReturnValue({ set: mockUpdateSet })
+    mockUpdateWhere.mockResolvedValue(undefined)
+  })
+
+  test("propagates error when findOrFail throws (broadcast not found)", async () => {
+    const notFoundError = new Error("Not found")
+    mockFindOrFail.mockRejectedValue(notFoundError)
+
+    await expect(
+      updateBroadcast(
+        { workspaceId: WORKSPACE_ID, id: BROADCAST_ID },
+        { name: "New Name" },
+      ),
+    ).rejects.toThrow("Not found")
+  })
+
+  test("calls db.update with parsedInput after finding broadcast", async () => {
+    const mockBroadcast = { id: BROADCAST_ID, workspaceId: WORKSPACE_ID }
+    mockFindOrFail.mockResolvedValue(mockBroadcast)
+
+    await updateBroadcast(
+      { workspaceId: WORKSPACE_ID, id: BROADCAST_ID },
+      { name: "Updated Name" },
+    )
+
+    expect(mockFindOrFail).toHaveBeenCalledOnce()
+    expect(mockFindOrFail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: BROADCAST_ID,
+          workspaceId: WORKSPACE_ID,
+        }),
+      }),
+    )
+    expect(mockDbUpdate).toHaveBeenCalledOnce()
+    expect(mockUpdateSet).toHaveBeenCalledWith({ name: "Updated Name" })
+  })
+
+  test("scopes findOrFail by workspaceId to prevent cross-workspace access", async () => {
+    const mockBroadcast = { id: BROADCAST_ID, workspaceId: WORKSPACE_ID }
+    mockFindOrFail.mockResolvedValue(mockBroadcast)
+
+    await updateBroadcast(
+      { workspaceId: "other-ws", id: BROADCAST_ID },
+      { name: "Name" },
+    )
+
+    const findOrFailArgs = mockFindOrFail.mock.calls[0]?.[0] as {
+      where: { workspaceId: string }
+    }
+    expect(findOrFailArgs.where.workspaceId).toBe("other-ws")
+  })
+
+  test("uses eq(broadcastModel.id, broadcast.id) in the where clause", async () => {
+    const mockBroadcast = { id: BROADCAST_ID, workspaceId: WORKSPACE_ID }
+    mockFindOrFail.mockResolvedValue(mockBroadcast)
+
+    await updateBroadcast(
+      { workspaceId: WORKSPACE_ID, id: BROADCAST_ID },
+      { name: "Name" },
+    )
+
+    expect(mockEq).toHaveBeenCalledWith(expect.anything(), mockBroadcast.id)
+    expect(mockUpdateWhere).toHaveBeenCalledWith(
+      expect.objectContaining({ __eq: expect.any(Array) }),
+    )
+  })
+
+  test("returns undefined on success", async () => {
+    const mockBroadcast = { id: BROADCAST_ID, workspaceId: WORKSPACE_ID }
+    mockFindOrFail.mockResolvedValue(mockBroadcast)
+
+    const result = await updateBroadcast(
+      { workspaceId: WORKSPACE_ID, id: BROADCAST_ID },
+      { name: "Final Name" },
+    )
+
+    expect(result).toBeUndefined()
+  })
+})

--- a/apps/builder/__tests__/update-sequence.action.test.ts
+++ b/apps/builder/__tests__/update-sequence.action.test.ts
@@ -1,0 +1,253 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+  mockUpdateWhere,
+  mockUpdateSet,
+  mockUpdate,
+  mockFindOrFail,
+  mockIsDatabaseError,
+  mockReturnValidationErrors,
+  mockGetTranslations,
+} = vi.hoisted(() => {
+  const mockUpdateWhere = vi.fn().mockResolvedValue(undefined)
+  const mockUpdateSet = vi.fn().mockReturnValue({ where: mockUpdateWhere })
+  const mockUpdate = vi.fn().mockReturnValue({ set: mockUpdateSet })
+
+  return {
+    mockUpdateWhere,
+    mockUpdateSet,
+    mockUpdate,
+    mockFindOrFail: vi.fn().mockResolvedValue(undefined),
+    mockIsDatabaseError: vi.fn().mockReturnValue(false),
+    mockReturnValidationErrors: vi
+      .fn()
+      .mockReturnValue({ __validationError: true }),
+    mockGetTranslations: vi.fn().mockResolvedValue((k: string) => k),
+  }
+})
+
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, unknown> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.inputSchema = () => chain
+  chain.action = (fn: unknown) => fn
+  return { workspaceActionClient: chain }
+})
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  and: (...args: unknown[]) => ({ and: args }),
+  db: { update: mockUpdate },
+  eq: (a: unknown, b: unknown) => ({ eq: [a, b] }),
+  findOrFail: mockFindOrFail,
+  isDatabaseError: mockIsDatabaseError,
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  sequenceModel: { id: "id", name: "name", workspaceId: "workspaceId" },
+}))
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: mockGetTranslations,
+}))
+
+vi.mock("next-safe-action", () => ({
+  returnValidationErrors: mockReturnValidationErrors,
+}))
+
+vi.mock("@/features/sequences/schema/action", () => ({
+  updateSequenceSchema: {},
+}))
+
+const { updateSequenceAction, updateSequence } = await import(
+  "../src/features/sequences/actions/update-sequence.action"
+)
+
+// With the safe-action chain mock, the exported action IS the raw handler.
+type ActionHandler = (args: {
+  bindArgsParsedInputs: [string, string]
+  parsedInput: { name?: string; active?: boolean }
+}) => Promise<unknown>
+
+const callAction = updateSequenceAction as unknown as ActionHandler
+
+const WS = "ws-1"
+const SEQ_ID = "seq-1"
+
+// Resets shared mock chain state between tests
+function resetUpdateChain() {
+  mockUpdate.mockReturnValue({ set: mockUpdateSet })
+  mockUpdateSet.mockReturnValue({ where: mockUpdateWhere })
+  mockUpdateWhere.mockResolvedValue(undefined)
+}
+
+describe("updateSequenceAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetUpdateChain()
+    mockFindOrFail.mockResolvedValue(undefined)
+    mockIsDatabaseError.mockReturnValue(false)
+    mockGetTranslations.mockResolvedValue((k: string) => k)
+    mockReturnValidationErrors.mockReturnValue({ __validationError: true })
+  })
+
+  describe("happy path", () => {
+    test("calls findOrFail then db.update on successful update", async () => {
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS, SEQ_ID],
+        parsedInput: { name: "Updated Name" },
+      })
+
+      // Assert
+      expect(mockFindOrFail).toHaveBeenCalledTimes(1)
+      expect(mockUpdate).toHaveBeenCalledTimes(1)
+    })
+
+    test("calls findOrFail with workspace-scoped where clause", async () => {
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS, SEQ_ID],
+        parsedInput: { name: "Updated" },
+      })
+
+      // Assert
+      const args = mockFindOrFail.mock.calls[0]?.[0] as {
+        where: { id: string; workspaceId: string }
+        message: string
+      }
+      expect(args.where.id).toBe(SEQ_ID)
+      expect(args.where.workspaceId).toBe(WS)
+      expect(args.message).toBe("Sequence not found")
+    })
+
+    test("passes parsedInput directly to db.update.set", async () => {
+      // Arrange
+      const parsedInput = { name: "New Name", active: true }
+
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS, SEQ_ID],
+        parsedInput,
+      })
+
+      // Assert
+      expect(mockUpdateSet).toHaveBeenCalledWith(parsedInput)
+    })
+
+    test("returns undefined on success (no explicit return value)", async () => {
+      // Act
+      const result = await callAction({
+        bindArgsParsedInputs: [WS, SEQ_ID],
+        parsedInput: { name: "Seq" },
+      })
+
+      // Assert
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe("sequence not found", () => {
+    test("propagates findOrFail error and does not call db.update", async () => {
+      // Arrange
+      mockFindOrFail.mockRejectedValue(new Error("Sequence not found"))
+
+      // Act & Assert
+      await expect(
+        callAction({
+          bindArgsParsedInputs: [WS, SEQ_ID],
+          parsedInput: { name: "Updated" },
+        }),
+      ).rejects.toThrow("Sequence not found")
+      expect(mockUpdate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("unique violation (23505)", () => {
+    test("returns returnValidationErrors result on duplicate name", async () => {
+      // Arrange
+      const dbError = Object.assign(new Error("unique violation"), {
+        cause: { code: "23505" },
+      })
+      mockUpdateWhere.mockRejectedValue(dbError)
+      mockIsDatabaseError.mockReturnValue(true)
+
+      // Act
+      const result = await callAction({
+        bindArgsParsedInputs: [WS, SEQ_ID],
+        parsedInput: { name: "Duplicate" },
+      })
+
+      // Assert
+      expect(mockReturnValidationErrors).toHaveBeenCalledTimes(1)
+      expect(result).toEqual({ __validationError: true })
+    })
+  })
+
+  describe("other DB errors", () => {
+    test("throws 'Failed to update sequence' for non-23505 DB error", async () => {
+      // Arrange
+      const dbError = Object.assign(new Error("other db"), {
+        cause: { code: "XXXXX" },
+      })
+      mockUpdateWhere.mockRejectedValue(dbError)
+      mockIsDatabaseError.mockReturnValue(true)
+
+      // Act & Assert
+      await expect(
+        callAction({
+          bindArgsParsedInputs: [WS, SEQ_ID],
+          parsedInput: { name: "Seq" },
+        }),
+      ).rejects.toThrow("Failed to update sequence")
+      expect(mockReturnValidationErrors).not.toHaveBeenCalled()
+    })
+
+    test("throws 'Failed to update sequence' for non-DB errors", async () => {
+      // Arrange
+      mockUpdateWhere.mockRejectedValue(new Error("network error"))
+      mockIsDatabaseError.mockReturnValue(false)
+
+      // Act & Assert
+      await expect(
+        callAction({
+          bindArgsParsedInputs: [WS, SEQ_ID],
+          parsedInput: { name: "Seq" },
+        }),
+      ).rejects.toThrow("Failed to update sequence")
+    })
+  })
+})
+
+describe("updateSequence (exported helper)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetUpdateChain()
+    mockFindOrFail.mockResolvedValue(undefined)
+    mockIsDatabaseError.mockReturnValue(false)
+    mockGetTranslations.mockResolvedValue((k: string) => k)
+    mockReturnValidationErrors.mockReturnValue({ __validationError: true })
+  })
+
+  test("is directly callable with ctx and parsedInput", async () => {
+    // Act
+    await updateSequence({ workspaceId: WS, id: SEQ_ID }, { name: "Direct" })
+
+    // Assert
+    expect(mockFindOrFail).toHaveBeenCalledTimes(1)
+    expect(mockUpdate).toHaveBeenCalledTimes(1)
+    expect(mockUpdateSet).toHaveBeenCalledWith({ name: "Direct" })
+  })
+
+  test("scopes findOrFail to the provided workspaceId", async () => {
+    // Act
+    await updateSequence({ workspaceId: "other-ws", id: SEQ_ID }, {})
+
+    // Assert
+    const args = mockFindOrFail.mock.calls[0]?.[0] as {
+      where: { workspaceId: string }
+    }
+    expect(args.where.workspaceId).toBe("other-ws")
+  })
+})

--- a/apps/builder/__tests__/upsert-sequence-step.action.test.ts
+++ b/apps/builder/__tests__/upsert-sequence-step.action.test.ts
@@ -1,0 +1,415 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+  mockFindFirst,
+  mockInsertReturning,
+  mockInsertValues,
+  mockInsert,
+  mockUpdateReturning,
+  mockUpdateWhere,
+  mockUpdateSet,
+  mockUpdate,
+  mockFindOrFail,
+  mockCreateId,
+  mockHandleStepCreationImpact,
+  mockHandleStepUpdateImpact,
+} = vi.hoisted(() => {
+  const mockInsertReturning = vi.fn().mockResolvedValue([{ id: "new-step-id" }])
+  const mockInsertValues = vi
+    .fn()
+    .mockReturnValue({ returning: mockInsertReturning })
+  const mockInsert = vi.fn().mockReturnValue({ values: mockInsertValues })
+
+  const mockUpdateReturning = vi.fn().mockResolvedValue([{ id: "step-1" }])
+  const mockUpdateWhere = vi
+    .fn()
+    .mockReturnValue({ returning: mockUpdateReturning })
+  const mockUpdateSet = vi.fn().mockReturnValue({ where: mockUpdateWhere })
+  const mockUpdate = vi.fn().mockReturnValue({ set: mockUpdateSet })
+
+  const mockFindFirst = vi.fn()
+
+  return {
+    mockFindFirst,
+    mockInsertReturning,
+    mockInsertValues,
+    mockInsert,
+    mockUpdateReturning,
+    mockUpdateWhere,
+    mockUpdateSet,
+    mockUpdate,
+    mockFindOrFail: vi.fn().mockResolvedValue(undefined),
+    mockCreateId: vi.fn().mockReturnValue("new-step-id"),
+    mockHandleStepCreationImpact: vi.fn().mockResolvedValue(undefined),
+    mockHandleStepUpdateImpact: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, unknown> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.inputSchema = () => chain
+  chain.action = (fn: unknown) => fn
+  return { workspaceActionClient: chain }
+})
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      sequenceStepModel: { findFirst: mockFindFirst },
+    },
+    insert: mockInsert,
+    update: mockUpdate,
+  },
+  eq: (a: unknown, b: unknown) => ({ eq: [a, b] }),
+  findOrFail: mockFindOrFail,
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  sequenceModel: { id: "id", workspaceId: "workspaceId" },
+  sequenceStepModel: { id: "id" },
+}))
+
+vi.mock("@chatbotx.io/utils", () => ({
+  createId: mockCreateId,
+}))
+
+vi.mock("@/features/common/schemas", () => ({
+  workspaceIdrequestParams: [],
+}))
+
+vi.mock("@/features/contact-sequences/utils/calculate-next-run-at", () => ({
+  handleStepCreationImpact: mockHandleStepCreationImpact,
+  handleStepUpdateImpact: mockHandleStepUpdateImpact,
+}))
+
+vi.mock("@/features/sequences/schema/action", () => ({
+  upsertSequenceStepRequest: {},
+}))
+
+const { upsertSequenceStepAction } = await import(
+  "../src/features/sequences/actions/upsert-sequence-step.action"
+)
+
+// With the safe-action chain mock, the exported action IS the raw handler.
+type ActionHandler = (args: {
+  bindArgsParsedInputs: [string]
+  parsedInput: {
+    stepId?: string
+    sequenceId: string
+    order: number
+    delayDays?: number
+    delayMinutes?: number
+    delayUnit?: string
+    flowId?: string
+    isActive?: boolean
+    anytime?: boolean
+    sendTimeStart?: string | null
+    sendTimeEnd?: string | null
+    sendDays?: string[]
+    specificDateTime?: string
+  }
+}) => Promise<unknown>
+
+const callAction = upsertSequenceStepAction as unknown as ActionHandler
+
+const WS = "ws-1"
+const SEQ_ID = "seq-1"
+const STEP_ID = "step-1"
+
+/** Returns a minimal step whose parent sequence's workspaceId can be set. */
+const makeStep = (workspaceId = WS) => ({
+  id: STEP_ID,
+  order: 1,
+  sequence: { workspaceId },
+})
+
+describe("upsertSequenceStepAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFindOrFail.mockResolvedValue(undefined)
+    mockFindFirst.mockResolvedValue(makeStep())
+    mockInsert.mockReturnValue({ values: mockInsertValues })
+    mockInsertValues.mockReturnValue({ returning: mockInsertReturning })
+    mockInsertReturning.mockResolvedValue([{ id: "new-step-id" }])
+    mockUpdate.mockReturnValue({ set: mockUpdateSet })
+    mockUpdateSet.mockReturnValue({ where: mockUpdateWhere })
+    mockUpdateWhere.mockReturnValue({ returning: mockUpdateReturning })
+    mockUpdateReturning.mockResolvedValue([{ id: STEP_ID }])
+    mockCreateId.mockReturnValue("new-step-id")
+    mockHandleStepCreationImpact.mockResolvedValue(undefined)
+    mockHandleStepUpdateImpact.mockResolvedValue(undefined)
+  })
+
+  // ── CREATE PATH (no stepId) ──────────────────────────────────────────────────
+  describe("create path (no stepId)", () => {
+    test("validates sequence ownership, inserts a new step, and returns stepId", async () => {
+      // Act
+      const result = await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { sequenceId: SEQ_ID, order: 0 },
+      })
+
+      // Assert
+      expect(mockFindOrFail).toHaveBeenCalledTimes(1)
+      expect(mockInsert).toHaveBeenCalledTimes(1)
+      expect(mockInsertReturning).toHaveBeenCalledTimes(1)
+      expect(result).toEqual({ stepId: "new-step-id" })
+    })
+
+    test("uses createId for the new step id", async () => {
+      // Arrange
+      mockCreateId.mockReturnValue("generated-id")
+      mockInsertReturning.mockResolvedValue([{ id: "generated-id" }])
+
+      // Act
+      const result = await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { sequenceId: SEQ_ID, order: 1 },
+      })
+
+      // Assert
+      expect(mockCreateId).toHaveBeenCalledTimes(1)
+      expect((result as { stepId: string }).stepId).toBe("generated-id")
+    })
+
+    test("inserts step with correct sequenceId and order", async () => {
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { sequenceId: SEQ_ID, order: 3 },
+      })
+
+      // Assert
+      const insertArg = mockInsertValues.mock.calls[0]?.[0] as {
+        sequenceId: string
+        order: number
+      }
+      expect(insertArg.sequenceId).toBe(SEQ_ID)
+      expect(insertArg.order).toBe(3)
+    })
+
+    test("calls handleStepCreationImpact with sequenceId, workspaceId, and order", async () => {
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { sequenceId: SEQ_ID, order: 2 },
+      })
+
+      // Assert
+      expect(mockHandleStepCreationImpact).toHaveBeenCalledWith(SEQ_ID, WS, 2)
+      expect(mockHandleStepUpdateImpact).not.toHaveBeenCalled()
+    })
+
+    test("does not call db.query.findFirst (step lookup) on create path", async () => {
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { sequenceId: SEQ_ID, order: 0 },
+      })
+
+      // Assert
+      expect(mockFindFirst).not.toHaveBeenCalled()
+    })
+
+    test("does not call db.update on create path", async () => {
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { sequenceId: SEQ_ID, order: 0 },
+      })
+
+      // Assert
+      expect(mockUpdate).not.toHaveBeenCalled()
+    })
+
+    test("validates sequence ownership via findOrFail with workspace scope", async () => {
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { sequenceId: SEQ_ID, order: 0 },
+      })
+
+      // Assert
+      const args = mockFindOrFail.mock.calls[0]?.[0] as {
+        where: { id: string; workspaceId: string }
+        message: string
+      }
+      expect(args.where.id).toBe(SEQ_ID)
+      expect(args.where.workspaceId).toBe(WS)
+      expect(args.message).toBe("Sequence not found")
+    })
+  })
+
+  // ── UPDATE PATH (stepId provided) ───────────────────────────────────────────
+  describe("update path (stepId provided)", () => {
+    test("validates sequence ownership, updates the step, and returns stepId", async () => {
+      // Act
+      const result = await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: {
+          stepId: STEP_ID,
+          sequenceId: SEQ_ID,
+          order: 1,
+          delayDays: 2,
+        },
+      })
+
+      // Assert
+      expect(mockFindOrFail).toHaveBeenCalledTimes(1)
+      expect(mockFindFirst).toHaveBeenCalledTimes(1)
+      expect(mockUpdate).toHaveBeenCalledTimes(1)
+      expect(mockUpdateReturning).toHaveBeenCalledTimes(1)
+      expect(result).toEqual({ stepId: STEP_ID })
+    })
+
+    test("calls handleStepUpdateImpact when delayDays changes", async () => {
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: {
+          stepId: STEP_ID,
+          sequenceId: SEQ_ID,
+          order: 1,
+          delayDays: 3,
+        },
+      })
+
+      // Assert
+      expect(mockHandleStepUpdateImpact).toHaveBeenCalledWith(
+        SEQ_ID,
+        WS,
+        STEP_ID,
+        1,
+      )
+      expect(mockHandleStepCreationImpact).not.toHaveBeenCalled()
+    })
+
+    test("calls handleStepUpdateImpact when isActive changes", async () => {
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: {
+          stepId: STEP_ID,
+          sequenceId: SEQ_ID,
+          order: 0,
+          isActive: false,
+        },
+      })
+
+      // Assert
+      expect(mockHandleStepUpdateImpact).toHaveBeenCalledTimes(1)
+    })
+
+    test("does not call handleStepUpdateImpact when only flowId changes", async () => {
+      await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: {
+          stepId: STEP_ID,
+          sequenceId: SEQ_ID,
+          order: 1,
+          flowId: "flow-abc",
+        },
+      })
+
+      expect(mockHandleStepUpdateImpact).not.toHaveBeenCalled()
+    })
+
+    test("queries step with correct stepId and includes sequence relation", async () => {
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { stepId: STEP_ID, sequenceId: SEQ_ID, order: 0 },
+      })
+
+      // Assert
+      const findArgs = mockFindFirst.mock.calls[0]?.[0] as {
+        where: { id: string }
+        with: { sequence: boolean }
+      }
+      expect(findArgs.where.id).toBe(STEP_ID)
+      expect(findArgs.with.sequence).toBe(true)
+    })
+
+    test("does not call db.insert on update path", async () => {
+      // Act
+      await callAction({
+        bindArgsParsedInputs: [WS],
+        parsedInput: { stepId: STEP_ID, sequenceId: SEQ_ID, order: 0 },
+      })
+
+      // Assert
+      expect(mockInsert).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── SEQUENCE NOT FOUND ───────────────────────────────────────────────────────
+  describe("sequence not found", () => {
+    test("throws when findOrFail rejects on create path", async () => {
+      // Arrange
+      mockFindOrFail.mockRejectedValue(new Error("Sequence not found"))
+
+      // Act & Assert
+      await expect(
+        callAction({
+          bindArgsParsedInputs: [WS],
+          parsedInput: { sequenceId: SEQ_ID, order: 0 },
+        }),
+      ).rejects.toThrow("Sequence not found")
+    })
+
+    test("throws when findOrFail rejects on update path", async () => {
+      // Arrange
+      mockFindOrFail.mockRejectedValue(new Error("Sequence not found"))
+
+      // Act & Assert
+      await expect(
+        callAction({
+          bindArgsParsedInputs: [WS],
+          parsedInput: { stepId: STEP_ID, sequenceId: SEQ_ID, order: 0 },
+        }),
+      ).rejects.toThrow("Sequence not found")
+
+      expect(mockFindFirst).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── STEP NOT FOUND (update path) ─────────────────────────────────────────────
+  describe("step not found (update path)", () => {
+    test("throws 'Step not found' when db query returns null", async () => {
+      // Arrange
+      mockFindFirst.mockResolvedValue(null)
+
+      // Act & Assert
+      await expect(
+        callAction({
+          bindArgsParsedInputs: [WS],
+          parsedInput: { stepId: STEP_ID, sequenceId: SEQ_ID, order: 0 },
+        }),
+      ).rejects.toThrow("Step not found")
+
+      expect(mockUpdate).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── WORKSPACE MISMATCH (update path) ─────────────────────────────────────────
+  describe("workspace mismatch (update path)", () => {
+    test("throws unauthorized error when step belongs to a different workspace", async () => {
+      // Arrange
+      mockFindFirst.mockResolvedValue(makeStep("other-ws"))
+
+      // Act & Assert
+      await expect(
+        callAction({
+          bindArgsParsedInputs: [WS],
+          parsedInput: { stepId: STEP_ID, sequenceId: SEQ_ID, order: 0 },
+        }),
+      ).rejects.toThrow("Unauthorized: Step does not belong to this workspace")
+
+      expect(mockUpdate).not.toHaveBeenCalled()
+      expect(mockHandleStepUpdateImpact).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/builder/src/features/broadcasts/actions/resend-broadcast.action.ts
+++ b/apps/builder/src/features/broadcasts/actions/resend-broadcast.action.ts
@@ -31,7 +31,7 @@ export const resendBroadcast = async (ctx: {
     throw new ChatbotXException("Broadcast is not sent")
   }
 
-  await db.transaction(async (tx) => {
+  const newBroadcast = await db.transaction(async (tx) => {
     const newBroadcast = await tx
       .insert(broadcastModel)
       .values({
@@ -55,5 +55,5 @@ export const resendBroadcast = async (ctx: {
     return newBroadcast
   })
 
-  return broadcast
+  return newBroadcast
 }

--- a/apps/builder/src/features/sequences/actions/upsert-sequence-step.action.ts
+++ b/apps/builder/src/features/sequences/actions/upsert-sequence-step.action.ts
@@ -121,6 +121,7 @@ function buildCreateData(
  */
 function shouldRecalculateOnUpdate(
   parsedInput: UpsertSequenceStepRequest,
+  previousOrder: number,
 ): boolean {
   const { delayDays, delayMinutes, delayUnit, isActive, order } = parsedInput
 
@@ -129,7 +130,7 @@ function shouldRecalculateOnUpdate(
     delayMinutes !== undefined ||
     delayUnit !== undefined ||
     isActive !== undefined ||
-    order !== undefined
+    order !== previousOrder
   )
 }
 
@@ -238,10 +239,14 @@ async function handleStepUpdate(
   workspaceId: string,
 ): Promise<{ stepId: string }> {
   const updateData = buildUpdateData(parsedInput)
-  const step = await updateSequenceStep(stepId, updateData, workspaceId)
+  const { previousOrder, step } = await updateSequenceStep(
+    stepId,
+    updateData,
+    workspaceId,
+  )
 
   // Only recalculate if changes affect scheduling
-  if (shouldRecalculateOnUpdate(parsedInput)) {
+  if (shouldRecalculateOnUpdate(parsedInput, previousOrder)) {
     // Use targeted recalculation based on updated step
     // Recalculate for:
     // - GROUP 1: Contacts waiting for this step (nextStepId = stepId)
@@ -288,7 +293,7 @@ async function updateSequenceStep(
     .where(eq(sequenceStepModel.id, stepId))
     .returning()
 
-  return updated
+  return { previousOrder: step.order, step: updated }
 }
 
 async function createSequenceStep(

--- a/apps/worker/__tests__/enqueue-broadcast.test.ts
+++ b/apps/worker/__tests__/enqueue-broadcast.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ── fixed "now" so startOfMinute is deterministic ─────────────────────────────
+const FIXED_START = new Date("2026-01-01T10:00:00.000Z")
+
+// ── db spy ────────────────────────────────────────────────────────────────────
+const findManyBroadcast = vi.fn()
+
+// ── queue spy ─────────────────────────────────────────────────────────────────
+const addBulkSpy = vi.fn()
+
+// ── mocks ─────────────────────────────────────────────────────────────────────
+vi.mock("date-fns", () => ({
+  startOfMinute: (_input: unknown) => FIXED_START,
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      broadcastModel: {
+        findMany: (...args: unknown[]) => findManyBroadcast(...args),
+      },
+    },
+  },
+}))
+
+vi.mock("@chatbotx.io/worker-config", () => ({
+  scheduleQueue: {
+    addBulk: (...args: unknown[]) => addBulkSpy(...args),
+  },
+  ScheduleJobData: {
+    sendBroadcast: "sendBroadcast",
+    prepareBroadcast: "prepareBroadcast",
+    enqueueBroadcast: "enqueueBroadcast",
+    finalizeBroadcasts: "finalizeBroadcasts",
+  },
+}))
+
+const { enqueueBroadcast } = await import(
+  "../src/schedule/handlers/enqueue-broadcast"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+const makeBroadcasts = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `broadcast-${i + 1}`,
+    status: "scheduled",
+    schedulesAt: new Date("2026-01-01T09:59:00.000Z"),
+  }))
+
+// ── setup ─────────────────────────────────────────────────────────────────────
+beforeEach(() => {
+  findManyBroadcast.mockResolvedValue([])
+  addBulkSpy.mockResolvedValue(undefined)
+})
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+describe("enqueueBroadcast", () => {
+  describe("no scheduled broadcasts found", () => {
+    test("returns { scanned: 0, enqueued: 0 } without calling addBulk", async () => {
+      findManyBroadcast.mockResolvedValue([])
+
+      const result = await enqueueBroadcast()
+
+      expect(result).toEqual({ scanned: 0, enqueued: 0 })
+      expect(addBulkSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("broadcasts found within one bulk chunk (<= 500)", () => {
+    test("calls addBulk once with prepareBroadcast jobs for each broadcast", async () => {
+      const broadcasts = makeBroadcasts(3)
+      findManyBroadcast.mockResolvedValue(broadcasts)
+
+      const result = await enqueueBroadcast()
+
+      expect(result).toEqual({ scanned: 3, enqueued: 3 })
+      expect(addBulkSpy).toHaveBeenCalledTimes(1)
+
+      const [jobs] = addBulkSpy.mock.calls[0] as [
+        Array<{
+          name: string
+          data: { type: string; data: { broadcastId: string } }
+          opts: { jobId: string }
+        }>,
+      ]
+      expect(jobs).toHaveLength(3)
+    })
+
+    test("each job has name prepareBroadcast with correct broadcastId and dedup jobId", async () => {
+      findManyBroadcast.mockResolvedValue(makeBroadcasts(1))
+
+      await enqueueBroadcast()
+
+      const [jobs] = addBulkSpy.mock.calls[0] as [
+        Array<{
+          name: string
+          data: { type: string; data: { broadcastId: string } }
+          opts: { jobId: string }
+        }>,
+      ]
+      const job = jobs[0]
+      expect(job.name).toBe("prepareBroadcast")
+      expect(job.data.type).toBe("prepareBroadcast")
+      expect(job.data.data.broadcastId).toBe("broadcast-1")
+      expect(job.opts.jobId).toBe("schedule-prepare-broadcast-broadcast-1")
+    })
+
+    test("queries broadcastModel with status 'scheduled' and schedulesAt lte startTime", async () => {
+      findManyBroadcast.mockResolvedValue(makeBroadcasts(1))
+
+      await enqueueBroadcast()
+
+      expect(findManyBroadcast).toHaveBeenCalledTimes(1)
+      const [queryArg] = findManyBroadcast.mock.calls[0] as [
+        { where: { status: string; schedulesAt: { lte: Date } } },
+      ]
+      expect(queryArg.where.status).toBe("scheduled")
+      expect(queryArg.where.schedulesAt.lte).toEqual(FIXED_START)
+    })
+  })
+
+  describe("more than 500 broadcasts (multi-chunk batching)", () => {
+    test("splits into chunks of 500 and calls addBulk once per chunk", async () => {
+      const broadcasts = makeBroadcasts(501)
+      findManyBroadcast.mockResolvedValue(broadcasts)
+
+      const result = await enqueueBroadcast()
+
+      expect(result).toEqual({ scanned: 501, enqueued: 501 })
+      expect(addBulkSpy).toHaveBeenCalledTimes(2)
+
+      const [firstBatch] = addBulkSpy.mock.calls[0] as [unknown[]]
+      const [secondBatch] = addBulkSpy.mock.calls[1] as [unknown[]]
+      expect(firstBatch).toHaveLength(500)
+      expect(secondBatch).toHaveLength(1)
+    })
+
+    test("exactly 1000 broadcasts → two equal batches of 500", async () => {
+      findManyBroadcast.mockResolvedValue(makeBroadcasts(1000))
+
+      const result = await enqueueBroadcast()
+
+      expect(result).toEqual({ scanned: 1000, enqueued: 1000 })
+      expect(addBulkSpy).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/apps/worker/__tests__/finalize-broadcasts.test.ts
+++ b/apps/worker/__tests__/finalize-broadcasts.test.ts
@@ -1,0 +1,259 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ── db spies ──────────────────────────────────────────────────────────────────
+const findManyBroadcast = vi.fn()
+const dbCountMock = vi.fn()
+
+type UpdateCall = {
+  table: unknown
+  values: Record<string, unknown>
+  condition: unknown
+}
+const updateCalls: UpdateCall[] = []
+
+// ── distributed lock spy ──────────────────────────────────────────────────────
+const runExclusiveSpy = vi.fn()
+
+// ── logger spy ────────────────────────────────────────────────────────────────
+const loggerInfoSpy = vi.fn()
+
+// ── mocks ─────────────────────────────────────────────────────────────────────
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      broadcastModel: {
+        findMany: (...args: unknown[]) => findManyBroadcast(...args),
+      },
+    },
+    $count: (...args: unknown[]) => dbCountMock(...args),
+    update: (table: unknown) => ({
+      set: (values: Record<string, unknown>) => ({
+        where: (condition: unknown) => {
+          updateCalls.push({ table, values, condition })
+          return Promise.resolve()
+        },
+      }),
+    }),
+  },
+  and: (...args: unknown[]) => ({ __and: args }),
+  eq: (a: unknown, b: unknown) => ({ __eq: [a, b] }),
+  or: (...args: unknown[]) => ({ __or: args }),
+  isNotNull: (a: unknown) => ({ __isNotNull: a }),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  broadcastModel: { id: "broadcast.id", __name: "broadcastModel" },
+  contactsOnBroadcastsModel: {
+    broadcastId: "cob.broadcastId",
+    deliveredAt: "cob.deliveredAt",
+    failedAt: "cob.failedAt",
+    __name: "contactsOnBroadcastsModel",
+  },
+}))
+
+vi.mock("@chatbotx.io/database/partials", () => ({
+  broadcastStatuses: {
+    enum: { scheduled: "scheduled", sending: "sending", sent: "sent" },
+  },
+}))
+
+vi.mock("@chatbotx.io/redis", () => ({
+  distributedLock: {
+    runExclusive: (opts: {
+      key: string
+      timeoutInSeconds: number
+      fn: () => Promise<unknown>
+    }) => {
+      runExclusiveSpy(opts)
+      return opts.fn()
+    },
+  },
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: {
+    info: (...args: unknown[]) => loggerInfoSpy(...args),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const { finalizeBroadcasts } = await import(
+  "../src/schedule/handlers/finalize-broadcasts"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+const makeBroadcast = (
+  id: string,
+  contactCount: number | null,
+  overrides: Record<string, unknown> = {},
+) => ({
+  id,
+  status: "sending",
+  contactCount,
+  ...overrides,
+})
+
+// ── setup ─────────────────────────────────────────────────────────────────────
+beforeEach(() => {
+  updateCalls.length = 0
+  findManyBroadcast.mockResolvedValue([])
+  dbCountMock.mockResolvedValue(0)
+})
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+describe("finalizeBroadcasts", () => {
+  describe("distributed lock", () => {
+    test("acquires lock with the expected key before executing", async () => {
+      findManyBroadcast.mockResolvedValue([])
+
+      await finalizeBroadcasts()
+
+      expect(runExclusiveSpy).toHaveBeenCalledTimes(1)
+      const [opts] = runExclusiveSpy.mock.calls[0] as [
+        { key: string; timeoutInSeconds: number },
+      ]
+      expect(opts.key).toBe("schedule:finalize-broadcasts")
+      expect(opts.timeoutInSeconds).toBe(55)
+    })
+  })
+
+  describe("no 'sending' broadcasts", () => {
+    test("returns { skipped: false, finalized: 0 } without any db updates", async () => {
+      findManyBroadcast.mockResolvedValue([])
+
+      const result = await finalizeBroadcasts()
+
+      expect(result).toEqual({ skipped: false, finalized: 0 })
+      expect(updateCalls).toHaveLength(0)
+    })
+  })
+
+  describe("broadcast with null or zero contactCount", () => {
+    test("skips broadcast with contactCount null", async () => {
+      findManyBroadcast.mockResolvedValue([makeBroadcast("b-1", null)])
+
+      const result = await finalizeBroadcasts()
+
+      expect(result).toEqual({ skipped: false, finalized: 0 })
+      expect(dbCountMock).not.toHaveBeenCalled()
+      expect(updateCalls).toHaveLength(0)
+    })
+
+    test("skips broadcast with contactCount 0", async () => {
+      findManyBroadcast.mockResolvedValue([makeBroadcast("b-1", 0)])
+
+      const result = await finalizeBroadcasts()
+
+      expect(result).toEqual({ skipped: false, finalized: 0 })
+      expect(dbCountMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("broadcast is complete (completed >= total)", () => {
+    test("updates broadcast status to 'sent' and increments finalized count", async () => {
+      findManyBroadcast.mockResolvedValue([makeBroadcast("b-1", 10)])
+      dbCountMock.mockResolvedValue(10) // completed === total
+
+      const result = await finalizeBroadcasts()
+
+      expect(result).toEqual({ skipped: false, finalized: 1 })
+      expect(updateCalls).toHaveLength(1)
+      expect(updateCalls[0].values).toMatchObject({ status: "sent" })
+    })
+
+    test("completed > total also finalizes", async () => {
+      findManyBroadcast.mockResolvedValue([makeBroadcast("b-1", 5)])
+      dbCountMock.mockResolvedValue(7) // more completed than total (edge case)
+
+      const result = await finalizeBroadcasts()
+
+      expect(result).toEqual({ skipped: false, finalized: 1 })
+    })
+  })
+
+  describe("broadcast is complete via missing threshold", () => {
+    test("finalizes broadcast when missing contacts are within 1% and at most 100", async () => {
+      // total = 20_000, completed = 19_900 -> missingCount = 100 (0.5%)
+      findManyBroadcast.mockResolvedValue([makeBroadcast("b-1", 20_000)])
+      dbCountMock.mockResolvedValue(19_900)
+
+      const result = await finalizeBroadcasts()
+
+      expect(result).toEqual({ skipped: false, finalized: 1 })
+    })
+
+    test("does not finalize when missing contacts are under 100 but over 1%", async () => {
+      // total = 200, completed = 198 -> missingCount = 2 (1%)
+      findManyBroadcast.mockResolvedValue([makeBroadcast("b-1", 200)])
+      dbCountMock.mockResolvedValue(197)
+
+      const result = await finalizeBroadcasts()
+
+      expect(result).toEqual({ skipped: false, finalized: 0 })
+      expect(updateCalls).toHaveLength(0)
+    })
+
+    test("does not finalize when missing contacts are over 100 even if under 1%", async () => {
+      // total = 20_000, completed = 19_899 -> missingCount = 101 (0.505%)
+      findManyBroadcast.mockResolvedValue([makeBroadcast("b-1", 20_000)])
+      dbCountMock.mockResolvedValue(19_899)
+
+      const result = await finalizeBroadcasts()
+
+      expect(result).toEqual({ skipped: false, finalized: 0 })
+      expect(updateCalls).toHaveLength(0)
+    })
+  })
+
+  describe("multiple broadcasts in one pass", () => {
+    test("finalizes completed broadcasts and skips incomplete ones", async () => {
+      findManyBroadcast.mockResolvedValue([
+        makeBroadcast("b-1", 10), // complete
+        makeBroadcast("b-2", 500), // incomplete (too many missing)
+        makeBroadcast("b-3", 50), // complete
+      ])
+      dbCountMock
+        .mockResolvedValueOnce(10) // b-1: completed >= total
+        .mockResolvedValueOnce(250) // b-2: 250 missing → not finalized
+        .mockResolvedValueOnce(50) // b-3: completed >= total
+
+      const result = await finalizeBroadcasts()
+
+      expect(result).toEqual({ skipped: false, finalized: 2 })
+      expect(updateCalls).toHaveLength(2)
+    })
+  })
+
+  describe("$count query arguments", () => {
+    test("counts contactsOnBroadcastsModel rows filtered by broadcastId and deliveredAt/failedAt", async () => {
+      findManyBroadcast.mockResolvedValue([makeBroadcast("b-1", 5)])
+      dbCountMock.mockResolvedValue(5)
+
+      await finalizeBroadcasts()
+
+      expect(dbCountMock).toHaveBeenCalledTimes(1)
+      // First arg is the model table, second is the where condition
+      const [table, where] = dbCountMock.mock.calls[0] as [
+        { __name: string },
+        { __and: unknown[] },
+      ]
+      expect(table.__name).toBe("contactsOnBroadcastsModel")
+      expect(where.__and).toHaveLength(2)
+    })
+  })
+
+  describe("logger output", () => {
+    test("logs finalized count after completing the pass", async () => {
+      findManyBroadcast.mockResolvedValue([makeBroadcast("b-1", 3)])
+      dbCountMock.mockResolvedValue(3)
+
+      await finalizeBroadcasts()
+
+      expect(loggerInfoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ finalized: 1 }),
+        "finalizeBroadcasts completed",
+      )
+    })
+  })
+})

--- a/apps/worker/__tests__/prepare-broadcast.test.ts
+++ b/apps/worker/__tests__/prepare-broadcast.test.ts
@@ -1,0 +1,353 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ── db spies ──────────────────────────────────────────────────────────────────
+const findFirstBroadcast = vi.fn()
+const findManyInbox = vi.fn()
+const findManyConversation = vi.fn()
+
+type UpdateCall = {
+  table: unknown
+  values: Record<string, unknown>
+  condition: unknown
+}
+const updateCalls: UpdateCall[] = []
+
+type InsertCall = { table: unknown; values: unknown }
+const insertCalls: InsertCall[] = []
+
+const onConflictSpy = vi.fn()
+
+// ── queue spy ─────────────────────────────────────────────────────────────────
+const scheduleAddSpy = vi.fn()
+
+// ── chunkById spy – controls whether callback is invoked ──────────────────────
+const chunkByIdMock = vi.fn()
+
+// ── mocks ─────────────────────────────────────────────────────────────────────
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      broadcastModel: {
+        findFirst: (...args: unknown[]) => findFirstBroadcast(...args),
+      },
+      inboxModel: {
+        findMany: (...args: unknown[]) => findManyInbox(...args),
+      },
+      conversationModel: {
+        findMany: (...args: unknown[]) => findManyConversation(...args),
+      },
+    },
+    update: (table: unknown) => ({
+      set: (values: Record<string, unknown>) => ({
+        where: (condition: unknown) => {
+          updateCalls.push({ table, values, condition })
+          return Promise.resolve()
+        },
+      }),
+    }),
+    insert: (table: unknown) => ({
+      values: (vals: unknown) => {
+        insertCalls.push({ table, values: vals })
+        return {
+          onConflictDoNothing: () => {
+            onConflictSpy()
+            return Promise.resolve()
+          },
+        }
+      },
+    }),
+    // select chain is only passed as a queryFn to the mocked chunkById; never called
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => ({
+            limit: () => Promise.resolve([]),
+          }),
+        }),
+      }),
+    }),
+  },
+  and: (...args: unknown[]) => ({ __and: args }),
+  eq: (a: unknown, b: unknown) => ({ __eq: [a, b] }),
+  gt: (a: unknown, b: unknown) => ({ __gt: [a, b] }),
+  inArray: (a: unknown, b: unknown) => ({ __inArray: [a, b] }),
+  asc: (a: unknown) => ({ __asc: a }),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  broadcastModel: { id: "broadcast.id", __name: "broadcastModel" },
+  contactInboxModel: {
+    id: "contactInbox.id",
+    inboxId: "contactInbox.inboxId",
+    __name: "contactInboxModel",
+  },
+  contactsOnBroadcastsModel: { __name: "contactsOnBroadcastsModel" },
+}))
+
+vi.mock("@chatbotx.io/database/partials", () => ({
+  broadcastStatuses: {
+    enum: { scheduled: "scheduled", sending: "sending", sent: "sent" },
+  },
+  channelTypes: {
+    enum: {
+      omnichannel: "omnichannel",
+      whatsapp: "whatsapp",
+      messenger: "messenger",
+    },
+  },
+}))
+
+vi.mock("@chatbotx.io/database/utils", () => ({
+  chunkById: (...args: unknown[]) => chunkByIdMock(...args),
+}))
+
+vi.mock("@chatbotx.io/worker-config", () => ({
+  scheduleQueue: {
+    add: (...args: unknown[]) => scheduleAddSpy(...args),
+  },
+  ScheduleJobData: {
+    sendBroadcast: "sendBroadcast",
+    prepareBroadcast: "prepareBroadcast",
+    enqueueBroadcast: "enqueueBroadcast",
+    finalizeBroadcasts: "finalizeBroadcasts",
+  },
+}))
+
+const { prepareBroadcast } = await import(
+  "../src/schedule/handlers/prepare-broadcast"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+const BROADCAST_ID = "broadcast-1"
+const WORKSPACE_ID = "workspace-1"
+
+const baseBroadcast = () => ({
+  id: BROADCAST_ID,
+  workspaceId: WORKSPACE_ID,
+  integrationWhatsappId: null as string | null,
+  integrationWhatsapp: null as { inboxId: string } | null,
+  channel: null as string | null,
+  status: "scheduled",
+})
+
+// ── setup ─────────────────────────────────────────────────────────────────────
+beforeEach(() => {
+  updateCalls.length = 0
+  insertCalls.length = 0
+  findFirstBroadcast.mockResolvedValue(undefined)
+  findManyInbox.mockResolvedValue([])
+  findManyConversation.mockResolvedValue([])
+  chunkByIdMock.mockResolvedValue(undefined)
+})
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+describe("prepareBroadcast", () => {
+  describe("broadcast not found", () => {
+    test("returns without any db writes or queue enqueues", async () => {
+      findFirstBroadcast.mockResolvedValue(undefined)
+
+      await prepareBroadcast(BROADCAST_ID)
+
+      expect(updateCalls).toHaveLength(0)
+      expect(insertCalls).toHaveLength(0)
+      expect(scheduleAddSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("integrationWhatsappId + integrationWhatsapp present", () => {
+    test("uses integrationWhatsapp.inboxId directly and skips inboxModel query", async () => {
+      findFirstBroadcast.mockResolvedValue({
+        ...baseBroadcast(),
+        integrationWhatsappId: "wa-int-1",
+        integrationWhatsapp: { inboxId: "inbox-wa" },
+      })
+      // no contacts → status sent
+      chunkByIdMock.mockResolvedValue(undefined)
+
+      await prepareBroadcast(BROADCAST_ID)
+
+      expect(findManyInbox).not.toHaveBeenCalled()
+      // inboxIds = ["inbox-wa"], not empty, so chunkById is called
+      expect(chunkByIdMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("inbox resolution via inboxModel", () => {
+    test("omnichannel channel → no channel key in where clause", async () => {
+      findFirstBroadcast.mockResolvedValue({
+        ...baseBroadcast(),
+        channel: "omnichannel",
+      })
+      findManyInbox.mockResolvedValue([{ id: "inbox-1" }])
+
+      await prepareBroadcast(BROADCAST_ID)
+
+      expect(findManyInbox).toHaveBeenCalledTimes(1)
+      const [arg] = findManyInbox.mock.calls[0] as [
+        { where: Record<string, unknown> },
+      ]
+      expect(arg.where).not.toHaveProperty("channel")
+    })
+
+    test("specific channel → channel key included in where clause", async () => {
+      findFirstBroadcast.mockResolvedValue({
+        ...baseBroadcast(),
+        channel: "whatsapp",
+      })
+      findManyInbox.mockResolvedValue([{ id: "inbox-1" }])
+
+      await prepareBroadcast(BROADCAST_ID)
+
+      const [arg] = findManyInbox.mock.calls[0] as [
+        { where: Record<string, unknown> },
+      ]
+      expect(arg.where).toHaveProperty("channel", "whatsapp")
+    })
+
+    test("null channel → no channel key in where clause", async () => {
+      findFirstBroadcast.mockResolvedValue({
+        ...baseBroadcast(),
+        channel: null,
+      })
+      findManyInbox.mockResolvedValue([{ id: "inbox-1" }])
+
+      await prepareBroadcast(BROADCAST_ID)
+
+      const [arg] = findManyInbox.mock.calls[0] as [
+        { where: Record<string, unknown> },
+      ]
+      expect(arg.where).not.toHaveProperty("channel")
+    })
+  })
+
+  describe("inboxIds resolves to empty list", () => {
+    test("updates broadcast status to 'sent' and returns early without calling chunkById", async () => {
+      findFirstBroadcast.mockResolvedValue(baseBroadcast())
+      findManyInbox.mockResolvedValue([])
+
+      await prepareBroadcast(BROADCAST_ID)
+
+      expect(updateCalls).toHaveLength(1)
+      expect(updateCalls[0].values).toMatchObject({ status: "sent" })
+      expect(chunkByIdMock).not.toHaveBeenCalled()
+      expect(scheduleAddSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("contacts are found (chunkById invokes callback)", () => {
+    type FakeContactInbox = { id: string; contactId: string }
+
+    beforeEach(() => {
+      findFirstBroadcast.mockResolvedValue({
+        ...baseBroadcast(),
+        channel: "whatsapp",
+      })
+      findManyInbox.mockResolvedValue([{ id: "inbox-1" }])
+      findManyConversation.mockResolvedValue([
+        { id: "conv-1", contactId: "contact-1" },
+      ])
+      chunkByIdMock.mockImplementation(
+        async (
+          _queryFn: unknown,
+          opts: {
+            callback: (
+              items: FakeContactInbox[],
+            ) => Promise<boolean | undefined>
+          },
+        ) => {
+          await opts.callback([{ id: "ci-1", contactId: "contact-1" }])
+        },
+      )
+    })
+
+    test("inserts a contactsOnBroadcasts row with correct shape", async () => {
+      await prepareBroadcast(BROADCAST_ID)
+
+      expect(insertCalls).toHaveLength(1)
+      expect(onConflictSpy).toHaveBeenCalledTimes(1)
+      const rows = insertCalls[0].values as Record<string, unknown>[]
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toMatchObject({
+        broadcastId: BROADCAST_ID,
+        contactId: "contact-1",
+        contactInboxId: "ci-1",
+      })
+    })
+
+    test("updates broadcast to status 'sending' with correct contactCount", async () => {
+      await prepareBroadcast(BROADCAST_ID)
+
+      expect(updateCalls).toHaveLength(1)
+      expect(updateCalls[0].values).toMatchObject({
+        status: "sending",
+        contactCount: 1,
+      })
+    })
+
+    test("enqueues sendBroadcast job in scheduleQueue", async () => {
+      await prepareBroadcast(BROADCAST_ID)
+
+      expect(scheduleAddSpy).toHaveBeenCalledTimes(1)
+      expect(scheduleAddSpy).toHaveBeenCalledWith(
+        "sendBroadcast",
+        expect.objectContaining({
+          type: "sendBroadcast",
+          data: { broadcastId: BROADCAST_ID },
+        }),
+      )
+    })
+
+    test("maps conversationId from conversationMap or empty string when missing", async () => {
+      // contactId "contact-2" has no matching conversation → conversationId = ""
+      chunkByIdMock.mockImplementation(
+        async (
+          _queryFn: unknown,
+          opts: {
+            callback: (
+              items: FakeContactInbox[],
+            ) => Promise<boolean | undefined>
+          },
+        ) => {
+          await opts.callback([
+            { id: "ci-1", contactId: "contact-1" },
+            { id: "ci-2", contactId: "contact-2" },
+          ])
+        },
+      )
+
+      await prepareBroadcast(BROADCAST_ID)
+
+      const rows = insertCalls[0].values as Record<string, unknown>[]
+      expect(rows).toHaveLength(2)
+      expect(rows[0]).toMatchObject({ conversationId: "conv-1" })
+      expect(rows[1]).toMatchObject({ conversationId: "" })
+    })
+  })
+
+  describe("no contacts found (chunkById never invokes callback)", () => {
+    beforeEach(() => {
+      findFirstBroadcast.mockResolvedValue({
+        ...baseBroadcast(),
+        channel: "whatsapp",
+      })
+      findManyInbox.mockResolvedValue([{ id: "inbox-1" }])
+      chunkByIdMock.mockResolvedValue(undefined)
+    })
+
+    test("updates broadcast to status 'sent' with contactCount 0", async () => {
+      await prepareBroadcast(BROADCAST_ID)
+
+      expect(updateCalls).toHaveLength(1)
+      expect(updateCalls[0].values).toMatchObject({
+        status: "sent",
+        contactCount: 0,
+      })
+    })
+
+    test("does not enqueue sendBroadcast job", async () => {
+      await prepareBroadcast(BROADCAST_ID)
+
+      expect(scheduleAddSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/worker/__tests__/process-broadcast-contacts.test.ts
+++ b/apps/worker/__tests__/process-broadcast-contacts.test.ts
@@ -1,0 +1,363 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ── db spies ──────────────────────────────────────────────────────────────────
+const findManyBroadcast = vi.fn()
+const findManyContactsOnBroadcasts = vi.fn()
+
+type UpdateCall = {
+  table: unknown
+  values: Record<string, unknown>
+  condition: unknown
+}
+const updateCalls: UpdateCall[] = []
+
+// ── queue spies ───────────────────────────────────────────────────────────────
+const chatAddSpy = vi.fn()
+const integrationAddSpy = vi.fn()
+
+// ── logger spy ────────────────────────────────────────────────────────────────
+const loggerErrorSpy = vi.fn()
+
+// ── mocks ─────────────────────────────────────────────────────────────────────
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      broadcastModel: {
+        findMany: (...args: unknown[]) => findManyBroadcast(...args),
+      },
+      contactsOnBroadcastsModel: {
+        findMany: (...args: unknown[]) => findManyContactsOnBroadcasts(...args),
+      },
+    },
+    update: (table: unknown) => ({
+      set: (values: Record<string, unknown>) => ({
+        where: (condition: unknown) => {
+          updateCalls.push({ table, values, condition })
+          return Promise.resolve()
+        },
+      }),
+    }),
+  },
+  and: (...args: unknown[]) => ({ __and: args }),
+  eq: (a: unknown, b: unknown) => ({ __eq: [a, b] }),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  broadcastModel: { id: "broadcast.id", __name: "broadcastModel" },
+  contactsOnBroadcastsModel: {
+    broadcastId: "cob.broadcastId",
+    contactId: "cob.contactId",
+    __name: "contactsOnBroadcastsModel",
+  },
+}))
+
+vi.mock("@chatbotx.io/database/partials", () => ({
+  broadcastStatuses: {
+    enum: { scheduled: "scheduled", sending: "sending", sent: "sent" },
+  },
+  channelTypes: {
+    enum: {
+      omnichannel: "omnichannel",
+      whatsapp: "whatsapp",
+      messenger: "messenger",
+    },
+  },
+}))
+
+vi.mock("@chatbotx.io/flow-config", () => ({
+  BROADCAST_PAYLOAD_TYPE: "broadcast",
+}))
+
+vi.mock("@chatbotx.io/worker-config", () => ({
+  chatQueue: {
+    add: (...args: unknown[]) => chatAddSpy(...args),
+  },
+  integrationQueue: {
+    add: (...args: unknown[]) => integrationAddSpy(...args),
+  },
+  ChatJobAction: {
+    sendWhatsappTemplateMessage: "sendWhatsappTemplateMessage",
+    sendMessengerTemplateMessage: "sendMessengerTemplateMessage",
+  },
+  IntegrationJobAction: {
+    sendFlow: "sendFlow",
+  },
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: (...args: unknown[]) => loggerErrorSpy(...args),
+  },
+}))
+
+const { processBroadcastContacts } = await import(
+  "../src/schedule/handlers/process-broadcast-contacts"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+const BROADCAST_ID = "broadcast-1"
+const WORKSPACE_ID = "workspace-1"
+
+const makeConversation = (id = "conv-1", contactId = "contact-1") => ({
+  id,
+  contactId,
+  workspaceId: WORKSPACE_ID,
+})
+
+const makeContactInbox = (id = "ci-1") => ({ id })
+
+const makeContactOnBroadcast = (overrides: Record<string, unknown> = {}) => ({
+  broadcastId: BROADCAST_ID,
+  contactId: "contact-1",
+  contactInboxId: "ci-1",
+  conversationId: "conv-1",
+  sent: false,
+  conversation: makeConversation(),
+  contactInbox: makeContactInbox(),
+  ...overrides,
+})
+
+const makeBroadcast = (overrides: Record<string, unknown> = {}) => ({
+  id: BROADCAST_ID,
+  workspaceId: WORKSPACE_ID,
+  status: "sending",
+  flowId: null as string | null,
+  templateId: null as string | null,
+  channel: null as string | null,
+  templateData: null as unknown,
+  ...overrides,
+})
+
+// ── setup ─────────────────────────────────────────────────────────────────────
+beforeEach(() => {
+  updateCalls.length = 0
+  findManyBroadcast.mockResolvedValue([])
+  findManyContactsOnBroadcasts.mockResolvedValue([])
+  chatAddSpy.mockResolvedValue(undefined)
+  integrationAddSpy.mockResolvedValue(undefined)
+})
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+describe("processBroadcastContacts", () => {
+  describe("no broadcasts in 'sending' status", () => {
+    test("returns { processed: 0 } without any db updates or queue adds", async () => {
+      findManyBroadcast.mockResolvedValue([])
+
+      const result = await processBroadcastContacts()
+
+      expect(result).toEqual({ processed: 0 })
+      expect(updateCalls).toHaveLength(0)
+      expect(chatAddSpy).not.toHaveBeenCalled()
+      expect(integrationAddSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("broadcast has no unsent contacts", () => {
+    test("updates broadcastModel status to 'sent' and returns processed: 0", async () => {
+      findManyBroadcast.mockResolvedValue([makeBroadcast()])
+      findManyContactsOnBroadcasts.mockResolvedValue([])
+
+      const result = await processBroadcastContacts()
+
+      expect(result).toEqual({ processed: 0 })
+      expect(updateCalls).toHaveLength(1)
+      expect(updateCalls[0].values).toMatchObject({ status: "sent" })
+      expect(chatAddSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("broadcast with flowId", () => {
+    test("enqueues integrationQueue sendFlow with correct payload", async () => {
+      findManyBroadcast.mockResolvedValue([makeBroadcast({ flowId: "flow-1" })])
+      findManyContactsOnBroadcasts.mockResolvedValue([makeContactOnBroadcast()])
+
+      await processBroadcastContacts()
+
+      expect(integrationAddSpy).toHaveBeenCalledTimes(1)
+      expect(integrationAddSpy).toHaveBeenCalledWith(
+        "sendFlow",
+        expect.objectContaining({
+          type: "sendFlow",
+          data: expect.objectContaining({
+            flowId: "flow-1",
+            conversationId: "conv-1",
+            contactInboxId: "ci-1",
+            metadata: expect.objectContaining({
+              type: "broadcast",
+              broadcastId: BROADCAST_ID,
+            }),
+          }),
+        }),
+      )
+    })
+
+    test("does not call chatQueue when only flowId is set", async () => {
+      findManyBroadcast.mockResolvedValue([makeBroadcast({ flowId: "flow-1" })])
+      findManyContactsOnBroadcasts.mockResolvedValue([makeContactOnBroadcast()])
+
+      await processBroadcastContacts()
+
+      expect(chatAddSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("broadcast with templateId on non-messenger channel", () => {
+    test("enqueues chatQueue sendWhatsappTemplateMessage with correct payload", async () => {
+      findManyBroadcast.mockResolvedValue([
+        makeBroadcast({
+          templateId: "tmpl-1",
+          channel: "whatsapp",
+          templateData: { components: [] },
+        }),
+      ])
+      findManyContactsOnBroadcasts.mockResolvedValue([makeContactOnBroadcast()])
+
+      await processBroadcastContacts()
+
+      expect(chatAddSpy).toHaveBeenCalledTimes(1)
+      expect(chatAddSpy).toHaveBeenCalledWith(
+        "sendWhatsappTemplateMessage",
+        expect.objectContaining({
+          type: "sendWhatsappTemplateMessage",
+          data: expect.objectContaining({
+            templateId: "tmpl-1",
+            broadcastId: BROADCAST_ID,
+            templateData: { components: [] },
+            metadata: expect.objectContaining({
+              type: "broadcast",
+              broadcastId: BROADCAST_ID,
+            }),
+          }),
+        }),
+      )
+    })
+  })
+
+  describe("broadcast with templateId on messenger channel", () => {
+    test("enqueues chatQueue sendMessengerTemplateMessage", async () => {
+      findManyBroadcast.mockResolvedValue([
+        makeBroadcast({
+          templateId: "tmpl-messenger",
+          channel: "messenger",
+          templateData: { text: "Hello" },
+        }),
+      ])
+      findManyContactsOnBroadcasts.mockResolvedValue([makeContactOnBroadcast()])
+
+      await processBroadcastContacts()
+
+      expect(chatAddSpy).toHaveBeenCalledTimes(1)
+      expect(chatAddSpy).toHaveBeenCalledWith(
+        "sendMessengerTemplateMessage",
+        expect.objectContaining({ type: "sendMessengerTemplateMessage" }),
+      )
+    })
+
+    test("separates buttons from templateData so job receives correct shapes", async () => {
+      const buttons = [{ id: "b1", label: "Yes", flowId: "flow-btn" }]
+      findManyBroadcast.mockResolvedValue([
+        makeBroadcast({
+          templateId: "tmpl-messenger",
+          channel: "messenger",
+          templateData: { text: "Pick one", buttons },
+        }),
+      ])
+      findManyContactsOnBroadcasts.mockResolvedValue([makeContactOnBroadcast()])
+
+      await processBroadcastContacts()
+
+      const callArgs = chatAddSpy.mock.calls[0] as [
+        string,
+        { data: { templateData: unknown; buttons: unknown } },
+      ]
+      const { data } = callArgs[1]
+      expect(data.buttons).toEqual(buttons)
+      expect(data.templateData).toEqual({ text: "Pick one" })
+    })
+
+    test("templateData is undefined when no non-button fields are present", async () => {
+      findManyBroadcast.mockResolvedValue([
+        makeBroadcast({
+          templateId: "tmpl-messenger",
+          channel: "messenger",
+          templateData: { buttons: [{ id: "b1", label: "Yes" }] },
+        }),
+      ])
+      findManyContactsOnBroadcasts.mockResolvedValue([makeContactOnBroadcast()])
+
+      await processBroadcastContacts()
+
+      const callArgs = chatAddSpy.mock.calls[0] as [
+        string,
+        { data: { templateData: unknown } },
+      ]
+      expect(callArgs[1].data.templateData).toBeUndefined()
+    })
+  })
+
+  describe("successful contact processing", () => {
+    test("marks contactOnBroadcast as sent=true after queue add", async () => {
+      findManyBroadcast.mockResolvedValue([
+        makeBroadcast({ templateId: "tmpl-1", channel: "whatsapp" }),
+      ])
+      findManyContactsOnBroadcasts.mockResolvedValue([makeContactOnBroadcast()])
+
+      const result = await processBroadcastContacts()
+
+      expect(result).toEqual({ processed: 1 })
+      // update to contactsOnBroadcastsModel
+      const cobUpdate = updateCalls.find(
+        (c) =>
+          (c.table as { __name?: string }).__name ===
+          "contactsOnBroadcastsModel",
+      )
+      expect(cobUpdate).toBeDefined()
+      expect(cobUpdate?.values).toMatchObject({ sent: true })
+    })
+
+    test("processes multiple contacts across multiple broadcasts and returns total count", async () => {
+      findManyBroadcast.mockResolvedValue([
+        makeBroadcast({ id: "b-1", templateId: "t-1", channel: "whatsapp" }),
+        makeBroadcast({ id: "b-2", templateId: "t-2", channel: "whatsapp" }),
+      ])
+      findManyContactsOnBroadcasts
+        .mockResolvedValueOnce([
+          makeContactOnBroadcast({ broadcastId: "b-1" }),
+          makeContactOnBroadcast({
+            broadcastId: "b-1",
+            contactId: "contact-2",
+          }),
+        ])
+        .mockResolvedValueOnce([makeContactOnBroadcast({ broadcastId: "b-2" })])
+
+      const result = await processBroadcastContacts()
+
+      expect(result).toEqual({ processed: 3 })
+    })
+  })
+
+  describe("error handling inside per-contact processing", () => {
+    test("logs the error and continues processing remaining contacts", async () => {
+      findManyBroadcast.mockResolvedValue([
+        makeBroadcast({ templateId: "tmpl-1", channel: "whatsapp" }),
+      ])
+      findManyContactsOnBroadcasts.mockResolvedValue([
+        makeContactOnBroadcast({ contactId: "contact-1" }),
+        makeContactOnBroadcast({ contactId: "contact-2" }),
+      ])
+
+      // first add throws, second succeeds
+      chatAddSpy
+        .mockRejectedValueOnce(new Error("queue unavailable"))
+        .mockResolvedValueOnce(undefined)
+
+      const result = await processBroadcastContacts()
+
+      expect(loggerErrorSpy).toHaveBeenCalledTimes(1)
+      // second contact still processed
+      expect(result).toEqual({ processed: 1 })
+    })
+  })
+})

--- a/apps/worker/__tests__/sequence-dispatch-processor.test.ts
+++ b/apps/worker/__tests__/sequence-dispatch-processor.test.ts
@@ -1,0 +1,279 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------- db chain spies ----------
+const findFirstSpy = vi.fn()
+const updateSpy = vi.fn()
+const setSpy = vi.fn()
+const whereSpy = vi.fn()
+const returningSpy = vi.fn()
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      sequenceDispatchModel: {
+        findFirst: (...args: unknown[]) => findFirstSpy(...args),
+      },
+    },
+    update: (table: unknown) => {
+      updateSpy(table)
+      return {
+        set: (values: unknown) => {
+          setSpy(values)
+          return {
+            where: (...args: unknown[]) => {
+              whereSpy(...args)
+              return { returning: (...a: unknown[]) => returningSpy(...a) }
+            },
+          }
+        },
+      }
+    },
+  },
+  and: (...args: unknown[]) => ({ __and: args }),
+  eq: (col: unknown, val: unknown) => ({ __eq: [col, val] }),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  sequenceDispatchModel: {
+    id: { __col: "id" },
+    workspaceId: { __col: "workspaceId" },
+    status: { __col: "status" },
+  },
+}))
+
+import { DispatchProcessorService } from "../src/sequence-scheduler/services/dispatch-processor.service"
+
+// ---------- shared fixtures ----------
+
+function makeDispatch(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "d1",
+    workspaceId: "ws1",
+    status: "pending",
+    runAtMs: Date.now() - 5000,
+    sequence: {},
+    contact: {},
+    enrollment: {},
+    ...overrides,
+  } as unknown as Parameters<DispatchProcessorService["validateDispatch"]>[0]
+}
+
+beforeEach(() => {
+  findFirstSpy.mockResolvedValue(undefined)
+  returningSpy.mockResolvedValue([])
+})
+
+// ---------- tests ----------
+
+describe("DispatchProcessorService", () => {
+  describe("fetchDispatch", () => {
+    test("returns the dispatch when db finds a record", async () => {
+      // Arrange
+      const dispatch = makeDispatch()
+      findFirstSpy.mockResolvedValue(dispatch)
+
+      // Act
+      const result = await new DispatchProcessorService().fetchDispatch("d1")
+
+      // Assert
+      expect(result).toEqual(dispatch)
+    })
+
+    test("returns null when db returns undefined (not found)", async () => {
+      // Arrange
+      findFirstSpy.mockResolvedValue(undefined)
+
+      // Act
+      const result = await new DispatchProcessorService().fetchDispatch(
+        "missing",
+      )
+
+      // Assert
+      expect(result).toBeNull()
+    })
+
+    test("returns null and logs error when db throws", async () => {
+      // Arrange
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined)
+      findFirstSpy.mockRejectedValue(new Error("connection refused"))
+
+      // Act
+      const result = await new DispatchProcessorService().fetchDispatch("d1")
+
+      // Assert
+      expect(result).toBeNull()
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[ERROR fetchDispatch]"),
+        expect.any(Error),
+      )
+    })
+
+    test("queries with id and fetches sequence/contact/enrollment relations", async () => {
+      // Arrange
+      findFirstSpy.mockResolvedValue({ id: "d99" })
+
+      // Act
+      await new DispatchProcessorService().fetchDispatch("d99")
+
+      // Assert
+      expect(findFirstSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: "d99" }),
+          with: { sequence: true, contact: true, enrollment: true },
+        }),
+      )
+    })
+  })
+
+  describe("validateDispatch", () => {
+    test("returns false when status is running", () => {
+      // Arrange
+      const dispatch = makeDispatch({ status: "running" })
+
+      // Act + Assert
+      expect(new DispatchProcessorService().validateDispatch(dispatch)).toBe(
+        false,
+      )
+    })
+
+    test("returns false when status is failed", () => {
+      // Arrange
+      const dispatch = makeDispatch({ status: "failed" })
+
+      // Act + Assert
+      expect(new DispatchProcessorService().validateDispatch(dispatch)).toBe(
+        false,
+      )
+    })
+
+    test("returns false when status is completed", () => {
+      // Arrange
+      const dispatch = makeDispatch({ status: "completed" })
+
+      // Act + Assert
+      expect(new DispatchProcessorService().validateDispatch(dispatch)).toBe(
+        false,
+      )
+    })
+
+    test("returns true when dispatch is pending", () => {
+      // Arrange
+      const dispatch = makeDispatch({ status: "pending" })
+
+      // Act + Assert
+      expect(new DispatchProcessorService().validateDispatch(dispatch)).toBe(
+        true,
+      )
+    })
+
+    test("returns false when dispatch is null", () => {
+      expect(new DispatchProcessorService().validateDispatch(null)).toBe(false)
+    })
+  })
+
+  describe("isDispatchReady", () => {
+    test("returns true when runAtMs is in the past", () => {
+      // Arrange
+      const dispatch = makeDispatch({ runAtMs: Date.now() - 10_000 })
+
+      // Act + Assert
+      expect(
+        new DispatchProcessorService().isDispatchReady(
+          dispatch as NonNullable<typeof dispatch>,
+        ),
+      ).toBe(true)
+    })
+
+    test("returns true when runAtMs is within the 1 second tolerance window", () => {
+      // Arrange
+      const dispatch = makeDispatch({ runAtMs: Date.now() + 800 })
+
+      // Act + Assert
+      expect(
+        new DispatchProcessorService().isDispatchReady(
+          dispatch as NonNullable<typeof dispatch>,
+        ),
+      ).toBe(true)
+    })
+
+    test("returns false when runAtMs is beyond the tolerance window", () => {
+      // Arrange
+      const dispatch = makeDispatch({ runAtMs: Date.now() + 60_000 })
+
+      // Act + Assert
+      expect(
+        new DispatchProcessorService().isDispatchReady(
+          dispatch as NonNullable<typeof dispatch>,
+        ),
+      ).toBe(false)
+    })
+  })
+
+  describe("lockDispatch", () => {
+    test("returns true when a row is updated (lock acquired)", async () => {
+      // Arrange
+      returningSpy.mockResolvedValue([{ id: "d1" }])
+      const dispatch = makeDispatch() as NonNullable<typeof makeDispatch>
+
+      // Act
+      const result = await new DispatchProcessorService().lockDispatch(
+        dispatch as NonNullable<typeof dispatch>,
+      )
+
+      // Assert
+      expect(result).toBe(true)
+    })
+
+    test("returns false when no rows updated — optimistic lock lost", async () => {
+      // Arrange
+      returningSpy.mockResolvedValue([])
+      const dispatch = makeDispatch() as NonNullable<typeof makeDispatch>
+
+      // Act
+      const result = await new DispatchProcessorService().lockDispatch(
+        dispatch as NonNullable<typeof dispatch>,
+      )
+
+      // Assert
+      expect(result).toBe(false)
+    })
+
+    test("sets status to running with a fresh lockedAt timestamp", async () => {
+      // Arrange
+      returningSpy.mockResolvedValue([{ id: "d1" }])
+      const dispatch = makeDispatch() as NonNullable<typeof makeDispatch>
+
+      // Act
+      const before = Date.now()
+      await new DispatchProcessorService().lockDispatch(
+        dispatch as NonNullable<typeof dispatch>,
+      )
+      const after = Date.now()
+
+      // Assert
+      const setArg = setSpy.mock.calls[0][0] as Record<string, unknown>
+      expect(setArg.status).toBe("running")
+      expect(setArg.lockedAt).toBeInstanceOf(Date)
+      const ts = (setArg.lockedAt as Date).getTime()
+      expect(ts).toBeGreaterThanOrEqual(before)
+      expect(ts).toBeLessThanOrEqual(after)
+    })
+
+    test("WHERE clause uses id + workspaceId + status=pending for optimistic concurrency", async () => {
+      // Arrange
+      returningSpy.mockResolvedValue([])
+      const dispatch = makeDispatch() as NonNullable<typeof makeDispatch>
+
+      // Act
+      await new DispatchProcessorService().lockDispatch(
+        dispatch as NonNullable<typeof dispatch>,
+      )
+
+      // Assert — three conditions prevent double-claiming
+      const whereArg = whereSpy.mock.calls[0][0] as { __and: unknown[] }
+      expect(whereArg.__and).toHaveLength(3)
+    })
+  })
+})

--- a/apps/worker/__tests__/sequence-flow.test.ts
+++ b/apps/worker/__tests__/sequence-flow.test.ts
@@ -1,0 +1,425 @@
+import type { Job } from "bullmq"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------- db chain spies ----------
+const dbFindFirstSpy = vi.fn()
+const dbUpdateSpy = vi.fn()
+const dbSetSpy = vi.fn()
+const dbWhereSpy = vi.fn()
+const dbWhereResolveSpy = vi.fn()
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      sequenceDispatchModel: {
+        findFirst: (...args: unknown[]) => dbFindFirstSpy(...args),
+      },
+    },
+    update: (table: unknown) => {
+      dbUpdateSpy(table)
+      return {
+        set: (values: unknown) => {
+          dbSetSpy(values)
+          return {
+            where: (...args: unknown[]) => {
+              dbWhereSpy(...args)
+              return dbWhereResolveSpy(...args)
+            },
+          }
+        },
+      }
+    },
+  },
+  and: (...args: unknown[]) => ({ __and: args }),
+  eq: (col: unknown, val: unknown) => ({ __eq: [col, val] }),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  sequenceDispatchModel: {
+    id: { __col: "id" },
+    workspaceId: { __col: "workspaceId" },
+  },
+}))
+
+// ---------- scheduler / redis spies ----------
+// removeFromScheduleSpy is accessed at instance-creation time (during tests,
+// not at import time), so vi.hoisted is not needed.
+const removeFromScheduleSpy = vi.fn()
+
+vi.mock("@chatbotx.io/scheduler", () => ({
+  SchedulerClient: class MockSchedulerClient {
+    removeFromSchedule = removeFromScheduleSpy
+  },
+}))
+
+vi.mock("@chatbotx.io/redis", () => ({
+  sequenceConnections: {
+    useExisting: vi.fn().mockResolvedValue({}),
+  },
+}))
+
+// ---------- sequence-scheduler spies ----------
+const advanceEnrollmentSpy = vi.fn()
+
+vi.mock("@chatbotx.io/sequence-scheduler", () => ({
+  advanceEnrollment: (...args: unknown[]) => advanceEnrollmentSpy(...args),
+}))
+
+// ---------- step executor spy (module-level singleton in source) ----------
+// Must use vi.hoisted() so the spies exist before the class field initializers
+// fire at module-import time (sequence-flow.ts does `new StepExecutorService()`
+// at module level, which runs before regular const declarations are initialized).
+const { fetchStepSpy, validateStepSpy } = vi.hoisted(() => ({
+  fetchStepSpy: vi.fn(),
+  validateStepSpy: vi.fn(),
+}))
+
+vi.mock("../src/sequence-scheduler/services/step-executor.service", () => ({
+  StepExecutorService: class MockStepExecutorService {
+    fetchStep = fetchStepSpy
+    validateStep = validateStepSpy
+  },
+}))
+
+// ---------- send-flow-direct spy ----------
+const sendFlowDirectSpy = vi.fn()
+
+vi.mock("../src/integration/handlers/send-flow-direct", () => ({
+  sendFlowDirect: (...args: unknown[]) => sendFlowDirectSpy(...args),
+}))
+
+// ---------- logger spy ----------
+const loggerErrorSpy = vi.fn()
+
+vi.mock("../src/lib/logger", () => ({
+  logger: { error: (...args: unknown[]) => loggerErrorSpy(...args) },
+}))
+
+import { handleSendSequenceFlow } from "../src/integration/handlers/sequence-flow"
+
+// ---------- fixtures ----------
+
+function makeData(
+  overrides: Record<string, unknown> = {},
+): Parameters<typeof handleSendSequenceFlow>[0] {
+  return {
+    dispatchId: "dispatch-1",
+    workspaceId: "ws-1",
+    stepId: "step-1",
+    bucket: 42,
+    contactId: "contact-1",
+    sequenceId: "seq-1",
+    enrollmentId: "enroll-1",
+    metadata: {},
+    ...overrides,
+  } as unknown as Parameters<typeof handleSendSequenceFlow>[0]
+}
+
+function makeJob(
+  overrides: Partial<{
+    attemptsMade: number
+    attempts: number
+    id: string
+  }> = {},
+): Job {
+  const { attemptsMade = 0, attempts = 3, id = "job-1" } = overrides
+  return {
+    id,
+    attemptsMade,
+    opts: { attempts },
+  } as unknown as Job
+}
+
+function makeDispatch(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "dispatch-1",
+    workspaceId: "ws-1",
+    status: "pending",
+    completedAt: null,
+    ...overrides,
+  }
+}
+
+function makeStep(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "step-1",
+    order: 1,
+    isActive: true,
+    flow: { id: "flow-1" },
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  // db defaults
+  dbFindFirstSpy.mockResolvedValue(makeDispatch())
+  dbWhereResolveSpy.mockResolvedValue(undefined)
+
+  // scheduler defaults
+  removeFromScheduleSpy.mockResolvedValue(undefined)
+  advanceEnrollmentSpy.mockResolvedValue(undefined)
+
+  // step executor defaults
+  const step = makeStep()
+  fetchStepSpy.mockResolvedValue(step)
+  validateStepSpy.mockReturnValue({ valid: true, step })
+
+  // send-flow-direct default
+  sendFlowDirectSpy.mockResolvedValue(new Date())
+})
+
+// ---------- tests ----------
+
+describe("handleSendSequenceFlow", () => {
+  describe("happy path — fresh dispatch (no completedAt)", () => {
+    test("calls sendFlowDirect then marks dispatch completed", async () => {
+      // Act
+      await handleSendSequenceFlow(makeData(), makeJob())
+
+      // Assert
+      expect(sendFlowDirectSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          flowId: "flow-1",
+          workspaceId: "ws-1",
+          contactId: "contact-1",
+        }),
+      )
+      const setArg = dbSetSpy.mock.calls.find(
+        (c: unknown[]) =>
+          (c[0] as Record<string, unknown>).status === "completed",
+      )
+      expect(setArg).toBeDefined()
+    })
+
+    test("calls advanceEnrollment with correct enrollment + step info", async () => {
+      // Act
+      await handleSendSequenceFlow(makeData(), makeJob())
+
+      // Assert
+      expect(advanceEnrollmentSpy).toHaveBeenCalledTimes(1)
+      expect(advanceEnrollmentSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enrollmentId: "enroll-1",
+          workspaceId: "ws-1",
+          sequenceId: "seq-1",
+          contactId: "contact-1",
+          currentStep: { id: "step-1", order: 1 },
+        }),
+      )
+    })
+
+    test("removes the dispatch from the schedule bucket", async () => {
+      // Act
+      await handleSendSequenceFlow(makeData(), makeJob())
+
+      // Assert
+      expect(removeFromScheduleSpy).toHaveBeenCalledWith(42, "dispatch-1")
+    })
+  })
+
+  describe("idempotent re-delivery — dispatch already has completedAt", () => {
+    test("skips sendFlowDirect and reuses the existing sentAt", async () => {
+      // Arrange
+      const completedAt = new Date("2025-01-01T10:00:00Z")
+      dbFindFirstSpy.mockResolvedValue(makeDispatch({ completedAt }))
+
+      // Act
+      await handleSendSequenceFlow(makeData(), makeJob())
+
+      // Assert — flow must NOT be sent again
+      expect(sendFlowDirectSpy).not.toHaveBeenCalled()
+      expect(advanceEnrollmentSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ sentAt: completedAt }),
+      )
+    })
+  })
+
+  describe("dispatch not found", () => {
+    test("returns early without touching db, scheduler, or advanceEnrollment", async () => {
+      // Arrange
+      dbFindFirstSpy.mockResolvedValue(undefined)
+
+      // Act
+      await handleSendSequenceFlow(makeData(), makeJob())
+
+      // Assert
+      expect(dbUpdateSpy).not.toHaveBeenCalled()
+      expect(sendFlowDirectSpy).not.toHaveBeenCalled()
+      expect(advanceEnrollmentSpy).not.toHaveBeenCalled()
+      expect(removeFromScheduleSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("step invalid — step exists in db", () => {
+    beforeEach(() => {
+      const step = makeStep({ isActive: false })
+      fetchStepSpy.mockResolvedValue(step)
+      validateStepSpy.mockReturnValue({ valid: false, reason: "step_inactive" })
+    })
+
+    test("marks dispatch canceled with the validation reason", async () => {
+      // Act
+      await handleSendSequenceFlow(makeData(), makeJob())
+
+      // Assert
+      const canceledSet = dbSetSpy.mock.calls.find(
+        (c: unknown[]) =>
+          (c[0] as Record<string, unknown>).status === "canceled",
+      )
+      expect(canceledSet).toBeDefined()
+      expect((canceledSet as unknown[])[0]).toMatchObject({
+        status: "canceled",
+        lastError: "step_inactive",
+      })
+    })
+
+    test("still calls advanceEnrollment so enrollment progresses past the dead step", async () => {
+      // Act
+      await handleSendSequenceFlow(makeData(), makeJob())
+
+      // Assert
+      expect(advanceEnrollmentSpy).toHaveBeenCalledTimes(1)
+    })
+
+    test("removes dispatch from schedule", async () => {
+      // Act
+      await handleSendSequenceFlow(makeData(), makeJob())
+
+      // Assert
+      expect(removeFromScheduleSpy).toHaveBeenCalledWith(42, "dispatch-1")
+    })
+
+    test("does NOT call sendFlowDirect", async () => {
+      // Act
+      await handleSendSequenceFlow(makeData(), makeJob())
+
+      // Assert
+      expect(sendFlowDirectSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("step not found in db", () => {
+    beforeEach(() => {
+      fetchStepSpy.mockResolvedValue(undefined)
+      validateStepSpy.mockReturnValue({
+        valid: false,
+        reason: "step_not_found",
+      })
+    })
+
+    test("marks dispatch canceled", async () => {
+      // Act
+      await handleSendSequenceFlow(makeData(), makeJob())
+
+      // Assert
+      const canceledSet = dbSetSpy.mock.calls.find(
+        (c: unknown[]) =>
+          (c[0] as Record<string, unknown>).status === "canceled",
+      )
+      expect(canceledSet).toBeDefined()
+    })
+
+    test("does NOT call advanceEnrollment — no step to advance past", async () => {
+      // Act
+      await handleSendSequenceFlow(makeData(), makeJob())
+
+      // Assert
+      expect(advanceEnrollmentSpy).not.toHaveBeenCalled()
+    })
+
+    test("still removes dispatch from schedule", async () => {
+      // Act
+      await handleSendSequenceFlow(makeData(), makeJob())
+
+      // Assert
+      expect(removeFromScheduleSpy).toHaveBeenCalledWith(42, "dispatch-1")
+    })
+  })
+
+  describe("sendFlowDirect throws on final attempt", () => {
+    beforeEach(() => {
+      sendFlowDirectSpy.mockRejectedValue(new Error("send failed"))
+    })
+
+    test("marks dispatch failed via terminal cleanup", async () => {
+      // Arrange — final attempt
+      const job = makeJob({ attemptsMade: 2, attempts: 3 })
+
+      // Act
+      await expect(handleSendSequenceFlow(makeData(), job)).rejects.toThrow(
+        "send failed",
+      )
+
+      // Assert
+      const failedSet = dbSetSpy.mock.calls.find(
+        (c: unknown[]) => (c[0] as Record<string, unknown>).status === "failed",
+      )
+      expect(failedSet).toBeDefined()
+      expect((failedSet as unknown[])[0]).toMatchObject({
+        status: "failed",
+        lastError: "send failed",
+      })
+    })
+
+    test("removes dispatch from schedule during terminal cleanup", async () => {
+      // Arrange
+      const job = makeJob({ attemptsMade: 2, attempts: 3 })
+
+      // Act
+      await expect(handleSendSequenceFlow(makeData(), job)).rejects.toThrow()
+
+      // Assert
+      expect(removeFromScheduleSpy).toHaveBeenCalledWith(42, "dispatch-1")
+    })
+
+    test("rethrows the error so BullMQ can retry", async () => {
+      // Arrange
+      const job = makeJob({ attemptsMade: 2, attempts: 3 })
+
+      // Act + Assert
+      await expect(handleSendSequenceFlow(makeData(), job)).rejects.toThrow(
+        "send failed",
+      )
+    })
+  })
+
+  describe("sendFlowDirect throws on non-final attempt", () => {
+    beforeEach(() => {
+      sendFlowDirectSpy.mockRejectedValue(new Error("transient error"))
+    })
+
+    test("rethrows without marking dispatch failed", async () => {
+      // Arrange — first of three attempts
+      const job = makeJob({ attemptsMade: 0, attempts: 3 })
+
+      // Act
+      await expect(handleSendSequenceFlow(makeData(), job)).rejects.toThrow(
+        "transient error",
+      )
+
+      // Assert — no terminal cleanup
+      const failedSet = dbSetSpy.mock.calls.find(
+        (c: unknown[]) => (c[0] as Record<string, unknown>).status === "failed",
+      )
+      expect(failedSet).toBeUndefined()
+    })
+
+    test("logs the error with attempt and isFinalAttempt info", async () => {
+      // Arrange
+      const job = makeJob({ attemptsMade: 0, attempts: 3 })
+
+      // Act
+      await expect(handleSendSequenceFlow(makeData(), job)).rejects.toThrow()
+
+      // Assert
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attempt: 1,
+          isFinalAttempt: false,
+          dispatchId: "dispatch-1",
+        }),
+        expect.any(String),
+      )
+    })
+  })
+})

--- a/apps/worker/__tests__/sequence-retry-scheduler.test.ts
+++ b/apps/worker/__tests__/sequence-retry-scheduler.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------- db chain spies ----------
+const updateSpy = vi.fn()
+const setSpy = vi.fn()
+const whereSpy = vi.fn()
+const whereResolveSpy = vi.fn()
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    update: (table: unknown) => {
+      updateSpy(table)
+      return {
+        set: (values: unknown) => {
+          setSpy(values)
+          return {
+            where: (...args: unknown[]) => {
+              whereSpy(...args)
+              return whereResolveSpy(...args)
+            },
+          }
+        },
+      }
+    },
+  },
+  and: (...args: unknown[]) => ({ __and: args }),
+  eq: (col: unknown, val: unknown) => ({ __eq: [col, val] }),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  sequenceDispatchModel: {
+    id: { __col: "id" },
+    workspaceId: { __col: "workspaceId" },
+  },
+}))
+
+// Logger is a pino child logger — mock the whole module
+const loggerErrorSpy = vi.fn()
+vi.mock("../src/lib/logger", () => ({
+  logger: { error: (...args: unknown[]) => loggerErrorSpy(...args) },
+}))
+
+import { RetrySchedulerService } from "../src/sequence-scheduler/services/retry-scheduler.service"
+
+beforeEach(() => {
+  whereResolveSpy.mockResolvedValue(undefined)
+})
+
+// ---------- tests ----------
+
+describe("RetrySchedulerService", () => {
+  describe("markDispatchFailed", () => {
+    test("updates dispatch to failed status with the provided error message", async () => {
+      // Act
+      await new RetrySchedulerService().markDispatchFailed(
+        "d1",
+        "ws1",
+        "something went wrong",
+      )
+
+      // Assert
+      expect(updateSpy).toHaveBeenCalledTimes(1)
+      const setArg = setSpy.mock.calls[0][0] as Record<string, unknown>
+      expect(setArg.status).toBe("failed")
+      expect(setArg.lastError).toBe("something went wrong")
+    })
+
+    test("stamps updatedAt with a current timestamp", async () => {
+      // Arrange
+      const before = Date.now()
+
+      // Act
+      await new RetrySchedulerService().markDispatchFailed("d1", "ws1", "err")
+
+      // Assert
+      const after = Date.now()
+      const setArg = setSpy.mock.calls[0][0] as Record<string, unknown>
+      expect(setArg.updatedAt).toBeInstanceOf(Date)
+      const ts = (setArg.updatedAt as Date).getTime()
+      expect(ts).toBeGreaterThanOrEqual(before)
+      expect(ts).toBeLessThanOrEqual(after)
+    })
+
+    test("WHERE clause includes both dispatchId and workspaceId", async () => {
+      // Act
+      await new RetrySchedulerService().markDispatchFailed("d1", "ws1", "err")
+
+      // Assert
+      const whereArg = whereSpy.mock.calls[0][0] as { __and: unknown[] }
+      expect(whereArg.__and).toHaveLength(2)
+    })
+
+    test("calls logger.error with dispatchId and errorMessage", async () => {
+      // Act
+      await new RetrySchedulerService().markDispatchFailed("d1", "ws1", "boom")
+
+      // Assert
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ dispatchId: "d1", errorMessage: "boom" }),
+        expect.any(String),
+      )
+    })
+  })
+
+  describe("markDispatchCanceled", () => {
+    test("updates dispatch to canceled status", async () => {
+      // Act
+      await new RetrySchedulerService().markDispatchCanceled(
+        "d1",
+        "ws1",
+        "step inactive",
+      )
+
+      // Assert
+      const setArg = setSpy.mock.calls[0][0] as Record<string, unknown>
+      expect(setArg.status).toBe("canceled")
+    })
+
+    test("stamps updatedAt with a current timestamp", async () => {
+      // Arrange
+      const before = Date.now()
+
+      // Act
+      await new RetrySchedulerService().markDispatchCanceled(
+        "d1",
+        "ws1",
+        "reason",
+      )
+
+      // Assert
+      const after = Date.now()
+      const setArg = setSpy.mock.calls[0][0] as Record<string, unknown>
+      expect(setArg.updatedAt).toBeInstanceOf(Date)
+      const ts = (setArg.updatedAt as Date).getTime()
+      expect(ts).toBeGreaterThanOrEqual(before)
+      expect(ts).toBeLessThanOrEqual(after)
+    })
+
+    test("WHERE clause includes both dispatchId and workspaceId", async () => {
+      // Act
+      await new RetrySchedulerService().markDispatchCanceled(
+        "d1",
+        "ws1",
+        "reason",
+      )
+
+      // Assert
+      const whereArg = whereSpy.mock.calls[0][0] as { __and: unknown[] }
+      expect(whereArg.__and).toHaveLength(2)
+    })
+
+    test("stores the reason string in lastError", async () => {
+      await new RetrySchedulerService().markDispatchCanceled(
+        "d1",
+        "ws1",
+        "step inactive",
+      )
+
+      const setArg = setSpy.mock.calls[0][0] as Record<string, unknown>
+      expect(setArg.lastError).toBe("step inactive")
+    })
+
+    test("does NOT call logger.error (only markDispatchFailed logs)", async () => {
+      // Act
+      await new RetrySchedulerService().markDispatchCanceled(
+        "d1",
+        "ws1",
+        "reason",
+      )
+
+      // Assert
+      expect(loggerErrorSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/worker/__tests__/sequence-step-executor.test.ts
+++ b/apps/worker/__tests__/sequence-step-executor.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------- db spies ----------
+const findFirstSpy = vi.fn()
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      sequenceStepModel: {
+        findFirst: (...args: unknown[]) => findFirstSpy(...args),
+      },
+    },
+  },
+}))
+
+import type { StepWithFlow } from "../src/sequence-scheduler/services/step-executor.service"
+import { StepExecutorService } from "../src/sequence-scheduler/services/step-executor.service"
+
+// ---------- fixtures ----------
+
+function makeStep(overrides: Partial<StepWithFlow> = {}): StepWithFlow {
+  return {
+    id: "step-1",
+    order: 1,
+    isActive: true,
+    flow: { id: "flow-1" },
+    ...overrides,
+  } as unknown as StepWithFlow
+}
+
+beforeEach(() => {
+  findFirstSpy.mockResolvedValue(undefined)
+})
+
+// ---------- tests ----------
+
+describe("StepExecutorService", () => {
+  describe("fetchStep", () => {
+    test("returns the step when db finds a record", async () => {
+      // Arrange
+      const step = makeStep()
+      findFirstSpy.mockResolvedValue(step)
+
+      // Act
+      const result = await new StepExecutorService().fetchStep("step-1")
+
+      // Assert
+      expect(result).toEqual(step)
+    })
+
+    test("returns undefined when db returns undefined (not found)", async () => {
+      // Arrange
+      findFirstSpy.mockResolvedValue(undefined)
+
+      // Act
+      const result = await new StepExecutorService().fetchStep("missing")
+
+      // Assert
+      expect(result).toBeUndefined()
+    })
+
+    test("queries by id with flow relation included", async () => {
+      // Arrange
+      findFirstSpy.mockResolvedValue(makeStep())
+
+      // Act
+      await new StepExecutorService().fetchStep("step-99")
+
+      // Assert
+      expect(findFirstSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: "step-99" }),
+          with: { flow: true },
+        }),
+      )
+    })
+  })
+
+  describe("validateStep", () => {
+    test("returns invalid with step_not_found reason when step is undefined", () => {
+      // Arrange + Act
+      const result = new StepExecutorService().validateStep(undefined)
+
+      // Assert
+      expect(result).toEqual({ valid: false, reason: "step_not_found" })
+    })
+
+    test("returns invalid with step_inactive reason when step.isActive is false", () => {
+      // Arrange
+      const step = makeStep({ isActive: false })
+
+      // Act
+      const result = new StepExecutorService().validateStep(step)
+
+      // Assert
+      expect(result).toEqual({ valid: false, reason: "step_inactive" })
+    })
+
+    test("returns invalid with flow_not_configured reason when step.flow is null", () => {
+      // Arrange
+      const step = makeStep({ flow: null as unknown as StepWithFlow["flow"] })
+
+      // Act
+      const result = new StepExecutorService().validateStep(step)
+
+      // Assert
+      expect(result).toEqual({ valid: false, reason: "flow_not_configured" })
+    })
+
+    test("returns valid with the step when all checks pass", () => {
+      // Arrange
+      const step = makeStep()
+
+      // Act
+      const result = new StepExecutorService().validateStep(step)
+
+      // Assert
+      expect(result).toEqual({ valid: true, step })
+    })
+
+    test("checks isActive before flow — inactive step with no flow yields step_inactive", () => {
+      // Arrange — both isActive=false and flow=null; inactive should win
+      const step = makeStep({
+        isActive: false,
+        flow: null as unknown as StepWithFlow["flow"],
+      })
+
+      // Act
+      const result = new StepExecutorService().validateStep(step)
+
+      // Assert
+      expect(result).toEqual({ valid: false, reason: "step_inactive" })
+    })
+  })
+})

--- a/apps/worker/src/integration/handlers/sequence-flow.ts
+++ b/apps/worker/src/integration/handlers/sequence-flow.ts
@@ -131,10 +131,6 @@ async function runSendSequenceFlow(data: SendSequenceFlowData): Promise<void> {
   if (completedAt) {
     sentAt = completedAt
   } else {
-    if (!validStep.flow) {
-      throw new Error(`Step ${validStep.id} has no flow configured`)
-    }
-
     await sendFlowDirect({
       flowId: validStep.flow.id,
       workspaceId,

--- a/apps/worker/src/schedule/handlers/finalize-broadcasts.ts
+++ b/apps/worker/src/schedule/handlers/finalize-broadcasts.ts
@@ -9,8 +9,8 @@ import { logger } from "../../lib/logger"
 
 const LOCK_KEY = "schedule:finalize-broadcasts"
 const LOCK_TTL_SECONDS = 55
-const MIN_CONTACTS_FOR_THRESHOLD = 100
-const MISSING_RATE_THRESHOLD = 1
+const MAX_MISSING_CONTACTS_FOR_THRESHOLD = 100
+const MISSING_RATE_THRESHOLD = 0.01
 
 export const finalizeBroadcasts = async () =>
   distributedLock.runExclusive({
@@ -52,7 +52,7 @@ export const finalizeBroadcasts = async () =>
 
         const isMissingThreshold =
           total > 0 &&
-          missingCount <= Math.min(missingCount, MIN_CONTACTS_FOR_THRESHOLD) &&
+          missingCount <= MAX_MISSING_CONTACTS_FOR_THRESHOLD &&
           missingRate <= MISSING_RATE_THRESHOLD
 
         const isComplete = completed >= total || isMissingThreshold

--- a/apps/worker/src/sequence-scheduler/services/dispatch-processor.service.ts
+++ b/apps/worker/src/sequence-scheduler/services/dispatch-processor.service.ts
@@ -26,7 +26,7 @@ export class DispatchProcessorService {
   validateDispatch(
     dispatch: Awaited<ReturnType<typeof this.fetchDispatch>>,
   ): dispatch is DispatchWithRelations {
-    if (dispatch && dispatch.status !== "pending") {
+    if (dispatch?.status !== "pending") {
       return false
     }
 

--- a/apps/worker/src/sequence-scheduler/services/retry-scheduler.service.ts
+++ b/apps/worker/src/sequence-scheduler/services/retry-scheduler.service.ts
@@ -28,12 +28,13 @@ export class RetrySchedulerService {
   async markDispatchCanceled(
     dispatchId: string,
     workspaceId: string,
-    _reason: string,
+    reason: string,
   ): Promise<void> {
     await db
       .update(sequenceDispatchModel)
       .set({
         status: "canceled",
+        lastError: reason,
         updatedAt: new Date(),
       })
       .where(

--- a/apps/worker/src/sequence-scheduler/services/step-executor.service.ts
+++ b/apps/worker/src/sequence-scheduler/services/step-executor.service.ts
@@ -7,9 +7,12 @@ type StepQueryResult = Awaited<
 >
 
 export type StepWithFlow = NonNullable<StepQueryResult>
+export type StepWithConfiguredFlow = StepWithFlow & {
+  flow: NonNullable<StepWithFlow["flow"]>
+}
 
 export type StepValidationResult =
-  | { valid: true; step: StepWithFlow }
+  | { valid: true; step: StepWithConfiguredFlow }
   | { valid: false; reason: string }
 
 export class StepExecutorService {
@@ -37,6 +40,6 @@ export class StepExecutorService {
       return { valid: false, reason: "flow_not_configured" }
     }
 
-    return { valid: true, step }
+    return { valid: true, step: step as StepWithConfiguredFlow }
   }
 }

--- a/packages/sequence-scheduler/__tests__/advance-enrollment.test.ts
+++ b/packages/sequence-scheduler/__tests__/advance-enrollment.test.ts
@@ -1,0 +1,402 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// --- top-level spies (captured by vi.mock factory closures) ---
+const findFirstMock = vi.fn()
+const updateMock = vi.fn()
+const setMock = vi.fn()
+const whereUpdateMock = vi.fn()
+const selectLimitMock = vi.fn()
+const transactionMock = vi.fn()
+
+// --- module mocks (hoisted) ---
+vi.mock("../src/contacts-on-sequences", () => ({
+  getContactInboxes: vi.fn(),
+}))
+
+vi.mock("../src/dispatch-manager", () => ({
+  createDispatch: vi.fn(),
+}))
+
+vi.mock("../src/calculate-next-run-at", () => ({
+  calculateNextRunAtFromStep: vi.fn(),
+}))
+
+vi.mock("../src/send-time-validator", () => ({
+  calculateNextValidSendTime: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      contactsOnSequenceModel: {
+        findFirst: (...args: unknown[]) => findFirstMock(...args),
+      },
+    },
+    select: () => ({
+      from: (_table: unknown) => ({
+        where: (_cond: unknown) => ({
+          orderBy: (_ord: unknown) => ({
+            limit: (...args: unknown[]) => selectLimitMock(...args),
+          }),
+        }),
+      }),
+    }),
+    update: (table: unknown) => {
+      updateMock(table)
+      return {
+        set: (vals: unknown) => {
+          setMock(vals)
+          return {
+            where: (...args: unknown[]) => whereUpdateMock(...args),
+          }
+        },
+      }
+    },
+    transaction: (...args: unknown[]) => transactionMock(...args),
+  },
+  and: (...a: unknown[]) => ({ __and: a }),
+  eq: (c: unknown, v: unknown) => ({ __eq: [c, v] }),
+  asc: (c: unknown) => ({ __asc: c }),
+  gt: (c: unknown, v: unknown) => ({ __gt: [c, v] }),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  contactsOnSequenceModel: { id: "__cos_id", workspaceId: "__cos_ws" },
+  sequenceStepModel: {
+    sequenceId: "__step_seqId",
+    order: "__step_order",
+    isActive: "__step_isActive",
+  },
+}))
+
+vi.mock("@chatbotx.io/utils", () => ({ createId: () => "test-id" }))
+
+import { advanceEnrollment } from "../src/advance-enrollment"
+// --- lazy imports after mocks ---
+import { calculateNextRunAtFromStep } from "../src/calculate-next-run-at"
+import { getContactInboxes } from "../src/contacts-on-sequences"
+import { createDispatch } from "../src/dispatch-manager"
+import { calculateNextValidSendTime } from "../src/send-time-validator"
+
+// --- helpers ---
+const SENT_AT = new Date("2024-03-01T12:00:00Z")
+const NEXT_RUN_AT = new Date("2024-03-02T09:00:00Z")
+
+const NEXT_STEP = {
+  id: "step-2",
+  order: 1,
+  delayDays: 1,
+  delayMinutes: 0,
+  delayUnit: null,
+  specificDateTime: null,
+  anytime: true,
+  sendTimeStart: null,
+  sendTimeEnd: null,
+  sendDays: null,
+}
+
+function makeActiveEnrollment(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    id: "enrollment-1",
+    workspaceId: "ws-1",
+    sequenceId: "seq-1",
+    contactId: "contact-1",
+    status: "active",
+    lastStepId: null,
+    currentStep: 0,
+    ...overrides,
+  }
+}
+
+function makeParams(
+  overrides: Partial<Parameters<typeof advanceEnrollment>[0]> = {},
+): Parameters<typeof advanceEnrollment>[0] {
+  return {
+    enrollmentId: "enrollment-1",
+    workspaceId: "ws-1",
+    sequenceId: "seq-1",
+    contactId: "contact-1",
+    currentStep: { id: "step-1", order: 0 },
+    sentAt: SENT_AT,
+    scheduler: { addToSchedule: vi.fn() } as unknown as Parameters<
+      typeof advanceEnrollment
+    >[0]["scheduler"],
+    ...overrides,
+  }
+}
+
+const FAKE_DISPATCH = { id: "dispatch-1", bucket: 7, runAtMs: "1700000000000" }
+
+// --- test setup ---
+beforeEach(() => {
+  // default: active enrollment exists
+  findFirstMock.mockResolvedValue(makeActiveEnrollment())
+  // default: no next step
+  selectLimitMock.mockResolvedValue([])
+  // default: update resolves
+  whereUpdateMock.mockResolvedValue(undefined)
+  // default: one inbox
+  vi.mocked(getContactInboxes).mockResolvedValue([
+    { id: "inbox-1" },
+  ] as unknown as Awaited<ReturnType<typeof getContactInboxes>>)
+  // default: dispatch created
+  vi.mocked(createDispatch).mockResolvedValue(FAKE_DISPATCH)
+  // default: calculateNextRunAtFromStep returns NEXT_RUN_AT
+  vi.mocked(calculateNextRunAtFromStep).mockReturnValue(NEXT_RUN_AT)
+  // default: calculateNextValidSendTime passes through
+  vi.mocked(calculateNextValidSendTime).mockImplementation(
+    (date: unknown) => date as Date,
+  )
+})
+
+// ---------------------------------------------------------------------------
+describe("advanceEnrollment", () => {
+  describe("when enrollment is not found", () => {
+    test("throws with message containing the enrollment id", async () => {
+      findFirstMock.mockResolvedValue(undefined)
+
+      await expect(
+        advanceEnrollment(makeParams({ enrollmentId: "missing-id" })),
+      ).rejects.toThrow("Enrollment missing-id not found")
+    })
+  })
+
+  describe("when enrollment status is not active", () => {
+    test("returns without updating when status is paused", async () => {
+      findFirstMock.mockResolvedValue(
+        makeActiveEnrollment({ status: "paused" }),
+      )
+
+      await advanceEnrollment(makeParams())
+
+      expect(updateMock).not.toHaveBeenCalled()
+    })
+
+    test("returns without updating when status is completed", async () => {
+      findFirstMock.mockResolvedValue(
+        makeActiveEnrollment({ status: "completed" }),
+      )
+
+      await advanceEnrollment(makeParams())
+
+      expect(updateMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when enrollment has already been advanced past the current step", () => {
+    test("returns without updating when lastStepId matches currentStep.id", async () => {
+      findFirstMock.mockResolvedValue(
+        makeActiveEnrollment({ lastStepId: "step-1" }),
+      )
+
+      await advanceEnrollment(
+        makeParams({ currentStep: { id: "step-1", order: 0 } }),
+      )
+
+      expect(updateMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when there is no next step (sequence completed)", () => {
+    test("updates enrollment status to completed", async () => {
+      selectLimitMock.mockResolvedValue([])
+
+      await advanceEnrollment(makeParams())
+
+      expect(setMock).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "completed" }),
+      )
+    })
+
+    test("sets completedAt to the sentAt value", async () => {
+      selectLimitMock.mockResolvedValue([])
+
+      await advanceEnrollment(makeParams())
+
+      expect(setMock).toHaveBeenCalledWith(
+        expect.objectContaining({ completedAt: SENT_AT }),
+      )
+    })
+
+    test("sets nextStepId and nextRunAt to null", async () => {
+      selectLimitMock.mockResolvedValue([])
+
+      await advanceEnrollment(makeParams())
+
+      expect(setMock).toHaveBeenCalledWith(
+        expect.objectContaining({ nextStepId: null, nextRunAt: null }),
+      )
+    })
+
+    test("increments currentStep to currentStep.order + 1", async () => {
+      selectLimitMock.mockResolvedValue([])
+
+      await advanceEnrollment(
+        makeParams({ currentStep: { id: "step-1", order: 2 } }),
+      )
+
+      expect(setMock).toHaveBeenCalledWith(
+        expect.objectContaining({ currentStep: 3 }),
+      )
+    })
+
+    test("does not create a dispatch or call scheduler", async () => {
+      selectLimitMock.mockResolvedValue([])
+
+      await advanceEnrollment(makeParams())
+
+      expect(vi.mocked(createDispatch)).not.toHaveBeenCalled()
+    })
+
+    test("does not start a transaction", async () => {
+      selectLimitMock.mockResolvedValue([])
+
+      await advanceEnrollment(makeParams())
+
+      expect(transactionMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when there is a next step", () => {
+    function setUpTransactionWithTxMocks(
+      txUpdateWhereMock = vi.fn().mockResolvedValue(undefined),
+    ) {
+      transactionMock.mockImplementation(
+        (cb: (tx: Record<string, unknown>) => Promise<unknown>) => {
+          const tx = {
+            update: (_table: unknown) => ({
+              set: (_vals: unknown) => ({
+                where: txUpdateWhereMock,
+              }),
+            }),
+          }
+          return cb(tx)
+        },
+      )
+      return txUpdateWhereMock
+    }
+
+    test("starts a database transaction", async () => {
+      selectLimitMock.mockResolvedValue([NEXT_STEP])
+      setUpTransactionWithTxMocks()
+
+      await advanceEnrollment(makeParams())
+
+      expect(transactionMock).toHaveBeenCalledTimes(1)
+    })
+
+    test("does NOT call the top-level db.update (uses tx.update instead)", async () => {
+      selectLimitMock.mockResolvedValue([NEXT_STEP])
+      setUpTransactionWithTxMocks()
+
+      await advanceEnrollment(makeParams())
+
+      expect(updateMock).not.toHaveBeenCalled()
+    })
+
+    test("creates a dispatch for each contact inbox inside the transaction", async () => {
+      selectLimitMock.mockResolvedValue([NEXT_STEP])
+      vi.mocked(getContactInboxes).mockResolvedValue([
+        { id: "inbox-1" },
+        { id: "inbox-2" },
+      ] as unknown as Awaited<ReturnType<typeof getContactInboxes>>)
+      setUpTransactionWithTxMocks()
+
+      await advanceEnrollment(makeParams())
+
+      expect(vi.mocked(createDispatch)).toHaveBeenCalledTimes(2)
+    })
+
+    test("passes correct params to createDispatch", async () => {
+      selectLimitMock.mockResolvedValue([NEXT_STEP])
+      vi.mocked(calculateNextRunAtFromStep).mockReturnValue(NEXT_RUN_AT)
+      vi.mocked(calculateNextValidSendTime).mockImplementation(
+        (date: unknown) => date as Date,
+      )
+      setUpTransactionWithTxMocks()
+
+      const params = makeParams()
+      await advanceEnrollment(params)
+
+      expect(vi.mocked(createDispatch)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspaceId: "ws-1",
+          sequenceId: "seq-1",
+          contactId: "contact-1",
+          stepId: "step-2",
+          enrollmentId: "enrollment-1",
+          runAt: NEXT_RUN_AT,
+          contactInboxId: "inbox-1",
+        }),
+      )
+    })
+
+    test("calls scheduler.addToSchedule for each dispatch created", async () => {
+      selectLimitMock.mockResolvedValue([NEXT_STEP])
+      vi.mocked(getContactInboxes).mockResolvedValue([
+        { id: "inbox-1" },
+        { id: "inbox-2" },
+      ] as unknown as Awaited<ReturnType<typeof getContactInboxes>>)
+      vi.mocked(createDispatch).mockResolvedValue(FAKE_DISPATCH)
+      setUpTransactionWithTxMocks()
+
+      const mockScheduler = {
+        addToSchedule: vi.fn().mockResolvedValue(undefined),
+      }
+      await advanceEnrollment(
+        makeParams({
+          scheduler: mockScheduler as unknown as Parameters<
+            typeof advanceEnrollment
+          >[0]["scheduler"],
+        }),
+      )
+
+      expect(mockScheduler.addToSchedule).toHaveBeenCalledTimes(2)
+      expect(mockScheduler.addToSchedule).toHaveBeenCalledWith(
+        FAKE_DISPATCH.bucket,
+        FAKE_DISPATCH.id,
+        Number(FAKE_DISPATCH.runAtMs),
+      )
+    })
+
+    test("does not create dispatches when contact has no inboxes", async () => {
+      selectLimitMock.mockResolvedValue([NEXT_STEP])
+      vi.mocked(getContactInboxes).mockResolvedValue([])
+      setUpTransactionWithTxMocks()
+
+      await advanceEnrollment(makeParams())
+
+      expect(vi.mocked(createDispatch)).not.toHaveBeenCalled()
+    })
+
+    test("sets lastStepId to current step id in the update", async () => {
+      selectLimitMock.mockResolvedValue([NEXT_STEP])
+      const txSetSpy = vi.fn()
+      transactionMock.mockImplementation(
+        (cb: (tx: Record<string, unknown>) => Promise<unknown>) => {
+          const tx = {
+            update: (_table: unknown) => ({
+              set: (vals: unknown) => {
+                txSetSpy(vals)
+                return {
+                  where: vi.fn().mockResolvedValue(undefined),
+                }
+              },
+            }),
+          }
+          return cb(tx)
+        },
+      )
+
+      await advanceEnrollment(
+        makeParams({ currentStep: { id: "step-1", order: 0 } }),
+      )
+
+      expect(txSetSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ lastStepId: "step-1", nextStepId: "step-2" }),
+      )
+    })
+  })
+})

--- a/packages/sequence-scheduler/__tests__/calculate-next-run-at.test.ts
+++ b/packages/sequence-scheduler/__tests__/calculate-next-run-at.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const findFirstMock = vi.fn()
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      sequenceStepModel: {
+        findFirst: findFirstMock,
+      },
+    },
+  },
+}))
+
+describe("calculateNextRunAtFromStep", () => {
+  test("returns a clone of specificDateTime when delayUnit is specificTime", async () => {
+    const { calculateNextRunAtFromStep } = await import(
+      "../src/calculate-next-run-at"
+    )
+    const specificDateTime = new Date("2024-06-01T10:00:00.000Z")
+    const step = {
+      delayDays: 0,
+      delayMinutes: 0,
+      delayUnit: "specificTime",
+      specificDateTime,
+    }
+
+    const result = calculateNextRunAtFromStep(step)
+
+    expect(result.getTime()).toBe(specificDateTime.getTime())
+    expect(result).not.toBe(specificDateTime)
+  })
+
+  test("returns baseTime as same reference when delay is zero", async () => {
+    const { calculateNextRunAtFromStep } = await import(
+      "../src/calculate-next-run-at"
+    )
+    const baseTime = new Date("2024-01-01T12:00:00.000Z")
+    const step = {
+      delayDays: 0,
+      delayMinutes: 0,
+      delayUnit: null,
+      specificDateTime: null,
+    }
+
+    const result = calculateNextRunAtFromStep(step, baseTime)
+
+    expect(result).toBe(baseTime)
+  })
+
+  test("returns baseTime as same reference when both delayDays and delayMinutes are zero", async () => {
+    const { calculateNextRunAtFromStep } = await import(
+      "../src/calculate-next-run-at"
+    )
+    const baseTime = new Date("2024-03-15T09:30:00.000Z")
+    const step = {
+      delayDays: 0,
+      delayMinutes: 0,
+      delayUnit: "days",
+      specificDateTime: null,
+    }
+
+    const result = calculateNextRunAtFromStep(step, baseTime)
+
+    expect(result).toBe(baseTime)
+  })
+
+  test("adds days and minutes to baseTime when delay is positive", async () => {
+    const { calculateNextRunAtFromStep } = await import(
+      "../src/calculate-next-run-at"
+    )
+    const baseTime = new Date("2024-01-01T00:00:00.000Z")
+    const step = {
+      delayDays: 2,
+      delayMinutes: 30,
+      delayUnit: null,
+      specificDateTime: null,
+    }
+
+    const result = calculateNextRunAtFromStep(step, baseTime)
+
+    const DAY_IN_MS = 24 * 60 * 60 * 1000
+    const MINUTE_IN_MS = 60 * 1000
+    const expected = new Date(
+      baseTime.getTime() + 2 * DAY_IN_MS + 30 * MINUTE_IN_MS,
+    )
+    expect(result).toEqual(expected)
+  })
+
+  test("adds only days when delayMinutes is zero", async () => {
+    const { calculateNextRunAtFromStep } = await import(
+      "../src/calculate-next-run-at"
+    )
+    const baseTime = new Date("2024-01-10T06:00:00.000Z")
+    const step = {
+      delayDays: 5,
+      delayMinutes: 0,
+      delayUnit: null,
+      specificDateTime: null,
+    }
+
+    const result = calculateNextRunAtFromStep(step, baseTime)
+
+    const expected = new Date(baseTime.getTime() + 5 * 24 * 60 * 60 * 1000)
+    expect(result).toEqual(expected)
+  })
+
+  test("ignores specificDateTime when delayUnit is not specificTime", async () => {
+    const { calculateNextRunAtFromStep } = await import(
+      "../src/calculate-next-run-at"
+    )
+    const baseTime = new Date("2024-01-01T00:00:00.000Z")
+    const specificDateTime = new Date("2099-12-31T00:00:00.000Z")
+    const step = {
+      delayDays: 0,
+      delayMinutes: 0,
+      delayUnit: "days",
+      specificDateTime,
+    }
+
+    const result = calculateNextRunAtFromStep(step, baseTime)
+
+    // delay is zero → returns baseTime, not specificDateTime
+    expect(result).toBe(baseTime)
+  })
+})
+
+describe("calculateNextRunAt", () => {
+  beforeEach(() => {
+    findFirstMock.mockResolvedValue(undefined)
+  })
+
+  test("returns enrolledAt with null nextStepId when no first step is found", async () => {
+    const { calculateNextRunAt } = await import("../src/calculate-next-run-at")
+    const enrolledAt = new Date("2024-01-15T08:00:00.000Z")
+    findFirstMock.mockResolvedValue(undefined)
+
+    const result = await calculateNextRunAt("seq-abc", enrolledAt)
+
+    expect(result).toEqual({ nextRunAt: enrolledAt, nextStepId: null })
+  })
+
+  test("returns computed nextRunAt and step id when first step exists with a delay", async () => {
+    const { calculateNextRunAt } = await import("../src/calculate-next-run-at")
+    const enrolledAt = new Date("2024-01-01T00:00:00.000Z")
+    findFirstMock.mockResolvedValue({
+      id: "step-xyz",
+      delayDays: 3,
+      delayMinutes: 0,
+      delayUnit: null,
+      specificDateTime: null,
+    })
+
+    const result = await calculateNextRunAt("seq-abc", enrolledAt)
+
+    expect(result.nextStepId).toBe("step-xyz")
+    expect(result.nextRunAt).toEqual(
+      new Date(enrolledAt.getTime() + 3 * 24 * 60 * 60 * 1000),
+    )
+  })
+
+  test("returns enrolledAt as nextRunAt when first step has zero delay", async () => {
+    const { calculateNextRunAt } = await import("../src/calculate-next-run-at")
+    const enrolledAt = new Date("2024-05-01T12:00:00.000Z")
+    findFirstMock.mockResolvedValue({
+      id: "step-zero",
+      delayDays: 0,
+      delayMinutes: 0,
+      delayUnit: null,
+      specificDateTime: null,
+    })
+
+    const result = await calculateNextRunAt("seq-abc", enrolledAt)
+
+    expect(result.nextStepId).toBe("step-zero")
+    // zero delay → calculateNextRunAtFromStep returns baseTime (same ref = enrolledAt)
+    expect(result.nextRunAt).toBe(enrolledAt)
+  })
+
+  test("uses provided transaction client instead of the default db", async () => {
+    const { calculateNextRunAt } = await import("../src/calculate-next-run-at")
+    const txFindFirstMock = vi.fn().mockResolvedValue(undefined)
+    const txClient = {
+      query: {
+        sequenceStepModel: {
+          findFirst: txFindFirstMock,
+        },
+      },
+    }
+    const enrolledAt = new Date("2024-01-01T00:00:00.000Z")
+
+    await calculateNextRunAt("seq-abc", enrolledAt, txClient as never)
+
+    expect(txFindFirstMock).toHaveBeenCalledTimes(1)
+    expect(findFirstMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sequence-scheduler/__tests__/contacts-on-sequences.test.ts
+++ b/packages/sequence-scheduler/__tests__/contacts-on-sequences.test.ts
@@ -1,0 +1,316 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const findManyInboxMock = vi.fn()
+const findManyContactInboxMock = vi.fn()
+const cancelPendingDispatchesMock = vi.fn()
+const findManyContactsOnSeqMock = vi.fn()
+const deleteWhereMock = vi.fn()
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      inboxModel: { findMany: findManyInboxMock },
+      contactInboxModel: { findMany: findManyContactInboxMock },
+    },
+  },
+  inArray: (c: unknown, v: unknown) => ({ __inArray: [c, v] }),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  contactsOnSequenceModel: { id: "__contactsOnSequenceModel.id" },
+}))
+
+vi.mock("../src/dispatch-manager", () => ({
+  cancelPendingDispatches: cancelPendingDispatchesMock,
+}))
+
+// Reusable mock db client with methods used in bulkRemoveIds and getAllSequenceIds
+const mockDbClient = {
+  query: {
+    contactsOnSequenceModel: {
+      findMany: findManyContactsOnSeqMock,
+    },
+  },
+  delete: () => ({ where: deleteWhereMock }),
+} as never
+
+beforeEach(() => {
+  findManyInboxMock.mockResolvedValue([])
+  findManyContactInboxMock.mockResolvedValue([])
+  cancelPendingDispatchesMock.mockResolvedValue([])
+  findManyContactsOnSeqMock.mockResolvedValue([])
+  deleteWhereMock.mockResolvedValue(undefined)
+})
+
+describe("calculateSequenceDiff", () => {
+  test("returns empty toAdd and toRemove when both current and new are empty", async () => {
+    const { contactsOnSequencesUtils } = await import(
+      "../src/contacts-on-sequences"
+    )
+
+    const result = contactsOnSequencesUtils.calculateSequenceDiff([], [])
+
+    expect(result).toEqual({ toAdd: [], toRemove: [] })
+  })
+
+  test("returns all new ids in toAdd and empty toRemove when current is empty", async () => {
+    const { contactsOnSequencesUtils } = await import(
+      "../src/contacts-on-sequences"
+    )
+
+    const result = contactsOnSequencesUtils.calculateSequenceDiff(
+      [],
+      ["seq-1", "seq-2"],
+    )
+
+    expect(result.toAdd).toEqual(expect.arrayContaining(["seq-1", "seq-2"]))
+    expect(result.toAdd).toHaveLength(2)
+    expect(result.toRemove).toEqual([])
+  })
+
+  test("returns empty toAdd and all current ids in toRemove when new is empty", async () => {
+    const { contactsOnSequencesUtils } = await import(
+      "../src/contacts-on-sequences"
+    )
+
+    const result = contactsOnSequencesUtils.calculateSequenceDiff(
+      ["seq-a", "seq-b"],
+      [],
+    )
+
+    expect(result.toAdd).toEqual([])
+    expect(result.toRemove).toEqual(expect.arrayContaining(["seq-a", "seq-b"]))
+    expect(result.toRemove).toHaveLength(2)
+  })
+
+  test("returns empty toAdd and toRemove when current and new are identical", async () => {
+    const { contactsOnSequencesUtils } = await import(
+      "../src/contacts-on-sequences"
+    )
+
+    const result = contactsOnSequencesUtils.calculateSequenceDiff(
+      ["seq-1", "seq-2"],
+      ["seq-1", "seq-2"],
+    )
+
+    expect(result).toEqual({ toAdd: [], toRemove: [] })
+  })
+
+  test("returns disjoint toAdd and toRemove for completely different sets", async () => {
+    const { contactsOnSequencesUtils } = await import(
+      "../src/contacts-on-sequences"
+    )
+
+    const result = contactsOnSequencesUtils.calculateSequenceDiff(
+      ["old-1", "old-2"],
+      ["new-1", "new-2"],
+    )
+
+    expect(result.toAdd).toEqual(expect.arrayContaining(["new-1", "new-2"]))
+    expect(result.toRemove).toEqual(expect.arrayContaining(["old-1", "old-2"]))
+  })
+
+  test("returns only the non-overlapping delta for partially overlapping sets", async () => {
+    const { contactsOnSequencesUtils } = await import(
+      "../src/contacts-on-sequences"
+    )
+
+    // seq-keep is shared, seq-old is removed, seq-new is added
+    const result = contactsOnSequencesUtils.calculateSequenceDiff(
+      ["seq-keep", "seq-old"],
+      ["seq-keep", "seq-new"],
+    )
+
+    expect(result.toAdd).toEqual(["seq-new"])
+    expect(result.toRemove).toEqual(["seq-old"])
+  })
+
+  test("deduplicates duplicate ids in the inputs", async () => {
+    const { contactsOnSequencesUtils } = await import(
+      "../src/contacts-on-sequences"
+    )
+
+    const result = contactsOnSequencesUtils.calculateSequenceDiff(
+      ["seq-1", "seq-1"],
+      ["seq-2", "seq-2"],
+    )
+
+    expect(result.toAdd).toEqual(["seq-2"])
+    expect(result.toRemove).toEqual(["seq-1"])
+  })
+})
+
+describe("getAllSequenceIds", () => {
+  test("returns an array of sequenceId strings from the rows", async () => {
+    const { contactsOnSequencesUtils } = await import(
+      "../src/contacts-on-sequences"
+    )
+    findManyContactsOnSeqMock.mockResolvedValue([
+      { sequenceId: "seq-1" },
+      { sequenceId: "seq-2" },
+    ])
+
+    const result = await contactsOnSequencesUtils.getAllSequenceIds(
+      mockDbClient,
+      { contactId: "contact-1" },
+    )
+
+    expect(result).toEqual(["seq-1", "seq-2"])
+  })
+
+  test("returns an empty array when no sequences are found", async () => {
+    const { contactsOnSequencesUtils } = await import(
+      "../src/contacts-on-sequences"
+    )
+    findManyContactsOnSeqMock.mockResolvedValue([])
+
+    const result = await contactsOnSequencesUtils.getAllSequenceIds(
+      mockDbClient,
+      { contactId: "contact-1" },
+    )
+
+    expect(result).toEqual([])
+  })
+})
+
+describe("bulkRemoveIds", () => {
+  test("returns immediately without any db call when sequenceIds is empty", async () => {
+    const { contactsOnSequencesUtils } = await import(
+      "../src/contacts-on-sequences"
+    )
+
+    await contactsOnSequencesUtils.bulkRemoveIds(mockDbClient, "contact-1", [])
+
+    expect(findManyContactsOnSeqMock).not.toHaveBeenCalled()
+    expect(cancelPendingDispatchesMock).not.toHaveBeenCalled()
+    expect(deleteWhereMock).not.toHaveBeenCalled()
+  })
+
+  test("returns without deleting when no enrollments match the sequenceIds", async () => {
+    const { contactsOnSequencesUtils } = await import(
+      "../src/contacts-on-sequences"
+    )
+    findManyContactsOnSeqMock.mockResolvedValue([])
+
+    await contactsOnSequencesUtils.bulkRemoveIds(mockDbClient, "contact-1", [
+      "seq-1",
+    ])
+
+    expect(cancelPendingDispatchesMock).not.toHaveBeenCalled()
+    expect(deleteWhereMock).not.toHaveBeenCalled()
+  })
+
+  test("calls cancelPendingDispatches once per enrollment then deletes all", async () => {
+    const { contactsOnSequencesUtils } = await import(
+      "../src/contacts-on-sequences"
+    )
+    const enrollments = [
+      {
+        id: "enroll-1",
+        workspaceId: "ws-1",
+        sequenceId: "seq-1",
+        contactId: "c-1",
+      },
+      {
+        id: "enroll-2",
+        workspaceId: "ws-1",
+        sequenceId: "seq-2",
+        contactId: "c-1",
+      },
+    ]
+    findManyContactsOnSeqMock.mockResolvedValue(enrollments)
+
+    await contactsOnSequencesUtils.bulkRemoveIds(mockDbClient, "c-1", [
+      "seq-1",
+      "seq-2",
+    ])
+
+    expect(cancelPendingDispatchesMock).toHaveBeenCalledTimes(2)
+    expect(cancelPendingDispatchesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enrollmentId: "enroll-1",
+        workspaceId: "ws-1",
+      }),
+    )
+    expect(cancelPendingDispatchesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enrollmentId: "enroll-2",
+        workspaceId: "ws-1",
+      }),
+    )
+    expect(deleteWhereMock).toHaveBeenCalledTimes(1)
+  })
+
+  test("passes the reason 'enrollment_removed' to cancelPendingDispatches", async () => {
+    const { contactsOnSequencesUtils } = await import(
+      "../src/contacts-on-sequences"
+    )
+    findManyContactsOnSeqMock.mockResolvedValue([
+      {
+        id: "enroll-1",
+        workspaceId: "ws-1",
+        sequenceId: "seq-1",
+        contactId: "c-1",
+      },
+    ])
+
+    await contactsOnSequencesUtils.bulkRemoveIds(mockDbClient, "c-1", ["seq-1"])
+
+    expect(cancelPendingDispatchesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "enrollment_removed" }),
+    )
+  })
+})
+
+describe("getContactInboxes", () => {
+  test("returns contact inboxes matching workspace inboxes", async () => {
+    const { getContactInboxes } = await import("../src/contacts-on-sequences")
+    findManyInboxMock.mockResolvedValue([{ id: "inbox-1" }, { id: "inbox-2" }])
+    const fakeContactInboxes = [
+      { id: "ci-1", contactId: "contact-1", inboxId: "inbox-1" },
+    ]
+    findManyContactInboxMock.mockResolvedValue(fakeContactInboxes)
+
+    const result = await getContactInboxes("ws-1", "contact-1")
+
+    expect(result).toEqual(fakeContactInboxes)
+  })
+
+  test("returns empty array when no inboxes exist in the workspace", async () => {
+    const { getContactInboxes } = await import("../src/contacts-on-sequences")
+    findManyInboxMock.mockResolvedValue([])
+    findManyContactInboxMock.mockResolvedValue([])
+
+    const result = await getContactInboxes("ws-1", "contact-1")
+
+    expect(result).toEqual([])
+  })
+
+  test("queries inboxModel scoped by workspaceId", async () => {
+    const { getContactInboxes } = await import("../src/contacts-on-sequences")
+    findManyInboxMock.mockResolvedValue([])
+    findManyContactInboxMock.mockResolvedValue([])
+
+    await getContactInboxes("my-workspace", "contact-1")
+
+    expect(findManyInboxMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ workspaceId: "my-workspace" }),
+      }),
+    )
+  })
+
+  test("queries contactInboxModel scoped by contactId", async () => {
+    const { getContactInboxes } = await import("../src/contacts-on-sequences")
+    findManyInboxMock.mockResolvedValue([{ id: "inbox-99" }])
+    findManyContactInboxMock.mockResolvedValue([])
+
+    await getContactInboxes("ws-1", "my-contact")
+
+    expect(findManyContactInboxMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ contactId: "my-contact" }),
+      }),
+    )
+  })
+})

--- a/packages/sequence-scheduler/__tests__/dispatch-manager.test.ts
+++ b/packages/sequence-scheduler/__tests__/dispatch-manager.test.ts
@@ -1,0 +1,272 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const returningInsertMock = vi.fn()
+const findManyMock = vi.fn()
+const updateWhereMock = vi.fn()
+const removeFromScheduleMock = vi.fn()
+const useExistingMock = vi.fn()
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    insert: () => ({ values: () => ({ returning: returningInsertMock }) }),
+    query: {
+      sequenceDispatchModel: { findMany: findManyMock },
+    },
+    update: () => ({ set: () => ({ where: updateWhereMock }) }),
+  },
+  and: (...a: unknown[]) => ({ __and: a }),
+  eq: (c: unknown, v: unknown) => ({ __eq: [c, v] }),
+  inArray: (c: unknown, v: unknown) => ({ __inArray: [c, v] }),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  sequenceDispatchModel: {
+    id: { __col: "id" },
+    bucket: { __col: "bucket" },
+    workspaceId: { __col: "workspaceId" },
+    status: { __col: "status" },
+  },
+}))
+
+vi.mock("@chatbotx.io/redis", () => ({
+  sequenceConnections: { useExisting: useExistingMock },
+}))
+
+vi.mock("@chatbotx.io/scheduler", () => ({
+  // Must use a regular function (not arrow) so that `new SchedulerClient()` works
+  SchedulerClient: vi.fn(function SchedulerClientMock() {
+    return { removeFromSchedule: removeFromScheduleMock }
+  }),
+}))
+
+vi.mock("@chatbotx.io/utils", () => ({
+  createId: () => "test-id",
+}))
+
+describe("calculateBucket", () => {
+  test("returns a number between 0 and 255 inclusive", async () => {
+    const { calculateBucket } = await import("../src/dispatch-manager")
+
+    const bucket = calculateBucket("workspace-1", "contact-1")
+
+    expect(bucket).toBeGreaterThanOrEqual(0)
+    expect(bucket).toBeLessThanOrEqual(255)
+  })
+
+  test("is deterministic — same inputs always produce the same bucket", async () => {
+    const { calculateBucket } = await import("../src/dispatch-manager")
+
+    const first = calculateBucket("workspace-abc", "contact-xyz")
+    const second = calculateBucket("workspace-abc", "contact-xyz")
+
+    expect(first).toBe(second)
+  })
+
+  test("produces different buckets for different workspaceId + contactId pairs", async () => {
+    const { calculateBucket } = await import("../src/dispatch-manager")
+
+    const bucketA = calculateBucket("workspace-1", "contact-1")
+    const bucketB = calculateBucket("workspace-2", "contact-2")
+
+    // Collision is possible (1/256 chance) but this pairing is chosen to differ
+    // so this test can assert the non-collision behavior for known inputs.
+    expect(bucketA).not.toBe(bucketB)
+  })
+})
+
+describe("generateIdempotencyKey", () => {
+  test("produces the exact format workspaceId:enrollmentId:stepId:runAt.toISOString()", async () => {
+    const { generateIdempotencyKey } = await import("../src/dispatch-manager")
+    const runAt = new Date("2024-06-01T10:30:00.000Z")
+
+    const key = generateIdempotencyKey("ws-1", "enroll-1", "step-1", runAt)
+
+    expect(key).toBe(`ws-1:enroll-1:step-1:${runAt.toISOString()}`)
+  })
+
+  test("uses runAt.toISOString so the key is stable across calls with the same Date", async () => {
+    const { generateIdempotencyKey } = await import("../src/dispatch-manager")
+    const runAt = new Date("2025-01-15T08:00:00.000Z")
+
+    const keyA = generateIdempotencyKey("ws-x", "e-1", "s-1", runAt)
+    const keyB = generateIdempotencyKey(
+      "ws-x",
+      "e-1",
+      "s-1",
+      new Date(runAt.getTime()),
+    )
+
+    expect(keyA).toBe(keyB)
+  })
+})
+
+describe("createDispatch", () => {
+  beforeEach(() => {
+    returningInsertMock.mockResolvedValue([
+      { id: "test-id", bucket: 77, runAtMs: "1700000000000" },
+    ])
+  })
+
+  test("returns the created dispatch record on success", async () => {
+    const { createDispatch } = await import("../src/dispatch-manager")
+    const runAt = new Date(1_700_000_000_000)
+
+    const result = await createDispatch({
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+      contactInboxId: "inbox-1",
+      enrollmentId: "enroll-1",
+      runAt,
+      sequenceId: "seq-1",
+      stepId: "step-1",
+    })
+
+    expect(result).toEqual({
+      id: "test-id",
+      bucket: 77,
+      runAtMs: "1700000000000",
+    })
+  })
+
+  test("throws 'Failed to create dispatch' when insert returns empty array", async () => {
+    const { createDispatch } = await import("../src/dispatch-manager")
+    returningInsertMock.mockResolvedValue([])
+
+    await expect(
+      createDispatch({
+        workspaceId: "ws-1",
+        contactId: "contact-1",
+        contactInboxId: "inbox-1",
+        enrollmentId: "enroll-1",
+        runAt: new Date(),
+        sequenceId: "seq-1",
+        stepId: "step-1",
+      }),
+    ).rejects.toThrow("Failed to create dispatch")
+  })
+
+  test("uses provided client instead of default db", async () => {
+    const { createDispatch } = await import("../src/dispatch-manager")
+    const customReturningMock = vi
+      .fn()
+      .mockResolvedValue([{ id: "custom-id", bucket: 5, runAtMs: "999" }])
+    const customClient = {
+      insert: () => ({ values: () => ({ returning: customReturningMock }) }),
+    } as never
+
+    const result = await createDispatch({
+      workspaceId: "ws-2",
+      contactId: "contact-2",
+      contactInboxId: "inbox-2",
+      enrollmentId: "enroll-2",
+      runAt: new Date(),
+      sequenceId: "seq-2",
+      stepId: "step-2",
+      client: customClient,
+    })
+
+    expect(customReturningMock).toHaveBeenCalledTimes(1)
+    expect(returningInsertMock).not.toHaveBeenCalled()
+    expect(result.id).toBe("custom-id")
+  })
+})
+
+describe("cancelPendingDispatches", () => {
+  beforeEach(() => {
+    findManyMock.mockResolvedValue([])
+    updateWhereMock.mockResolvedValue(undefined)
+    useExistingMock.mockResolvedValue({})
+    removeFromScheduleMock.mockResolvedValue(undefined)
+  })
+
+  test("returns empty array and skips update when no pending dispatches exist", async () => {
+    const { cancelPendingDispatches } = await import("../src/dispatch-manager")
+    findManyMock.mockResolvedValue([])
+
+    const result = await cancelPendingDispatches({
+      enrollmentId: "enroll-1",
+      workspaceId: "ws-1",
+    })
+
+    expect(result).toEqual([])
+    expect(updateWhereMock).not.toHaveBeenCalled()
+    expect(removeFromScheduleMock).not.toHaveBeenCalled()
+  })
+
+  test("cancels pending dispatches, calls removeFromSchedule for each, and returns id+bucket", async () => {
+    const { cancelPendingDispatches } = await import("../src/dispatch-manager")
+    const pendingDispatches = [
+      {
+        id: "d-1",
+        bucket: 10,
+        sequenceId: "seq-1",
+        contactId: "c-1",
+        stepId: "s-1",
+      },
+      {
+        id: "d-2",
+        bucket: 20,
+        sequenceId: "seq-1",
+        contactId: "c-1",
+        stepId: "s-2",
+      },
+    ]
+    findManyMock.mockResolvedValue(pendingDispatches)
+
+    const result = await cancelPendingDispatches({
+      enrollmentId: "enroll-1",
+      workspaceId: "ws-1",
+    })
+
+    expect(updateWhereMock).toHaveBeenCalledTimes(1)
+    expect(removeFromScheduleMock).toHaveBeenCalledTimes(2)
+    expect(removeFromScheduleMock).toHaveBeenCalledWith(10, "d-1")
+    expect(removeFromScheduleMock).toHaveBeenCalledWith(20, "d-2")
+    expect(result).toEqual([
+      { id: "d-1", bucket: 10 },
+      { id: "d-2", bucket: 20 },
+    ])
+  })
+
+  test("calls useExisting to obtain the redis client before scheduling removal", async () => {
+    const { cancelPendingDispatches } = await import("../src/dispatch-manager")
+    findManyMock.mockResolvedValue([
+      {
+        id: "d-1",
+        bucket: 5,
+        sequenceId: "seq-1",
+        contactId: "c-1",
+        stepId: "s-1",
+      },
+    ])
+
+    await cancelPendingDispatches({
+      enrollmentId: "enroll-1",
+      workspaceId: "ws-1",
+    })
+
+    expect(useExistingMock).toHaveBeenCalledTimes(1)
+  })
+
+  test("uses provided client instead of default db for the query", async () => {
+    const { cancelPendingDispatches } = await import("../src/dispatch-manager")
+    const customFindManyMock = vi.fn().mockResolvedValue([])
+    const customClient = {
+      query: {
+        sequenceDispatchModel: { findMany: customFindManyMock },
+      },
+      update: () => ({
+        set: () => ({ where: vi.fn().mockResolvedValue(undefined) }),
+      }),
+    } as never
+
+    await cancelPendingDispatches({
+      enrollmentId: "enroll-1",
+      workspaceId: "ws-1",
+      client: customClient,
+    })
+
+    expect(customFindManyMock).toHaveBeenCalledTimes(1)
+    expect(findManyMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sequence-scheduler/__tests__/enroll-contact.test.ts
+++ b/packages/sequence-scheduler/__tests__/enroll-contact.test.ts
@@ -1,0 +1,380 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// --- top-level spies (captured by vi.mock factory closures) ---
+const findFirstMock = vi.fn()
+const insertMock = vi.fn()
+const returningMock = vi.fn()
+const bulkReturningMock = vi.fn()
+const addToScheduleMock = vi.fn()
+
+// --- module mocks (hoisted) ---
+vi.mock("../src/contacts-on-sequences", () => ({
+  getContactInboxes: vi.fn(),
+}))
+
+vi.mock("../src/dispatch-manager", () => ({
+  createDispatch: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      contactsOnSequenceModel: {
+        findFirst: (...args: unknown[]) => findFirstMock(...args),
+      },
+    },
+    insert: (table: unknown) => {
+      insertMock(table)
+      return {
+        values: (_vals: unknown) => ({
+          returning: (...args: unknown[]) => returningMock(...args),
+          onConflictDoNothing: () => ({
+            returning: (...args: unknown[]) => bulkReturningMock(...args),
+          }),
+        }),
+      }
+    },
+  },
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  contactsOnSequenceModel: { id: "__contactsOnSequence_id" },
+}))
+
+vi.mock("@chatbotx.io/redis", () => ({
+  sequenceConnections: {
+    useExisting: vi.fn().mockResolvedValue({}),
+  },
+}))
+
+vi.mock("@chatbotx.io/scheduler", () => ({
+  // Must be a class so it survives `new` and Biome's useArrowFunction rule
+  SchedulerClient: class {
+    addToSchedule = addToScheduleMock
+  },
+}))
+
+vi.mock("@chatbotx.io/utils", () => ({ createId: () => "test-id" }))
+
+// --- lazy imports after mocks ---
+import { getContactInboxes } from "../src/contacts-on-sequences"
+import { createDispatch } from "../src/dispatch-manager"
+import {
+  enrollContactInSequence,
+  enrollContactsInSequenceBulk,
+} from "../src/enroll-contact"
+
+// --- helpers ---
+const NOW = new Date("2024-03-01T10:00:00Z")
+
+function makeEnrollParams(
+  overrides: Partial<Parameters<typeof enrollContactInSequence>[0]> = {},
+): Parameters<typeof enrollContactInSequence>[0] {
+  return {
+    workspaceId: "ws-1",
+    contactId: "contact-1",
+    sequenceId: "seq-1",
+    nextRunAt: NOW,
+    nextStepId: "step-1",
+    ...overrides,
+  }
+}
+
+function makeBulkParams(
+  overrides: Partial<Parameters<typeof enrollContactsInSequenceBulk>[0]> = {},
+): Parameters<typeof enrollContactsInSequenceBulk>[0] {
+  return {
+    workspaceId: "ws-1",
+    enrollments: [
+      {
+        contactId: "contact-1",
+        sequenceId: "seq-1",
+        nextRunAt: NOW,
+        nextStepId: "step-1",
+      },
+    ],
+    ...overrides,
+  }
+}
+
+const FAKE_DISPATCH = { id: "dispatch-1", bucket: 42, runAtMs: "1700000000000" }
+
+// --- test setup ---
+beforeEach(() => {
+  // default: no existing enrollment
+  findFirstMock.mockResolvedValue(undefined)
+  // default: successful insert returns one row
+  returningMock.mockResolvedValue([{ id: "enrollment-1" }])
+  // default: one contact inbox
+  vi.mocked(getContactInboxes).mockResolvedValue([
+    { id: "inbox-1" },
+  ] as unknown as Awaited<ReturnType<typeof getContactInboxes>>)
+  // default: dispatch created successfully
+  vi.mocked(createDispatch).mockResolvedValue(FAKE_DISPATCH)
+  addToScheduleMock.mockResolvedValue(undefined)
+})
+
+// ---------------------------------------------------------------------------
+describe("enrollContactInSequence", () => {
+  describe("when enrollment already exists", () => {
+    test("returns early without inserting", async () => {
+      findFirstMock.mockResolvedValue({ id: "existing-enrollment" })
+
+      await enrollContactInSequence(makeEnrollParams())
+
+      expect(insertMock).not.toHaveBeenCalled()
+    })
+
+    test("does not create a dispatch or schedule when returning early", async () => {
+      findFirstMock.mockResolvedValue({ id: "existing-enrollment" })
+
+      await enrollContactInSequence(makeEnrollParams())
+
+      expect(vi.mocked(createDispatch)).not.toHaveBeenCalled()
+      expect(addToScheduleMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when enrollment does not exist and nextStepId is provided", () => {
+    test("inserts a new enrollment row", async () => {
+      await enrollContactInSequence(makeEnrollParams())
+
+      expect(insertMock).toHaveBeenCalledTimes(1)
+      expect(returningMock).toHaveBeenCalledTimes(1)
+    })
+
+    test("creates a dispatch for each contact inbox", async () => {
+      vi.mocked(getContactInboxes).mockResolvedValue([
+        { id: "inbox-1" },
+        { id: "inbox-2" },
+      ] as unknown as Awaited<ReturnType<typeof getContactInboxes>>)
+
+      await enrollContactInSequence(makeEnrollParams())
+
+      expect(vi.mocked(createDispatch)).toHaveBeenCalledTimes(2)
+    })
+
+    test("passes correct params to createDispatch", async () => {
+      await enrollContactInSequence(makeEnrollParams())
+
+      expect(vi.mocked(createDispatch)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspaceId: "ws-1",
+          contactId: "contact-1",
+          sequenceId: "seq-1",
+          contactInboxId: "inbox-1",
+          stepId: "step-1",
+          enrollmentId: "enrollment-1",
+          runAt: NOW,
+        }),
+      )
+    })
+
+    test("schedules each created dispatch", async () => {
+      vi.mocked(getContactInboxes).mockResolvedValue([
+        { id: "inbox-1" },
+        { id: "inbox-2" },
+      ] as unknown as Awaited<ReturnType<typeof getContactInboxes>>)
+      vi.mocked(createDispatch).mockResolvedValue(FAKE_DISPATCH)
+
+      await enrollContactInSequence(makeEnrollParams())
+
+      expect(addToScheduleMock).toHaveBeenCalledTimes(2)
+      expect(addToScheduleMock).toHaveBeenCalledWith(
+        FAKE_DISPATCH.bucket,
+        FAKE_DISPATCH.id,
+        Number(FAKE_DISPATCH.runAtMs),
+      )
+    })
+
+    test("does not create dispatches when contact has no inboxes", async () => {
+      vi.mocked(getContactInboxes).mockResolvedValue([])
+
+      await enrollContactInSequence(makeEnrollParams())
+
+      expect(vi.mocked(createDispatch)).not.toHaveBeenCalled()
+      expect(addToScheduleMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when nextStepId is null", () => {
+    test("inserts the enrollment row", async () => {
+      await enrollContactInSequence(makeEnrollParams({ nextStepId: null }))
+
+      expect(insertMock).toHaveBeenCalledTimes(1)
+    })
+
+    test("does not create a dispatch or schedule", async () => {
+      await enrollContactInSequence(makeEnrollParams({ nextStepId: null }))
+
+      expect(vi.mocked(createDispatch)).not.toHaveBeenCalled()
+      expect(addToScheduleMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when insert returns empty array (unexpected db failure)", () => {
+    test("does not create a dispatch or schedule", async () => {
+      returningMock.mockResolvedValue([])
+
+      await enrollContactInSequence(makeEnrollParams())
+
+      expect(vi.mocked(createDispatch)).not.toHaveBeenCalled()
+      expect(addToScheduleMock).not.toHaveBeenCalled()
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe("enrollContactsInSequenceBulk", () => {
+  function setUpBulkInsert(
+    insertedRows: Array<{
+      id: string
+      contactId: string
+      sequenceId: string
+      nextRunAt: Date | null
+      nextStepId: string | null
+    }>,
+  ) {
+    bulkReturningMock.mockResolvedValue(insertedRows)
+  }
+
+  test("calls addToSchedule for each inbox per enrollment", async () => {
+    setUpBulkInsert([
+      {
+        id: "enroll-1",
+        contactId: "contact-1",
+        sequenceId: "seq-1",
+        nextRunAt: NOW,
+        nextStepId: "step-1",
+      },
+    ])
+    vi.mocked(getContactInboxes).mockResolvedValue([
+      { id: "inbox-1" },
+      { id: "inbox-2" },
+    ] as unknown as Awaited<ReturnType<typeof getContactInboxes>>)
+    vi.mocked(createDispatch).mockResolvedValue(FAKE_DISPATCH)
+
+    await enrollContactsInSequenceBulk(makeBulkParams())
+
+    expect(addToScheduleMock).toHaveBeenCalledTimes(2)
+  })
+
+  test("does not schedule enrollments that already existed before bulk insert", async () => {
+    setUpBulkInsert([])
+
+    await enrollContactsInSequenceBulk(makeBulkParams())
+
+    expect(vi.mocked(createDispatch)).not.toHaveBeenCalled()
+    expect(addToScheduleMock).not.toHaveBeenCalled()
+  })
+
+  test("calls addToSchedule once per enrollment when one inbox exists", async () => {
+    setUpBulkInsert([
+      {
+        id: "enroll-1",
+        contactId: "contact-1",
+        sequenceId: "seq-1",
+        nextRunAt: NOW,
+        nextStepId: "step-1",
+      },
+      {
+        id: "enroll-2",
+        contactId: "contact-2",
+        sequenceId: "seq-1",
+        nextRunAt: NOW,
+        nextStepId: "step-1",
+      },
+    ])
+    vi.mocked(getContactInboxes).mockResolvedValue([
+      { id: "inbox-1" },
+    ] as unknown as Awaited<ReturnType<typeof getContactInboxes>>)
+    vi.mocked(createDispatch).mockResolvedValue(FAKE_DISPATCH)
+
+    await enrollContactsInSequenceBulk(makeBulkParams())
+
+    // 2 enrollments × 1 inbox each
+    expect(addToScheduleMock).toHaveBeenCalledTimes(2)
+  })
+
+  test("skips enrollment when nextStepId is null", async () => {
+    setUpBulkInsert([
+      {
+        id: "enroll-1",
+        contactId: "contact-1",
+        sequenceId: "seq-1",
+        nextRunAt: NOW,
+        nextStepId: null,
+      },
+    ])
+
+    await enrollContactsInSequenceBulk(makeBulkParams())
+
+    expect(vi.mocked(createDispatch)).not.toHaveBeenCalled()
+    expect(addToScheduleMock).not.toHaveBeenCalled()
+  })
+
+  test("skips enrollment when nextRunAt is null", async () => {
+    setUpBulkInsert([
+      {
+        id: "enroll-1",
+        contactId: "contact-1",
+        sequenceId: "seq-1",
+        nextRunAt: null,
+        nextStepId: "step-1",
+      },
+    ])
+
+    await enrollContactsInSequenceBulk(makeBulkParams())
+
+    expect(vi.mocked(createDispatch)).not.toHaveBeenCalled()
+    expect(addToScheduleMock).not.toHaveBeenCalled()
+  })
+
+  test("skips enrollment when both nextStepId and nextRunAt are null", async () => {
+    setUpBulkInsert([
+      {
+        id: "enroll-1",
+        contactId: "contact-1",
+        sequenceId: "seq-1",
+        nextRunAt: null,
+        nextStepId: null,
+      },
+    ])
+
+    await enrollContactsInSequenceBulk(makeBulkParams())
+
+    expect(vi.mocked(createDispatch)).not.toHaveBeenCalled()
+    expect(addToScheduleMock).not.toHaveBeenCalled()
+  })
+
+  test("passes correct params to createDispatch including enrollment id and runAt", async () => {
+    const runAt = new Date("2024-06-01T09:00:00Z")
+    setUpBulkInsert([
+      {
+        id: "enroll-42",
+        contactId: "contact-1",
+        sequenceId: "seq-1",
+        nextRunAt: runAt,
+        nextStepId: "step-99",
+      },
+    ])
+    vi.mocked(getContactInboxes).mockResolvedValue([
+      { id: "inbox-X" },
+    ] as unknown as Awaited<ReturnType<typeof getContactInboxes>>)
+    vi.mocked(createDispatch).mockResolvedValue(FAKE_DISPATCH)
+
+    await enrollContactsInSequenceBulk(makeBulkParams())
+
+    expect(vi.mocked(createDispatch)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "ws-1",
+        contactId: "contact-1",
+        sequenceId: "seq-1",
+        contactInboxId: "inbox-X",
+        stepId: "step-99",
+        enrollmentId: "enroll-42",
+        runAt,
+      }),
+    )
+  })
+})

--- a/packages/sequence-scheduler/__tests__/send-time-validator.test.ts
+++ b/packages/sequence-scheduler/__tests__/send-time-validator.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from "vitest"
+
+// Pure function — no mocks required
+
+// January 1 2024 is a Monday (getDay() === 1).
+// All Date constructors below use local-time form (year, month, day, h, m, s, ms)
+// so that date-fns getHours / getMinutes / getDay operate on predictable local values.
+
+describe("calculateNextValidSendTime", () => {
+  test("returns baseTime unchanged when anytime is true", async () => {
+    const { calculateNextValidSendTime } = await import(
+      "../src/send-time-validator"
+    )
+    const baseTime = new Date(2024, 0, 1, 10, 0, 0, 0)
+
+    const result = calculateNextValidSendTime(baseTime, {
+      anytime: true,
+      sendDays: '["monday"]',
+      sendTimeStart: "09:00",
+      sendTimeEnd: "17:00",
+    })
+
+    expect(result).toBe(baseTime)
+  })
+
+  test("rolls to startOfDay next allowed day when current day is not in sendDays", async () => {
+    const { calculateNextValidSendTime } = await import(
+      "../src/send-time-validator"
+    )
+    // Monday Jan 1 2024 at 10:00
+    const baseTime = new Date(2024, 0, 1, 10, 0, 0, 0)
+
+    const result = calculateNextValidSendTime(baseTime, {
+      anytime: false,
+      sendDays: '["tuesday"]',
+      sendTimeStart: null,
+      sendTimeEnd: null,
+    })
+
+    // Should land on Tuesday Jan 2 at 00:00
+    const expected = new Date(2024, 0, 2, 0, 0, 0, 0)
+    expect(result).toEqual(expected)
+  })
+
+  test("snaps to window start time when current time is before the send window", async () => {
+    const { calculateNextValidSendTime } = await import(
+      "../src/send-time-validator"
+    )
+    // Monday Jan 1 at 07:00 — before 09:00 window
+    const baseTime = new Date(2024, 0, 1, 7, 0, 0, 0)
+
+    const result = calculateNextValidSendTime(baseTime, {
+      anytime: false,
+      sendDays: '["monday"]',
+      sendTimeStart: "09:00",
+      sendTimeEnd: "17:00",
+    })
+
+    // Same day, snapped to 09:00:00.000
+    const expected = new Date(2024, 0, 1, 9, 0, 0, 0)
+    expect(result).toEqual(expected)
+  })
+
+  test("snaps to window start on next allowed day when time equals window end", async () => {
+    const { calculateNextValidSendTime } = await import(
+      "../src/send-time-validator"
+    )
+    // Monday at exactly 17:00 — boundary triggers >= endTimeInMin → rolls to next day.
+    // Next day (Tuesday) midnight is BEFORE window start (09:00) → snaps to 09:00.
+    const baseTime = new Date(2024, 0, 1, 17, 0, 0, 0)
+
+    const result = calculateNextValidSendTime(baseTime, {
+      anytime: false,
+      sendDays: '["monday","tuesday"]',
+      sendTimeStart: "09:00",
+      sendTimeEnd: "17:00",
+    })
+
+    // Lands on Tuesday Jan 2 at window start 09:00
+    const expected = new Date(2024, 0, 2, 9, 0, 0, 0)
+    expect(result).toEqual(expected)
+  })
+
+  test("snaps to window start on next allowed day when time is after window end", async () => {
+    const { calculateNextValidSendTime } = await import(
+      "../src/send-time-validator"
+    )
+    // Monday at 20:00 — past window → rolls to Tuesday midnight → snaps to 09:00.
+    const baseTime = new Date(2024, 0, 1, 20, 0, 0, 0)
+
+    const result = calculateNextValidSendTime(baseTime, {
+      anytime: false,
+      sendDays: '["monday","tuesday"]',
+      sendTimeStart: "09:00",
+      sendTimeEnd: "17:00",
+    })
+
+    const expected = new Date(2024, 0, 2, 9, 0, 0, 0)
+    expect(result).toEqual(expected)
+  })
+
+  test("returns unchanged time when time is inside the send window", async () => {
+    const { calculateNextValidSendTime } = await import(
+      "../src/send-time-validator"
+    )
+    // Monday at 12:00 — inside 09:00-17:00
+    const baseTime = new Date(2024, 0, 1, 12, 30, 0, 0)
+
+    const result = calculateNextValidSendTime(baseTime, {
+      anytime: false,
+      sendDays: '["monday"]',
+      sendTimeStart: "09:00",
+      sendTimeEnd: "17:00",
+    })
+
+    expect(result).toEqual(baseTime)
+  })
+
+  test("returns unchanged time when no time window is set and day is allowed", async () => {
+    const { calculateNextValidSendTime } = await import(
+      "../src/send-time-validator"
+    )
+    const baseTime = new Date(2024, 0, 1, 5, 0, 0, 0)
+
+    const result = calculateNextValidSendTime(baseTime, {
+      anytime: false,
+      sendDays: '["monday"]',
+      sendTimeStart: null,
+      sendTimeEnd: null,
+    })
+
+    expect(result).toEqual(baseTime)
+  })
+
+  test("falls back to ALL_DAYS when sendDays is invalid JSON", async () => {
+    const { calculateNextValidSendTime } = await import(
+      "../src/send-time-validator"
+    )
+    // Monday — present in ALL_DAYS fallback, no time window
+    const baseTime = new Date(2024, 0, 1, 10, 0, 0, 0)
+
+    const result = calculateNextValidSendTime(baseTime, {
+      anytime: false,
+      sendDays: "not-valid-json",
+      sendTimeStart: null,
+      sendTimeEnd: null,
+    })
+
+    expect(result).toEqual(baseTime)
+  })
+
+  test("allows all days when sendDays is null", async () => {
+    const { calculateNextValidSendTime } = await import(
+      "../src/send-time-validator"
+    )
+    // Saturday — should be allowed since null → ALL_DAYS
+    const baseTime = new Date(2024, 0, 6, 14, 0, 0, 0) // Saturday Jan 6 2024
+    // getDay() for Jan 6 2024 = Saturday = 6 → DAY_NAMES[6] = "saturday"
+
+    const result = calculateNextValidSendTime(baseTime, {
+      anytime: false,
+      sendDays: null,
+      sendTimeStart: null,
+      sendTimeEnd: null,
+    })
+
+    expect(result).toEqual(baseTime)
+  })
+
+  test("returns original baseTime after MAX_ATTEMPTS when sendDays is empty array", async () => {
+    const { calculateNextValidSendTime } = await import(
+      "../src/send-time-validator"
+    )
+    // Empty sendDays → no day is ever allowed → 14 attempts → returns baseTime
+    const baseTime = new Date(2024, 0, 1, 10, 0, 0, 0)
+
+    const result = calculateNextValidSendTime(baseTime, {
+      anytime: false,
+      sendDays: "[]",
+      sendTimeStart: null,
+      sendTimeEnd: null,
+    })
+
+    // MAX_ATTEMPTS exhausted → returns original baseTime reference
+    expect(result).toBe(baseTime)
+  })
+
+  test("skips multiple non-allowed days before landing on an allowed one", async () => {
+    const { calculateNextValidSendTime } = await import(
+      "../src/send-time-validator"
+    )
+    // Monday Jan 1 — only friday is allowed
+    const baseTime = new Date(2024, 0, 1, 10, 0, 0, 0)
+
+    const result = calculateNextValidSendTime(baseTime, {
+      anytime: false,
+      sendDays: '["friday"]',
+      sendTimeStart: null,
+      sendTimeEnd: null,
+    })
+
+    // Friday Jan 5 2024 at 00:00
+    const expected = new Date(2024, 0, 5, 0, 0, 0, 0)
+    expect(result).toEqual(expected)
+  })
+})

--- a/packages/sequence-scheduler/__tests__/sequence-dispatch.test.ts
+++ b/packages/sequence-scheduler/__tests__/sequence-dispatch.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const findManyDispatchMock = vi.fn()
+const returningUpdateMock = vi.fn()
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  // db is not used directly in sequence-dispatch.ts; only the helpers are
+  db: {},
+  and: (...a: unknown[]) => ({ __and: a }),
+  eq: (c: unknown, v: unknown) => ({ __eq: [c, v] }),
+  inArray: (c: unknown, v: unknown) => ({ __inArray: [c, v] }),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  sequenceDispatchModel: {
+    id: { __col: "sequenceDispatchModel.id" },
+    status: { __col: "sequenceDispatchModel.status" },
+  },
+}))
+
+// Reusable mock client whose update chain terminates at returningUpdateMock
+const mockDbClient = {
+  query: {
+    sequenceDispatchModel: { findMany: findManyDispatchMock },
+  },
+  update: () => ({
+    set: () => ({
+      where: () => ({
+        returning: returningUpdateMock,
+      }),
+    }),
+  }),
+} as never
+
+beforeEach(() => {
+  findManyDispatchMock.mockResolvedValue([])
+  returningUpdateMock.mockResolvedValue([])
+})
+
+describe("sequenceDispatchUtils.bulkCancelPendingDispatches", () => {
+  test("returns empty array when no pending dispatches are found", async () => {
+    const { sequenceDispatchUtils } = await import("../src/sequence-dispatch")
+    findManyDispatchMock.mockResolvedValue([])
+
+    const result = await sequenceDispatchUtils.bulkCancelPendingDispatches({
+      dbClient: mockDbClient,
+      workspaceId: "ws-1",
+      enrollmentId: "enroll-1",
+    })
+
+    expect(result).toEqual([])
+  })
+
+  test("does not call update when no pending dispatches are found", async () => {
+    const { sequenceDispatchUtils } = await import("../src/sequence-dispatch")
+    findManyDispatchMock.mockResolvedValue([])
+
+    await sequenceDispatchUtils.bulkCancelPendingDispatches({
+      dbClient: mockDbClient,
+      workspaceId: "ws-1",
+      enrollmentId: "enroll-1",
+    })
+
+    expect(returningUpdateMock).not.toHaveBeenCalled()
+  })
+
+  test("returns empty array when update affects no rows (concurrent cancel)", async () => {
+    const { sequenceDispatchUtils } = await import("../src/sequence-dispatch")
+    findManyDispatchMock.mockResolvedValue([
+      {
+        id: "d-1",
+        bucket: 10,
+        sequenceId: "seq-1",
+        contactId: "c-1",
+        stepId: "s-1",
+      },
+    ])
+    returningUpdateMock.mockResolvedValue([]) // update matched nothing
+
+    const result = await sequenceDispatchUtils.bulkCancelPendingDispatches({
+      dbClient: mockDbClient,
+      workspaceId: "ws-1",
+      enrollmentId: "enroll-1",
+    })
+
+    expect(result).toEqual([])
+  })
+
+  test("returns mapped {id, bucket} pairs when dispatches are successfully canceled", async () => {
+    const { sequenceDispatchUtils } = await import("../src/sequence-dispatch")
+    const pendingDispatches = [
+      {
+        id: "d-1",
+        bucket: 10,
+        sequenceId: "seq-1",
+        contactId: "c-1",
+        stepId: "s-1",
+      },
+      {
+        id: "d-2",
+        bucket: 20,
+        sequenceId: "seq-1",
+        contactId: "c-1",
+        stepId: "s-2",
+      },
+    ]
+    findManyDispatchMock.mockResolvedValue(pendingDispatches)
+    returningUpdateMock.mockResolvedValue(pendingDispatches) // non-empty → success path
+
+    const result = await sequenceDispatchUtils.bulkCancelPendingDispatches({
+      dbClient: mockDbClient,
+      workspaceId: "ws-1",
+      enrollmentId: "enroll-1",
+    })
+
+    expect(result).toEqual([
+      { id: "d-1", bucket: 10 },
+      { id: "d-2", bucket: 20 },
+    ])
+  })
+
+  test("calls update exactly once regardless of how many dispatches are found", async () => {
+    const { sequenceDispatchUtils } = await import("../src/sequence-dispatch")
+    const dispatches = Array.from({ length: 5 }, (_, i) => ({
+      id: `d-${i}`,
+      bucket: i,
+      sequenceId: "seq-1",
+      contactId: "c-1",
+      stepId: `s-${i}`,
+    }))
+    findManyDispatchMock.mockResolvedValue(dispatches)
+    returningUpdateMock.mockResolvedValue(dispatches)
+
+    await sequenceDispatchUtils.bulkCancelPendingDispatches({
+      dbClient: mockDbClient,
+      workspaceId: "ws-1",
+      enrollmentId: "enroll-1",
+    })
+
+    expect(returningUpdateMock).toHaveBeenCalledTimes(1)
+  })
+
+  test("uses the provided workspaceId and enrollmentId when querying pending dispatches", async () => {
+    const { sequenceDispatchUtils } = await import("../src/sequence-dispatch")
+    findManyDispatchMock.mockResolvedValue([])
+
+    await sequenceDispatchUtils.bulkCancelPendingDispatches({
+      dbClient: mockDbClient,
+      workspaceId: "my-workspace",
+      enrollmentId: "my-enrollment",
+    })
+
+    expect(findManyDispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          enrollmentId: "my-enrollment",
+          workspaceId: "my-workspace",
+          status: "pending",
+        }),
+      }),
+    )
+  })
+})

--- a/packages/sequence-scheduler/src/enroll-contact.ts
+++ b/packages/sequence-scheduler/src/enroll-contact.ts
@@ -99,42 +99,29 @@ export async function enrollContactsInSequenceBulk(
   params: EnrollContactsBulkParams,
 ) {
   const { workspaceId, enrollments, enrolledAt = new Date() } = params
-  const createdEnrollments = await db.transaction(async (tx) => {
-    await tx
-      .insert(contactsOnSequenceModel)
-      .values(
-        enrollments.map((e) => ({
-          id: createId(),
-          workspaceId,
-          contactId: e.contactId,
-          sequenceId: e.sequenceId,
-          currentStep: 0,
-          status: "active" as const,
-          nextRunAt: e.nextRunAt,
-          nextStepId: e.nextStepId,
-          enrolledAt,
-        })),
-      )
-      .onConflictDoNothing()
-
-    const contactIds = enrollments.map((e) => e.contactId)
-    const sequenceIds = enrollments.map((e) => e.sequenceId)
-
-    return await tx.query.contactsOnSequenceModel.findMany({
-      where: {
+  const createdEnrollments = await db
+    .insert(contactsOnSequenceModel)
+    .values(
+      enrollments.map((e) => ({
+        id: createId(),
         workspaceId,
-        contactId: { in: contactIds },
-        sequenceId: { in: sequenceIds },
-      },
-      columns: {
-        id: true,
-        contactId: true,
-        sequenceId: true,
-        nextRunAt: true,
-        nextStepId: true,
-      },
+        contactId: e.contactId,
+        sequenceId: e.sequenceId,
+        currentStep: 0,
+        status: "active" as const,
+        nextRunAt: e.nextRunAt,
+        nextStepId: e.nextStepId,
+        enrolledAt,
+      })),
+    )
+    .onConflictDoNothing()
+    .returning({
+      id: contactsOnSequenceModel.id,
+      contactId: contactsOnSequenceModel.contactId,
+      sequenceId: contactsOnSequenceModel.sequenceId,
+      nextRunAt: contactsOnSequenceModel.nextRunAt,
+      nextStepId: contactsOnSequenceModel.nextStepId,
     })
-  })
   const redisClient = await sequenceConnections.useExisting()
   const scheduler = new SchedulerClient(redisClient)
   for (const enrollment of createdEnrollments) {


### PR DESCRIPTION
## Summary

Adds **257 unit tests** for the broadcast and sequence features and fixes **6 correctness bugs** the tests surfaced. All tests, lint, and typecheck pass locally.

### Tests (23 files, AAA + behavior names, db/queue/redis mocked)
- **packages/sequence-scheduler** — `calculateNextRunAtFromStep`, `calculateNextValidSendTime` (send-window branches), bucket/idempotency key, `calculateSequenceDiff`, `enrollContactInSequence` (single + bulk), `advanceEnrollment` (next-step vs complete, workspace-scoped WHERE).
- **apps/worker** — broadcast `prepare`/`enqueue`/`process-contacts`/`finalize` (batching, rate-limit, inbox resolution, status transitions); sequence `dispatch-processor` (optimistic lock), `step-executor`, `retry-scheduler`, `sequence-flow` (idempotent re-delivery, terminal cleanup).
- **apps/builder** — create/update/resend broadcast and create/update/delete sequence + steps (happy path, workspace scoping, validation and not-found paths).

### Bug fixes (driven out by the tests)
| File | Fix |
|------|-----|
| `finalize-broadcasts.ts` | dropped redundant `Math.min`, set `MISSING_RATE_THRESHOLD` 1→0.01 — early-finalize now bounded by both count (≤100) **and** rate (≤1%); previously any broadcast with ≤100 missing finalized regardless of total size |
| `dispatch-processor.service.ts` | `validateDispatch(null)` returns `false` (optional chaining) instead of misclassifying null as valid |
| `retry-scheduler.service.ts` | `markDispatchCanceled` now persists the cancellation `reason` in `lastError` |
| `upsert-sequence-step.action.ts` | recalculate only when step `order` actually changes (`order !== previousOrder`) |
| `sequence-flow.ts` / `step-executor.service.ts` | removed unreachable `!flow` guard; `StepWithConfiguredFlow` makes `flow` statically non-null after validation |
| `enroll-contact.ts` | `enrollContactsInSequenceBulk` simplified to a single `insert … onConflictDoNothing().returning()` |

## Test plan
- [x] `pnpm --filter @chatbotx.io/sequence-scheduler test` — 91 passed
- [x] `pnpm --filter worker test <new files>` — 91 passed
- [x] `pnpm --filter builder test <new files>` — 77 passed
- [x] `biome check` on all new test files — clean
- [x] `check-types` (worker, builder, sequence-scheduler) — no errors

> Note: CI builds Docker images only and does not run Vitest; gates were run locally per `.agents/skills/testing-workflow`.