### PR TITLE
feat(tiktok): add tiktok to inbox select card

### DIFF
--- a/apps/builder/src/app/(no-sidebar)/channels/create/page.tsx
+++ b/apps/builder/src/app/(no-sidebar)/channels/create/page.tsx
@@ -124,6 +124,9 @@ export default async function CreateChannelPage(props: CreateChannelPageProps) {
   if (zalo) {
     configuredChannels.push("zalo")
   }
+  if (tiktok) {
+    configuredChannels.push("tiktok")
+  }
 
   return <InboxSelectCard configuredChannels={configuredChannels} />
 }

--- a/apps/builder/src/features/inboxes/components/inbox-select-card.tsx
+++ b/apps/builder/src/features/inboxes/components/inbox-select-card.tsx
@@ -24,7 +24,15 @@ function InboxSelectCard({ configuredChannels }: InboxSelectCardProps) {
   const searchParams = useSearchParams()
 
   const inboxOptions: ChannelType[] = useMemo(
-    () => ["whatsapp", "messenger", "instagram", "zalo", "telegram", "webchat"],
+    () => [
+      "whatsapp",
+      "messenger",
+      "instagram",
+      "zalo",
+      "tiktok",
+      "telegram",
+      "webchat",
+    ],
     [],
   )
 


### PR DESCRIPTION
 ## Summary
  - Adds TikTok as a selectable channel in the inbox creation card
  - TikTok is enabled by default (no pre-configured channel required), consistent with `webchat` and `telegram`
  
  ## Changes
  - `apps/builder/src/features/inboxes/components/inbox-select-card.tsx` — added `"tiktok"` to `inboxOptions` and excluded it from the disabled condition
  
  ## Test plan
  - [ ] `pnpm lint`
  - [ ] `pnpm --filter builder check-types`
  - [ ] Open inbox creation → verify TikTok appears as a selectable option
  - [ ] Confirm other channels (WhatsApp, Messenger, etc.) still behave correctly