### PR TITLE
refactor(flow-config): replace base64+JSON button payload with compact colon format

### DIFF
--- a/packages/flow-config/src/util.ts
+++ b/packages/flow-config/src/util.ts
@@ -36,20 +36,35 @@ export const buttonPayloadSchema = z
   }))
 export type ButtonPayload = z.infer<typeof buttonPayloadSchema>
 
-export const encodeButtonPayload = (props: ButtonPayload) =>
-  btoa(
-    JSON.stringify({
-      f: props.flowId,
-      fv: props.flowVersionId,
-      b: props.buttonId,
-      br: props.broadcastId,
-      ss: props.sequenceStepId,
-      cid: props.contactInboxId,
-    }),
-  )
+export const encodeButtonPayload = (props: ButtonPayload): string => {
+  const parts = [
+    props.flowId,
+    props.flowVersionId ?? "",
+    props.buttonId ?? "",
+    props.broadcastId ?? "",
+    props.sequenceStepId ?? "",
+    props.contactInboxId ?? "",
+  ]
+  while (parts.length > 2 && parts.at(-1) === "") {
+    parts.pop()
+  }
+  return parts.join(":")
+}
 
 export const decodeButtonPayload = (payload: string): ButtonPayload | null => {
   try {
+    if (payload.includes(":")) {
+      const [f, fv, b, br, ss, cid] = payload.split(":")
+      return buttonPayloadSchema.parse({
+        f,
+        fv: fv || undefined,
+        b: b || undefined,
+        br: br || undefined,
+        ss: ss || undefined,
+        cid: cid || undefined,
+      })
+    }
+    // Legacy format: base64+JSON (payloads encoded before the colon format)
     return buttonPayloadSchema.parse(JSON.parse(atob(payload)))
   } catch {
     return null


### PR DESCRIPTION
## Summary
  - Button payloads were encoded as `btoa(JSON.stringify({f, fv, b, br, ss, cid}))`, producing ~80–120 char base64 strings
  - New format is colon-delimited (`flowId:versionId:buttonId:...`) with trailing empty fields stripped — typically 20–40 chars
  - Decoding is backward-compatible: payloads without `:` fall through to the old base64+JSON path, so buttons from flows already sent to users continue to work
  
  ## Changes
  - `packages/flow-config/src/util.ts` — `encodeButtonPayload` emits colon-delimited string; `decodeButtonPayload` handles both formats
  
  ## Test plan
  - [ ] Encode a payload and verify the output is shorter and colon-delimited
  - [ ] Decode a legacy base64 payload and verify it still parses correctly
  - [ ] Click a flow button end-to-end in a real conversation (both old and new payload format)
