### PR TITLE
fix(database): drop Plan_organizationId_fkey before dropping Organization table

### DIFF
--- a/packages/database/drizzle/20260522000000_drop_organization_add_enterprise_tables/migration.sql
+++ b/packages/database/drizzle/20260522000000_drop_organization_add_enterprise_tables/migration.sql
@@ -10,6 +10,7 @@ ALTER TABLE "Invitation" DROP CONSTRAINT IF EXISTS "Invitation_organizationId_Or
 ALTER TABLE "OrganizationMember" DROP CONSTRAINT IF EXISTS "OrganizationMember_organizationId_Organization_id_fkey";--> statement-breakpoint
 ALTER TABLE "OrganizationMember" DROP CONSTRAINT IF EXISTS "OrganizationMember_userId_User_id_fkey";--> statement-breakpoint
 ALTER TABLE "Workspace" DROP CONSTRAINT IF EXISTS "Workspace_organizationId_Organization_id_fkey";--> statement-breakpoint
+ALTER TABLE "Plan" DROP CONSTRAINT IF EXISTS "Plan_organizationId_fkey";--> statement-breakpoint
 
 -- 2. Create CustomDomain table (enterprise)
 CREATE TABLE IF NOT EXISTS "CustomDomain" (


### PR DESCRIPTION
## Summary

- Fresh install fails at migration `20260522000000_drop_organization_add_enterprise_tables` with:
  ```
  ERROR: cannot drop table "Organization" because other objects depend on it
  DETAIL: constraint Plan_organizationId_fkey on table "Plan" depends on table "Organization"
  HINT: Use DROP ... CASCADE to drop the dependent objects too.
  ```
- Step 1 of the migration drops FK constraints from `Invitation`, `OrganizationMember`, and `Workspace` referencing `Organization`, but omits the FK from `Plan` (`Plan_organizationId_fkey` created in the initial migration).
- Fix: add the missing `ALTER TABLE "Plan" DROP CONSTRAINT IF EXISTS "Plan_organizationId_fkey"` alongside the other FK drops.

## Test plan

- [ ] Fresh Docker + `pnpm --filter @chatbotx.io/database db:migrate` completes without error on a clean database
- [ ] Re-running migration on an existing database (idempotent `IF EXISTS`) is a no-op

🤖 Generated with [Claude Code](https://claude.ai/claude-code)