### PR TITLE
feat(whatsapp): run embedded-signup SDK on the broker host for white-label

### DIFF
--- a/apps/builder/__tests__/whatsapp-embedded-signup-redirect-uri.test.ts
+++ b/apps/builder/__tests__/whatsapp-embedded-signup-redirect-uri.test.ts
@@ -21,24 +21,78 @@ afterEach(() => {
   vi.doUnmock("@/env")
 })
 
-describe("getEmbeddedSignupRedirectUri", () => {
-  test("points the redirect_uri at the broker host when configured", async () => {
-    const { getEmbeddedSignupRedirectUri } = await loadWith({
+describe("shouldRedirectToBroker", () => {
+  test("redirects to the broker from a white-label custom domain", async () => {
+    const { shouldRedirectToBroker } = await loadWith({
       NEXT_PUBLIC_BROKER_URL: BROKER_URL,
     })
 
-    expect(getEmbeddedSignupRedirectUri()).toBe(
-      `${BROKER_URL}/integrations/whatsapp/callback`,
-    )
+    expect(shouldRedirectToBroker("chat.reseller.com")).toBe(true)
   })
 
-  test("falls back to the builder host for single-domain deploys", async () => {
-    const { getEmbeddedSignupRedirectUri } = await loadWith({
+  test("does not redirect when already on the broker host", async () => {
+    const { shouldRedirectToBroker } = await loadWith({
+      NEXT_PUBLIC_BROKER_URL: BROKER_URL,
+    })
+
+    expect(shouldRedirectToBroker("broker.example.com")).toBe(false)
+  })
+
+  test("does not redirect on single-domain deploys (no broker configured)", async () => {
+    const { shouldRedirectToBroker } = await loadWith({
       NEXT_PUBLIC_BROKER_URL: undefined,
     })
 
-    expect(getEmbeddedSignupRedirectUri()).toBe(
-      `${BUILDER_URL}/integrations/whatsapp/callback`,
+    expect(shouldRedirectToBroker("chat.reseller.com")).toBe(false)
+  })
+})
+
+describe("buildBrokerEmbeddedSignupUrl", () => {
+  test("builds the SDK page URL on the broker host with public config + flags", async () => {
+    const { buildBrokerEmbeddedSignupUrl } = await loadWith({
+      NEXT_PUBLIC_BROKER_URL: BROKER_URL,
+    })
+
+    const result = new URL(
+      buildBrokerEmbeddedSignupUrl({
+        callbackURL: "https://chat.reseller.com",
+        workspaceId: "123",
+        clientId: "client-1",
+        configId: "config-1",
+        version: "v21.0",
+        connectExisting: false,
+        transferPhoneNumber: true,
+      }),
     )
+
+    expect(result.origin).toBe(BROKER_URL)
+    expect(result.pathname).toBe("/integrations/whatsapp/embedded-signup")
+    expect(result.searchParams.get("callbackURL")).toBe(
+      "https://chat.reseller.com",
+    )
+    expect(result.searchParams.get("workspaceId")).toBe("123")
+    expect(result.searchParams.get("clientId")).toBe("client-1")
+    expect(result.searchParams.get("configId")).toBe("config-1")
+    expect(result.searchParams.get("transferPhoneNumber")).toBe("true")
+  })
+
+  test("omits workspaceId when not provided", async () => {
+    const { buildBrokerEmbeddedSignupUrl } = await loadWith({
+      NEXT_PUBLIC_BROKER_URL: BROKER_URL,
+    })
+
+    const result = new URL(
+      buildBrokerEmbeddedSignupUrl({
+        callbackURL: "https://chat.reseller.com",
+        clientId: "client-1",
+        configId: "config-1",
+        version: "v21.0",
+        connectExisting: true,
+        transferPhoneNumber: false,
+      }),
+    )
+
+    expect(result.searchParams.has("workspaceId")).toBe(false)
+    expect(result.searchParams.get("connectExisting")).toBe("true")
   })
 })

--- a/apps/builder/__tests__/whatsapp-embedded-signup-redirect-uri.test.ts
+++ b/apps/builder/__tests__/whatsapp-embedded-signup-redirect-uri.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, test, vi } from "vitest"
+
+const BUILDER_URL = "https://app.example.com"
+const BROKER_URL = "https://broker.example.com"
+
+async function loadWith(envOverrides: Record<string, string | undefined>) {
+  vi.resetModules()
+  vi.doMock("@/env", () => ({
+    env: {
+      NEXT_PUBLIC_BUILDER_URL: BUILDER_URL,
+      ...envOverrides,
+    },
+  }))
+  return await import("@/features/integration-whatsapp/libs/embedded-signup")
+}
+
+afterEach(() => {
+  vi.resetModules()
+  vi.doUnmock("@/env")
+})
+
+describe("getEmbeddedSignupRedirectUri", () => {
+  test("points the redirect_uri at the broker host when configured", async () => {
+    const { getEmbeddedSignupRedirectUri } = await loadWith({
+      NEXT_PUBLIC_BROKER_URL: BROKER_URL,
+    })
+
+    expect(getEmbeddedSignupRedirectUri()).toBe(
+      `${BROKER_URL}/integrations/whatsapp/callback`,
+    )
+  })
+
+  test("falls back to the builder host for single-domain deploys", async () => {
+    const { getEmbeddedSignupRedirectUri } = await loadWith({
+      NEXT_PUBLIC_BROKER_URL: undefined,
+    })
+
+    expect(getEmbeddedSignupRedirectUri()).toBe(
+      `${BUILDER_URL}/integrations/whatsapp/callback`,
+    )
+  })
+})

--- a/apps/builder/__tests__/whatsapp-embedded-signup-return-route.test.ts
+++ b/apps/builder/__tests__/whatsapp-embedded-signup-return-route.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+import { afterEach, expect, test, vi } from "vitest"
+
+const sanitizeReferer = vi.fn()
+
+vi.mock("@/env", () => ({
+  env: { NEXT_PUBLIC_BUILDER_URL: "https://app.example.com" },
+}))
+vi.mock("@/lib/oauth-referer", () => ({ sanitizeReferer }))
+vi.mock("@/lib/log", () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+}))
+vi.mock("@chatbotx.io/utils", () => ({
+  getPublicUrlFromRequest: (req: Request) => new URL(req.url),
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+const { GET } = await import(
+  "../src/app/integrations/whatsapp/embedded-signup/return/route"
+)
+
+test("relays the captured signup result back to an allowed reseller domain", async () => {
+  sanitizeReferer.mockResolvedValueOnce("https://chat.reseller.com")
+  const req = new Request(
+    "https://broker.example.com/integrations/whatsapp/embedded-signup/return?callbackURL=https%3A%2F%2Fchat.reseller.com&workspaceId=123&waCode=abc&waba_id=w1&phone_number_id=p1&business_id=b1&transferPhoneNumber=true",
+  )
+
+  const res = await GET(req)
+  const location = new URL(res.headers.get("location") ?? "")
+
+  expect(res.status).toBe(307)
+  expect(location.origin).toBe("https://chat.reseller.com")
+  expect(location.pathname).toBe("/channels/create")
+  expect(location.searchParams.get("channel")).toBe("whatsapp")
+  expect(location.searchParams.get("waCode")).toBe("abc")
+  expect(location.searchParams.get("waba_id")).toBe("w1")
+  expect(location.searchParams.get("phone_number_id")).toBe("p1")
+  expect(location.searchParams.get("business_id")).toBe("b1")
+  expect(location.searchParams.get("workspaceId")).toBe("123")
+  expect(location.searchParams.get("transferPhoneNumber")).toBe("true")
+})
+
+test("relays a cancel/error back to the reseller as waError", async () => {
+  sanitizeReferer.mockResolvedValueOnce("https://chat.reseller.com")
+  const req = new Request(
+    "https://broker.example.com/integrations/whatsapp/embedded-signup/return?callbackURL=https%3A%2F%2Fchat.reseller.com&waError=1",
+  )
+
+  const res = await GET(req)
+  const location = new URL(res.headers.get("location") ?? "")
+
+  expect(location.origin).toBe("https://chat.reseller.com")
+  expect(location.searchParams.get("waError")).toBe("1")
+  expect(location.searchParams.get("waCode")).toBeNull()
+})
+
+test("open-redirect guard: never forwards to an attacker-supplied origin", async () => {
+  // sanitizeReferer returns the safe in-app fallback path for disallowed origins.
+  sanitizeReferer.mockResolvedValueOnce("/manage")
+  const req = new Request(
+    "https://broker.example.com/integrations/whatsapp/embedded-signup/return?callbackURL=https%3A%2F%2Fevil.com&waCode=abc",
+  )
+
+  const res = await GET(req)
+  const location = new URL(res.headers.get("location") ?? "")
+
+  expect(location.origin).toBe("https://broker.example.com")
+  expect(location.pathname).toBe("/manage")
+  expect(location.href).not.toContain("evil.com")
+})

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -2226,6 +2226,8 @@
       "label": "Commands"
     },
     "connectExisting": "Connect an existing WhatsApp Business Account",
+    "embeddedSignupBrokerHint": "Complete the secure WhatsApp signup, then you'll be returned to finish connecting.",
+    "embeddedSignupProcessing": "Finishing up — please wait…",
     "fillRequiredFields": "Please fill in all required fields",
     "continueManualConnect": "Continue — manual connect",
     "icebreakers": {

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -2238,6 +2238,8 @@
       "label": "Lệnh"
     },
     "connectExisting": "Kết nối tài khoản WhatsApp Business hiện có",
+    "embeddedSignupBrokerHint": "Hoàn tất đăng ký WhatsApp an toàn, sau đó bạn sẽ được đưa trở lại để hoàn tất kết nối.",
+    "embeddedSignupProcessing": "Đang hoàn tất — vui lòng đợi…",
     "fillRequiredFields": "Vui lòng điền đầy đủ các trường bắt buộc",
     "continueManualConnect": "Tiếp tục — kết nối thủ công",
     "icebreakers": {

--- a/apps/builder/src/app/integrations/whatsapp/embedded-signup/page.tsx
+++ b/apps/builder/src/app/integrations/whatsapp/embedded-signup/page.tsx
@@ -1,0 +1,50 @@
+import { notFound } from "next/navigation"
+import { WhatsappEmbeddedSignupBroker } from "@/features/integration-whatsapp/components/whatsapp-embedded-signup-broker"
+
+export const dynamic = "force-dynamic"
+
+type EmbeddedSignupPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+function readParam(
+  params: Record<string, string | string[] | undefined>,
+  key: string,
+): string | undefined {
+  const value = params[key]
+  return Array.isArray(value) ? value[0] : value
+}
+
+/**
+ * Broker-hosted WhatsApp embedded-signup page (public — under the `/integrations`
+ * prefix, no session). Runs the Facebook SDK on the registered broker origin for
+ * white-label resellers. The SDK config (clientId/configId/version) is public and
+ * passed in by the originating reseller page; the broker runs in the ROOT tenant
+ * and cannot resolve it from the DB itself (invariant #10).
+ */
+export default async function WhatsappEmbeddedSignupPage(
+  props: EmbeddedSignupPageProps,
+) {
+  const searchParams = await props.searchParams
+
+  const callbackURL = readParam(searchParams, "callbackURL")
+  const clientId = readParam(searchParams, "clientId")
+  const configId = readParam(searchParams, "configId")
+  const version = readParam(searchParams, "version")
+
+  if (!(callbackURL && clientId && configId && version)) {
+    return notFound()
+  }
+
+  return (
+    <WhatsappEmbeddedSignupBroker
+      callbackURL={callbackURL}
+      connectExisting={readParam(searchParams, "connectExisting") === "true"}
+      settings={{ clientId, configId, version }}
+      transferPhoneNumber={
+        readParam(searchParams, "transferPhoneNumber") === "true"
+      }
+      workspaceId={readParam(searchParams, "workspaceId")}
+    />
+  )
+}

--- a/apps/builder/src/app/integrations/whatsapp/embedded-signup/return/route.ts
+++ b/apps/builder/src/app/integrations/whatsapp/embedded-signup/return/route.ts
@@ -1,0 +1,53 @@
+import { getPublicUrlFromRequest } from "@chatbotx.io/utils"
+import { NextResponse } from "next/server"
+import {
+  CHANNELS_CREATE_PATH,
+  FALLBACK_REDIRECT_AFTER_RELAY,
+} from "@/features/integration-whatsapp/libs/embedded-signup"
+import { logger } from "@/lib/log"
+import { sanitizeReferer } from "@/lib/oauth-referer"
+
+const RELAYED_PARAMS = [
+  "workspaceId",
+  "waCode",
+  "waba_id",
+  "phone_number_id",
+  "business_id",
+  "transferPhoneNumber",
+  "waError",
+] as const
+
+/**
+ * Broker return route for WhatsApp embedded signup. The broker-hosted SDK page
+ * (running on the registered broker origin) bounces here with the captured
+ * `code` + session info and the originating reseller's `callbackURL`. We validate
+ * the callbackURL against origins we control (open-redirect guard, shared with the
+ * #601 OAuth-broker relay) and 302 back to the reseller `/channels/create`, where
+ * the session cookie lives and `connectWhatsappAction` can run.
+ */
+export async function GET(req: Request) {
+  const url = new URL(getPublicUrlFromRequest(req))
+  const callbackURL = url.searchParams.get("callbackURL") ?? ""
+
+  // sanitizeReferer returns the URL only when it is an origin we control
+  // (broker host, builder host, or an active custom domain); otherwise a safe
+  // in-app fallback path — never an attacker-supplied origin.
+  const safeTarget = await sanitizeReferer(callbackURL)
+  if (!safeTarget.startsWith("http")) {
+    logger.warn({ callbackURL }, "[wa-embedded-signup] rejected relay target")
+    return NextResponse.redirect(
+      new URL(FALLBACK_REDIRECT_AFTER_RELAY, url.origin),
+    )
+  }
+
+  const target = new URL(CHANNELS_CREATE_PATH, new URL(safeTarget).origin)
+  target.searchParams.set("channel", "whatsapp")
+  for (const key of RELAYED_PARAMS) {
+    const value = url.searchParams.get(key)
+    if (value) {
+      target.searchParams.set(key, value)
+    }
+  }
+
+  return NextResponse.redirect(target)
+}

--- a/apps/builder/src/features/integration-whatsapp/components/whatsapp-create.tsx
+++ b/apps/builder/src/features/integration-whatsapp/components/whatsapp-create.tsx
@@ -17,14 +17,11 @@ import {
   CardTitle,
 } from "@chatbotx.io/ui/components/ui/card"
 import { Form } from "@chatbotx.io/ui/components/ui/form"
-import FacebookLogin, {
-  type InitParams,
-} from "@greatsumini/react-facebook-login"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hooks"
 import ky from "ky"
 import { Loader2Icon } from "lucide-react"
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { useCallback, useEffect, useRef, useState, useTransition } from "react"
 import { useFormContext, useWatch } from "react-hook-form"
@@ -33,14 +30,22 @@ import { InboxIcon } from "@/features/inboxes/components/inbox-icon"
 import { CoexistPopup } from "@/features/shared/coexist-popup"
 import { clientErrorHandler } from "@/lib/errors/client-handler"
 import { connectWhatsappAction } from "../actions/connect.action"
-import { getEmbeddedSignupRedirectUri } from "../libs/embedded-signup"
+import {
+  buildBrokerEmbeddedSignupUrl,
+  shouldRedirectToBroker,
+} from "../libs/embedded-signup"
 import { connectWhatsappSchema, type ManualOnboardingResult } from "../schemas"
+import { WhatsappEmbeddedLogin } from "./whatsapp-embedded-login"
 import { WhatsappOnboardingResult } from "./whatsapp-onboarding-result"
 
 // Constants
 const API_ENDPOINT = "/api/whatsapp/phone-numbers/list"
 const MAX_CARD_WIDTH = "max-w-md"
 const CARD_MARGIN = "mx-auto mt-40"
+
+// Shared styling for the "Continue" embedded-signup trigger (FB button / broker link).
+const CONTINUE_BUTTON_CLASS =
+  "inline-flex h-8 items-center justify-start gap-2 whitespace-nowrap rounded-md bg-secondary px-4 py-2 font-medium text-secondary-foreground text-sm shadow-xs transition-all hover:bg-secondary/80 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"
 
 // Form field names
 const FORM_FIELDS = {
@@ -53,15 +58,6 @@ const FORM_FIELDS = {
   PHONE_NUMBER_ID: "phoneNumberId",
   BUSINESS_ID: "businessId",
   CODE: "code",
-} as const
-
-const EMBEDDED_SIGNUP_FEATURE_TYPES = {
-  WHATSAPP_BUSINESS_APP_ONBOARDING: "whatsapp_business_app_onboarding",
-  ONLY_WABA_SHARING: "only_waba_sharing",
-} as const
-
-const EMBEDDED_SIGNUP_FEATURES = {
-  MARKETING_MESSAGES_LITE: "marketing_messages_lite",
 } as const
 
 type FormVisibility = {
@@ -116,6 +112,7 @@ export default function WhatsappCreate({
   const t = useTranslations()
   const { visibility, updateVisibility } = useFormVisibility()
   const router = useRouter()
+  const searchParams = useSearchParams()
   const [manualResult, setManualResult] =
     useState<ManualOnboardingResult | null>(null)
   const [showCoexist, setShowCoexist] = useState<{
@@ -178,58 +175,51 @@ export default function WhatsappCreate({
   const watchTransferPhoneNumber = watch(FORM_FIELDS.TRANSFER_PHONE_NUMBER)
   const watchManualConnect = watch(FORM_FIELDS.MANUAL_CONNECT)
 
+  // Broker relay return: the broker-hosted SDK page redirected back here with the
+  // captured embedded-signup result. Populate the form and auto-submit under the
+  // reseller session (where connectWhatsappAction must run). Guarded against
+  // refresh/double-submit by stripping the params and a ref latch.
+  const relayHandledRef = useRef(false)
   useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      if (!event.origin.endsWith("facebook.com")) {
-        return
-      }
-
-      try {
-        const data = JSON.parse(event.data)
-        if (data.type === "WA_EMBEDDED_SIGNUP") {
-          /*
-           * {
-           *     "data": {
-           *         "phone_number_id": "111598575218611",
-           *         "waba_id": "119496914420376",
-           *         "business_id": "553355495727951"
-           *     },
-           *     "type": "WA_EMBEDDED_SIGNUP",
-           *     "event": "FINISH",
-           *     "version": "3"
-           * }
-           */
-          if (
-            data.event === "FINISH" ||
-            data.event === "FINISH_ONLY_WABA" ||
-            data.event === "FINISH_WHATSAPP_BUSINESS_APP_ONBOARDING"
-          ) {
-            setValue(FORM_FIELDS.BUSINESS_ID, data.data.business_id ?? "")
-            setValue(FORM_FIELDS.WABA_ID, data.data.waba_id ?? "")
-            setValue(
-              FORM_FIELDS.PHONE_NUMBER_ID,
-              data.data.phone_number_id ?? "",
-            )
-          } else if (data.event === "CANCEL") {
-            setValue(FORM_FIELDS.BUSINESS_ID, "")
-            setValue(FORM_FIELDS.WABA_ID, "")
-            setValue(FORM_FIELDS.PHONE_NUMBER_ID, "")
-            toast.error(t("messages.connectFailed", { feature: "Whatsapp" }))
-          }
-        }
-      } catch {
-        // Ignore malformed postMessage payloads from Facebook SDK
-      }
+    if (relayHandledRef.current) {
+      return
     }
 
-    // Add the event listener
-    window.addEventListener("message", handleMessage)
+    const cleanUrl = `/channels/create?channel=whatsapp${
+      workspaceId ? `&workspaceId=${workspaceId}` : ""
+    }`
 
-    // Cleanup function to remove the event listener
-    return () => {
-      window.removeEventListener("message", handleMessage)
+    if (searchParams.get("waError")) {
+      relayHandledRef.current = true
+      toast.error(t("messages.connectFailed", { feature: "Whatsapp" }))
+      router.replace(cleanUrl)
+      return
     }
-  }, [setValue, t]) // Empty dependency array ensures the effect runs only once on mount and unmount
+
+    const waCode = searchParams.get("waCode")
+    if (!waCode) {
+      return
+    }
+
+    relayHandledRef.current = true
+    setValue(FORM_FIELDS.CODE, waCode)
+    setValue(FORM_FIELDS.WABA_ID, searchParams.get("waba_id") ?? "")
+    setValue(
+      FORM_FIELDS.PHONE_NUMBER_ID,
+      searchParams.get("phone_number_id") ?? "",
+    )
+    setValue(FORM_FIELDS.BUSINESS_ID, searchParams.get("business_id") ?? "")
+    setValue(
+      FORM_FIELDS.TRANSFER_PHONE_NUMBER,
+      searchParams.get("transferPhoneNumber") === "true",
+    )
+    setValue(FORM_FIELDS.CONNECT_EXISTING, false)
+    setValue(FORM_FIELDS.MANUAL_CONNECT, false)
+    setValue(FORM_FIELDS.MARKETING_MESSAGE_LITE, true)
+
+    router.replace(cleanUrl)
+    handleSubmitWithAction()
+  }, [searchParams, setValue, handleSubmitWithAction, router, workspaceId, t])
 
   // Form visibility effects
   useEffect(() => {
@@ -293,6 +283,7 @@ export default function WhatsappCreate({
                   settings={settings}
                   visibility={visibility}
                   watchManualConnect={watchManualConnect}
+                  workspaceId={workspaceId}
                 />
               )}
             </form>
@@ -307,12 +298,14 @@ type SdkConnectSectionProps = {
   visibility: FormVisibility
   watchManualConnect: boolean
   settings: WhatsappCredentialPublic
+  workspaceId?: string | null
 }
 
 function SdkConnectSection({
   visibility,
   watchManualConnect,
   settings,
+  workspaceId,
 }: SdkConnectSectionProps) {
   const t = useTranslations()
   const { setValue, watch, formState, trigger } = useFormContext()
@@ -327,13 +320,36 @@ function SdkConnectSection({
     name: FORM_FIELDS.TRANSFER_PHONE_NUMBER,
   })
 
-  let embeddedSignupFeatureType: string | undefined
-  if (watchTransferPhoneNumber) {
-    embeddedSignupFeatureType =
-      EMBEDDED_SIGNUP_FEATURE_TYPES.WHATSAPP_BUSINESS_APP_ONBOARDING
-  } else if (watchConnectExisting) {
-    embeddedSignupFeatureType = EMBEDDED_SIGNUP_FEATURE_TYPES.ONLY_WABA_SHARING
-  }
+  // The Facebook JS SDK derives its OAuth domain from window.location, so on a
+  // white-label custom domain it must run on the registered broker host instead.
+  // Resolved post-mount to avoid a hydration mismatch (window is server-undefined).
+  const [useBrokerRedirect, setUseBrokerRedirect] = useState(false)
+  useEffect(() => {
+    setUseBrokerRedirect(shouldRedirectToBroker(window.location.host))
+  }, [])
+
+  const redirectToBroker = useCallback(() => {
+    window.location.href = buildBrokerEmbeddedSignupUrl({
+      callbackURL: window.location.origin,
+      workspaceId,
+      clientId: settings.clientId,
+      configId: settings.configId,
+      version: settings.version,
+      connectExisting: Boolean(watchConnectExisting),
+      transferPhoneNumber: Boolean(watchTransferPhoneNumber),
+    })
+  }, [workspaceId, settings, watchConnectExisting, watchTransferPhoneNumber])
+
+  const handleCode = useCallback(
+    async (code: string) => {
+      setValue(FORM_FIELDS.CODE, code)
+      const valid = await trigger()
+      if (valid) {
+        finalSubmitRef.current?.click()
+      }
+    },
+    [setValue, trigger],
+  )
 
   return (
     <>
@@ -360,55 +376,43 @@ function SdkConnectSection({
       )}
 
       <div className="flex items-center justify-end gap-2">
-        {!(watchManualConnect || watch(FORM_FIELDS.CODE)) && (
-          <FacebookLogin
-            appId={settings.clientId}
-            className="inline-flex h-8 items-center justify-start gap-2 whitespace-nowrap rounded-md bg-secondary px-4 py-2 font-medium text-secondary-foreground text-sm shadow-xs transition-all hover:bg-secondary/80 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"
-            dialogParams={{
-              redirect_uri: getEmbeddedSignupRedirectUri(),
-              response_type: "code",
-              state: "facebookdirect",
-            }}
-            initParams={{
-              version: (settings.version as InitParams["version"]) ?? "v21.0",
-            }}
-            key={embeddedSignupFeatureType ?? "default"}
-            loginOptions={
-              {
-                config_id: settings.configId,
-                response_type: "code",
-                override_default_response_type: true,
-                return_scopes: true,
-                extras: {
-                  sessionInfoVersion: 3,
-                  setup: {},
-                  features: [EMBEDDED_SIGNUP_FEATURES.MARKETING_MESSAGES_LITE],
-                  ...(embeddedSignupFeatureType
-                    ? { featureType: embeddedSignupFeatureType }
-                    : {}),
-                },
-                // biome-ignore lint/suspicious/noExplicitAny: some types are not supported
-              } as any
-            }
-            onFail={() => {
-              toast.error(t("messages.connectFailed", { feature: "Whatsapp" }))
-            }}
-            // biome-ignore lint/suspicious/noExplicitAny: this library does not support code returned
-            onSuccess={async (res: any) => {
-              if (res.code) {
-                setValue(FORM_FIELDS.CODE, res.code)
-                const valid = await trigger()
-
-                if (valid) {
-                  finalSubmitRef.current?.click()
-                }
-              }
-            }}
-            scope=""
-          >
-            {t("actions.continue")}
-          </FacebookLogin>
-        )}
+        {!(watchManualConnect || watch(FORM_FIELDS.CODE)) &&
+          (useBrokerRedirect ? (
+            <Button
+              className={CONTINUE_BUTTON_CLASS}
+              onClick={redirectToBroker}
+              type="button"
+            >
+              {t("actions.continue")}
+            </Button>
+          ) : (
+            <WhatsappEmbeddedLogin
+              className={CONTINUE_BUTTON_CLASS}
+              connectExisting={Boolean(watchConnectExisting)}
+              label={t("actions.continue")}
+              onCancel={() => {
+                setValue(FORM_FIELDS.BUSINESS_ID, "")
+                setValue(FORM_FIELDS.WABA_ID, "")
+                setValue(FORM_FIELDS.PHONE_NUMBER_ID, "")
+                toast.error(
+                  t("messages.connectFailed", { feature: "Whatsapp" }),
+                )
+              }}
+              onCode={handleCode}
+              onFail={() => {
+                toast.error(
+                  t("messages.connectFailed", { feature: "Whatsapp" }),
+                )
+              }}
+              onSessionInfo={(info) => {
+                setValue(FORM_FIELDS.BUSINESS_ID, info.businessId)
+                setValue(FORM_FIELDS.WABA_ID, info.wabaId)
+                setValue(FORM_FIELDS.PHONE_NUMBER_ID, info.phoneNumberId)
+              }}
+              settings={settings}
+              transferPhoneNumber={Boolean(watchTransferPhoneNumber)}
+            />
+          ))}
 
         {watchCode && (
           <div className="flex items-center justify-end gap-2">

--- a/apps/builder/src/features/integration-whatsapp/components/whatsapp-create.tsx
+++ b/apps/builder/src/features/integration-whatsapp/components/whatsapp-create.tsx
@@ -33,6 +33,7 @@ import { InboxIcon } from "@/features/inboxes/components/inbox-icon"
 import { CoexistPopup } from "@/features/shared/coexist-popup"
 import { clientErrorHandler } from "@/lib/errors/client-handler"
 import { connectWhatsappAction } from "../actions/connect.action"
+import { getEmbeddedSignupRedirectUri } from "../libs/embedded-signup"
 import { connectWhatsappSchema, type ManualOnboardingResult } from "../schemas"
 import { WhatsappOnboardingResult } from "./whatsapp-onboarding-result"
 
@@ -363,6 +364,11 @@ function SdkConnectSection({
           <FacebookLogin
             appId={settings.clientId}
             className="inline-flex h-8 items-center justify-start gap-2 whitespace-nowrap rounded-md bg-secondary px-4 py-2 font-medium text-secondary-foreground text-sm shadow-xs transition-all hover:bg-secondary/80 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"
+            dialogParams={{
+              redirect_uri: getEmbeddedSignupRedirectUri(),
+              response_type: "code",
+              state: "facebookdirect",
+            }}
             initParams={{
               version: (settings.version as InitParams["version"]) ?? "v21.0",
             }}

--- a/apps/builder/src/features/integration-whatsapp/components/whatsapp-embedded-login.tsx
+++ b/apps/builder/src/features/integration-whatsapp/components/whatsapp-embedded-login.tsx
@@ -1,0 +1,126 @@
+"use client"
+
+import FacebookLogin, {
+  type InitParams,
+} from "@greatsumini/react-facebook-login"
+import { useEffect } from "react"
+import {
+  buildEmbeddedSignupExtras,
+  resolveEmbeddedSignupFeatureType,
+} from "../libs/embedded-signup"
+
+const DEFAULT_VERSION: InitParams["version"] = "v21.0"
+
+export type EmbeddedSignupSessionInfo = {
+  businessId: string
+  wabaId: string
+  phoneNumberId: string
+}
+
+/** The subset of the WhatsApp public credential the embedded-signup SDK needs. */
+export type EmbeddedSignupSettings = {
+  clientId: string
+  configId: string
+  version: string
+}
+
+type WhatsappEmbeddedLoginProps = {
+  settings: EmbeddedSignupSettings
+  connectExisting: boolean
+  transferPhoneNumber: boolean
+  label: string
+  className?: string
+  onCode: (code: string) => void
+  onSessionInfo: (info: EmbeddedSignupSessionInfo) => void
+  onCancel: () => void
+  onFail: () => void
+}
+
+/**
+ * Renders the Facebook embedded-signup button via `@greatsumini/react-facebook-login`
+ * and captures the `WA_EMBEDDED_SIGNUP` postMessage that carries the
+ * waba_id / phone_number_id / business_id (these only arrive via postMessage, not
+ * via a plain OAuth redirect). Used both inline (platform host) and on the broker
+ * page (white-label), so the SDK config lives in exactly one place.
+ */
+export function WhatsappEmbeddedLogin({
+  settings,
+  connectExisting,
+  transferPhoneNumber,
+  label,
+  className,
+  onCode,
+  onSessionInfo,
+  onCancel,
+  onFail,
+}: WhatsappEmbeddedLoginProps) {
+  const featureType = resolveEmbeddedSignupFeatureType({
+    connectExisting,
+    transferPhoneNumber,
+  })
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      if (!event.origin.endsWith("facebook.com")) {
+        return
+      }
+
+      try {
+        const data = JSON.parse(event.data)
+        if (data.type !== "WA_EMBEDDED_SIGNUP") {
+          return
+        }
+
+        if (
+          data.event === "FINISH" ||
+          data.event === "FINISH_ONLY_WABA" ||
+          data.event === "FINISH_WHATSAPP_BUSINESS_APP_ONBOARDING"
+        ) {
+          onSessionInfo({
+            businessId: data.data?.business_id ?? "",
+            wabaId: data.data?.waba_id ?? "",
+            phoneNumberId: data.data?.phone_number_id ?? "",
+          })
+        } else if (data.event === "CANCEL") {
+          onCancel()
+        }
+      } catch {
+        // Ignore malformed postMessage payloads from the Facebook SDK
+      }
+    }
+
+    window.addEventListener("message", handleMessage)
+    return () => window.removeEventListener("message", handleMessage)
+  }, [onSessionInfo, onCancel])
+
+  return (
+    <FacebookLogin
+      appId={settings.clientId}
+      className={className}
+      initParams={{
+        version: (settings.version as InitParams["version"]) ?? DEFAULT_VERSION,
+      }}
+      key={featureType ?? "default"}
+      loginOptions={
+        {
+          config_id: settings.configId,
+          response_type: "code",
+          override_default_response_type: true,
+          return_scopes: true,
+          extras: buildEmbeddedSignupExtras(featureType),
+          // biome-ignore lint/suspicious/noExplicitAny: some SDK types are not supported
+        } as any
+      }
+      onFail={onFail}
+      // biome-ignore lint/suspicious/noExplicitAny: this library does not type the returned code
+      onSuccess={(res: any) => {
+        if (res?.code) {
+          onCode(res.code)
+        }
+      }}
+      scope=""
+    >
+      {label}
+    </FacebookLogin>
+  )
+}

--- a/apps/builder/src/features/integration-whatsapp/components/whatsapp-embedded-signup-broker.tsx
+++ b/apps/builder/src/features/integration-whatsapp/components/whatsapp-embedded-signup-broker.tsx
@@ -1,0 +1,144 @@
+"use client"
+
+import { Button } from "@chatbotx.io/ui/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@chatbotx.io/ui/components/ui/card"
+import { Loader2Icon } from "lucide-react"
+import { useTranslations } from "next-intl"
+import { useCallback, useRef, useState } from "react"
+import { InboxIcon } from "@/features/inboxes/components/inbox-icon"
+import { BROKER_EMBEDDED_SIGNUP_RETURN_PATH } from "../libs/embedded-signup"
+import {
+  type EmbeddedSignupSessionInfo,
+  type EmbeddedSignupSettings,
+  WhatsappEmbeddedLogin,
+} from "./whatsapp-embedded-login"
+
+const CONTINUE_BUTTON_CLASS =
+  "inline-flex h-8 items-center justify-start gap-2 whitespace-nowrap rounded-md bg-secondary px-4 py-2 font-medium text-secondary-foreground text-sm shadow-xs transition-all hover:bg-secondary/80"
+
+type WhatsappEmbeddedSignupBrokerProps = {
+  settings: EmbeddedSignupSettings
+  callbackURL: string
+  workspaceId?: string | null
+  connectExisting: boolean
+  transferPhoneNumber: boolean
+}
+
+/**
+ * Broker-hosted page that runs the Facebook embedded-signup SDK on the registered
+ * broker origin (so Meta accepts it for white-label resellers), captures the
+ * `code` + session info, then bounces to the broker return route which validates
+ * the relay target and 302s back to the reseller domain where the session lives.
+ */
+export function WhatsappEmbeddedSignupBroker({
+  settings,
+  callbackURL,
+  workspaceId,
+  connectExisting,
+  transferPhoneNumber,
+}: WhatsappEmbeddedSignupBrokerProps) {
+  const t = useTranslations()
+  const [isRelaying, setIsRelaying] = useState(false)
+
+  // Code and session info arrive via two independent SDK events; relay once both
+  // are present (or immediately on error/cancel).
+  const codeRef = useRef<string | null>(null)
+  const sessionRef = useRef<EmbeddedSignupSessionInfo | null>(null)
+  const relayedRef = useRef(false)
+
+  const relay = useCallback(
+    (params: Record<string, string>) => {
+      if (relayedRef.current) {
+        return
+      }
+      relayedRef.current = true
+      setIsRelaying(true)
+
+      const url = new URL(
+        BROKER_EMBEDDED_SIGNUP_RETURN_PATH,
+        window.location.origin,
+      )
+      url.searchParams.set("callbackURL", callbackURL)
+      if (workspaceId) {
+        url.searchParams.set("workspaceId", workspaceId)
+      }
+      for (const [key, value] of Object.entries(params)) {
+        url.searchParams.set(key, value)
+      }
+      window.location.href = url.toString()
+    },
+    [callbackURL, workspaceId],
+  )
+
+  const tryRelaySuccess = useCallback(() => {
+    const code = codeRef.current
+    const session = sessionRef.current
+    if (!(code && session)) {
+      return
+    }
+    relay({
+      waCode: code,
+      waba_id: session.wabaId,
+      phone_number_id: session.phoneNumberId,
+      business_id: session.businessId,
+      transferPhoneNumber: String(transferPhoneNumber),
+    })
+  }, [relay, transferPhoneNumber])
+
+  const relayError = useCallback(() => relay({ waError: "1" }), [relay])
+
+  return (
+    <Card className="mx-auto mt-40 max-w-md">
+      <CardHeader>
+        <CardTitle>
+          <InboxIcon channel="whatsapp" size="large" />
+        </CardTitle>
+        <CardDescription>
+          {t("whatsapp.embeddedSignupBrokerHint")}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isRelaying ? (
+          <div className="flex items-center justify-center gap-2 py-4 text-muted-foreground text-sm">
+            <Loader2Icon className="animate-spin" />
+            {t("whatsapp.embeddedSignupProcessing")}
+          </div>
+        ) : (
+          <div className="flex items-center justify-end gap-2">
+            <WhatsappEmbeddedLogin
+              className={CONTINUE_BUTTON_CLASS}
+              connectExisting={connectExisting}
+              label={t("actions.continue")}
+              onCancel={relayError}
+              onCode={(code) => {
+                codeRef.current = code
+                tryRelaySuccess()
+              }}
+              onFail={relayError}
+              onSessionInfo={(info) => {
+                sessionRef.current = info
+                tryRelaySuccess()
+              }}
+              settings={settings}
+              transferPhoneNumber={transferPhoneNumber}
+            />
+            <Button
+              onClick={relayError}
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
+              {t("actions.cancel")}
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/builder/src/features/integration-whatsapp/libs/embedded-signup.ts
+++ b/apps/builder/src/features/integration-whatsapp/libs/embedded-signup.ts
@@ -1,0 +1,11 @@
+import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
+
+/**
+ * Meta-registered OAuth redirect_uri for WhatsApp embedded signup. Must live on
+ * the broker host (the only origin registered with Meta), never the reseller
+ * white-label domain the SDK happens to run on. Mirrors the persisted
+ * `redirectUrl` built server-side in `webhook-url.ts` `buildAuthValue`.
+ */
+export function getEmbeddedSignupRedirectUri(): string {
+  return buildBrokerCallbackUrl("/integrations/whatsapp/callback")
+}

--- a/apps/builder/src/features/integration-whatsapp/libs/embedded-signup.ts
+++ b/apps/builder/src/features/integration-whatsapp/libs/embedded-signup.ts
@@ -1,11 +1,106 @@
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
+import { env } from "@/env"
+import { getBrokerOrigin, isBrokerHost } from "@/lib/oauth-broker"
 
 /**
- * Meta-registered OAuth redirect_uri for WhatsApp embedded signup. Must live on
- * the broker host (the only origin registered with Meta), never the reseller
- * white-label domain the SDK happens to run on. Mirrors the persisted
- * `redirectUrl` built server-side in `webhook-url.ts` `buildAuthValue`.
+ * WhatsApp embedded-signup helpers.
+ *
+ * The Facebook JS SDK derives its OAuth domain/origin from `window.location`, not
+ * from any prop — so on a reseller white-label custom domain (which is not
+ * registered with Meta) the SDK is rejected. The only registered origin is the
+ * broker host. The fix is to run the SDK on the broker host and relay the result
+ * back to the originating domain (mirrors the #601 OAuth-broker relay pattern).
  */
-export function getEmbeddedSignupRedirectUri(): string {
-  return buildBrokerCallbackUrl("/integrations/whatsapp/callback")
+
+export const EMBEDDED_SIGNUP_FEATURE_TYPES = {
+  WHATSAPP_BUSINESS_APP_ONBOARDING: "whatsapp_business_app_onboarding",
+  ONLY_WABA_SHARING: "only_waba_sharing",
+} as const
+
+export const EMBEDDED_SIGNUP_FEATURES = {
+  MARKETING_MESSAGES_LITE: "marketing_messages_lite",
+} as const
+
+/** The broker-hosted page that runs the embedded-signup SDK. */
+export const BROKER_EMBEDDED_SIGNUP_PATH =
+  "/integrations/whatsapp/embedded-signup"
+
+/** The broker route that validates the relay target and 302s back to the reseller. */
+export const BROKER_EMBEDDED_SIGNUP_RETURN_PATH =
+  "/integrations/whatsapp/embedded-signup/return"
+
+/** Where the reseller resumes after the relay (carries the captured params). */
+export const CHANNELS_CREATE_PATH = "/channels/create"
+
+/** Safe in-app fallback when the relay target fails the open-redirect guard. */
+export const FALLBACK_REDIRECT_AFTER_RELAY = "/manage"
+
+/**
+ * Derive Meta's embedded-signup `featureType` from the user's intent. Mirrors the
+ * original inline logic: transfer (coexist) onboarding vs. existing-WABA sharing.
+ */
+export function resolveEmbeddedSignupFeatureType(params: {
+  connectExisting: boolean
+  transferPhoneNumber: boolean
+}): string | undefined {
+  if (params.transferPhoneNumber) {
+    return EMBEDDED_SIGNUP_FEATURE_TYPES.WHATSAPP_BUSINESS_APP_ONBOARDING
+  }
+  if (params.connectExisting) {
+    return EMBEDDED_SIGNUP_FEATURE_TYPES.ONLY_WABA_SHARING
+  }
+  return
+}
+
+/** The exact `loginOptions.extras` object Meta expects for embedded signup. */
+export function buildEmbeddedSignupExtras(featureType?: string) {
+  return {
+    sessionInfoVersion: 3,
+    setup: {},
+    features: [EMBEDDED_SIGNUP_FEATURES.MARKETING_MESSAGES_LITE],
+    ...(featureType ? { featureType } : {}),
+  }
+}
+
+/**
+ * Whether the SDK must run on the broker host instead of the current domain.
+ * True only when a dedicated broker is configured and we are not already on it
+ * (platform / single-domain deploys keep running the SDK inline).
+ */
+export function shouldRedirectToBroker(host: string): boolean {
+  return Boolean(env.NEXT_PUBLIC_BROKER_URL) && !isBrokerHost(host)
+}
+
+export type BrokerEmbeddedSignupParams = {
+  callbackURL: string
+  workspaceId?: string | null
+  clientId: string
+  configId: string
+  version: string
+  connectExisting: boolean
+  transferPhoneNumber: boolean
+}
+
+/**
+ * Build the absolute broker URL the reseller redirects to. The SDK config
+ * (clientId/configId/version) is already public (it ships in the browser today),
+ * so passing it in the query is no new exposure — and the broker cannot resolve
+ * it from the DB itself, since it runs in the ROOT tenant (invariant #10).
+ */
+export function buildBrokerEmbeddedSignupUrl(
+  params: BrokerEmbeddedSignupParams,
+): string {
+  const url = new URL(BROKER_EMBEDDED_SIGNUP_PATH, getBrokerOrigin())
+  url.searchParams.set("callbackURL", params.callbackURL)
+  if (params.workspaceId) {
+    url.searchParams.set("workspaceId", params.workspaceId)
+  }
+  url.searchParams.set("clientId", params.clientId)
+  url.searchParams.set("configId", params.configId)
+  url.searchParams.set("version", params.version)
+  url.searchParams.set("connectExisting", String(params.connectExisting))
+  url.searchParams.set(
+    "transferPhoneNumber",
+    String(params.transferPhoneNumber),
+  )
+  return url.toString()
 }


### PR DESCRIPTION
## Summary

White-label resellers couldn't complete WhatsApp embedded signup: the Facebook JS SDK validates the domain it runs on against the Meta app's allowed domains, and reseller custom domains aren't registered there (only the broker host is). The earlier attempt set `dialogParams.redirect_uri` to the broker — but the **JS SDK derives its OAuth domain/origin from `window.location`**, not from any prop (confirmed live: the FB OAuth URL still carried `domain=app.mt1.space`, `origin=https://app.mt1.space`). A prop can't fix this — **the SDK must execute on the broker origin.**

This PR runs the SDK on the broker host and relays the result back, mirroring the #601 OAuth-broker relay pattern. The `@greatsumini/react-facebook-login` wrapper is kept.

## Flow

1. **Reseller** (`SdkConnectSection`): on a white-label domain (`shouldRedirectToBroker`), the Continue button full-page-redirects to the broker embedded-signup page (`buildBrokerEmbeddedSignupUrl`), passing the public SDK config + `callbackURL = window.location.origin`. On the platform/broker host it renders the SDK inline as before.
2. **Broker page** (`/integrations/whatsapp/embedded-signup`, public, ROOT tenant): runs the SDK on the registered broker origin, captures `code` (onSuccess) + `waba_id`/`phone_number_id`/`business_id` (the `WA_EMBEDDED_SIGNUP` postMessage), then bounces to the return route.
3. **Return route** (`/integrations/whatsapp/embedded-signup/return`): validates `callbackURL` with `sanitizeReferer` (open-redirect guard) and 302s back to the reseller `/channels/create` with the captured params.
4. **Reseller** (`WhatsappCreate`): reads the relay params, populates the form, strips the params, and auto-submits `connectWhatsappAction` under the reseller session (guarded against double-submit).

## Changes

- **New** `libs/embedded-signup.ts` — `shouldRedirectToBroker`, `buildBrokerEmbeddedSignupUrl`, feature-type/extras helpers, route constants (reuses `@/lib/oauth-broker`).
- **New** `components/whatsapp-embedded-login.tsx` — shared FB SDK button + postMessage capture (single source for inline + broker).
- **New** `components/whatsapp-embedded-signup-broker.tsx` — broker-page client component.
- **New** `app/integrations/whatsapp/embedded-signup/page.tsx` — public broker page.
- **New** `app/integrations/whatsapp/embedded-signup/return/route.ts` — validated relay 302.
- `components/whatsapp-create.tsx` — white-label redirect branch + return-param auto-submit.
- `messages/{en,vi}.json` — 2 new `whatsapp.*` keys.
- Tests for the helpers and the return-route relay/open-redirect guard.

## Security / tenancy

- Broker page is public (under the existing `/integrations` prefix) and runs in the ROOT tenant — it never resolves per-tenant DB data; the public SDK config arrives via query (same exposure as today's client bundle).
- `code` is single-use and useless without the reseller-owner `client_secret` (server-side exchange only) — same exposure as the existing `?code=` relayed in `[...integration]/callback.ts`.
- `callbackURL` is gated by `sanitizeReferer` (broker/builder origin or active custom domain); anything else falls back to `/manage`.

## Test plan

- [x] `pnpm --filter builder check-types`
- [x] `pnpm lint`
- [x] `vitest run` — helper + return-route tests (8/8)
- [x] `invariant-guard` — PASS (i18n, tenancy, no-dynamic-import, open-redirect)
- [ ] Platform/single-domain: `NEXT_PUBLIC_BROKER_URL` unset → SDK renders inline, connects as before (existing WABA, coexist/transfer, new WABA)
- [ ] White-label: set `NEXT_PUBLIC_BROKER_URL` to a distinct registered host → from a reseller domain, Continue redirects to the broker page, SDK runs there, returns to reseller, inbox created under reseller session
- [ ] Open-redirect: return route with `callbackURL=https://evil.com` falls back, never redirects off-platform