### PR TITLE
feat(whatsapp): connect via Facebook OAuth dialog through broker

### DIFF
--- a/apps/builder/__tests__/whatsapp-embedded-signup.test.ts
+++ b/apps/builder/__tests__/whatsapp-embedded-signup.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, test, vi } from "vitest"
+
+const BUILDER_URL = "https://app.example.com"
+const BROKER_URL = "https://broker.example.com"
+const RESELLER_ORIGIN = "https://chat.reseller.com"
+
+async function loadWith(envOverrides: Record<string, string | undefined>) {
+  vi.resetModules()
+  vi.doMock("@/env", () => ({
+    env: {
+      NEXT_PUBLIC_BUILDER_URL: BUILDER_URL,
+      ...envOverrides,
+    },
+  }))
+  return await import("@/features/integration-whatsapp/libs/embedded-signup")
+}
+
+afterEach(() => {
+  vi.resetModules()
+  vi.doUnmock("@/env")
+})
+
+describe("buildFacebookOAuthDialogUrl", () => {
+  test("opens the Facebook dialog with the broker callback as redirect_uri", async () => {
+    const { buildFacebookOAuthDialogUrl, decodeOAuthState } = await loadWith({
+      NEXT_PUBLIC_BROKER_URL: BROKER_URL,
+    })
+
+    const result = new URL(
+      buildFacebookOAuthDialogUrl({
+        resellerOrigin: RESELLER_ORIGIN,
+        clientId: "client-1",
+        configId: "config-1",
+        version: "v21.0",
+        connectExisting: false,
+        transferPhoneNumber: true,
+        locale: "vi",
+      }),
+    )
+
+    expect(result.origin).toBe("https://www.facebook.com")
+    expect(result.pathname).toBe("/v21.0/dialog/oauth")
+    expect(result.searchParams.get("client_id")).toBe("client-1")
+    expect(result.searchParams.get("config_id")).toBe("config-1")
+    expect(result.searchParams.get("response_type")).toBe("code")
+    // redirect_uri must be the Meta-registered broker callback, not the reseller.
+    expect(result.searchParams.get("redirect_uri")).toBe(
+      `${BROKER_URL}/integrations/whatsapp/callback`,
+    )
+
+    const state = decodeOAuthState(result.searchParams.get("state") ?? "")
+    expect(state).toEqual({ referer: RESELLER_ORIGIN, locale: "vi" })
+
+    // transferPhoneNumber drives the coexist onboarding featureType in extras.
+    const extras = JSON.parse(result.searchParams.get("extras") ?? "{}")
+    expect(extras.featureType).toBe("whatsapp_business_app_onboarding")
+  })
+
+  test("falls back to the builder origin when no broker is configured", async () => {
+    const { buildFacebookOAuthDialogUrl } = await loadWith({
+      NEXT_PUBLIC_BROKER_URL: undefined,
+    })
+
+    const result = new URL(
+      buildFacebookOAuthDialogUrl({
+        resellerOrigin: RESELLER_ORIGIN,
+        clientId: "client-1",
+        configId: "config-1",
+        version: "v21.0",
+        connectExisting: true,
+        transferPhoneNumber: false,
+      }),
+    )
+
+    expect(result.searchParams.get("redirect_uri")).toBe(
+      `${BUILDER_URL}/integrations/whatsapp/callback`,
+    )
+  })
+})
+
+describe("encodeOAuthState / decodeOAuthState", () => {
+  test("round-trips referer and locale", async () => {
+    const { encodeOAuthState, decodeOAuthState } = await loadWith({
+      NEXT_PUBLIC_BROKER_URL: BROKER_URL,
+    })
+
+    const encoded = encodeOAuthState({ referer: RESELLER_ORIGIN, locale: "en" })
+    expect(decodeOAuthState(encoded)).toEqual({
+      referer: RESELLER_ORIGIN,
+      locale: "en",
+    })
+  })
+
+  test("rejects malformed state", async () => {
+    const { decodeOAuthState } = await loadWith({
+      NEXT_PUBLIC_BROKER_URL: BROKER_URL,
+    })
+
+    expect(decodeOAuthState("not-base64-json")).toBeNull()
+  })
+
+  test("rejects state without a referer", async () => {
+    const { decodeOAuthState } = await loadWith({
+      NEXT_PUBLIC_BROKER_URL: BROKER_URL,
+    })
+
+    const encoded = btoa(JSON.stringify({ locale: "en" }))
+    expect(decodeOAuthState(encoded)).toBeNull()
+  })
+})
+
+describe("resolveEmbeddedSignupFeatureType", () => {
+  test("returns the coexist onboarding type when transferring a phone", async () => {
+    const { resolveEmbeddedSignupFeatureType, EMBEDDED_SIGNUP_FEATURE_TYPES } =
+      await loadWith({ NEXT_PUBLIC_BROKER_URL: BROKER_URL })
+
+    expect(
+      resolveEmbeddedSignupFeatureType({
+        connectExisting: false,
+        transferPhoneNumber: true,
+      }),
+    ).toBe(EMBEDDED_SIGNUP_FEATURE_TYPES.WHATSAPP_BUSINESS_APP_ONBOARDING)
+  })
+
+  test("returns WABA sharing when connecting an existing account", async () => {
+    const { resolveEmbeddedSignupFeatureType, EMBEDDED_SIGNUP_FEATURE_TYPES } =
+      await loadWith({ NEXT_PUBLIC_BROKER_URL: BROKER_URL })
+
+    expect(
+      resolveEmbeddedSignupFeatureType({
+        connectExisting: true,
+        transferPhoneNumber: false,
+      }),
+    ).toBe(EMBEDDED_SIGNUP_FEATURE_TYPES.ONLY_WABA_SHARING)
+  })
+
+  test("returns undefined for a fresh signup", async () => {
+    const { resolveEmbeddedSignupFeatureType } = await loadWith({
+      NEXT_PUBLIC_BROKER_URL: BROKER_URL,
+    })
+
+    expect(
+      resolveEmbeddedSignupFeatureType({
+        connectExisting: false,
+        transferPhoneNumber: false,
+      }),
+    ).toBeUndefined()
+  })
+})

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -2226,6 +2226,8 @@
       "label": "Commands"
     },
     "connectExisting": "Connect an existing WhatsApp Business Account",
+    "embeddedSignupDone": "Signup complete — you can close this tab.",
+    "embeddedSignupPopupBlocked": "Please allow pop-ups for this site, then try again.",
     "fillRequiredFields": "Please fill in all required fields",
     "continueManualConnect": "Continue — manual connect",
     "icebreakers": {

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -2238,6 +2238,8 @@
       "label": "Lệnh"
     },
     "connectExisting": "Kết nối tài khoản WhatsApp Business hiện có",
+    "embeddedSignupDone": "Đã hoàn tất đăng ký — bạn có thể đóng tab này.",
+    "embeddedSignupPopupBlocked": "Vui lòng cho phép cửa sổ bật lên cho trang này rồi thử lại.",
     "fillRequiredFields": "Vui lòng điền đầy đủ các trường bắt buộc",
     "continueManualConnect": "Tiếp tục — kết nối thủ công",
     "icebreakers": {

--- a/apps/builder/src/app/integrations/whatsapp/callback/route.ts
+++ b/apps/builder/src/app/integrations/whatsapp/callback/route.ts
@@ -1,0 +1,128 @@
+import { getPublicUrlFromRequest } from "@chatbotx.io/utils"
+import type { NextRequest } from "next/server"
+import { getTranslations } from "next-intl/server"
+import {
+  decodeOAuthState,
+  WA_OAUTH_RESULT,
+  type WhatsappOAuthRelayResult,
+} from "@/features/integration-whatsapp/libs/embedded-signup"
+import { logger } from "@/lib/log"
+import { sanitizeReferer } from "@/lib/oauth-referer"
+
+export const dynamic = "force-dynamic"
+
+const SUPPORTED_LOCALES = new Set(["en", "vi"])
+
+// Characters that could break out of an inline <script>: `<` (so `</script>`
+// can't close the tag) and the JS line terminators U+2028 / U+2029 (emitted raw
+// by JSON.stringify, but valid line breaks in older parsers).
+const SCRIPT_BREAKOUT_RE = /[<\u2028\u2029]/g
+const HTML_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+}
+const HTML_ESCAPE_RE = /[&<>"]/g
+
+/** Safe to embed inside an inline <script>. */
+function safeJson(value: unknown): string {
+  return JSON.stringify(value).replace(
+    SCRIPT_BREAKOUT_RE,
+    (c) => `\\u${c.charCodeAt(0).toString(16).padStart(4, "0")}`,
+  )
+}
+
+/** Safe to embed in HTML text content. */
+function escapeHtml(value: string): string {
+  return value.replace(HTML_ESCAPE_RE, (c) => HTML_ESCAPES[c] ?? c)
+}
+
+function relayHtml(params: {
+  result: WhatsappOAuthRelayResult
+  targetOrigin: string
+  message: string
+}): string {
+  return `<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>WhatsApp</title></head>
+  <body style="font-family: system-ui, sans-serif; padding: 24px; text-align: center;">
+    <p>${escapeHtml(params.message)}</p>
+    <script>
+      (function () {
+        try {
+          if (window.opener) {
+            window.opener.postMessage(${safeJson(params.result)}, ${safeJson(params.targetOrigin)});
+          }
+        } catch (e) {}
+        window.setTimeout(function () { window.close(); }, 300);
+      })();
+    </script>
+  </body>
+</html>`
+}
+
+// This relay page frames nothing and is framed by nothing; its only script is the
+// inline relay above. Lock it down accordingly. If a nonce-based CSP is added app
+// wide later, plumb the nonce in here instead of `'unsafe-inline'`.
+const RELAY_RESPONSE_HEADERS = {
+  "content-type": "text/html; charset=utf-8",
+  "x-frame-options": "DENY",
+  "x-content-type-options": "nosniff",
+  "referrer-policy": "no-referrer",
+  "content-security-policy":
+    "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; frame-ancestors 'none'",
+} as const
+
+/**
+ * Broker callback for WhatsApp embedded signup. Facebook redirects the OAuth
+ * `code` here (the only Meta-registered `redirect_uri`). This route runs on the
+ * broker host, relays the `code` back to the originating reseller tab via
+ * `window.opener.postMessage` — targeting the reseller origin carried in `state`
+ * and validated against origins we control — then closes the popup. The reseller
+ * tab, where the session cookie lives, exchanges the code and finishes the
+ * connect. No DB access, no token exchange happens here.
+ */
+export async function GET(req: NextRequest): Promise<Response> {
+  const url = new URL(getPublicUrlFromRequest(req))
+  const code = url.searchParams.get("code")
+  const error = url.searchParams.get("error")
+  const state = decodeOAuthState(url.searchParams.get("state") ?? "")
+
+  if (!state) {
+    logger.warn("[wa-oauth-callback] missing or invalid state")
+    return new Response("Invalid request", { status: 400 })
+  }
+
+  // sanitizeReferer returns the input only when it is an origin we control
+  // (broker host, builder host, or an active custom domain); otherwise a safe
+  // in-app path. We must not postMessage a `code` to an unknown origin.
+  const safeReferer = await sanitizeReferer(state.referer)
+  if (!safeReferer.startsWith("http")) {
+    logger.warn(
+      { referer: state.referer },
+      "[wa-oauth-callback] rejected relay target",
+    )
+    return new Response("Invalid request", { status: 400 })
+  }
+
+  const targetOrigin = new URL(safeReferer).origin
+  const locale = SUPPORTED_LOCALES.has(state.locale ?? "")
+    ? (state.locale as string)
+    : "en"
+  const t = await getTranslations({ locale, namespace: "whatsapp" })
+
+  const result: WhatsappOAuthRelayResult =
+    code && !error
+      ? { type: WA_OAUTH_RESULT, status: "success", code }
+      : { type: WA_OAUTH_RESULT, status: "error" }
+
+  return new Response(
+    relayHtml({
+      result,
+      targetOrigin,
+      message: t("embeddedSignupDone"),
+    }),
+    { headers: RELAY_RESPONSE_HEADERS },
+  )
+}

--- a/apps/builder/src/features/integration-whatsapp/actions/connect.action.ts
+++ b/apps/builder/src/features/integration-whatsapp/actions/connect.action.ts
@@ -21,21 +21,26 @@ import {
   shareCreditLine,
   type WhatsappAuthValue,
 } from "@chatbotx.io/integration-whatsapp"
-import { exchangeAccessToken } from "@chatbotx.io/integration-whatsapp/api/auth"
+import {
+  exchangeAccessToken,
+  getSharedWabaId,
+} from "@chatbotx.io/integration-whatsapp/api/auth"
 import {
   getCoexistEligibility,
   normalizeWhatsappDisplayPhoneNumber,
   type WhatsappPhoneNumber,
   listPhoneNumbers as whatsappListPhoneNumbers,
 } from "@chatbotx.io/integration-whatsapp/api/phone-number"
+import { findWaba } from "@chatbotx.io/integration-whatsapp/api/waba"
 import { subscribeWebhook } from "@chatbotx.io/integration-whatsapp/api/webhook"
 import { invalidateCacheByTags } from "@chatbotx.io/redis"
 import { SdkException } from "@chatbotx.io/sdk"
 import { createId } from "@chatbotx.io/utils"
 import { updateWorkspaceLogo } from "@/features/workspaces/actions/upload-logo"
 import { logger } from "@/lib/log"
-import { getBrokerOrigin } from "@/lib/oauth-broker"
+import { buildBrokerCallbackUrl, getBrokerOrigin } from "@/lib/oauth-broker"
 import { authActionClient } from "@/lib/safe-action"
+import { WHATSAPP_OAUTH_CALLBACK_PATH } from "../libs/embedded-signup"
 import {
   type ConnectWhatsappResult,
   type ConnectWhatsappSchema,
@@ -52,14 +57,64 @@ async function resolveAccessToken(
   }
 
   if (input.code) {
+    // The code came from the Facebook OAuth dialog opened with an explicit
+    // `redirect_uri` (the broker callback), so the exchange must echo the exact
+    // same redirect_uri. Mirrors `buildFacebookOAuthDialogUrl`.
     const exchangeResult = await exchangeAccessToken(
       whatsappSettings,
       input.code,
+      buildBrokerCallbackUrl(WHATSAPP_OAUTH_CALLBACK_PATH),
     )
     return exchangeResult.access_token
   }
 
   throw new ChatbotXException("Access token is required")
+}
+
+/**
+ * Reconstruct the connect inputs (WABA / phone number / business) server-side
+ * from the access token. The Facebook OAuth dialog returns only a `code`; the
+ * SDK-only `WA_EMBEDDED_SIGNUP` postMessage that normally carries these ids never
+ * fires for a directly-opened dialog. The token's `whatsapp_business_management`
+ * grant identifies the WABA, and the WABA exposes its phone numbers + owning
+ * business.
+ */
+async function deriveSignupTargets(
+  accessToken: string,
+  version: string,
+): Promise<{
+  wabaId: string
+  phoneNumber: WhatsappPhoneNumber
+  businessId: string
+}> {
+  const wabaId = await getSharedWabaId(accessToken)
+  if (!wabaId) {
+    throw new ChatbotXException(
+      "Could not resolve WhatsApp Business Account from authorization",
+    )
+  }
+
+  // findWaba returns the phone numbers inline, so the caller can use the result
+  // directly instead of round-tripping to /phone_numbers a second time.
+  const waba = await findWaba({
+    wabaId,
+    acessToken: accessToken,
+    version,
+    fields: "owner_business_info,phone_numbers",
+  })
+
+  const phoneNumber = waba.phone_numbers?.data?.[0]
+  if (!phoneNumber) {
+    throw new ChatbotXException(
+      "No phone number found on the WhatsApp Business Account",
+    )
+  }
+
+  return {
+    wabaId,
+    phoneNumber,
+    businessId: waba.owner_business_info?.id ?? "",
+  }
 }
 
 async function fetchAndValidatePhoneNumber(params: {
@@ -306,17 +361,38 @@ export const connectWhatsappAction = authActionClient
         }
         const whatsappSettings = whatsappCredential.config
 
+        const isManual = parsedInput.manualConnect
+
         const accessToken = await resolveAccessToken(
           parsedInput,
           whatsappSettings,
         )
 
-        const phoneNumber = await fetchAndValidatePhoneNumber({
-          wabaId: parsedInput.wabaId,
-          phoneNumberId: parsedInput.phoneNumberId,
-          accessToken,
-          version: whatsappSettings.version,
-        })
+        // Manual connect supplies the ids directly. The OAuth dialog returns only
+        // a `code`, so derive the WABA / phone / business server-side from the
+        // exchanged token when they are missing.
+        let wabaId = parsedInput.wabaId ?? ""
+        let businessId = parsedInput.businessId ?? ""
+        let phoneNumber: WhatsappPhoneNumber
+
+        if (isManual || (wabaId && parsedInput.phoneNumberId)) {
+          phoneNumber = await fetchAndValidatePhoneNumber({
+            wabaId,
+            phoneNumberId: parsedInput.phoneNumberId ?? "",
+            accessToken,
+            version: whatsappSettings.version,
+          })
+        } else {
+          const derived = await deriveSignupTargets(
+            accessToken,
+            whatsappSettings.version,
+          )
+          wabaId = derived.wabaId
+          phoneNumber = derived.phoneNumber
+          if (!businessId) {
+            businessId = derived.businessId
+          }
+        }
 
         await ensurePhoneNumberNotConnected(phoneNumber.id)
 
@@ -327,8 +403,6 @@ export const connectWhatsappAction = authActionClient
         // Mirrors the broker pattern used by messenger/instagram (lib/oauth-broker.ts).
         const originUrl = getBrokerOrigin()
         const integrationId = createId()
-        const isManual = parsedInput.manualConnect
-        const businessId = parsedInput.businessId ?? ""
 
         const { webhookUrl, verifyToken } = buildWebhookConfig({
           isManual,
@@ -343,7 +417,7 @@ export const connectWhatsappAction = authActionClient
           verifyToken,
           webhookUrl,
           originUrl,
-          wabaId: parsedInput.wabaId,
+          wabaId,
           phoneNumber,
           businessId,
           isManual,
@@ -403,7 +477,7 @@ export const connectWhatsappAction = authActionClient
             workspaceId: parsedInput.workspaceId,
             integrationId,
             phoneNumber,
-            wabaId: parsedInput.wabaId,
+            wabaId,
             businessId,
             auth,
             isCoexist,

--- a/apps/builder/src/features/integration-whatsapp/components/whatsapp-create.tsx
+++ b/apps/builder/src/features/integration-whatsapp/components/whatsapp-create.tsx
@@ -17,9 +17,6 @@ import {
   CardTitle,
 } from "@chatbotx.io/ui/components/ui/card"
 import { Form } from "@chatbotx.io/ui/components/ui/form"
-import FacebookLogin, {
-  type InitParams,
-} from "@greatsumini/react-facebook-login"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hooks"
 import ky from "ky"
@@ -32,7 +29,13 @@ import { toast } from "sonner"
 import { InboxIcon } from "@/features/inboxes/components/inbox-icon"
 import { CoexistPopup } from "@/features/shared/coexist-popup"
 import { clientErrorHandler } from "@/lib/errors/client-handler"
+import { getBrokerOrigin } from "@/lib/oauth-broker"
 import { connectWhatsappAction } from "../actions/connect.action"
+import {
+  buildFacebookOAuthDialogUrl,
+  WA_OAUTH_RESULT,
+  type WhatsappOAuthRelayResult,
+} from "../libs/embedded-signup"
 import { connectWhatsappSchema, type ManualOnboardingResult } from "../schemas"
 import { WhatsappOnboardingResult } from "./whatsapp-onboarding-result"
 
@@ -52,15 +55,6 @@ const FORM_FIELDS = {
   PHONE_NUMBER_ID: "phoneNumberId",
   BUSINESS_ID: "businessId",
   CODE: "code",
-} as const
-
-const EMBEDDED_SIGNUP_FEATURE_TYPES = {
-  WHATSAPP_BUSINESS_APP_ONBOARDING: "whatsapp_business_app_onboarding",
-  ONLY_WABA_SHARING: "only_waba_sharing",
-} as const
-
-const EMBEDDED_SIGNUP_FEATURES = {
-  MARKETING_MESSAGES_LITE: "marketing_messages_lite",
 } as const
 
 type FormVisibility = {
@@ -177,59 +171,6 @@ export default function WhatsappCreate({
   const watchTransferPhoneNumber = watch(FORM_FIELDS.TRANSFER_PHONE_NUMBER)
   const watchManualConnect = watch(FORM_FIELDS.MANUAL_CONNECT)
 
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      if (!event.origin.endsWith("facebook.com")) {
-        return
-      }
-
-      try {
-        const data = JSON.parse(event.data)
-        if (data.type === "WA_EMBEDDED_SIGNUP") {
-          /*
-           * {
-           *     "data": {
-           *         "phone_number_id": "111598575218611",
-           *         "waba_id": "119496914420376",
-           *         "business_id": "553355495727951"
-           *     },
-           *     "type": "WA_EMBEDDED_SIGNUP",
-           *     "event": "FINISH",
-           *     "version": "3"
-           * }
-           */
-          if (
-            data.event === "FINISH" ||
-            data.event === "FINISH_ONLY_WABA" ||
-            data.event === "FINISH_WHATSAPP_BUSINESS_APP_ONBOARDING"
-          ) {
-            setValue(FORM_FIELDS.BUSINESS_ID, data.data.business_id ?? "")
-            setValue(FORM_FIELDS.WABA_ID, data.data.waba_id ?? "")
-            setValue(
-              FORM_FIELDS.PHONE_NUMBER_ID,
-              data.data.phone_number_id ?? "",
-            )
-          } else if (data.event === "CANCEL") {
-            setValue(FORM_FIELDS.BUSINESS_ID, "")
-            setValue(FORM_FIELDS.WABA_ID, "")
-            setValue(FORM_FIELDS.PHONE_NUMBER_ID, "")
-            toast.error(t("messages.connectFailed", { feature: "Whatsapp" }))
-          }
-        }
-      } catch {
-        // Ignore malformed postMessage payloads from Facebook SDK
-      }
-    }
-
-    // Add the event listener
-    window.addEventListener("message", handleMessage)
-
-    // Cleanup function to remove the event listener
-    return () => {
-      window.removeEventListener("message", handleMessage)
-    }
-  }, [setValue, t]) // Empty dependency array ensures the effect runs only once on mount and unmount
-
   // Form visibility effects
   useEffect(() => {
     updateVisibility({
@@ -308,16 +249,19 @@ type SdkConnectSectionProps = {
   settings: WhatsappCredentialPublic
 }
 
+const LAUNCH_BUTTON_CLASS =
+  "inline-flex h-8 items-center justify-center gap-2 whitespace-nowrap rounded-md bg-secondary px-4 py-2 font-medium text-secondary-foreground text-sm shadow-xs transition-all hover:bg-secondary/80 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"
+
+const SWITCH_FIELD_CLASS =
+  "flex items-center gap-2 flex-row-reverse justify-end"
+
 function SdkConnectSection({
   visibility,
   watchManualConnect,
   settings,
 }: SdkConnectSectionProps) {
   const t = useTranslations()
-  const { setValue, watch, formState, trigger } = useFormContext()
-
-  const switchFieldClassName =
-    "flex items-center gap-2 flex-row-reverse justify-end"
+  const { setValue, formState, trigger } = useFormContext()
 
   const finalSubmitRef = useRef<HTMLButtonElement>(null)
   const watchCode = useWatch({ name: FORM_FIELDS.CODE })
@@ -326,19 +270,74 @@ function SdkConnectSection({
     name: FORM_FIELDS.TRANSFER_PHONE_NUMBER,
   })
 
-  let embeddedSignupFeatureType: string | undefined
-  if (watchTransferPhoneNumber) {
-    embeddedSignupFeatureType =
-      EMBEDDED_SIGNUP_FEATURE_TYPES.WHATSAPP_BUSINESS_APP_ONBOARDING
-  } else if (watchConnectExisting) {
-    embeddedSignupFeatureType = EMBEDDED_SIGNUP_FEATURE_TYPES.ONLY_WABA_SHARING
-  }
+  // Submit once we have the OAuth code. The WABA / phone / business ids are not
+  // in the OAuth redirect — they are derived server-side from the token in
+  // connectWhatsappAction.
+  const submitWithCode = useCallback(
+    async (code: string) => {
+      setValue(FORM_FIELDS.CODE, code)
+      try {
+        const valid = await trigger()
+        if (valid) {
+          finalSubmitRef.current?.click()
+        }
+      } catch {
+        toast.error(t("messages.connectFailed", { feature: "Whatsapp" }))
+      }
+    },
+    [setValue, trigger, t],
+  )
+
+  // The Facebook OAuth dialog redirects the code to the broker callback, which
+  // relays it back to this tab via postMessage. Trust only the broker origin —
+  // a payload from any other origin is ignored.
+  useEffect(() => {
+    const brokerOrigin = getBrokerOrigin()
+    const handleMessage = (event: MessageEvent) => {
+      if (event.origin !== brokerOrigin) {
+        return
+      }
+      const data = event.data as WhatsappOAuthRelayResult | undefined
+      if (data?.type !== WA_OAUTH_RESULT) {
+        return
+      }
+      if (data.status === "success" && data.code) {
+        submitWithCode(data.code)
+      } else {
+        toast.error(t("messages.connectFailed", { feature: "Whatsapp" }))
+      }
+    }
+    window.addEventListener("message", handleMessage)
+    return () => window.removeEventListener("message", handleMessage)
+  }, [submitWithCode, t])
+
+  const openFacebookDialog = useCallback(() => {
+    const url = buildFacebookOAuthDialogUrl({
+      resellerOrigin: window.location.origin,
+      clientId: settings.clientId,
+      configId: settings.configId,
+      version: settings.version,
+      connectExisting: Boolean(watchConnectExisting),
+      transferPhoneNumber: Boolean(watchTransferPhoneNumber),
+      locale: document.documentElement.lang || undefined,
+    })
+    const popup = window.open(
+      url,
+      "wa_oauth_signup",
+      "popup,width=600,height=720",
+    )
+    if (!popup) {
+      toast.error(t("whatsapp.embeddedSignupPopupBlocked"))
+    }
+  }, [settings, watchConnectExisting, watchTransferPhoneNumber, t])
+
+  const showLaunch = !(watchManualConnect || watchCode)
 
   return (
     <>
       {visibility.connectExisting && (
         <SwitchField
-          formItemClassName={switchFieldClassName}
+          formItemClassName={SWITCH_FIELD_CLASS}
           label={t("whatsapp.connectExisting")}
           name={FORM_FIELDS.CONNECT_EXISTING}
           required
@@ -347,7 +346,7 @@ function SdkConnectSection({
 
       {visibility.transferPhoneNumber && (
         <SwitchField
-          formItemClassName={switchFieldClassName}
+          formItemClassName={SWITCH_FIELD_CLASS}
           label={t("whatsapp.transferPhoneNumber")}
           name={FORM_FIELDS.TRANSFER_PHONE_NUMBER}
           required
@@ -359,49 +358,14 @@ function SdkConnectSection({
       )}
 
       <div className="flex items-center justify-end gap-2">
-        {!(watchManualConnect || watch(FORM_FIELDS.CODE)) && (
-          <FacebookLogin
-            appId={settings.clientId}
-            className="inline-flex h-8 items-center justify-start gap-2 whitespace-nowrap rounded-md bg-secondary px-4 py-2 font-medium text-secondary-foreground text-sm shadow-xs transition-all hover:bg-secondary/80 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"
-            initParams={{
-              version: (settings.version as InitParams["version"]) ?? "v21.0",
-            }}
-            key={embeddedSignupFeatureType ?? "default"}
-            loginOptions={
-              {
-                config_id: settings.configId,
-                response_type: "code",
-                override_default_response_type: true,
-                return_scopes: true,
-                extras: {
-                  sessionInfoVersion: 3,
-                  setup: {},
-                  features: [EMBEDDED_SIGNUP_FEATURES.MARKETING_MESSAGES_LITE],
-                  ...(embeddedSignupFeatureType
-                    ? { featureType: embeddedSignupFeatureType }
-                    : {}),
-                },
-                // biome-ignore lint/suspicious/noExplicitAny: some types are not supported
-              } as any
-            }
-            onFail={() => {
-              toast.error(t("messages.connectFailed", { feature: "Whatsapp" }))
-            }}
-            // biome-ignore lint/suspicious/noExplicitAny: this library does not support code returned
-            onSuccess={async (res: any) => {
-              if (res.code) {
-                setValue(FORM_FIELDS.CODE, res.code)
-                const valid = await trigger()
-
-                if (valid) {
-                  finalSubmitRef.current?.click()
-                }
-              }
-            }}
-            scope=""
+        {showLaunch && (
+          <Button
+            className={LAUNCH_BUTTON_CLASS}
+            onClick={openFacebookDialog}
+            type="button"
           >
             {t("actions.continue")}
-          </FacebookLogin>
+          </Button>
         )}
 
         {watchCode && (
@@ -433,9 +397,6 @@ function ManualConnectSection({
   watchManualConnect,
 }: ManualConnectSectionProps) {
   const t = useTranslations()
-  const switchFieldClassName =
-    "flex items-center gap-2 flex-row-reverse justify-end"
-
   const { setValue, getValues, formState } = useFormContext()
 
   const {
@@ -489,7 +450,7 @@ function ManualConnectSection({
   return (
     <>
       <SwitchField
-        formItemClassName={switchFieldClassName}
+        formItemClassName={SWITCH_FIELD_CLASS}
         label={t("whatsapp.manualConnect")}
         name={FORM_FIELDS.MANUAL_CONNECT}
         required

--- a/apps/builder/src/features/integration-whatsapp/components/whatsapp-create.tsx
+++ b/apps/builder/src/features/integration-whatsapp/components/whatsapp-create.tsx
@@ -321,12 +321,10 @@ function SdkConnectSection({
       transferPhoneNumber: Boolean(watchTransferPhoneNumber),
       locale: document.documentElement.lang || undefined,
     })
-    const popup = window.open(
-      url,
-      "wa_oauth_signup",
-      "popup,width=600,height=720",
-    )
-    if (!popup) {
+    // Open a real tab (not a popup window) — popups get blocked, and a tab keeps
+    // `window.opener` set so the broker callback can relay the code back here.
+    const authTab = window.open(url, "_blank")
+    if (!authTab) {
       toast.error(t("whatsapp.embeddedSignupPopupBlocked"))
     }
   }, [settings, watchConnectExisting, watchTransferPhoneNumber, t])

--- a/apps/builder/src/features/integration-whatsapp/libs/embedded-signup.ts
+++ b/apps/builder/src/features/integration-whatsapp/libs/embedded-signup.ts
@@ -1,0 +1,141 @@
+import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
+
+/**
+ * WhatsApp embedded-signup helpers.
+ *
+ * Instead of running the Facebook JS SDK (whose OAuth origin is bound to
+ * `window.location`, so it breaks on a white-label reseller custom domain), we
+ * open the Facebook OAuth dialog directly with `redirect_uri` set to the fixed,
+ * Meta-registered broker callback. Facebook returns the `code` to that broker
+ * route, which relays it back to the originating reseller tab via
+ * `window.opener.postMessage`. The reseller — where the session cookie lives —
+ * exchanges the code and derives the WABA/phone/business ids server-side.
+ */
+
+export const EMBEDDED_SIGNUP_FEATURE_TYPES = {
+  WHATSAPP_BUSINESS_APP_ONBOARDING: "whatsapp_business_app_onboarding",
+  ONLY_WABA_SHARING: "only_waba_sharing",
+} as const
+
+const EMBEDDED_SIGNUP_FEATURES = {
+  MARKETING_MESSAGES_LITE: "marketing_messages_lite",
+} as const
+
+const FACEBOOK_DIALOG_BASE = "https://www.facebook.com"
+
+/** Broker route Facebook redirects the `code` to (the only registered URI). */
+export const WHATSAPP_OAUTH_CALLBACK_PATH = "/integrations/whatsapp/callback"
+
+/**
+ * `window.postMessage` contract between the broker callback route and the
+ * reseller tab. The reseller validates `event.origin === getBrokerOrigin()`
+ * before trusting it, and the broker validates the reseller origin (from `state`)
+ * before posting — so a signup `code` is never relayed to an origin we do not
+ * control.
+ */
+export const WA_OAUTH_RESULT = "WA_OAUTH_RESULT" as const
+
+export type WhatsappOAuthRelayResult = {
+  type: typeof WA_OAUTH_RESULT
+  status: "success" | "error"
+  code?: string
+}
+
+/** State round-tripped through Facebook so the broker knows where to relay back. */
+export type WhatsappOAuthState = {
+  referer: string
+  locale?: string
+}
+
+export function encodeOAuthState(state: WhatsappOAuthState): string {
+  return btoa(JSON.stringify(state))
+}
+
+export function decodeOAuthState(raw: string): WhatsappOAuthState | null {
+  try {
+    const parsed = JSON.parse(atob(raw)) as Partial<WhatsappOAuthState>
+    if (typeof parsed.referer !== "string") {
+      return null
+    }
+    return {
+      referer: parsed.referer,
+      locale: typeof parsed.locale === "string" ? parsed.locale : undefined,
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Derive Meta's embedded-signup `featureType` from the user's intent. Mirrors the
+ * original inline logic: transfer (coexist) onboarding vs. existing-WABA sharing.
+ */
+export function resolveEmbeddedSignupFeatureType(params: {
+  connectExisting: boolean
+  transferPhoneNumber: boolean
+}): string | undefined {
+  if (params.transferPhoneNumber) {
+    return EMBEDDED_SIGNUP_FEATURE_TYPES.WHATSAPP_BUSINESS_APP_ONBOARDING
+  }
+  if (params.connectExisting) {
+    return EMBEDDED_SIGNUP_FEATURE_TYPES.ONLY_WABA_SHARING
+  }
+  return
+}
+
+/** The exact embedded-signup `extras` object Meta expects. */
+function buildEmbeddedSignupExtras(featureType?: string) {
+  return {
+    sessionInfoVersion: 3,
+    setup: {},
+    features: [EMBEDDED_SIGNUP_FEATURES.MARKETING_MESSAGES_LITE],
+    ...(featureType ? { featureType } : {}),
+  }
+}
+
+export type FacebookOAuthDialogParams = {
+  /** The reseller origin the broker relays the result back to. */
+  resellerOrigin: string
+  clientId: string
+  configId: string
+  version: string
+  connectExisting: boolean
+  transferPhoneNumber: boolean
+  locale?: string
+}
+
+/**
+ * Build the absolute Facebook OAuth dialog URL to open in a popup. `redirect_uri`
+ * is the broker callback (the only origin registered with Meta); `state` carries
+ * the reseller origin so the broker can relay the `code` back to the right tab.
+ */
+export function buildFacebookOAuthDialogUrl(
+  params: FacebookOAuthDialogParams,
+): string {
+  const url = new URL(`${FACEBOOK_DIALOG_BASE}/${params.version}/dialog/oauth`)
+  url.searchParams.set("client_id", params.clientId)
+  url.searchParams.set("config_id", params.configId)
+  url.searchParams.set(
+    "redirect_uri",
+    buildBrokerCallbackUrl(WHATSAPP_OAUTH_CALLBACK_PATH),
+  )
+  url.searchParams.set("response_type", "code")
+  url.searchParams.set(
+    "state",
+    encodeOAuthState({
+      referer: params.resellerOrigin,
+      locale: params.locale,
+    }),
+  )
+
+  const featureType = resolveEmbeddedSignupFeatureType({
+    connectExisting: params.connectExisting,
+    transferPhoneNumber: params.transferPhoneNumber,
+  })
+  url.searchParams.set(
+    "extras",
+    JSON.stringify(buildEmbeddedSignupExtras(featureType)),
+  )
+
+  return url.toString()
+}

--- a/apps/builder/src/features/integration-whatsapp/schemas/index.ts
+++ b/apps/builder/src/features/integration-whatsapp/schemas/index.ts
@@ -20,29 +20,51 @@ export type ConnectWhatsappResult =
 export const connectWhatsappSchema = z
   .object({
     businessId: z.string().nullish(),
-    wabaId: z.string().min(1),
+    // Optional for the OAuth dialog flow: only a `code` comes back and the
+    // server derives wabaId/phoneNumberId/businessId from the token. Manual
+    // connect supplies them directly (enforced below).
+    wabaId: z.string().nullish(),
     connectExisting: z.boolean(),
     transferPhoneNumber: z.boolean(),
     manualConnect: z.boolean(),
     marketingMessageLite: z.boolean(),
-    phoneNumberId: z.string().min(1),
+    phoneNumberId: z.string().nullish(),
     workspaceId: z.string().nullish(),
     accessToken: z.string().nullish(),
     code: z.string().nullish(),
   })
   .superRefine((data, ctx) => {
-    if (!(data.manualConnect || data.businessId)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Required business id",
-        path: ["businessId"],
-      })
+    if (data.manualConnect) {
+      if (!data.wabaId) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Required waba id",
+          path: ["wabaId"],
+        })
+      }
+      if (!data.phoneNumberId) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Required phone number id",
+          path: ["phoneNumberId"],
+        })
+      }
+      if (!data.accessToken) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Required access token",
+          path: ["accessToken"],
+        })
+      }
+      return
     }
 
-    if (!(data.accessToken || data.code)) {
+    // OAuth dialog flow: the `code` is the only required input.
+    if (!data.code) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "Required access token or code",
+        message: "Required code",
+        path: ["code"],
       })
     }
   })

--- a/apps/builder/src/features/platform-credentials/whatsapp/whatsapp-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/whatsapp/whatsapp-settings.tsx
@@ -230,7 +230,7 @@ export function EditWhatsappSettingsForm({
           mode: "onChange",
           defaultValues: {
             clientId: publicConfig?.clientId ?? "",
-            version: publicConfig?.version ?? "v20.0",
+            version: publicConfig?.version ?? "v25.0",
             configId: publicConfig?.configId ?? "",
             systemUserId: publicConfig?.systemUserId ?? "",
             businessId: publicConfig?.businessId ?? "",

--- a/integrations/whatsapp/src/api/auth.ts
+++ b/integrations/whatsapp/src/api/auth.ts
@@ -9,19 +9,34 @@ type ExchangeAccessTokenResponse = {
   token_type: string
 }
 
+/** One entry of `debug_token`'s `granular_scopes`: a permission + its target ids. */
+export type DebugTokenGranularScope = {
+  scope: string
+  target_ids?: string[]
+}
+
 export type DebugTokenData = {
   app_id: string
   is_valid: boolean
   user_id: string
+  granular_scopes?: DebugTokenGranularScope[]
 }
 
 type DebugTokenResponse = {
   data: DebugTokenData
 }
 
+const WHATSAPP_BUSINESS_MANAGEMENT_SCOPE = "whatsapp_business_management"
+
 export const exchangeAccessToken = (
   settings: Pick<Oauth2Config, "clientId" | "clientSecret" | "version">,
   code: string,
+  /**
+   * Must be passed (and exactly match) when the `code` came from a standard OAuth
+   * dialog opened with an explicit `redirect_uri`. Omit for embedded-signup codes
+   * returned by the JS SDK, which are exchanged without a redirect_uri.
+   */
+  redirectUri?: string,
 ): Promise<ExchangeAccessTokenResponse> => {
   const { version = DEFAULT_API_VERSION } = settings
 
@@ -34,6 +49,7 @@ export const exchangeAccessToken = (
             client_id: settings.clientId,
             client_secret: settings.clientSecret,
             code,
+            ...(redirectUri ? { redirect_uri: redirectUri } : {}),
           },
         },
       )
@@ -63,4 +79,21 @@ export async function debugToken(
     logger.error(e, "Failed to debug token")
     return null
   }
+}
+
+/**
+ * Resolve the WhatsApp Business Account id granted to the access token. Embedded
+ * signup grants exactly one WABA via the `whatsapp_business_management` scope, so
+ * its `target_ids[0]` is the connected WABA. Used to reconstruct the connect
+ * inputs server-side when the OAuth dialog returns only a `code` (the SDK-only
+ * `WA_EMBEDDED_SIGNUP` postMessage that normally carries the ids never fires).
+ */
+export async function getSharedWabaId(
+  accessToken: string,
+): Promise<string | null> {
+  const data = await debugToken(accessToken)
+  const scope = data?.granular_scopes?.find(
+    (s) => s.scope === WHATSAPP_BUSINESS_MANAGEMENT_SCOPE,
+  )
+  return scope?.target_ids?.[0] ?? null
 }


### PR DESCRIPTION
Replace the Facebook JS SDK embedded-signup (whose OAuth origin is bound to window.location, so it breaks on a white-label reseller custom domain) with a directly-opened Facebook OAuth dialog popup.

- Open the dialog with redirect_uri = the Meta-registered broker callback; state carries the reseller origin for the relay back.
- New broker route /integrations/whatsapp/callback validates the reseller origin (sanitizeReferer) and postMessages the code back to the opener tab; hardened with CSP, X-Frame-Options, and script/HTML escaping.
- connectWhatsappAction exchanges the code (echoing the same redirect_uri) and derives wabaId/phoneNumberId/businessId server-side from the token (debug_token granular_scopes + findWaba), since the SDK-only WA_EMBEDDED_SIGNUP postMessage no longer fires.
- Relax connect schema: dialog flow requires only `code`; manual connect still requires the ids + token.
- Surface popup-blocked failures; dedupe a redundant /phone_numbers call.

Tests cover the dialog URL builder, state round-trip, and feature-type resolution.