### PR TITLE
fix(database): refactor conversation uniqueness and expand message schema

### DIFF
--- a/packages/database/drizzle/20260622055234_update_message_table/migration.sql
+++ b/packages/database/drizzle/20260622055234_update_message_table/migration.sql
@@ -1,0 +1,31 @@
+ALTER TABLE "Conversation" ADD COLUMN "sourceId" text;--> statement-breakpoint
+UPDATE "Conversation" c
+SET "sourceId" = ci."sourceConversationId"
+FROM "ContactInbox" ci
+WHERE ci."contactId" = c."contactId"
+  AND ci."sourceConversationId" IS NOT NULL;--> statement-breakpoint
+ALTER TABLE "Conversation" DROP CONSTRAINT IF EXISTS "Conversation_contactId_key";--> statement-breakpoint
+CREATE UNIQUE INDEX "Conversation_contactId_sourceId_key" ON "Conversation" ("contactId","sourceId") WHERE "sourceId" IS NOT NULL;--> statement-breakpoint
+ALTER TABLE "ContactInbox" DROP COLUMN "sourceConversationId";
+
+ALTER TABLE "Message" ADD COLUMN "deletedAt" timestamp with time zone;--> statement-breakpoint
+CREATE INDEX "Message_deletedAt_idx" ON "Message" ("deletedAt");--> statement-breakpoint
+UPDATE "Message" SET "deletedAt" = "updatedAt" WHERE ("contentAttributes"->>'deleted')::boolean = true;
+
+CREATE TYPE "messageKind" AS ENUM('message', 'comment');--> statement-breakpoint
+ALTER TABLE "Message" ADD COLUMN "type" "messageKind" DEFAULT 'message'::"messageKind" NOT NULL;--> statement-breakpoint
+ALTER TABLE "Message" ADD COLUMN "parentId" text;--> statement-breakpoint
+UPDATE "Message" SET "type" = 'comment' WHERE "contentAttributes"->>'isComment' = 'true';--> statement-breakpoint
+UPDATE "Message" SET "parentId" = "contentAttributes"->>'parentId' WHERE "contentAttributes"->>'parentId' IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "Message_conversationId_type_idx" ON "Message" ("conversationId","type");--> statement-breakpoint
+CREATE INDEX "Message_parentId_idx" ON "Message" ("parentId") WHERE "parentId" IS NOT NULL;
+
+ALTER TABLE "Message" ADD COLUMN "attributes" jsonb;
+
+CREATE UNIQUE INDEX "Conversation_contactId_dm_key" ON "Conversation" ("contactId") WHERE "sourceId" IS NULL;
+
+DROP INDEX "Message_deletedAt_idx";--> statement-breakpoint
+DROP INDEX "Message_conversationId_type_idx";--> statement-breakpoint
+CREATE INDEX "Message_conversationId_type_idx" ON "Message" ("workspaceId","conversationId","type","createdAt" DESC NULLS LAST);--> statement-breakpoint
+DROP INDEX "Message_parentId_idx";--> statement-breakpoint
+CREATE INDEX "Message_parentId_idx" ON "Message" ("workspaceId","parentId","type","createdAt" DESC NULLS LAST) WHERE "parentId" IS NOT NULL;


### PR DESCRIPTION

  - Replace the single-column unique constraint on Conversation.contactId with composite partial indexes to handle both DM and source-linked conversations without collisions
  - Promote sourceConversationId from ContactInbox into a first-class Conversation.sourceId column and drop the old column
  - Expand Message with deletedAt, type (messageKind enum), parentId, and attributes; backfill from existing contentAttributes JSON

  Changes

  - packages/database/drizzle/20260622055234_update_message_table/migration.sql — covers conversation unique index refactor, ContactInbox column migration & drop, Message schema expansion with data backfill, and
  Message index recreation with workspaceId prefix for partition-aligned plans

  Test plan

  - [ ] pnpm --filter @chatbotx.io/database db:migrate completes without errors on fresh DB
  - [ ] Migration is idempotent on a DB with the old schema
  - [ ] Conversations with a sourceId coexist without unique violations
  - [ ] DM conversations (sourceId IS NULL) remain uniquely constrained per contact
  - [ ] Message queries hit the new workspaceId-prefixed indexes
  - [ ] pnpm lint
  - [ ] pnpm --filter builder check-types

