### PR TITLE
feat(instagram): Instagram post comments

### DIFF
--- a/apps/builder/src/enterprise/features/audit-logs/audit-logs-table-columns.tsx
+++ b/apps/builder/src/enterprise/features/audit-logs/audit-logs-table-columns.tsx
@@ -35,7 +35,7 @@ export function getAuditColumns(): ColumnDef<AuditLogResource>[] {
               </Avatar>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <div className="max-w-[200px] truncate">
+                  <div className="inline-block max-w-[200px] truncate">
                     {row.original.user.name}
                   </div>
                 </TooltipTrigger>
@@ -69,7 +69,9 @@ export function getAuditColumns(): ColumnDef<AuditLogResource>[] {
       cell: ({ row }) => (
         <Tooltip>
           <TooltipTrigger asChild>
-            <div className="max-w-[300px] truncate">{row.original.detail}</div>
+            <div className="inline-block max-w-[300px] truncate">
+              {row.original.detail}
+            </div>
           </TooltipTrigger>
           <TooltipContent>
             <p>{row.original.detail}</p>

--- a/apps/builder/src/features/ai-files/ai-files-table.tsx
+++ b/apps/builder/src/features/ai-files/ai-files-table.tsx
@@ -117,7 +117,9 @@ export default function AIFilesTable({ promises }: AIFilesTableProps) {
         cell: ({ row }) => (
           <Tooltip>
             <TooltipTrigger asChild>
-              <div className="max-w-[300px] truncate">{row.original.name}</div>
+              <div className="inline-block max-w-[300px] truncate">
+                {row.original.name}
+              </div>
             </TooltipTrigger>
             <TooltipContent>
               <p>{row.original.name}</p>

--- a/apps/builder/src/features/ai-mcp-servers/ai-mcp-servers-columns.tsx
+++ b/apps/builder/src/features/ai-mcp-servers/ai-mcp-servers-columns.tsx
@@ -63,7 +63,9 @@ export const getAIMcpServerColumns = ({
     cell: ({ row }) => (
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="max-w-[300px] truncate">{row.original.name}</div>
+          <div className="inline-block max-w-[300px] truncate">
+            {row.original.name}
+          </div>
         </TooltipTrigger>
         <TooltipContent>
           <p>{row.original.name}</p>

--- a/apps/builder/src/features/bot-fields/bot-field-table.tsx
+++ b/apps/builder/src/features/bot-fields/bot-field-table.tsx
@@ -99,7 +99,9 @@ export function BotFieldsTable({
         cell: ({ row }) => (
           <Tooltip>
             <TooltipTrigger asChild>
-              <div className="max-w-[200px] truncate">{row.original.name}</div>
+              <div className="inline-block max-w-[200px] truncate">
+                {row.original.name}
+              </div>
             </TooltipTrigger>
             <TooltipContent>
               <p>{row.original.name}</p>
@@ -124,7 +126,7 @@ export function BotFieldsTable({
         cell: ({ row }) => (
           <Tooltip>
             <TooltipTrigger asChild>
-              <div className="max-w-[200px] truncate">
+              <div className="inline-block max-w-[200px] truncate">
                 {row.original.description}
               </div>
             </TooltipTrigger>
@@ -154,7 +156,9 @@ export function BotFieldsTable({
         cell: ({ row }) => (
           <Tooltip>
             <TooltipTrigger asChild>
-              <div className="max-w-[200px] truncate">{row.original.value}</div>
+              <div className="inline-block max-w-[200px] truncate">
+                {row.original.value}
+              </div>
             </TooltipTrigger>
             <TooltipContent>
               <p>{row.original.value}</p>

--- a/apps/builder/src/features/broadcasts/broadcasts-table.tsx
+++ b/apps/builder/src/features/broadcasts/broadcasts-table.tsx
@@ -69,7 +69,7 @@ export function BroadcastsTable({ promises }: BroadcastsTableProps) {
         cell: ({ row }) => (
           <Tooltip>
             <TooltipTrigger asChild>
-              <div className="max-w-[200px] truncate">
+              <div className="inline-block max-w-[200px] truncate">
                 {row.original.name ?? ""}
               </div>
             </TooltipTrigger>

--- a/apps/builder/src/features/chat/store/chat-store.ts
+++ b/apps/builder/src/features/chat/store/chat-store.ts
@@ -3,11 +3,11 @@ import type {
   ConversationBotCategory,
   ConversationStatus,
 } from "@chatbotx.io/database/partials"
-import type { FacebookPostDetails } from "@chatbotx.io/integration-messenger/apis/post"
 import ky from "ky"
 import { createStore } from "zustand/vanilla"
 import type { ContactFilterRequest } from "@/features/contacts/schemas/contact-filter"
 import type { ContactResource } from "@/features/contacts/schemas/resource"
+import type { PostDetails } from "@/features/conversations/schema/query"
 import type {
   ConversationResource,
   ListConversationItemResource,
@@ -50,7 +50,7 @@ export type ChatState = {
   replyToMessage: MessageResourceWithRelations | null
 
   // active facebook post (for comment conversations)
-  activePost: FacebookPostDetails | null
+  activePost: PostDetails | null
 }
 
 export type ChatActions = {
@@ -601,7 +601,8 @@ export const createChatStore = () => {
 
       if (
         !conversation?.sourceId ||
-        contactInbox?.channel !== "messenger" ||
+        (contactInbox?.channel !== "messenger" &&
+          contactInbox?.channel !== "instagram") ||
         !contactInbox?.inboxId
       ) {
         set({ activePost: null })
@@ -609,17 +610,13 @@ export const createChatStore = () => {
       }
 
       try {
-        const post = await ky
-          .get<FacebookPostDetails>(
-            `/api/workspaces/${workspaceId}/conversations/post-details`,
-            {
-              searchParams: {
-                inboxId: contactInbox.inboxId,
-                postId: conversation.sourceId,
-              },
-            },
-          )
-          .json()
+        const post =
+          await client.conversationsAPI.getPostDetailsAuthenticatedAPI({
+            workspaceId,
+            inboxId: contactInbox.inboxId,
+            postId: conversation.sourceId,
+            channel: contactInbox.channel,
+          })
         set({ activePost: post })
       } catch {
         set({ activePost: null })

--- a/apps/builder/src/features/contacts/contacts-table.tsx
+++ b/apps/builder/src/features/contacts/contacts-table.tsx
@@ -162,7 +162,7 @@ export function ContactsTable({
         cell: ({ row }) => (
           <Tooltip>
             <TooltipTrigger asChild>
-              <div className="max-w-[200px] truncate">
+              <div className="inline-block max-w-[200px] truncate">
                 {getUserName(
                   row.original.conversation?.assignedUser,
                   t("assignAdmin.unAssigned"),

--- a/apps/builder/src/features/conversations/api/authenticated.ts
+++ b/apps/builder/src/features/conversations/api/authenticated.ts
@@ -1,3 +1,4 @@
+import { channelTypes } from "@chatbotx.io/database/partials"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import z from "zod"
 import { workspaceAuthorizedMidddleware } from "@/middlewares/auth"
@@ -14,11 +15,12 @@ import {
   listConversationsResponse,
 } from "../schema/resource"
 
-const facebookPostDetailsSchema = z.object({
-  message: z.string().optional(),
-  full_picture: z.string().optional(),
+const postDetailsSchema = z.object({
+  text: z.string().optional(),
+  picture: z.string().optional(),
   from: z.object({ id: z.string(), name: z.string() }).optional(),
-  created_time: z.string(),
+  createdAt: z.string(),
+  link: z.string().optional(),
 })
 
 export const conversationsAuthenticatedAPI = {
@@ -70,11 +72,12 @@ export const conversationsAuthenticatedAPI = {
         workspaceId: zodBigintAsString(),
         inboxId: z.string(),
         postId: z.string(),
+        channel: channelTypes,
       }),
     )
     .use(workspaceAuthorizedMidddleware, (input) => input.workspaceId)
-    .output(facebookPostDetailsSchema)
+    .output(postDetailsSchema)
     .handler(async ({ input }) =>
-      getPostDetailsQuery(input.inboxId, input.postId),
+      getPostDetailsQuery(input.inboxId, input.postId, input.channel),
     ),
 }

--- a/apps/builder/src/features/conversations/components/conversation-info.tsx
+++ b/apps/builder/src/features/conversations/components/conversation-info.tsx
@@ -23,9 +23,10 @@ export function ConversationInfo() {
     | ChannelType
     | undefined
   const postLink =
-    channel && activeConversation?.sourceId
+    activePost?.link ??
+    (channel && activeConversation?.sourceId
       ? buildPostLink(channel, activeConversation.sourceId)
-      : null
+      : null)
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: reload on conversation change only
   useEffect(() => {
@@ -44,23 +45,23 @@ export function ConversationInfo() {
             {activePost.from.name}
           </span>
         )}
-        {activePost.message && (
+        {activePost.text && (
           <p className="whitespace-pre-line text-muted-foreground text-xs">
-            {activePost.message}
+            {activePost.text}
           </p>
         )}
-        {activePost.full_picture && (
+        {activePost.picture && (
           <Image
             alt=""
             className="shrink-0 rounded object-cover"
             height={56}
-            src={activePost.full_picture}
+            src={activePost.picture}
             unoptimized
             width={56}
           />
         )}
         <span className="text-[11px] text-muted-foreground">
-          {formatDate(activePost.created_time, {
+          {formatDate(activePost.createdAt, {
             hour: "2-digit",
             minute: "2-digit",
             day: "2-digit",

--- a/apps/builder/src/features/conversations/queries/get-post-details.query.ts
+++ b/apps/builder/src/features/conversations/queries/get-post-details.query.ts
@@ -1,24 +1,53 @@
-import { buildContext } from "@chatbotx.io/business"
-import { findOrFail } from "@chatbotx.io/database/client"
-import { integrationMessengerModel } from "@chatbotx.io/database/schema"
-import { getPostDetails } from "@chatbotx.io/integration-messenger/apis/post"
+import {
+  buildContext,
+  findInstagramIntegrationByInboxId,
+  findMessengerIntegrationByInboxId,
+} from "@chatbotx.io/business"
+import type { ChannelType } from "@chatbotx.io/database/partials"
+import type { InstagramAuthValue } from "@chatbotx.io/integration-instagram"
 import type { MessengerAuthValue } from "@chatbotx.io/integration-messenger/schema"
 import { withCache } from "@chatbotx.io/redis"
+import { integrations } from "@/integration"
+import type { PostDetails } from "../schema/query"
 
 const POST_DETAILS_CACHE_TTL = 60 * 60 * 24
 
 function getPostDetailsCacheKey(inboxId: string, postId: string): string {
-  return `messenger:post-details:${inboxId}:${postId}`
+  return `post-details:${inboxId}:${postId}`
 }
 
-export function getPostDetailsQuery(inboxId: string, postId: string) {
+export function getPostDetailsQuery(
+  inboxId: string,
+  postId: string,
+  channel: ChannelType,
+): Promise<PostDetails> {
   return withCache(
     getPostDetailsCacheKey(inboxId, postId),
-    async () => {
-      const integration = await findOrFail({
-        table: integrationMessengerModel,
-        where: { inboxId },
-      })
+    async (): Promise<PostDetails> => {
+      if (channel === "instagram") {
+        const integration = await findInstagramIntegrationByInboxId(inboxId)
+        const ctx = await buildContext({
+          workspaceId: integration.workspaceId,
+          integrationType: "instagram",
+          integration: {
+            ...integration,
+            auth: integration.auth as InstagramAuthValue,
+          },
+        })
+        const raw = await integrations.instagram.runAction("getPostDetails", {
+          ctx,
+          input: { postId },
+        })
+        return {
+          text: raw.caption,
+          picture: raw.thumbnail_url ?? raw.media_url,
+          from: { id: integration.igId, name: integration.name },
+          createdAt: raw.timestamp,
+          link: raw.permalink,
+        }
+      }
+
+      const integration = await findMessengerIntegrationByInboxId(inboxId)
       const ctx = await buildContext({
         workspaceId: integration.workspaceId,
         integrationType: "messenger",
@@ -27,7 +56,16 @@ export function getPostDetailsQuery(inboxId: string, postId: string) {
           auth: integration.auth as MessengerAuthValue,
         },
       })
-      return getPostDetails({ ctx, input: { postId } })
+      const raw = await integrations.messenger.runAction("getPostDetails", {
+        ctx,
+        input: { postId },
+      })
+      return {
+        text: raw.message,
+        picture: raw.full_picture,
+        from: raw.from,
+        createdAt: raw.created_time,
+      }
     },
     { ttl: POST_DETAILS_CACHE_TTL },
   )

--- a/apps/builder/src/features/conversations/schema/query.ts
+++ b/apps/builder/src/features/conversations/schema/query.ts
@@ -25,3 +25,11 @@ export const listConversationsRequest = z.object({
   ...cursorPaginationRequest.shape,
 })
 export type ListConversationsRequest = z.infer<typeof listConversationsRequest>
+
+export type PostDetails = {
+  text?: string
+  picture?: string
+  from?: { id: string; name: string }
+  createdAt: string
+  link?: string
+}

--- a/apps/builder/src/features/custom-fields/custom-field-table.tsx
+++ b/apps/builder/src/features/custom-fields/custom-field-table.tsx
@@ -111,7 +111,7 @@ export function CustomFieldsTable({
           <div>
             <Tooltip>
               <TooltipTrigger asChild>
-                <div className="max-w-[200px] truncate">
+                <div className="inline-block max-w-[200px] truncate">
                   {row.original.name}
                 </div>
               </TooltipTrigger>
@@ -143,7 +143,7 @@ export function CustomFieldsTable({
           <div>
             <Tooltip>
               <TooltipTrigger asChild>
-                <div className="max-w-[200px] truncate">
+                <div className="inline-block max-w-[200px] truncate">
                   {row.original.description}
                 </div>
               </TooltipTrigger>

--- a/apps/builder/src/features/integration-webchat/columns/webchat-columns.tsx
+++ b/apps/builder/src/features/integration-webchat/columns/webchat-columns.tsx
@@ -44,7 +44,9 @@ export function getWebchatColumns({
         return (
           <Tooltip>
             <TooltipTrigger asChild>
-              <div className="max-w-[300px] truncate">{webchat.name}</div>
+              <div className="inline-block max-w-[300px] truncate">
+                {webchat.name}
+              </div>
             </TooltipTrigger>
             <TooltipContent>
               <p>{webchat.name}</p>

--- a/apps/builder/src/features/magic-links/magic-links-table.tsx
+++ b/apps/builder/src/features/magic-links/magic-links-table.tsx
@@ -117,7 +117,9 @@ export const MagicLinksTable = ({
         cell: ({ row }) => (
           <Tooltip>
             <TooltipTrigger asChild>
-              <div className="max-w-[200px] truncate">{row.original.name}</div>
+              <div className="inline-block max-w-[200px] truncate">
+                {row.original.name}
+              </div>
             </TooltipTrigger>
             <TooltipContent>
               <p>{row.original.name}</p>

--- a/apps/builder/src/features/messages/components/message-input.tsx
+++ b/apps/builder/src/features/messages/components/message-input.tsx
@@ -209,7 +209,7 @@ export const MessageInput = () => {
   }, [])
 
   const sendMessage = useCallback(() => {
-    if (lastContactComment) {
+    if (!replyToMessage && lastContactComment) {
       form.setValue("replyToMessageId", lastContactComment.id)
       form.setValue(
         "replyToMessageCreatedAt",
@@ -217,7 +217,7 @@ export const MessageInput = () => {
       )
     }
     handleSubmitWithAction()
-  }, [lastContactComment, form, handleSubmitWithAction])
+  }, [replyToMessage, lastContactComment, form, handleSubmitWithAction])
 
   // Memoize keyboard handler
   const onKeyDown = useCallback(
@@ -250,6 +250,10 @@ export const MessageInput = () => {
   //   return isOver7Days && currentInboxType === "messenger"
   // }, [isOver7Days])
   const placeholder = isDisabled ? t("messages.userInactive") : "Message..."
+
+  const isInstagramPostComment =
+    conversation?.contactInboxes[0]?.channel === "instagram" &&
+    conversation?.sourceId != null
 
   // Check if files are attached
   const files = useWatch({
@@ -315,9 +319,11 @@ export const MessageInput = () => {
               )}
             />
           </div>
-          <div className="px-2">
-            <FileUploadPreview ref={fileUploadRef} />
-          </div>
+          {!isInstagramPostComment && (
+            <div className="px-2">
+              <FileUploadPreview ref={fileUploadRef} />
+            </div>
+          )}
           <div className="flex w-full items-center pl-2.5">
             <div className="flex-1">
               <InboxIcon
@@ -331,15 +337,17 @@ export const MessageInput = () => {
             {!isDisabled && (
               <div className="message-toolbar flex items-center gap-2">
                 {!hasFiles && <InputMenu setContent={setContent} />}
-                <Button
-                  aria-label="Attach file"
-                  className="px-2 py-1.5 [&_svg]:size-5"
-                  onClick={onClickAttachment}
-                  type="button"
-                  variant="ghost"
-                >
-                  <PaperclipIcon aria-hidden="true" />
-                </Button>
+                {!isInstagramPostComment && (
+                  <Button
+                    aria-label="Attach file"
+                    className="px-2 py-1.5 [&_svg]:size-5"
+                    onClick={onClickAttachment}
+                    type="button"
+                    variant="ghost"
+                  >
+                    <PaperclipIcon aria-hidden="true" />
+                  </Button>
+                )}
                 <Button
                   aria-label="Send message"
                   className="px-2 py-1.5 [&_svg]:size-5"

--- a/apps/builder/src/features/qr-codes/qr-codes-table.tsx
+++ b/apps/builder/src/features/qr-codes/qr-codes-table.tsx
@@ -117,7 +117,7 @@ export function QrCodesTable({ workspaceId, promises }: QrCodesTableProps) {
         cell: ({ row }) => (
           <Tooltip>
             <TooltipTrigger asChild>
-              <div className="max-w-[200px] truncate">
+              <div className="inline-block max-w-[200px] truncate">
                 {row.original.flow.name}
               </div>
             </TooltipTrigger>

--- a/apps/builder/src/features/reflinks/reflinks-table.tsx
+++ b/apps/builder/src/features/reflinks/reflinks-table.tsx
@@ -95,7 +95,9 @@ export function ReflinksTable({ workspaceId, promises }: ReflinksTableProps) {
         cell: ({ row }) => (
           <Tooltip>
             <TooltipTrigger asChild>
-              <div className="max-w-[200px] truncate">{row.original.name}</div>
+              <div className="inline-block max-w-[200px] truncate">
+                {row.original.name}
+              </div>
             </TooltipTrigger>
             <TooltipContent>
               <p>{row.original.name}</p>
@@ -121,7 +123,7 @@ export function ReflinksTable({ workspaceId, promises }: ReflinksTableProps) {
         cell: ({ row }) => (
           <Tooltip>
             <TooltipTrigger asChild>
-              <div className="max-w-[200px] truncate">
+              <div className="inline-block max-w-[200px] truncate">
                 {row.original.flow.name}
               </div>
             </TooltipTrigger>

--- a/apps/builder/src/features/spreadsheets/spreadsheets-table-columns.tsx
+++ b/apps/builder/src/features/spreadsheets/spreadsheets-table-columns.tsx
@@ -41,7 +41,9 @@ export function getSpreadsheetColumns({
       cell: ({ row }) => (
         <Tooltip>
           <TooltipTrigger asChild>
-            <div className="max-w-[300px] truncate">{row.original.name}</div>
+            <div className="inline-block max-w-[300px] truncate">
+              {row.original.name}
+            </div>
           </TooltipTrigger>
           <TooltipContent>
             <p>{row.original.name}</p>
@@ -60,7 +62,7 @@ export function getSpreadsheetColumns({
       cell: ({ row }) => (
         <Tooltip>
           <TooltipTrigger asChild>
-            <div className="max-w-[300px] truncate">
+            <div className="inline-block max-w-[300px] truncate">
               <Link
                 className="truncate"
                 href={row.original.url}

--- a/apps/builder/src/features/tags/tags-table-columns.tsx
+++ b/apps/builder/src/features/tags/tags-table-columns.tsx
@@ -80,7 +80,9 @@ export function getTagColumns({
       cell: ({ row }) => (
         <Tooltip>
           <TooltipTrigger asChild>
-            <div className="max-w-[300px] truncate">{row.original.name}</div>
+            <div className="inline-block max-w-[300px] truncate">
+              {row.original.name}
+            </div>
           </TooltipTrigger>
           <TooltipContent>
             <p>{row.original.name}</p>

--- a/apps/builder/src/features/triggers/triggers-table-columns.tsx
+++ b/apps/builder/src/features/triggers/triggers-table-columns.tsx
@@ -81,7 +81,7 @@ export function getColumns({
       cell: ({ row }) => (
         <Tooltip>
           <TooltipTrigger asChild>
-            <div className="max-w-[300px] truncate">
+            <div className="inline-block max-w-[300px] truncate">
               <Link
                 className="truncate"
                 href={`/space/${workspaceId}/triggers/${row.original.id}/edit`}

--- a/apps/builder/src/features/workspace-members/workspace-members-table.tsx
+++ b/apps/builder/src/features/workspace-members/workspace-members-table.tsx
@@ -71,7 +71,7 @@ export function WorkspaceMembersTable({
 
             <Tooltip>
               <TooltipTrigger asChild>
-                <div className="max-w-[200px] truncate">
+                <div className="inline-block max-w-[200px] truncate">
                   {row.original.user.name}
                 </div>
               </TooltipTrigger>

--- a/apps/worker/src/integration/handlers/received-message.ts
+++ b/apps/worker/src/integration/handlers/received-message.ts
@@ -328,16 +328,16 @@ export const receiveComment = async (
 ): Promise<void> => {
   setWebhookExecutionContext({ source: "webhook" })
 
-  const { integrationIdentifier, commentData } = props
+  const { integrationType, integrationIdentifier, commentData } = props
 
   const { inbox, integrationRow } =
     await integrationService.identifyInboxAndIntegrationAuthFromIdentifier(
-      "messenger",
+      integrationType as IntegrationType,
       integrationIdentifier,
     )
 
-  // `from.id` is the commenter's PSID, so `detectContactAndConversation` can
-  // enrich the profile via `getProfile`; `fromName` is the fallback firstName.
+  // `from.id` is the commenter's ID (PSID for Messenger, Instagram User ID for Instagram);
+  // `fromName` is the fallback firstName.
   const incomingContact: IncomingContact = {
     sourceId: commentData.fromId,
     sourceConversationId: commentData.postId,
@@ -383,16 +383,16 @@ export const receiveComment = async (
   })
 }
 
-// When a commenter edits their comment on Facebook, sync the new text to the DB
+// When a commenter edits their comment, sync the new text to the DB
 // and broadcast the change to the inbox in real-time.
 export const updateIncomingComment = async (
   props: IntegrationJobUpdateIncomingComment["data"],
 ): Promise<void> => {
-  const { integrationIdentifier, commentId, newText } = props
+  const { integrationType, integrationIdentifier, commentId, newText } = props
 
   const { inbox } =
     await integrationService.identifyInboxAndIntegrationAuthFromIdentifier(
-      "messenger",
+      integrationType as IntegrationType,
       integrationIdentifier,
     )
 
@@ -422,16 +422,16 @@ export const updateIncomingComment = async (
   }
 }
 
-// When a commenter deletes their comment on Facebook, soft-delete it (and any
+// When a commenter deletes their comment, soft-delete it (and any
 // child comments) in the DB and broadcast the deletion to the inbox.
 export const deleteIncomingComment = async (
   props: IntegrationJobDeleteIncomingComment["data"],
 ): Promise<void> => {
-  const { integrationIdentifier, commentId } = props
+  const { integrationType, integrationIdentifier, commentId } = props
 
   const { inbox } =
     await integrationService.identifyInboxAndIntegrationAuthFromIdentifier(
-      "messenger",
+      integrationType as IntegrationType,
       integrationIdentifier,
     )
 

--- a/integrations/instagram/src/apis/comment.ts
+++ b/integrations/instagram/src/apis/comment.ts
@@ -1,0 +1,57 @@
+import { DEFAULT_API_VERSION } from "../constants"
+import { rescue } from "../exception"
+import { instagramBusinessClient } from "../lib/http-client"
+import type { InstagramAuthValue } from "../schemas"
+
+export const sendComment = (
+  auth: InstagramAuthValue,
+  commentId: string,
+  message: string | null,
+): Promise<{ id: string }> => {
+  const version = auth.metadata.version ?? DEFAULT_API_VERSION
+  const endpoint = `${version}/${commentId}/replies`
+
+  return rescue(endpoint, () =>
+    instagramBusinessClient.post<{ id: string }>(endpoint, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${auth.tokens.accessToken}`,
+      },
+      json: { message },
+    }),
+  )
+}
+
+export const deleteComment = (
+  auth: InstagramAuthValue,
+  commentId: string,
+): Promise<{ success: boolean }> => {
+  const version = auth.metadata.version ?? DEFAULT_API_VERSION
+  const endpoint = `${version}/${commentId}`
+
+  return rescue(endpoint, () =>
+    instagramBusinessClient.delete<{ success: boolean }>(endpoint, {
+      headers: {
+        Authorization: `Bearer ${auth.tokens.accessToken}`,
+      },
+    }),
+  )
+}
+
+export const hideComment = (
+  auth: InstagramAuthValue,
+  commentId: string,
+  hidden: boolean,
+): Promise<{ success: boolean }> => {
+  const version = auth.metadata.version ?? DEFAULT_API_VERSION
+  const endpoint = `${version}/${commentId}`
+
+  return rescue(endpoint, () =>
+    instagramBusinessClient.post<{ success: boolean }>(endpoint, {
+      headers: {
+        Authorization: `Bearer ${auth.tokens.accessToken}`,
+      },
+      searchParams: { hide: String(hidden) },
+    }),
+  )
+}

--- a/integrations/instagram/src/apis/page.ts
+++ b/integrations/instagram/src/apis/page.ts
@@ -23,6 +23,7 @@ export const INSTAGRAM_SUBSCRIBE_FIELDS = [
   "messaging_optins",
   "messaging_seen",
   "messaging_referral",
+  "comments",
 ]
 
 export const refreshLongLivedToken = (accessToken: string): Promise<string> => {

--- a/integrations/instagram/src/apis/post.ts
+++ b/integrations/instagram/src/apis/post.ts
@@ -1,0 +1,33 @@
+import type { Context } from "@chatbotx.io/sdk"
+import { DEFAULT_API_VERSION } from "../constants"
+import { rescue } from "../exception"
+import { instagramBusinessClient } from "../lib/http-client"
+import type { InstagramAuthValue } from "../schemas"
+
+export type InstagramMediaDetails = {
+  caption?: string
+  media_url?: string
+  thumbnail_url?: string
+  timestamp: string
+  permalink?: string
+}
+
+export const getPostDetails = (props: {
+  ctx: Context<InstagramAuthValue>
+  input: { postId: string }
+}): Promise<InstagramMediaDetails> => {
+  const { ctx, input } = props
+  const version = ctx.auth.metadata.version ?? DEFAULT_API_VERSION
+  const endpoint = `${version}/${input.postId}`
+
+  return rescue(endpoint, () =>
+    instagramBusinessClient.get<InstagramMediaDetails>(endpoint, {
+      headers: {
+        Authorization: `Bearer ${ctx.auth.tokens.accessToken}`,
+      },
+      searchParams: {
+        fields: "caption,media_url,thumbnail_url,timestamp,permalink",
+      },
+    }),
+  )
+}

--- a/integrations/instagram/src/constants.ts
+++ b/integrations/instagram/src/constants.ts
@@ -9,4 +9,5 @@ export const DEFAULT_API_VERSION = "v22.0"
 export const INSTAGRAM_BUSINESS_SCOPES = [
   "instagram_business_basic",
   "instagram_business_manage_messages",
+  "instagram_business_manage_comments",
 ]

--- a/integrations/instagram/src/handlers/comment/actions.ts
+++ b/integrations/instagram/src/handlers/comment/actions.ts
@@ -1,0 +1,50 @@
+import type { CommentHandlers } from "@chatbotx.io/sdk"
+import {
+  deleteComment as deleteCommentApi,
+  hideComment as hideCommentApi,
+} from "../../apis/comment"
+import { mapToChannelError } from "../../lib/error-mapper"
+import { logger } from "../../lib/logger"
+import type { InstagramAuthValue } from "../../schemas"
+
+export const deleteComment: CommentHandlers<InstagramAuthValue>["deleteComment"] =
+  async ({ ctx, data }) => {
+    try {
+      await deleteCommentApi(ctx.auth, data.commentId)
+      logger.info(`Comment deleted: ${data.commentId}`)
+    } catch (error) {
+      logger.error(error, "An error occurred while deleting the comment")
+      throw mapToChannelError(error)
+    }
+  }
+
+export const hideComment: CommentHandlers<InstagramAuthValue>["hideComment"] =
+  async ({ ctx, data }) => {
+    try {
+      await hideCommentApi(ctx.auth, data.commentId, data.hidden)
+      logger.info(
+        `Comment ${data.hidden ? "hidden" : "unhidden"}: ${data.commentId}`,
+      )
+    } catch (error) {
+      logger.error(error, "An error occurred while hiding the comment")
+      throw mapToChannelError(error)
+    }
+  }
+
+export const likeComment: CommentHandlers<InstagramAuthValue>["likeComment"] =
+  ({ data }) => {
+    logger.info(
+      { commentId: data.commentId },
+      "likeComment: Instagram does not support liking comments via API, skipping",
+    )
+    return Promise.resolve()
+  }
+
+export const editComment: CommentHandlers<InstagramAuthValue>["editComment"] =
+  ({ data }) => {
+    logger.info(
+      { commentId: data.commentId },
+      "editComment: Instagram does not support editing comments via API, skipping",
+    )
+    return Promise.resolve()
+  }

--- a/integrations/instagram/src/handlers/comment/index.ts
+++ b/integrations/instagram/src/handlers/comment/index.ts
@@ -1,0 +1,10 @@
+import { deleteComment, editComment, hideComment, likeComment } from "./actions"
+import { sendComment } from "./outgoing-comment"
+
+export const commentHandlers = {
+  sendComment,
+  editComment,
+  deleteComment,
+  likeComment,
+  hideComment,
+}

--- a/integrations/instagram/src/handlers/comment/outgoing-comment/index.ts
+++ b/integrations/instagram/src/handlers/comment/outgoing-comment/index.ts
@@ -1,0 +1,45 @@
+import {
+  ChannelError,
+  ChannelErrorCategory,
+  type CommentHandlers,
+} from "@chatbotx.io/sdk"
+import { sendComment as sendCommentApi } from "../../../apis/comment"
+import { mapToChannelError } from "../../../lib/error-mapper"
+import { logger } from "../../../lib/logger"
+import type { InstagramAuthValue } from "../../../schemas"
+
+export const sendComment: CommentHandlers<InstagramAuthValue>["sendComment"] =
+  async (props) => {
+    const {
+      ctx,
+      data: { message },
+    } = props
+
+    const replyToCommentId = message.contentAttributes?.replyToCommentId
+    if (typeof replyToCommentId !== "string") {
+      throw new ChannelError(
+        "Cannot send comment reply: replyToCommentId is missing. The outgoing message must be linked to a parent comment.",
+        ChannelErrorCategory.PAYLOAD_INVALID,
+      )
+    }
+
+    if (!message.text) {
+      logger.warn(
+        { replyToCommentId },
+        "sendComment: message has no text — skipping API call",
+      )
+      return { messageIds: [] }
+    }
+
+    try {
+      const result = await sendCommentApi(
+        ctx.auth,
+        replyToCommentId,
+        message.text,
+      )
+      return { messageIds: result.id ? [result.id] : [] }
+    } catch (error) {
+      logger.error(error, "An error occurred while sending the comment reply")
+      throw mapToChannelError(error)
+    }
+  }

--- a/integrations/instagram/src/handlers/message/incomming-message.ts
+++ b/integrations/instagram/src/handlers/message/incomming-message.ts
@@ -64,7 +64,7 @@ export const receiveMessage = async ({
 
   const entry = validatedData.entry[0]
 
-  if (!entry.messaging[0]) {
+  if (!entry.messaging?.[0]) {
     throw new InstagramException("No messaging found")
   }
 

--- a/integrations/instagram/src/handlers/webhook.ts
+++ b/integrations/instagram/src/handlers/webhook.ts
@@ -2,9 +2,11 @@ import type { ContextQueue, HandleRequestProps } from "@chatbotx.io/sdk"
 import crypto from "crypto"
 import z from "zod"
 import { InstagramWebhookException } from "../exception"
+import { logger } from "../lib/logger"
 import {
   INSTAGRAM_MESSAGE_METADATA,
   type InstagramConfig,
+  instagramCommentEventValueSchema,
   instagramWebhookEventSchema,
 } from "../schemas"
 
@@ -69,13 +71,64 @@ const handleWebhookEvent = async (
       )
     }
 
-    if (webhookData.entry[0].messaging[0]?.read) {
+    const entry = webhookData.entry[0]
+
+    // Handle Instagram post comment events (changes.comments).
+    // Instagram only sends webhooks for new comments — no edit/delete events.
+    const commentChange = entry.changes?.find(
+      (c: { field: string }) => c.field === "comments",
+    )
+    if (commentChange) {
+      const parsed = instagramCommentEventValueSchema.safeParse(
+        commentChange.value,
+      )
+      if (!parsed.success) {
+        logger.warn(
+          { error: parsed.error, value: commentChange.value },
+          "comment event parse failed — skipping",
+        )
+        return
+      }
+      const value = parsed.data
+      if (!value.media?.id) {
+        logger.warn(
+          { commentId: value.id },
+          "comment webhook missing media.id — skipping",
+        )
+        return
+      }
+      await queue?.add("incomingComment", {
+        type: "incomingComment",
+        data: {
+          integrationType: "instagram",
+          integrationIdentifier: entry.id,
+          commentData: {
+            commentId: value.id,
+            postId: value.media.id,
+            parentId: value.parent_id,
+            fromId: value.from.id,
+            fromName: value.from.username ?? value.from.id,
+            message: value.text,
+            createdTime: entry.time,
+          },
+        },
+      })
+      return
+    }
+
+    // Handle DM messaging events
+    const messaging = entry.messaging
+    if (!messaging || messaging.length === 0) {
+      return
+    }
+
+    if (messaging[0]?.read) {
       await queue?.add("contactMarkAsRead", {
         type: "contactMarkAsRead",
         data: {
           integrationType: "instagram",
-          integrationIdentifier: webhookData.entry[0].id,
-          sourceConversationId: webhookData.entry[0].messaging[0].sender.id,
+          integrationIdentifier: entry.id,
+          sourceConversationId: messaging[0].sender.id,
           payload: webhookData,
         },
       })
@@ -83,29 +136,22 @@ const handleWebhookEvent = async (
     }
 
     // Skip if this message is not a message or postback
-    if (
-      !(
-        webhookData.entry[0].messaging[0].message ||
-        webhookData.entry[0].messaging[0].postback
-      )
-    ) {
+    if (!(messaging[0].message || messaging[0].postback)) {
       return
     }
 
     if (
-      webhookData.entry[0].messaging[0].message?.is_echo === true &&
-      webhookData.entry[0].messaging[0].message?.metadata ===
-        INSTAGRAM_MESSAGE_METADATA
+      messaging[0].message?.is_echo === true &&
+      messaging[0].message?.metadata === INSTAGRAM_MESSAGE_METADATA
     ) {
       // Skip if this message is from our own bot
       return
     }
 
     // Calculate integration identifier
-    const integrationIdentifier = webhookData.entry[0].messaging[0].message
-      ?.is_echo
-      ? webhookData.entry[0].messaging[0].sender.id
-      : webhookData.entry[0].messaging[0].recipient.id
+    const integrationIdentifier = messaging[0].message?.is_echo
+      ? messaging[0].sender.id
+      : messaging[0].recipient.id
 
     await queue?.add("incomingMessage", {
       type: "incomingMessage",

--- a/integrations/instagram/src/integration.ts
+++ b/integrations/instagram/src/integration.ts
@@ -4,8 +4,10 @@ import {
   type IntegrationDefinition,
 } from "@chatbotx.io/sdk"
 import { unsubscribePageFromInstagramWebhook } from "./apis/page"
+import { getPostDetails } from "./apis/post"
 import { InstagramAPIException } from "./exception"
 import { botHandlers } from "./handlers/bot"
+import { commentHandlers } from "./handlers/comment"
 import { contactHandlers } from "./handlers/contact"
 import { conversationHandlers } from "./handlers/conversation"
 import { messageHandlers } from "./handlers/message"
@@ -25,12 +27,15 @@ const config: IntegrationDefinition<
   channels: {
     channel: {
       message: messageHandlers,
+      comment: commentHandlers,
       conversation: conversationHandlers,
       contact: contactHandlers,
       bot: botHandlers,
     },
   },
-  actions: {},
+  actions: {
+    getPostDetails,
+  },
   handleRequest: async (props) => {
     const segments = new URL(props.req.url).pathname.split("/")
     const action = segments.pop()

--- a/integrations/instagram/src/schemas.ts
+++ b/integrations/instagram/src/schemas.ts
@@ -1,4 +1,4 @@
-import type { Oauth2AuthValue, Oauth2Config } from "@chatbotx.io/sdk"
+import type { Context, Oauth2AuthValue, Oauth2Config } from "@chatbotx.io/sdk"
 import { z } from "zod"
 
 export const INSTAGRAM_MESSAGE_METADATA = "SENT_FROM_CHATBOTX"
@@ -20,7 +20,12 @@ export type InstagramAuthValue = Oauth2AuthValue & {
   }
 }
 
-export type InstagramActions = Record<string, never>
+export type InstagramActions = {
+  getPostDetails: (props: {
+    ctx: Context<InstagramAuthValue>
+    input: { postId: string }
+  }) => Promise<import("./apis/post").InstagramMediaDetails>
+}
 
 // Common attachment types
 const attachmentTypeSchema = z.enum(["image", "video", "audio", "file"])
@@ -88,9 +93,29 @@ export type InstagramMessagingEvent = z.infer<
 export const instagramPageEntrySchema = z.object({
   id: z.string(),
   time: z.number(),
-  messaging: z.array(instagramMessagingEventSchema),
+  messaging: z.array(instagramMessagingEventSchema).optional(),
+  changes: z
+    .array(z.object({ field: z.string(), value: z.unknown() }))
+    .optional(),
 })
 export type InstagramPageEntry = z.infer<typeof instagramPageEntrySchema>
+
+// Instagram only fires comment webhooks for new comments (no edit/delete events).
+// The "text" field holds the comment body; "from" is always present.
+export const instagramCommentEventValueSchema = z.object({
+  id: z.string(),
+  text: z.string().optional(),
+  from: z.object({ id: z.string(), username: z.string().optional() }),
+  media: z
+    .object({ id: z.string(), media_product_type: z.string().optional() })
+    .optional(),
+  parent_id: z.string().optional(),
+  sender_id: z.string().optional(),
+  recipient_id: z.string().optional(),
+})
+export type InstagramCommentEventValue = z.infer<
+  typeof instagramCommentEventValueSchema
+>
 
 export const instagramWebhookEventSchema = z.object({
   object: z.literal("instagram"),

--- a/packages/business/src/inbox/utils.ts
+++ b/packages/business/src/inbox/utils.ts
@@ -88,7 +88,7 @@ export function getInboxLinks(
 export function buildPostLink(channel: ChannelType, postId: string): string {
   const allLinkConfigs: Record<ChannelType, string> = {
     messenger: `https://fb.com/${postId}`,
-    instagram: `https://instagram.com/p/${postId}`,
+    instagram: "",
     whatsapp: "",
     telegram: "",
     zalo: "",

--- a/packages/business/src/integration-instagram/index.ts
+++ b/packages/business/src/integration-instagram/index.ts
@@ -1,1 +1,2 @@
 export * from "./schema"
+export * from "./service"

--- a/packages/business/src/integration-instagram/service.ts
+++ b/packages/business/src/integration-instagram/service.ts
@@ -1,0 +1,6 @@
+import { findOrFail } from "@chatbotx.io/database/client"
+import { integrationInstagramModel } from "@chatbotx.io/database/schema"
+
+export function findInstagramIntegrationByInboxId(inboxId: string) {
+  return findOrFail({ table: integrationInstagramModel, where: { inboxId } })
+}

--- a/packages/business/src/integration-messenger/index.ts
+++ b/packages/business/src/integration-messenger/index.ts
@@ -1,1 +1,2 @@
 export * from "./schema"
+export * from "./service"

--- a/packages/business/src/integration-messenger/service.ts
+++ b/packages/business/src/integration-messenger/service.ts
@@ -1,0 +1,6 @@
+import { findOrFail } from "@chatbotx.io/database/client"
+import { integrationMessengerModel } from "@chatbotx.io/database/schema"
+
+export function findMessengerIntegrationByInboxId(inboxId: string) {
+  return findOrFail({ table: integrationMessengerModel, where: { inboxId } })
+}


### PR DESCRIPTION
 ## Summary
  - Receives incoming comments on posts via the Instagram feed webhook and stores them as `type=comment` messages in the conversation inbox
  - Outgoing replies are sent through the Graph API; the resulting Instagram comment ID is written back so the agent can delete it later
  - Ships inline message actions ( delete, hide toggle) for comment-type messages in the inbox UI
  
  ## Changes
  - `integrations/messenger/` — new `comment.ts` / `post.ts` Graph API clients, `handlers/comment/` for inbound and outbound routing, updated webhook to dispatch `incomingComment` jobs on feed changes
  
  ## Test plan
  - [ ] Send a Instagram comment on a post → appears as a comment-type message in the inbox
  - [ ] Reply from the inbox → reply visible on Instagram; comment ID stored on the message
  - [ ] Delete a comment reply from the inbox → removed on Instagram, shown as deleted in UI
  - [ ] Hide a comment → `attributes` persisted in DB 
  - [ ] Open a normal DM conversation → unaffected (sourceId-null index holds)
  - [ ] `pnpm lint` passes
  - [ ] `pnpm check-types` passes across all packages
