### PR TITLE
fix(builder): point pricing links to canonical /portal/pricing path

### DIFF
--- a/apps/builder/src/app/trial-expired/page.tsx
+++ b/apps/builder/src/app/trial-expired/page.tsx
@@ -14,7 +14,7 @@ export default async function TrialExpiredPage() {
       </div>
       <div className="flex flex-col items-center gap-3">
         <Button asChild size="lg">
-          <Link href="/pricing">{t("cta")}</Link>
+          <Link href="/portal/pricing">{t("cta")}</Link>
         </Button>
         <SignOut />
       </div>

--- a/apps/builder/src/enterprise/features/billing/upgrade-plan-dialog.tsx
+++ b/apps/builder/src/enterprise/features/billing/upgrade-plan-dialog.tsx
@@ -18,10 +18,13 @@ import { reconcileTenantEntitlementAction } from "./actions/reconcile-tenant-ent
  * apps/builder/next.config.ts). We embed it in an iframe so all pricing and
  * plan-detail logic stays in the portal and never lands in this repo.
  *
- * Must stay relative (same-origin) so the user's session cookies flow into the
- * iframe and framing is not blocked by X-Frame-Options.
+ * Uses the canonical `/portal/*` prefix (the same one portal-nav.ts links to)
+ * so it resolves in both dev (the `/portal/:path*` rewrite) and prod (Caddy
+ * routes `/portal/*` to the portal). Must stay relative (same-origin) so the
+ * user's session cookies flow into the iframe and framing is not blocked by
+ * X-Frame-Options.
  */
-const PRICING_PATH = "/pricing"
+const PRICING_PATH = "/portal/pricing"
 
 /** Message the portal posts on a successful upgrade so we can refresh in-app. */
 const UPGRADE_SUCCESS_TYPE = "billing:upgrade-success"


### PR DESCRIPTION
## Summary

Both the trial-expired CTA and the upgrade-plan dialog iframe linked to `/pricing`, but pricing lives in the **portal**, not the builder app. This re-points them to the canonical `/portal/pricing` prefix.

- `apps/builder/src/app/trial-expired/page.tsx` — CTA link `/pricing` → `/portal/pricing`
- `apps/builder/src/enterprise/features/billing/upgrade-plan-dialog.tsx` — iframe `PRICING_PATH` `/pricing` → `/portal/pricing`

The `/portal/*` prefix is the same one `portal-nav.ts` links to, so it resolves in both:
- **dev** — via the `/portal/:path*` rewrite
- **prod** — Caddy routes `/portal/*` to the portal

The path stays relative (same-origin) so the user's session cookies flow into the iframe and framing is not blocked by `X-Frame-Options`.

## Test plan

- [ ] In dev, trial-expired CTA navigates to the portal pricing page
- [ ] Upgrade-plan dialog iframe loads the portal pricing page (same-origin, cookies flow, no X-Frame-Options block)
- [ ] `billing:upgrade-success` postMessage still triggers in-app refresh
- [ ] Verify in prod that Caddy routes `/portal/pricing` correctly
