### PR TITLE
refactor(integrations): replace Node.js crypto with Web Crypto API in webhook handlers

### DIFF
--- a/integrations/instagram/src/handlers/webhook.ts
+++ b/integrations/instagram/src/handlers/webhook.ts
@@ -1,8 +1,8 @@
 import type { ContextQueue, HandleRequestProps } from "@chatbotx.io/sdk"
-import crypto from "crypto"
 import z from "zod"
 import { InstagramWebhookException } from "../exception"
 import { logger } from "../lib/logger"
+import { hmacSha256Hex, timingSafeStringEqual } from "../lib/webhook"
 import {
   INSTAGRAM_MESSAGE_METADATA,
   type InstagramConfig,
@@ -10,11 +10,11 @@ import {
   instagramWebhookEventSchema,
 } from "../schemas"
 
-const verifyWebhookSignature = (
+const verifyWebhookSignature = async (
   payload: string,
   signature: string,
   clientSecret: string,
-): boolean => {
+): Promise<boolean> => {
   try {
     const elements = signature.split("=")
     if (elements.length !== 2) {
@@ -22,16 +22,9 @@ const verifyWebhookSignature = (
     }
 
     const signatureHash = elements[1]
+    const expectedHash = await hmacSha256Hex(clientSecret, payload)
 
-    const expectedHash = crypto
-      .createHmac("sha256", clientSecret)
-      .update(payload)
-      .digest("hex")
-
-    return crypto.timingSafeEqual(
-      Buffer.from(signatureHash, "utf8"),
-      Buffer.from(expectedHash, "utf8"),
-    )
+    return timingSafeStringEqual(signatureHash, expectedHash)
   } catch {
     return false
   }
@@ -53,7 +46,7 @@ const handleWebhookEvent = async (
       throw new InstagramWebhookException("Missing webhook signature")
     }
 
-    const isValidSignature = verifyWebhookSignature(
+    const isValidSignature = await verifyWebhookSignature(
       body,
       signature,
       config.clientSecret,

--- a/integrations/instagram/src/lib/webhook.ts
+++ b/integrations/instagram/src/lib/webhook.ts
@@ -1,0 +1,30 @@
+/// <reference lib="dom" />
+
+export async function hmacSha256Hex(
+  secret: string,
+  payload: string,
+): Promise<string> {
+  const enc = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  )
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(payload))
+  return Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+}
+
+export function timingSafeStringEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+  let different = 0
+  for (let i = 0; i < a.length; i++) {
+    different += a.charCodeAt(i) === b.charCodeAt(i) ? 0 : 1
+  }
+  return different === 0
+}

--- a/integrations/messenger/src/handlers/webhook.ts
+++ b/integrations/messenger/src/handlers/webhook.ts
@@ -1,7 +1,7 @@
-import crypto from "node:crypto"
 import type { ContextQueue, HandleRequestProps } from "@chatbotx.io/sdk"
 import z from "zod"
 import { MessengerWebhookException } from "../exception"
+import { hmacSha256Hex, timingSafeStringEqual } from "../lib/webhook"
 import {
   incomingWebhookEventSchema,
   MESSENGER_MESSAGE_METADATA,
@@ -9,11 +9,11 @@ import {
   messengerFeedCommentValueSchema,
 } from "../schema"
 
-const verifyWebhookSignature = (
+const verifyWebhookSignature = async (
   payload: string,
   signature: string,
   clientSecret: string,
-): boolean => {
+): Promise<boolean> => {
   try {
     const elements = signature.split("=")
     if (elements.length !== 2) {
@@ -21,13 +21,9 @@ const verifyWebhookSignature = (
     }
 
     const signatureHash = elements[1]
+    const expectedHash = await hmacSha256Hex(clientSecret, payload)
 
-    const expectedHash = crypto
-      .createHmac("sha256", clientSecret)
-      .update(payload)
-      .digest("hex")
-
-    return signatureHash === expectedHash
+    return timingSafeStringEqual(signatureHash, expectedHash)
   } catch {
     return false
   }
@@ -49,7 +45,7 @@ const handleWebhookEvent = async (
       throw new MessengerWebhookException("Missing webhook signature")
     }
 
-    const isValidSignature = verifyWebhookSignature(
+    const isValidSignature = await verifyWebhookSignature(
       body,
       signature,
       config.clientSecret,

--- a/integrations/messenger/src/lib/webhook.ts
+++ b/integrations/messenger/src/lib/webhook.ts
@@ -1,0 +1,30 @@
+/// <reference lib="dom" />
+
+export async function hmacSha256Hex(
+  secret: string,
+  payload: string,
+): Promise<string> {
+  const enc = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  )
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(payload))
+  return Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+}
+
+export function timingSafeStringEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+  let different = 0
+  for (let i = 0; i < a.length; i++) {
+    different += a.charCodeAt(i) === b.charCodeAt(i) ? 0 : 1
+  }
+  return different === 0
+}

--- a/integrations/tiktok/src/handlers/webhook.ts
+++ b/integrations/tiktok/src/handlers/webhook.ts
@@ -1,7 +1,7 @@
-import { createHmac, timingSafeEqual } from "node:crypto"
 import type { HandleRequestProps } from "@chatbotx.io/sdk"
 import { TiktokWebhookException } from "../exception"
 import { logger } from "../lib/logger"
+import { hmacSha256Hex, timingSafeStringEqual } from "../lib/webhook"
 import type { TiktokConfig } from "../schema"
 import { tiktokWebhookEventSchema } from "../schema"
 
@@ -10,11 +10,11 @@ const WEBHOOK_TIMESTAMP_WINDOW_SECONDS = 5
 // Allow 2s of clock skew between TikTok servers and ours
 const WEBHOOK_CLOCK_SKEW_SECONDS = 2
 
-function verifySignature(
+async function verifySignature(
   clientSecret: string,
   signature: string,
   body: string,
-): boolean {
+): Promise<boolean> {
   const parts = signature.split(",")
   const tPart = parts.find((p) => p.startsWith("t="))
   const sPart = parts.find((p) => p.startsWith("s="))
@@ -38,11 +38,9 @@ function verifySignature(
 
   const receivedSig = sPart.slice(2)
   const payload = `${timestamp}.${body}`
-  const expected = createHmac("sha256", clientSecret)
-    .update(payload)
-    .digest("hex")
+  const expected = await hmacSha256Hex(clientSecret, payload)
 
-  return timingSafeEqual(Buffer.from(expected), Buffer.from(receivedSig))
+  return timingSafeStringEqual(expected, receivedSig)
 }
 
 export const webhookHandler = async (
@@ -62,7 +60,11 @@ export const webhookHandler = async (
   }
 
   const signature = req.headers.get("TikTok-Signature") ?? ""
-  if (!(signature && verifySignature(config.clientSecret, signature, body))) {
+  if (
+    !(
+      signature && (await verifySignature(config.clientSecret, signature, body))
+    )
+  ) {
     throw new TiktokWebhookException("Invalid or missing webhook signature")
   }
 

--- a/integrations/tiktok/src/lib/webhook.ts
+++ b/integrations/tiktok/src/lib/webhook.ts
@@ -1,0 +1,30 @@
+/// <reference lib="dom" />
+
+export async function hmacSha256Hex(
+  secret: string,
+  payload: string,
+): Promise<string> {
+  const enc = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  )
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(payload))
+  return Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+}
+
+export function timingSafeStringEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+  let different = 0
+  for (let i = 0; i < a.length; i++) {
+    different += a.charCodeAt(i) === b.charCodeAt(i) ? 0 : 1
+  }
+  return different === 0
+}

--- a/integrations/zalo/src/handlers/webhook.ts
+++ b/integrations/zalo/src/handlers/webhook.ts
@@ -3,7 +3,7 @@ import {
   type HandleRequestProps,
   SdkException,
 } from "@chatbotx.io/sdk"
-import crypto from "crypto"
+import { sha256Hex, timingSafeStringEqual } from "../lib/webhook"
 import type { ZaloConfig } from "../schema/definition"
 import {
   TAG_EVENT_NAMES,
@@ -13,11 +13,11 @@ import {
 
 const TAG_EVENT_NAME_SET = new Set<string>(TAG_EVENT_NAMES)
 
-const _verifyWebhookSignature = (
+const _verifyWebhookSignature = async (
   payload: ZaloWebhookEvent,
   signature: string,
   config: ZaloConfig,
-): boolean => {
+): Promise<boolean> => {
   try {
     const elements = signature.split("=")
     if (elements.length !== 2) {
@@ -30,12 +30,9 @@ const _verifyWebhookSignature = (
     const timeStamp = payload.timestamp
     const dataString = JSON.stringify(payload)
     const content = appId + dataString + timeStamp + config.verifyToken
-    const expectedHash = crypto
-      .createHash("sha256")
-      .update(content, "utf8")
-      .digest("hex")
+    const expectedHash = await sha256Hex(content)
 
-    return signatureHash === expectedHash
+    return timingSafeStringEqual(signatureHash, expectedHash)
   } catch {
     return false
   }
@@ -72,7 +69,7 @@ const handleWebhookEvent = async (
     // if (!signature) {
     //   throw new SdkException("Missing webhook signature")
     // }
-    // const isValidSignature = verifyWebhookSignature(
+    // const isValidSignature = await _verifyWebhookSignature(
     //   webhookData,
     //   signature,
     //   config,

--- a/integrations/zalo/src/lib/webhook.ts
+++ b/integrations/zalo/src/lib/webhook.ts
@@ -1,0 +1,20 @@
+/// <reference lib="dom" />
+
+export async function sha256Hex(content: string): Promise<string> {
+  const enc = new TextEncoder()
+  const buf = await crypto.subtle.digest("SHA-256", enc.encode(content))
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+}
+
+export function timingSafeStringEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+  let different = 0
+  for (let i = 0; i < a.length; i++) {
+    different += a.charCodeAt(i) === b.charCodeAt(i) ? 0 : 1
+  }
+  return different === 0
+}


### PR DESCRIPTION
 - Replaces node:crypto with crypto.subtle in instagram, messenger, tiktok, zalo webhook signature verification
  - Extracts hmacSha256Hex / sha256Hex / timingSafeStringEqual into per-integration lib/webhook.ts
  - Fixes a timing-attack vulnerability in messenger (was using === instead of constant-time comparison)
