### PR TITLE
fix(worker): auto-discover worker roster in docker entrypoint

### DIFF
--- a/apps/worker/__tests__/docker-entrypoint.test.ts
+++ b/apps/worker/__tests__/docker-entrypoint.test.ts
@@ -1,0 +1,111 @@
+import { execFileSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+const SCRIPT = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../docker/rootfs/usr/local/bin/docker-entrypoint.sh",
+)
+
+// Mirrors the real dist/ layout: one worker*.mjs per tsdown entry, plus a
+// `foo` worker that exists in no hardcoded list — proving auto-discovery.
+const STANDARD_WORKERS = [
+  "chat",
+  "events",
+  "integration",
+  "ai-agent",
+  "default",
+  "trigger",
+  "webhook",
+  "schedule",
+  "sequence-scheduler",
+  "foo",
+]
+
+let distDir: string
+
+function touch(path: string): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, "")
+}
+
+function run(...args: string[]): { stdout: string; status: number } {
+  try {
+    const stdout = execFileSync("sh", [SCRIPT, ...args], {
+      // /bin/echo stub avoids launching node: a resolved `worker <name>` exec
+      // simply echoes the script path instead of running it.
+      env: { ...process.env, WORKER_DIST_DIR: distDir, NODE_BIN: "/bin/echo" },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+    return { stdout, status: 0 }
+  } catch (error) {
+    const err = error as { status?: number; stdout?: string; stderr?: string }
+    return {
+      stdout: `${err.stdout ?? ""}${err.stderr ?? ""}`,
+      status: err.status ?? 1,
+    }
+  }
+}
+
+beforeEach(() => {
+  distDir = mkdtempSync(join(tmpdir(), "worker-dist-"))
+  for (const w of STANDARD_WORKERS) {
+    touch(join(distDir, w, "worker.mjs"))
+  }
+  touch(join(distDir, "sequence-scheduler", "worker-producer.mjs"))
+  touch(join(distDir, "sequence-scheduler", "worker-consumer.mjs"))
+})
+
+afterEach(() => {
+  rmSync(distDir, { recursive: true, force: true })
+})
+
+describe("docker-entrypoint worker discovery", () => {
+  test("resolves a standard worker to its dist bundle", () => {
+    const { stdout, status } = run("worker", "chat")
+    expect(status).toBe(0)
+    expect(stdout.trim()).toBe(join(distDir, "chat", "worker.mjs"))
+  })
+
+  test("aliases sequence variants to their historical CLI names", () => {
+    expect(run("worker", "sequence-producer").stdout.trim()).toBe(
+      join(distDir, "sequence-scheduler", "worker-producer.mjs"),
+    )
+    expect(run("worker", "sequence-consumer").stdout.trim()).toBe(
+      join(distDir, "sequence-scheduler", "worker-consumer.mjs"),
+    )
+  })
+
+  test("auto-discovers a new worker with no script edit", () => {
+    const { stdout, status } = run("worker", "foo")
+    expect(status).toBe(0)
+    expect(stdout.trim()).toBe(join(distDir, "foo", "worker.mjs"))
+  })
+
+  test("rejects a worker that was not built (e.g. removed analytics)", () => {
+    const { stdout, status } = run("worker", "analytics")
+    expect(status).toBe(3)
+    expect(stdout).toContain("Usage:")
+  })
+
+  test("usage lists discovered workers including events and sequence variants", () => {
+    const { stdout } = run("worker", "badname")
+    expect(stdout).toContain("events")
+    expect(stdout).toContain("sequence-producer")
+    expect(stdout).toContain("sequence-consumer")
+    // The stale analytics worker must never appear.
+    expect(stdout).not.toContain("analytics")
+  })
+
+  test("errors when no worker bundles are present", () => {
+    rmSync(distDir, { recursive: true, force: true })
+    mkdirSync(distDir, { recursive: true })
+    const { stdout, status } = run("worker", "all")
+    expect(status).toBe(4)
+    expect(stdout).toContain("No worker bundles found")
+  })
+})

--- a/apps/worker/docker/rootfs/usr/local/bin/docker-entrypoint.sh
+++ b/apps/worker/docker/rootfs/usr/local/bin/docker-entrypoint.sh
@@ -2,58 +2,57 @@
 
 set -eu
 
-WORKER_DIST_DIR="/app/apps/worker/dist"
-NODE_BIN="/usr/local/bin/node"
-# ALL_WORKERS="chat integration ai-agent default webhook trigger analytics schedule sequence-scheduler sequence-producer sequence-consumer"
-ALL_WORKERS="chat integration ai-agent default webhook trigger analytics schedule sequence-scheduler"
+WORKER_DIST_DIR="${WORKER_DIST_DIR:-/app/apps/worker/dist}"
+NODE_BIN="${NODE_BIN:-/usr/local/bin/node}"
+
+# Map a built bundle (dir + file basename without .mjs) to its roster name.
+# Standard:  <dir>/worker.mjs            -> <dir>
+# Variants:  <dir>/worker-<suffix>.mjs   -> <dir>-<suffix>, with aliases below
+#            to preserve the historical sequence-* CLI names.
+map_worker_name() {
+  dir="$1"
+  file="$2"
+  if [ "$file" = "worker" ]; then
+    echo "$dir"
+    return 0
+  fi
+  case "${dir}/${file}" in
+    "sequence-scheduler/worker-producer") echo "sequence-producer" ;;
+    "sequence-scheduler/worker-consumer") echo "sequence-consumer" ;;
+    *) echo "${dir}-${file#worker-}" ;;
+  esac
+}
+
+# Scan dist/ and emit a "name|path" line per built worker bundle, sorted.
+# The roster is derived from what was actually built, so it can never drift
+# from the tsdown entrypoints or reference a worker that does not exist.
+discover_workers() {
+  for path in "$WORKER_DIST_DIR"/*/worker*.mjs; do
+    [ -f "$path" ] || continue   # skip the literal pattern when nothing matches
+    rel="${path#"$WORKER_DIST_DIR"/}"
+    dir="${rel%%/*}"
+    file="${rel##*/}"
+    file="${file%.mjs}"
+    printf '%s|%s\n' "$(map_worker_name "$dir" "$file")" "$path"
+  done | sort
+}
+
+WORKER_TABLE="$(discover_workers)"
+
+all_worker_names() {
+  printf '%s\n' "$WORKER_TABLE" | cut -d'|' -f1
+}
 
 print_usage() {
-    echo "Usage: ${0} worker [all|ai-agent|analytics|chat|default|integration|schedule|sequence-consumer|sequence-producer|sequence-scheduler|trigger|webhook]" >&2
+    names="$(all_worker_names | tr '\n' '|' | sed 's/|$//')"
+    echo "Usage: ${0} worker [all${names:+|}${names}]" >&2
     echo "       ${0} {bash|sh}" >&2
 }
 
 resolve_worker_script() {
-  case "$1" in
-    "ai-agent")
-      echo "${WORKER_DIST_DIR}/ai-agent/worker.mjs"
-      ;;
-    "analytics")
-      echo "${WORKER_DIST_DIR}/analytics/worker.mjs"
-      ;;
-    "chat")
-      echo "${WORKER_DIST_DIR}/chat/worker.mjs"
-      ;;
-    "default")
-      echo "${WORKER_DIST_DIR}/default/worker.mjs"
-      ;;
-    "integration")
-      echo "${WORKER_DIST_DIR}/integration/worker.mjs"
-      ;;
-    "schedule")
-      echo "${WORKER_DIST_DIR}/schedule/worker.mjs"
-      ;;
-    "sequence-consumer")
-      echo "${WORKER_DIST_DIR}/sequence-scheduler/worker-consumer.mjs"
-      ;;
-    "sequence-producer")
-      echo "${WORKER_DIST_DIR}/sequence-scheduler/worker-producer.mjs"
-      ;;
-    "sequence-scheduler")
-      echo "${WORKER_DIST_DIR}/sequence-scheduler/worker.mjs"
-      ;;
-    "trigger")
-      echo "${WORKER_DIST_DIR}/trigger/worker.mjs"
-      ;;
-    "webhook")
-      echo "${WORKER_DIST_DIR}/webhook/worker.mjs"
-      ;;
-    "events")
-      echo "${WORKER_DIST_DIR}/events/worker.mjs"
-      ;;
-    *)
-      return 1
-      ;;
-  esac
+  line="$(printf '%s\n' "$WORKER_TABLE" | grep "^$1|" | head -n1)"
+  [ -n "$line" ] || return 1
+  printf '%s\n' "${line#*|}"
 }
 
 require_script() {
@@ -64,6 +63,11 @@ require_script() {
 }
 
 run_all_workers() {
+  if [ -z "$WORKER_TABLE" ]; then
+    echo "No worker bundles found under $WORKER_DIST_DIR" >&2
+    exit 4
+  fi
+
   pids=""
 
   handle_shutdown() {
@@ -77,12 +81,12 @@ run_all_workers() {
   trap 'handle_shutdown' INT TERM
 
   # Validate all worker entrypoints first so we never start partially.
-  for worker in $ALL_WORKERS; do
+  for worker in $(all_worker_names); do
     script="$(resolve_worker_script "$worker")"
     require_script "$script"
   done
 
-  for worker in $ALL_WORKERS; do
+  for worker in $(all_worker_names); do
     script="$(resolve_worker_script "$worker")"
     echo "Starting worker: $worker ($script)"
     "$NODE_BIN" "$script" &


### PR DESCRIPTION
## Problem

`apps/worker/docker/rootfs/usr/local/bin/docker-entrypoint.sh` hardcoded the worker roster in **three** places — `ALL_WORKERS`, the `resolve_worker_script` case statement, and the `print_usage` string. The real source of truth is the `entry` array in `apps/worker/tsdown.config.ts`, which compiles one `dist/<dir>/worker*.mjs` bundle per entry. The two drifted:

- **`analytics`** (folded into the `events` worker) was still listed in `ALL_WORKERS`. Because the pre-start `require_script` check validates every entry, **`worker all` crashed at startup** (exit 4 on the missing `dist/analytics/worker.mjs`).
- **`events`**, **`sequence-producer`**, and **`sequence-consumer`** — all real built workers — were missing from `ALL_WORKERS`.

## Fix

Derive the roster at container startup by scanning `dist/` for `worker*.mjs` instead of hardcoding it. `ALL_WORKERS`, the resolver, and the usage string are all computed from the same discovered table.

- **Adding a worker to `tsdown.config.ts` is now the only change ever needed** — the container auto-discovers the new bundle.
- The script can never again reference a worker that wasn't built (kills the `analytics`-style crash class permanently).
- Path → name is mechanical (`<dir>/worker.mjs` → `<dir>`); a 2-line alias preserves the historical `sequence-producer` / `sequence-consumer` CLI names for the `worker-producer.mjs` / `worker-consumer.mjs` variants.
- `WORKER_DIST_DIR` / `NODE_BIN` are now env-overridable (defaults unchanged) so the script is testable.
- Added an empty-roster guard (clear error + exit 4 instead of silently starting nothing).

`worker all` start order becomes alphabetical (sorted) — workers are independent background processes, so order is not significant; this just makes it deterministic.

## Test plan

- [x] `sh -n` syntax check passes
- [x] New `apps/worker/__tests__/docker-entrypoint.test.ts` (vitest, 6 tests) — standard resolution, sequence aliases, auto-pickup of a brand-new `foo` worker with no script edit, rejection of an unbuilt worker (`analytics` → exit 3), dynamic usage list contains `events`/sequence variants and not `analytics`, empty-dist guard (exit 4). `pnpm --filter worker test docker-entrypoint` → 6/6 pass.
- [x] `pnpm --filter worker check-types` clean
- [x] Lint clean (ultracite)
- [x] Verified against the real built `dist/`: roster resolves to exactly the 11 built workers including `events` + sequence variants, no `analytics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
