### PR TITLE
fix(docker): emit seed runner as CommonJS to fix dynamic require crash

### DIFF
--- a/apps/builder/docker/Dockerfile
+++ b/apps/builder/docker/Dockerfile
@@ -42,8 +42,8 @@ RUN bash /app/migrate-runner/scripts/create-runner-package.sh migrate ./database
 WORKDIR /app
 RUN mkdir -p /app/seed-runner \
   && pnpm --filter "@chatbotx.io/database" exec esbuild src/seed/index.ts \
-    --bundle --platform=node --format=esm \
-    --outfile=/app/seed-runner/seed.mjs \
+    --bundle --platform=node --format=cjs \
+    --outfile=/app/seed-runner/seed.cjs \
     --external:pg
 
 WORKDIR /app/seed-runner

--- a/apps/builder/docker/rootfs/usr/local/bin/docker-entrypoint.sh
+++ b/apps/builder/docker/rootfs/usr/local/bin/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 if [ "${RUN_DB_SEED:-}" = "true" ]; then
   echo "Running database seed..."
-  SKIP_ENV_CHECK="${SKIP_ENV_CHECK:-true}" NODE_OPTIONS=--no-node-snapshot node /app/seed-runner/seed.mjs
+  SKIP_ENV_CHECK="${SKIP_ENV_CHECK:-true}" NODE_OPTIONS=--no-node-snapshot node /app/seed-runner/seed.cjs
 fi
 
 NODE_OPTIONS=--no-node-snapshot HOSTNAME="${HOSTNAME:-0.0.0.0}" PORT="${PORT:-3000}" exec node apps/builder/server.js


### PR DESCRIPTION
## Problem

The standalone builder image bundles `packages/database/src/seed/index.ts` with esbuild and runs it via `docker-entrypoint.sh` when `RUN_DB_SEED=true`. The seed crashed at runtime:

```
Error: Dynamic require of "node:os" is not supported
    at file:///app/seed-runner/seed.mjs:11:9
    at .../pino@10.3.1/node_modules/pino/pino.js
```

**Root cause:** the chain `seed/index.ts → ../client → ./logger → pino` pulls in `pino`, a CommonJS library that dynamically `require()`s Node built-ins at module-eval time. With `--format=esm`, esbuild cannot statically resolve those calls, so it emits a `__require` shim that throws in an ESM context (where `require` is undefined). This is esbuild CJS→ESM interop — unrelated to the repo's "no dynamic `import()`" rule.

## Fix

Emit the seed runner as a CommonJS bundle so `require` is native and the throwing shim is never generated. CJS is the natural fit — pino and the rest of the bundle are CJS-native, and the bundle is a runtime helper, not a workspace module.

- `apps/builder/docker/Dockerfile`: `--format=esm` → `--format=cjs`, `--outfile=…/seed.mjs` → `…/seed.cjs`
- `apps/builder/docker/rootfs/.../docker-entrypoint.sh`: seed invocation points at `seed.cjs`

No change to `create-runner-package.sh` — a `.cjs` extension is always CommonJS regardless of the generated runner `package.json` `type:module`.

## Test plan

- [x] Local bundle smoke test: rebuild with `--format=cjs`; the throwing `Dynamic require of` shim is no longer present in the output (`grep` count `0`).
- [x] Ran the CJS bundle under `node` against an unreachable DB — it loads cleanly through pino → drizzle → `pg` and fails only at DB connect (`ECONNREFUSED`), confirming the dynamic-require crash is gone.
- [ ] Docker build of the builder image succeeds at the esbuild step.
- [ ] Container run with `RUN_DB_SEED=true` against a live DB completes the seed and starts the app.