### PR TITLE
fix(docker): harden builder image build and seed/entrypoint runtime

### DIFF
--- a/apps/builder/docker/Dockerfile
+++ b/apps/builder/docker/Dockerfile
@@ -25,6 +25,15 @@ RUN pnpm install --frozen-lockfile
 COPY --from=pre /app/out/full/ .
 # COPY --from=pre /app/.env .env
 
+# Build-time placeholders. `next build` evaluates module-level code (better-auth
+# is instantiated when route/instrumentation modules load), so without these the
+# build logs a "Base URL could not be determined" warning and falls back to
+# better-auth's insecure default secret. Build-only: the `release` stage is a
+# fresh `FROM base`, so these never reach the runtime image — real values come
+# from the container environment at runtime.
+ENV BETTER_AUTH_SECRET="docker-build-time-placeholder-not-used-at-runtime-0"
+ENV BETTER_AUTH_URL="http://localhost:3000"
+
 RUN SKIP_ENV_CHECK=true pnpm turbo run build --filter=builder
 
 # Standalone image has no pnpm workspace; bundle a tiny migration runner (drizzle-orm + pg only).
@@ -40,6 +49,10 @@ RUN bash /app/migrate-runner/scripts/create-runner-package.sh migrate ./database
 
 # Bundled seed (workspace TS → single ESM file; `pg` stays external — installed below).
 WORKDIR /app
+# `turbo prune` omits the repo-root tsconfig.base.json that packages/database's
+# tsconfig extends; copy it back so esbuild resolves the `extends` instead of
+# warning "Cannot find base config file ../../tsconfig.base.json".
+COPY tsconfig.base.json ./tsconfig.base.json
 RUN mkdir -p /app/seed-runner \
   && pnpm --filter "@chatbotx.io/database" exec esbuild src/seed/index.ts \
     --bundle --platform=node --format=cjs \
@@ -67,4 +80,8 @@ COPY --from=deps --chown=nextjs:nodejs /app/migrate-runner ./migrate-runner
 COPY --from=deps --chown=nextjs:nodejs /app/seed-runner ./seed-runner
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+# Default command passed to the entrypoint. `serve` runs env-gated migrate/seed
+# then starts the server; override at run time with `migrate`, `seed`,
+# `migrate-seed`, or any other command (e.g. `sh`) — see docker-entrypoint.sh.
+CMD ["serve"]
 EXPOSE 3000

--- a/apps/builder/docker/rootfs/usr/local/bin/docker-entrypoint.sh
+++ b/apps/builder/docker/rootfs/usr/local/bin/docker-entrypoint.sh
@@ -2,14 +2,29 @@
 set -eu
 
 # Standalone output has no pnpm workspace; use /migrate-runner and /seed-runner (see Dockerfile).
-if [ "${RUN_DB_MIGRATE:-}" = "true" ]; then
+
+run_migrate() {
   echo "Running database migrations..."
   NODE_OPTIONS=--no-node-snapshot node /app/migrate-runner/scripts/run-migrations.mjs
-fi
+}
 
-if [ "${RUN_DB_SEED:-}" = "true" ]; then
+run_seed() {
   echo "Running database seed..."
   SKIP_ENV_CHECK="${SKIP_ENV_CHECK:-true}" NODE_OPTIONS=--no-node-snapshot node /app/seed-runner/seed.cjs
-fi
+}
 
-NODE_OPTIONS=--no-node-snapshot HOSTNAME="${HOSTNAME:-0.0.0.0}" PORT="${PORT:-3000}" exec node apps/builder/server.js
+start_server() {
+  # Backward-compatible env gating (no command passed): migrate/seed, then serve.
+  if [ "${RUN_DB_MIGRATE:-}" = "true" ]; then run_migrate; fi
+  if [ "${RUN_DB_SEED:-}" = "true" ]; then run_seed; fi
+  NODE_OPTIONS=--no-node-snapshot HOSTNAME="${HOSTNAME:-0.0.0.0}" PORT="${PORT:-3000}" \
+    exec node apps/builder/server.js
+}
+
+case "${1:-}" in
+  migrate)       run_migrate ;;            # one-shot, exits
+  seed)          run_seed ;;               # one-shot, exits
+  migrate-seed)  run_migrate; run_seed ;;  # one-shot, exits
+  serve|"")      start_server ;;           # default: env-gated + server
+  *)             exec "$@" ;;              # escape hatch (e.g. sh/debug)
+esac

--- a/apps/builder/src/instrumentation.ts
+++ b/apps/builder/src/instrumentation.ts
@@ -1,3 +1,13 @@
+import { PHASE_PRODUCTION_BUILD } from "next/constants"
+
 export async function register() {
+  // Next.js runs `register()` when it boots a server instance — including the
+  // throwaway instance spun up during `next build`. Skipping that phase keeps
+  // build from importing the oRPC server (and its transitive cache/DB clients),
+  // so no Redis/Postgres connection is attempted against a host that isn't there
+  // at build time.
+  if (process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD) {
+    return
+  }
   await import("./lib/orpc/orpc.server")
 }

--- a/packages/redis/src/redis-client.ts
+++ b/packages/redis/src/redis-client.ts
@@ -1,14 +1,27 @@
+import logger from "@chatbotx.io/logger"
 import { Redis, type RedisOptions } from "ioredis"
 
-export async function createRedisConnection(
+export function createRedisConnection(
   url: string,
   options: Partial<RedisOptions> = {},
-): Promise<Redis> {
+): Redis {
   const config: Partial<RedisOptions> = {
     maxRetriesPerRequest: null,
     keepAlive: 5000,
     ...options,
   }
 
-  return await new Redis(url, config)
+  const connection = new Redis(url, config)
+
+  // A shared, long-lived ioredis client emits 'error' on socket-level failures
+  // (server down, or — as during `next build` — a connection attempted with no
+  // Redis reachable). Without a listener Node treats 'error' as unhandled:
+  // ioredis logs a noisy "[ioredis] Unhandled error event", and an idle error
+  // with no in-flight command can crash the process. Callers already fail fast
+  // and fall back, so we only log here.
+  connection.on("error", (err) => {
+    logger.warn({ err }, "Redis connection error")
+  })
+
+  return connection
 }


### PR DESCRIPTION
## Summary

Fixes the noisy/incorrect behavior in the builder Docker image build (observed in the GitHub Actions build) and hardens the standalone runtime entrypoint. Two commits:

1. **Seed runner as CommonJS** (`4499f2b6`) — emit `seed.cjs` with `--format=cjs` so the bundled seed no longer crashes on a dynamic `require`.
2. **Build cleanup + entrypoint command dispatch** (this PR's new commit).

## Build-time warnings addressed

| Symptom | Fix |
|---|---|
| `[Better Auth] Base URL could not be determined` | Build-only `BETTER_AUTH_URL` placeholder in the `deps` stage |
| `[BetterAuthError] You are using the default secret` | Build-only `BETTER_AUTH_SECRET` placeholder in the `deps` stage |
| `[ioredis] Unhandled error event: ECONNREFUSED 127.0.0.1:6379` | Skip `instrumentation.register()` during `PHASE_PRODUCTION_BUILD` so the build never imports the oRPC server / connects to Redis; **plus** attach an `error` listener to the shared ioredis factory |
| esbuild `Cannot find base config file ../../tsconfig.base.json` | `COPY tsconfig.base.json` before the seed esbuild bundle so `extends` resolves |

The auth placeholders live only in the `deps` build stage — the `release` stage is a fresh `FROM base`, so they never reach the runtime image; real values come from the container environment at runtime.

## Runtime hardening

- **ioredis error listener**: a shared, long-lived client with no `error` listener can crash the process on an idle socket error (and produces the "Unhandled error event" log). Errors now log through the structured logger; callers already fail fast and fall back.
- **Entrypoint command dispatch**: `docker-entrypoint.sh` now routes `migrate` / `seed` / `migrate-seed` / `serve` one-shots, with `CMD ["serve"]` as the explicit default. The `serve` path is backward-compatible with the previous env-gated (`RUN_DB_MIGRATE` / `RUN_DB_SEED`) behavior.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm --filter builder check-types` and `@chatbotx.io/redis check-types` pass (full typecheck ran via commit hook)
- [ ] CI Docker build for builder produces a clean log (no Better Auth / ioredis / esbuild warnings)
- [ ] `docker run <img> migrate` / `seed` / `migrate-seed` run as one-shots and exit; default `serve` boots the server