### PR TITLE
build(apps): emit and enable source maps for server apps in production

### DIFF
--- a/apps/builder/docker/rootfs/usr/local/bin/docker-entrypoint.sh
+++ b/apps/builder/docker/rootfs/usr/local/bin/docker-entrypoint.sh
@@ -2,22 +2,23 @@
 set -eu
 
 # Standalone output has no pnpm workspace; use /migrate-runner and /seed-runner (see Dockerfile).
+# --enable-source-maps resolves production stack traces back to original TypeScript source.
 
 run_migrate() {
   echo "Running database migrations..."
-  NODE_OPTIONS=--no-node-snapshot node /app/migrate-runner/scripts/run-migrations.mjs
+  NODE_OPTIONS="--no-node-snapshot --enable-source-maps" node /app/migrate-runner/scripts/run-migrations.mjs
 }
 
 run_seed() {
   echo "Running database seed..."
-  SKIP_ENV_CHECK="${SKIP_ENV_CHECK:-true}" NODE_OPTIONS=--no-node-snapshot node /app/seed-runner/seed.cjs
+  SKIP_ENV_CHECK="${SKIP_ENV_CHECK:-true}" NODE_OPTIONS="--no-node-snapshot --enable-source-maps" node /app/seed-runner/seed.cjs
 }
 
 start_server() {
   # Backward-compatible env gating (no command passed): migrate/seed, then serve.
   if [ "${RUN_DB_MIGRATE:-}" = "true" ]; then run_migrate; fi
   if [ "${RUN_DB_SEED:-}" = "true" ]; then run_seed; fi
-  NODE_OPTIONS=--no-node-snapshot HOSTNAME="${HOSTNAME:-0.0.0.0}" PORT="${PORT:-3000}" \
+  NODE_OPTIONS="--no-node-snapshot --enable-source-maps" HOSTNAME="${HOSTNAME:-0.0.0.0}" PORT="${PORT:-3000}" \
     exec node apps/builder/server.js
 }
 

--- a/apps/mcp-server/docker/rootfs/usr/local/bin/docker-entrypoint.sh
+++ b/apps/mcp-server/docker/rootfs/usr/local/bin/docker-entrypoint.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-NODE_OPTIONS=--no-node-snapshot HOSTNAME=${HOSTNAME:-0.0.0.0} PORT=${PORT:-3000} node apps/mcp-server/dist/index.mjs;
+# --enable-source-maps resolves production stack traces back to original TypeScript source.
+NODE_OPTIONS="--no-node-snapshot --enable-source-maps" HOSTNAME=${HOSTNAME:-0.0.0.0} PORT=${PORT:-3000} node apps/mcp-server/dist/index.mjs;

--- a/apps/mcp-server/tsdown.config.ts
+++ b/apps/mcp-server/tsdown.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   // esbuildOptions(options) {
   //   options.jsx = "automatic"
   // },
-  sourcemap: false,
+  sourcemap: true,
   treeshake: true,
   banner: {
     js: "#!/usr/bin/env node",

--- a/apps/worker/docker/rootfs/usr/local/bin/docker-entrypoint.sh
+++ b/apps/worker/docker/rootfs/usr/local/bin/docker-entrypoint.sh
@@ -5,6 +5,10 @@ set -eu
 WORKER_DIST_DIR="${WORKER_DIST_DIR:-/app/apps/worker/dist}"
 NODE_BIN="${NODE_BIN:-/usr/local/bin/node}"
 
+# --enable-source-maps resolves production stack traces back to original TypeScript
+# source. Exported so every worker launched below (loop and single-worker exec) inherits it.
+export NODE_OPTIONS="${NODE_OPTIONS:-} --enable-source-maps"
+
 # Map a built bundle (dir + file basename without .mjs) to its roster name.
 # Standard:  <dir>/worker.mjs            -> <dir>
 # Variants:  <dir>/worker-<suffix>.mjs   -> <dir>-<suffix>, with aliases below

--- a/apps/worker/tsdown.config.ts
+++ b/apps/worker/tsdown.config.ts
@@ -29,6 +29,6 @@ export default defineConfig({
   minify: false,
   unbundle: false,
   // splitting: false,
-  sourcemap: false,
+  sourcemap: true,
   treeshake: true,
 })


### PR DESCRIPTION
## Why

Production stack traces are unreadable. Every server app builds **without source maps** and runs **without \`--enable-source-maps\`**, so traces point into bundled/minified output instead of original TypeScript. (Builder is a half-case: Next.js standalone *does* emit server \`.js.map\`, but \`node server.js\` ran without the flag, so they were never applied.)

## What changed

Two coordinated changes per app — *emit maps at build* + *enable them at the Node runtime*:

| App | Build | Runtime |
|-----|-------|---------|
| **worker** (tsdown, not minified) | `sourcemap: true` | `--enable-source-maps` exported once in entrypoint → inherited by the roster loop and single-worker `exec` |
| **mcp-server** (tsdown, minified) | `sourcemap: true` (minify kept — maps reverse it) | `--enable-source-maps` on the node invocation |
| **builder** (Next.js standalone) | no change — server `.js.map` already emitted | `--enable-source-maps` added to all node invocations (migrate, seed, serve) |

**No Dockerfile changes needed** — builder copies the whole `.next/standalone` (server maps included) and worker/mcp `COPY .../dist .../dist` wholesale, so the new `.map` files ship automatically.

## Out of scope (deliberate)
- CLI source maps (published npm package size tradeoff)
- Browser/client source maps for the builder (`productionBrowserSourceMaps` left off so client source stays private)
- `realtime` running `partykit dev` in prod; wiring a remote error sink (Sentry)

## Test plan
- [x] `pnpm --filter worker build` → 11 worker entry `.mjs.map` emitted; `//# sourceMappingURL=` present in bundles
- [x] `pnpm --filter chatbotx-mcp-server build` → `index.cjs.map` + `index.mjs.map` emitted
- [x] Runtime smoke test: running the worker bundle with `--enable-source-maps` produced a trace resolving to original TS — `packages/database/src/keys.ts:5:3` — not a bundled offset
- [x] `ultracite check` clean on edited TS configs
- [ ] (Optional) Build the worker/builder Docker images and confirm `.map` files are present inside the image