### PR TITLE
style(billing): make upgrade plan dialog responsive across breakpoints

### DIFF
--- a/apps/builder/src/enterprise/features/billing/upgrade-plan-dialog.tsx
+++ b/apps/builder/src/enterprise/features/billing/upgrade-plan-dialog.tsx
@@ -73,7 +73,7 @@ export function UpgradePlanDialog({
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent className="flex h-[85vh] w-[min(95vw,1100px)] max-w-none flex-col overflow-hidden p-0">
+      <DialogContent className="flex h-[92vh] w-[95vw] max-w-none flex-col overflow-hidden p-0 sm:max-w-none md:h-[88vh] md:w-[92vw] lg:h-[85vh] lg:w-[min(92vw,1100px)] xl:w-[min(90vw,1320px)] 2xl:w-[min(88vw,1480px)]">
         <DialogHeader className="border-b px-6 py-4 text-left">
           <DialogTitle className="flex items-center gap-2">
             <CrownIcon aria-hidden className="size-4 text-primary" />


### PR DESCRIPTION
## Summary

Makes the `UpgradePlanDialog` size adapt to the device viewport instead of using a single fixed size, so the plan comparison fits better on small screens and uses more of the available space on large displays.

## Changes

- `apps/builder/src/enterprise/features/billing/upgrade-plan-dialog.tsx`: replaced the static `DialogContent` sizing (`h-[85vh] w-[min(95vw,1100px)]`) with responsive breakpoint-based height/width:
  - **base (mobile):** `h-[92vh] w-[95vw]`
  - **md:** `h-[88vh] w-[92vw]`
  - **lg:** `h-[85vh] w-[min(92vw,1100px)]`
  - **xl:** `w-[min(90vw,1320px)]`
  - **2xl:** `w-[min(88vw,1480px)]`

## Test plan

- [ ] Open the upgrade plan dialog at 320 / 375 / 768 / 1024 / 1440 / 1920 widths — verify no overflow and the content fits comfortably at each breakpoint
- [ ] Confirm the dialog still scrolls internally and the header/border layout is intact