### PR TITLE
chore(deps): enable dependabot npm updates for pnpm workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,26 @@ updates:
       interval: "daily"
     registries:
       - dockerhub
+
+  # pnpm workspace: a single root entry covers every apps/* packages/* integrations/*
+  # member because they share one root pnpm-lock.yaml. Dependabot reads
+  # pnpm-workspace.yaml + packageManager (pnpm@10.x) automatically.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      production-minor-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"


### PR DESCRIPTION
## Summary
- Dependabot currently only updates Docker images; npm/pnpm dependencies and the root `pnpm-lock.yaml` are never bumped.
- Adds an `npm` package-ecosystem entry so Dependabot keeps the workspace dependencies up to date (relevant given the 64 vulnerabilities flagged on the default branch).

## Changes
- `.github/dependabot.yml`: single `package-ecosystem: "npm"` entry at `/`. One root entry covers every `apps/* packages/* integrations/*` member because they share one root `pnpm-lock.yaml`; Dependabot reads `pnpm-workspace.yaml` and the pinned pnpm version (`pnpm@10.33.2`) automatically.
- Weekly schedule, grouped dev + production minor/patch updates, and a 10-PR cap to limit noise. Major versions still arrive as individual PRs for review.

## Notes
- `"npm"` is Dependabot's umbrella ecosystem for the JS toolchain (npm/Yarn/pnpm) — there is no `"pnpm"` value. It updates `pnpm-lock.yaml`, not `package-lock.json`.
- Config takes effect once merged to `main`; GitHub schedules the first npm run after that.

## Test plan
- [ ] Dependabot validates the config (no errors under repo Insights → Dependency graph → Dependabot)
- [ ] First weekly run opens grouped PRs that modify `pnpm-lock.yaml`