### PR TITLE
feat(user-quota): stamp bootstrap trial row on cloud sign-up, per-tenant default plan

### DIFF
--- a/.devin/rules/chatbotx.md
+++ b/.devin/rules/chatbotx.md
@@ -20,6 +20,7 @@ pnpm workspaces + Turborepo · TypeScript 5 · React 19 · Next.js 16 (builder) 
 7. **No direct `db` in `apps/` or `integrations/`** — go through a service (`@chatbotx.io/business`) or repository (`@chatbotx.io/database/repositories`). See `.agents/rules/data-access.md`.
 8. **No dynamic `import()`** — it breaks the tsdown build. See `.agents/rules/no-dynamic-import.md`.
 9. **New workspace package** — run `CI=true pnpm install --no-frozen-lockfile` to link it.
+10. **Cloud signup stamps a bootstrap quota row.** On the cloud edition, `onUserCreated` synchronously writes a conservative `UserQuota` trial row (`ensureBootstrapPlan`) before enqueuing `publishEntitlements`. Don't assume a new cloud user has *no* quota row during the worker-sync gap, and don't treat the OSS layer as read-only for plan identity at signup. The private `quota-worker` remains the authority and re-anchors the row on its run.
 
 ## Workflow
 - After any change: `pnpm lint` + `pnpm --filter <app> check-types`. Use `pnpm fix`, never hand-format.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -476,3 +476,4 @@ See **`.agents/rules/git.md`** for the full canonical rules (commit format, bran
 - **No direct `db` in `apps/` or `integrations/`** — go through a service (`@chatbotx.io/business`) or repository (`@chatbotx.io/database/repositories`). See `.agents/rules/data-access.md`.
 - **No dynamic `import()`** — it breaks the tsdown build. See `.agents/rules/no-dynamic-import.md`.
 - **New workspace package** — run `CI=true pnpm install --no-frozen-lockfile` to link it.
+- **Cloud signup stamps a bootstrap quota row.** On the cloud edition, `onUserCreated` synchronously writes a conservative `UserQuota` trial row (`ensureBootstrapPlan`) before enqueuing `publishEntitlements`. Don't assume a new cloud user has *no* quota row during the worker-sync gap, and don't treat the OSS layer as read-only for plan identity at signup. The private `quota-worker` remains the authority and re-anchors the row on its run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,8 @@ These are the most common mistakes — read before writing any code:
 
 10. **White-label tenancy** — `User`/`Workspace` carry a `tenantId` that defaults to `ROOT_TENANT_ID` (`"1"`, the platform). `User` email is unique *per tenant* (`User_email_tenant_key`), never globally. Derive a new workspace's tenant via `workspaceService.resolveTenantForOwner` (owner-derived, never host-derived) — don't set `tenantId` from request input. Never accept or return `tenantId` from client input in auth: the tenant-scoped adapter stamps it from `getTenantId()`. See `docs/tenancy.md`.
 
+11. **Cloud signup stamps a bootstrap quota row.** On the cloud edition, `onUserCreated` synchronously writes a conservative `UserQuota` trial row (`ensureBootstrapPlan`) before enqueuing `publishEntitlements`. Don't assume a new cloud user has *no* quota row during the worker-sync gap, and don't treat the OSS layer as read-only for plan identity at signup. The private `quota-worker` remains the authority and re-anchors the row on its run.
+
 ## Git conventions
 
 See **`.agents/rules/git.md`** for the full canonical rules (commit format, branch naming, staging, PRs, changelog).

--- a/apps/builder/__tests__/on-user-created.test.ts
+++ b/apps/builder/__tests__/on-user-created.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment node
+
+import type { AuthCreatedUser } from "@chatbotx.io/auth/server"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { ensureBootstrapPlan, isCloud, loggerWarn, quotaQueueAdd } = vi.hoisted(
+  () => ({
+    ensureBootstrapPlan: vi.fn(async () => undefined),
+    isCloud: vi.fn(() => true),
+    loggerWarn: vi.fn(),
+    quotaQueueAdd: vi.fn(async () => undefined),
+  }),
+)
+
+vi.mock("@chatbotx.io/business", () => ({
+  userQuotaService: { ensureBootstrapPlan },
+}))
+
+vi.mock("@chatbotx.io/worker-config", () => ({
+  QuotaJobAction: { publishEntitlements: "publishEntitlements" },
+  quotaQueue: { add: quotaQueueAdd },
+}))
+
+vi.mock("@/env", () => ({ isCloud }))
+vi.mock("@/lib/log", () => ({ logger: { warn: loggerWarn } }))
+
+const { onUserCreated } = await import("@/lib/auth/on-user-created")
+
+const user = (overrides: Partial<AuthCreatedUser> = {}) =>
+  ({
+    id: "user-1",
+    isAnonymous: false,
+    ...overrides,
+  }) as AuthCreatedUser
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  isCloud.mockReturnValue(true)
+  ensureBootstrapPlan.mockResolvedValue(undefined)
+  quotaQueueAdd.mockResolvedValue(undefined)
+})
+
+describe("onUserCreated quota bootstrap", () => {
+  test("stamps the bootstrap plan before enqueueing entitlements on cloud", async () => {
+    const calls: string[] = []
+    ensureBootstrapPlan.mockImplementation(() => {
+      calls.push("bootstrap")
+      return Promise.resolve(undefined)
+    })
+    quotaQueueAdd.mockImplementation(() => {
+      calls.push("enqueue")
+      return Promise.resolve(undefined)
+    })
+
+    await onUserCreated(user())
+
+    expect(ensureBootstrapPlan).toHaveBeenCalledWith("user-1")
+    expect(quotaQueueAdd).toHaveBeenCalledWith("publishEntitlements", {
+      type: "publishEntitlements",
+      data: { userId: "user-1" },
+    })
+    expect(calls).toEqual(["bootstrap", "enqueue"])
+  })
+
+  test("skips bootstrap and enqueue outside cloud", async () => {
+    isCloud.mockReturnValue(false)
+
+    await onUserCreated(user())
+
+    expect(ensureBootstrapPlan).not.toHaveBeenCalled()
+    expect(quotaQueueAdd).not.toHaveBeenCalled()
+  })
+
+  test("skips bootstrap and enqueue for anonymous users", async () => {
+    await onUserCreated(user({ isAnonymous: true }))
+
+    expect(ensureBootstrapPlan).not.toHaveBeenCalled()
+    expect(quotaQueueAdd).not.toHaveBeenCalled()
+  })
+
+  test("continues enqueueing when bootstrap stamping fails", async () => {
+    const err = new Error("db down")
+    ensureBootstrapPlan.mockRejectedValue(err)
+
+    await expect(onUserCreated(user())).resolves.toBeUndefined()
+
+    expect(quotaQueueAdd).toHaveBeenCalledWith("publishEntitlements", {
+      type: "publishEntitlements",
+      data: { userId: "user-1" },
+    })
+    expect(loggerWarn).toHaveBeenCalledWith(
+      { err, userId: "user-1" },
+      "Failed to stamp bootstrap quota on sign-up",
+    )
+  })
+})

--- a/apps/builder/__tests__/on-user-created.test.ts
+++ b/apps/builder/__tests__/on-user-created.test.ts
@@ -54,7 +54,10 @@ describe("onUserCreated quota bootstrap", () => {
 
     await onUserCreated(user())
 
-    expect(ensureBootstrapPlan).toHaveBeenCalledWith("user-1")
+    expect(ensureBootstrapPlan).toHaveBeenCalledWith({
+      userId: "user-1",
+      tenantId: undefined,
+    })
     expect(quotaQueueAdd).toHaveBeenCalledWith("publishEntitlements", {
       type: "publishEntitlements",
       data: { userId: "user-1" },
@@ -92,5 +95,14 @@ describe("onUserCreated quota bootstrap", () => {
       { err, userId: "user-1" },
       "Failed to stamp bootstrap quota on sign-up",
     )
+  })
+
+  test("passes tenant id to the bootstrap stamp", async () => {
+    await onUserCreated(user({ tenantId: "tenant-42" }))
+
+    expect(ensureBootstrapPlan).toHaveBeenCalledWith({
+      userId: "user-1",
+      tenantId: "tenant-42",
+    })
   })
 })

--- a/apps/builder/next.config.ts
+++ b/apps/builder/next.config.ts
@@ -57,11 +57,11 @@ const nextConfig: NextConfig = {
           destination: `${s3Endpoint}/${s3Bucket}/:path*`,
         },
         { source: "/portal/:path*", destination: `${portalUrl}/portal/:path*` },
-        { source: "/pricing", destination: `${portalUrl}/portal/pricing` },
-        {
-          source: "/checkout/:path*",
-          destination: `${portalUrl}/portal/checkout/:path*`,
-        },
+        // { source: "/pricing", destination: `${portalUrl}/portal/pricing` },
+        // {
+        //   source: "/checkout/:path*",
+        //   destination: `${portalUrl}/portal/checkout/:path*`,
+        // },
         {
           source: "/api/checkout/:path*",
           destination: `${portalUrl}/portal/api/checkout/:path*`,

--- a/apps/builder/src/lib/auth/on-user-created.ts
+++ b/apps/builder/src/lib/auth/on-user-created.ts
@@ -26,7 +26,10 @@ export async function onUserCreated(user: AuthCreatedUser): Promise<void> {
   }
 
   try {
-    await userQuotaService.ensureBootstrapPlan(user.id)
+    await userQuotaService.ensureBootstrapPlan({
+      userId: user.id,
+      tenantId: user.tenantId,
+    })
   } catch (err) {
     logger.warn(
       { err, userId: user.id },

--- a/apps/builder/src/lib/auth/on-user-created.ts
+++ b/apps/builder/src/lib/auth/on-user-created.ts
@@ -1,26 +1,37 @@
 import type { AuthCreatedUser } from "@chatbotx.io/auth/server"
+import { userQuotaService } from "@chatbotx.io/business"
 import { QuotaJobAction, quotaQueue } from "@chatbotx.io/worker-config"
 import { isCloud } from "@/env"
 import { logger } from "@/lib/log"
 
 /**
  * Wired into `createAuth` as the `onUserCreated` callback, so it fires once on
- * every sign-up path (email/password, social, magic link). On cloud it enqueues
- * a `publishEntitlements` job on the BullMQ `quota` queue — the cross-repo
- * contract the private `quota-worker` consumes to write the new user's
- * trial/free entitlement snapshot. The contract is the queue name + job shape
- * only; no enterprise package is imported here. On other editions it's a no-op
- * (no quota row → unlimited). Anonymous-plugin users are skipped — they're
- * throwaway accounts that shouldn't get a subscription.
+ * every sign-up path (email/password, social, magic link). On cloud it first
+ * stamps a conservative bootstrap trial row, then enqueues a
+ * `publishEntitlements` job on the BullMQ `quota` queue — the cross-repo
+ * contract the private `quota-worker` consumes to reconcile the new user's
+ * authoritative entitlement snapshot. The contract is the queue name + job
+ * shape only; no enterprise package is imported here. On other editions it's a
+ * no-op (no quota row → unlimited). Anonymous-plugin users are skipped —
+ * they're throwaway accounts that shouldn't get a subscription.
  *
- * Best-effort: a brief gap between sign-up and the worker writing the per-user
- * row is covered by the fail-open `entitlements:default-plan` overlay, so a
- * failed enqueue is logged and swallowed and never blocks sign-up. The backfill
- * job reconciles anything missed here.
+ * Best-effort: the bootstrap row closes the sign-up-to-worker gap; the
+ * fail-open `entitlements:default-plan` overlay is now only a secondary
+ * last-resort fallback. Failures are logged and swallowed and never block
+ * sign-up. The backfill job reconciles anything missed here.
  */
 export async function onUserCreated(user: AuthCreatedUser): Promise<void> {
   if (!isCloud() || user.isAnonymous) {
     return
+  }
+
+  try {
+    await userQuotaService.ensureBootstrapPlan(user.id)
+  } catch (err) {
+    logger.warn(
+      { err, userId: user.id },
+      "Failed to stamp bootstrap quota on sign-up",
+    )
   }
 
   try {

--- a/packages/business/__tests__/user-quota-bootstrap-plan.test.ts
+++ b/packages/business/__tests__/user-quota-bootstrap-plan.test.ts
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const DEFAULT_PLAN_ENTITLEMENT_KEY = "entitlements:default-plan"
+const USER = "user-1"
+
+const {
+  dbInsert,
+  distributedStore,
+  insertBuilder,
+  isCloud,
+  loggerWarn,
+  userQuotaModel,
+} = vi.hoisted(() => {
+  const userQuotaModel = {
+    userId: "userId-column",
+    contactsUsed: "contactsUsed-column",
+    workspacesUsed: "workspacesUsed-column",
+    channelsUsed: "channelsUsed-column",
+    teamMembersUsed: "teamMembersUsed-column",
+    macUsed: "macUsed-column",
+  }
+  const insertBuilder = {
+    values: vi.fn(),
+    onConflictDoNothing: vi.fn(),
+    returning: vi.fn(async () => [{ userId: USER }]),
+  }
+  insertBuilder.values.mockReturnValue(insertBuilder)
+  insertBuilder.onConflictDoNothing.mockReturnValue(insertBuilder)
+
+  return {
+    dbInsert: vi.fn(() => insertBuilder),
+    distributedStore: {
+      get: vi.fn(async () => null as unknown),
+      put: vi.fn(async () => undefined),
+      delete: vi.fn(async () => undefined),
+    },
+    insertBuilder,
+    isCloud: vi.fn(() => true),
+    loggerWarn: vi.fn(),
+    userQuotaModel,
+  }
+})
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    insert: dbInsert,
+    query: { userQuotaModel: { findFirst: vi.fn(async () => null) } },
+  },
+  eq: vi.fn(),
+  sql: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({ userQuotaModel }))
+
+vi.mock("@chatbotx.io/redis", () => ({
+  cacheConnections: {
+    useExisting: vi.fn(async () => ({
+      hget: vi.fn(async () => null),
+      hsetnx: vi.fn(async () => 1),
+      hincrby: vi.fn(async () => 1),
+    })),
+  },
+  distributedStore,
+  invalidateCacheByTags: vi.fn(async () => undefined),
+}))
+
+vi.mock("../src/keys", () => ({ isCloud }))
+vi.mock("../src/logger", () => ({ logger: { warn: loggerWarn } }))
+
+const { userQuotaService } = await import("../src/user-quota/service")
+
+const snapshot = {
+  channelsLimit: 2,
+  contactsLimit: 1000,
+  macLimit: 100,
+  planName: "Free",
+  saasMode: true,
+  ssoSaml: false,
+  teamMembersLimit: 3,
+  trialDays: 14,
+  whiteLabel: true,
+  workspacesLimit: 4,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  isCloud.mockReturnValue(true)
+  distributedStore.get.mockResolvedValue(null)
+  insertBuilder.values.mockClear().mockReturnValue(insertBuilder)
+  insertBuilder.onConflictDoNothing.mockClear().mockReturnValue(insertBuilder)
+  insertBuilder.returning.mockClear().mockResolvedValue([{ userId: USER }])
+})
+
+describe("userQuotaService.ensureBootstrapPlan", () => {
+  test("stamps a trial row from the default-plan snapshot", async () => {
+    distributedStore.get.mockImplementation(async (key: string) =>
+      key === DEFAULT_PLAN_ENTITLEMENT_KEY ? snapshot : null,
+    )
+
+    await userQuotaService.ensureBootstrapPlan(USER)
+
+    expect(dbInsert).toHaveBeenCalledWith(userQuotaModel)
+    expect(insertBuilder.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: USER,
+        contactsLimit: 1000,
+        workspacesLimit: 4,
+        channelsLimit: 2,
+        teamMembersLimit: 3,
+        macLimit: 100,
+        whiteLabel: false,
+        ssoSaml: false,
+        saasMode: false,
+        planName: "Free",
+        planStatus: "trial",
+      }),
+    )
+    expect(insertBuilder.onConflictDoNothing).toHaveBeenCalledWith({
+      target: userQuotaModel.userId,
+    })
+    const [values] = insertBuilder.values.mock.calls[0]
+    expect(values.periodStart).toBeInstanceOf(Date)
+    expect(values.periodEnd).toBeInstanceOf(Date)
+    expect(values.periodEnd.getTime()).toBeGreaterThan(Date.now())
+    expect(distributedStore.delete).toHaveBeenCalledWith(`user-quota:${USER}`)
+  })
+
+  test("falls back to the lockdown trial length when snapshot trialDays is invalid", async () => {
+    distributedStore.get.mockImplementation(async (key: string) =>
+      key === DEFAULT_PLAN_ENTITLEMENT_KEY
+        ? { ...snapshot, trialDays: undefined }
+        : null,
+    )
+
+    const before = Date.now()
+
+    await userQuotaService.ensureBootstrapPlan(USER)
+
+    const [values] = insertBuilder.values.mock.calls[0]
+    const fallbackMs = 24 * 60 * 60 * 1000
+    expect(values.planStatus).toBe("trial")
+    expect(values.periodEnd).toBeInstanceOf(Date)
+    expect(values.periodEnd.getTime()).toBeGreaterThanOrEqual(
+      before + fallbackMs,
+    )
+    expect(values.periodEnd.getTime()).toBeLessThanOrEqual(
+      Date.now() + fallbackMs,
+    )
+  })
+
+  test("stamps an active, never-expiring row when snapshot trialDays is 0", async () => {
+    distributedStore.get.mockImplementation(async (key: string) =>
+      key === DEFAULT_PLAN_ENTITLEMENT_KEY
+        ? { ...snapshot, trialDays: 0 }
+        : null,
+    )
+
+    await userQuotaService.ensureBootstrapPlan(USER)
+
+    const [values] = insertBuilder.values.mock.calls[0]
+    expect(values.planStatus).toBe("active")
+    expect(values.periodEnd).toBeNull()
+
+    const accessState = userQuotaService.getAccessStateFromQuota({
+      id: "quota-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      contactsUsed: 0,
+      workspacesUsed: 0,
+      channelsUsed: 0,
+      teamMembersUsed: 0,
+      macUsed: 0,
+      ...values,
+    })
+    expect(accessState).toMatchObject({ blocked: false, status: "active" })
+    expect(accessState.trialEndsAt).toBeNull()
+  })
+
+  test("skips the cache bust when the insert was a no-op conflict", async () => {
+    insertBuilder.returning.mockResolvedValue([])
+
+    await userQuotaService.ensureBootstrapPlan(USER)
+
+    expect(insertBuilder.onConflictDoNothing).toHaveBeenCalledWith({
+      target: userQuotaModel.userId,
+    })
+    expect(distributedStore.delete).not.toHaveBeenCalled()
+  })
+
+  test("stamps the lockdown fallback when the snapshot is absent", async () => {
+    await userQuotaService.ensureBootstrapPlan(USER)
+
+    expect(insertBuilder.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: USER,
+        contactsLimit: 100,
+        workspacesLimit: 1,
+        channelsLimit: 1,
+        teamMembersLimit: 1,
+        macLimit: 1,
+        whiteLabel: false,
+        ssoSaml: false,
+        saasMode: false,
+        planName: "Trial",
+        planStatus: "trial",
+      }),
+    )
+  })
+
+  test("does not clobber an existing quota row", async () => {
+    await userQuotaService.ensureBootstrapPlan(USER)
+
+    expect(insertBuilder.onConflictDoNothing).toHaveBeenCalledWith({
+      target: userQuotaModel.userId,
+    })
+    expect(dbInsert).toHaveBeenCalledTimes(1)
+  })
+
+  test("no-ops outside cloud edition", async () => {
+    isCloud.mockReturnValue(false)
+
+    await userQuotaService.ensureBootstrapPlan(USER)
+
+    expect(distributedStore.get).not.toHaveBeenCalled()
+    expect(dbInsert).not.toHaveBeenCalled()
+    expect(distributedStore.delete).not.toHaveBeenCalled()
+  })
+
+  test("creates an unblocked active trial access state", async () => {
+    await userQuotaService.ensureBootstrapPlan(USER)
+
+    const [values] = insertBuilder.values.mock.calls[0]
+    const accessState = userQuotaService.getAccessStateFromQuota({
+      id: "quota-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      contactsUsed: 0,
+      workspacesUsed: 0,
+      channelsUsed: 0,
+      teamMembersUsed: 0,
+      macUsed: 0,
+      ...values,
+    })
+
+    expect(accessState).toMatchObject({
+      blocked: false,
+      planName: "Trial",
+      status: "trial",
+    })
+    expect(accessState.trialEndsAt).toBeInstanceOf(Date)
+  })
+})

--- a/packages/business/__tests__/user-quota-bootstrap-plan.test.ts
+++ b/packages/business/__tests__/user-quota-bootstrap-plan.test.ts
@@ -50,7 +50,10 @@ vi.mock("@chatbotx.io/database/client", () => ({
   sql: vi.fn(),
 }))
 
-vi.mock("@chatbotx.io/database/schema", () => ({ userQuotaModel }))
+vi.mock("@chatbotx.io/database/schema", () => ({
+  ROOT_TENANT_ID: "1",
+  userQuotaModel,
+}))
 
 vi.mock("@chatbotx.io/redis", () => ({
   cacheConnections: {
@@ -97,7 +100,7 @@ describe("userQuotaService.ensureBootstrapPlan", () => {
       key === DEFAULT_PLAN_ENTITLEMENT_KEY ? snapshot : null,
     )
 
-    await userQuotaService.ensureBootstrapPlan(USER)
+    await userQuotaService.ensureBootstrapPlan({ userId: USER })
 
     expect(dbInsert).toHaveBeenCalledWith(userQuotaModel)
     expect(insertBuilder.values).toHaveBeenCalledWith(
@@ -134,7 +137,7 @@ describe("userQuotaService.ensureBootstrapPlan", () => {
 
     const before = Date.now()
 
-    await userQuotaService.ensureBootstrapPlan(USER)
+    await userQuotaService.ensureBootstrapPlan({ userId: USER })
 
     const [values] = insertBuilder.values.mock.calls[0]
     const fallbackMs = 24 * 60 * 60 * 1000
@@ -155,7 +158,7 @@ describe("userQuotaService.ensureBootstrapPlan", () => {
         : null,
     )
 
-    await userQuotaService.ensureBootstrapPlan(USER)
+    await userQuotaService.ensureBootstrapPlan({ userId: USER })
 
     const [values] = insertBuilder.values.mock.calls[0]
     expect(values.planStatus).toBe("active")
@@ -179,7 +182,7 @@ describe("userQuotaService.ensureBootstrapPlan", () => {
   test("skips the cache bust when the insert was a no-op conflict", async () => {
     insertBuilder.returning.mockResolvedValue([])
 
-    await userQuotaService.ensureBootstrapPlan(USER)
+    await userQuotaService.ensureBootstrapPlan({ userId: USER })
 
     expect(insertBuilder.onConflictDoNothing).toHaveBeenCalledWith({
       target: userQuotaModel.userId,
@@ -188,7 +191,7 @@ describe("userQuotaService.ensureBootstrapPlan", () => {
   })
 
   test("stamps the lockdown fallback when the snapshot is absent", async () => {
-    await userQuotaService.ensureBootstrapPlan(USER)
+    await userQuotaService.ensureBootstrapPlan({ userId: USER })
 
     expect(insertBuilder.values).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -208,7 +211,7 @@ describe("userQuotaService.ensureBootstrapPlan", () => {
   })
 
   test("does not clobber an existing quota row", async () => {
-    await userQuotaService.ensureBootstrapPlan(USER)
+    await userQuotaService.ensureBootstrapPlan({ userId: USER })
 
     expect(insertBuilder.onConflictDoNothing).toHaveBeenCalledWith({
       target: userQuotaModel.userId,
@@ -219,7 +222,7 @@ describe("userQuotaService.ensureBootstrapPlan", () => {
   test("no-ops outside cloud edition", async () => {
     isCloud.mockReturnValue(false)
 
-    await userQuotaService.ensureBootstrapPlan(USER)
+    await userQuotaService.ensureBootstrapPlan({ userId: USER })
 
     expect(distributedStore.get).not.toHaveBeenCalled()
     expect(dbInsert).not.toHaveBeenCalled()
@@ -227,7 +230,7 @@ describe("userQuotaService.ensureBootstrapPlan", () => {
   })
 
   test("creates an unblocked active trial access state", async () => {
-    await userQuotaService.ensureBootstrapPlan(USER)
+    await userQuotaService.ensureBootstrapPlan({ userId: USER })
 
     const [values] = insertBuilder.values.mock.calls[0]
     const accessState = userQuotaService.getAccessStateFromQuota({
@@ -248,5 +251,58 @@ describe("userQuotaService.ensureBootstrapPlan", () => {
       status: "trial",
     })
     expect(accessState.trialEndsAt).toBeInstanceOf(Date)
+  })
+
+  test("uses a tenant snapshot for a non-root tenant", async () => {
+    const tenantId = "tenant-42"
+    distributedStore.get.mockImplementation(async (key: string) =>
+      key === `${DEFAULT_PLAN_ENTITLEMENT_KEY}:${tenantId}`
+        ? { ...snapshot, planName: "Tenant Free", macLimit: 250 }
+        : null,
+    )
+
+    await userQuotaService.ensureBootstrapPlan({ userId: USER, tenantId })
+
+    expect(distributedStore.get).toHaveBeenCalledWith(
+      `${DEFAULT_PLAN_ENTITLEMENT_KEY}:${tenantId}`,
+    )
+    expect(distributedStore.get).not.toHaveBeenCalledWith(
+      DEFAULT_PLAN_ENTITLEMENT_KEY,
+    )
+    expect(insertBuilder.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: USER,
+        macLimit: 250,
+        planName: "Tenant Free",
+      }),
+    )
+  })
+
+  test("uses the lockdown fallback when a tenant snapshot is missing", async () => {
+    const tenantId = "tenant-42"
+    distributedStore.get.mockImplementation(async (key: string) =>
+      key === DEFAULT_PLAN_ENTITLEMENT_KEY ? snapshot : null,
+    )
+
+    await userQuotaService.ensureBootstrapPlan({ userId: USER, tenantId })
+
+    expect(distributedStore.get).toHaveBeenCalledWith(
+      `${DEFAULT_PLAN_ENTITLEMENT_KEY}:${tenantId}`,
+    )
+    expect(distributedStore.get).not.toHaveBeenCalledWith(
+      DEFAULT_PLAN_ENTITLEMENT_KEY,
+    )
+    expect(insertBuilder.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: USER,
+        contactsLimit: 0,
+        workspacesLimit: 0,
+        channelsLimit: 0,
+        teamMembersLimit: 0,
+        macLimit: 0,
+        planName: "Trial",
+        planStatus: "trial",
+      }),
+    )
   })
 })

--- a/packages/business/__tests__/user-quota-bootstrap-plan.test.ts
+++ b/packages/business/__tests__/user-quota-bootstrap-plan.test.ts
@@ -193,11 +193,11 @@ describe("userQuotaService.ensureBootstrapPlan", () => {
     expect(insertBuilder.values).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: USER,
-        contactsLimit: 100,
-        workspacesLimit: 1,
-        channelsLimit: 1,
-        teamMembersLimit: 1,
-        macLimit: 1,
+        contactsLimit: 0,
+        workspacesLimit: 0,
+        channelsLimit: 0,
+        teamMembersLimit: 0,
+        macLimit: 0,
         whiteLabel: false,
         ssoSaml: false,
         saasMode: false,

--- a/packages/business/__tests__/user-quota-default-plan.test.ts
+++ b/packages/business/__tests__/user-quota-default-plan.test.ts
@@ -3,12 +3,21 @@ import { beforeEach, describe, expect, test, vi } from "vitest"
 const DEFAULT_PLAN_ENTITLEMENT_KEY = "entitlements:default-plan"
 
 const findFirstQuota = vi.fn(async () => null as unknown)
+const findFirstUser = vi.fn(async () => null as unknown)
 vi.mock("@chatbotx.io/database/client", () => ({
-  db: { query: { userQuotaModel: { findFirst: findFirstQuota } } },
+  db: {
+    query: {
+      userQuotaModel: { findFirst: findFirstQuota },
+      userModel: { findFirst: findFirstUser },
+    },
+  },
   eq: vi.fn(),
   sql: vi.fn(),
 }))
-vi.mock("@chatbotx.io/database/schema", () => ({ userQuotaModel: {} }))
+vi.mock("@chatbotx.io/database/schema", () => ({
+  userQuotaModel: {},
+  ROOT_TENANT_ID: "1",
+}))
 
 const storeGet = vi.fn(async (_key: string) => null as unknown)
 const distributedStore = {
@@ -61,6 +70,8 @@ beforeEach(() => {
   vi.clearAllMocks()
   storeGet.mockResolvedValue(null)
   findFirstQuota.mockResolvedValue(null)
+  // Default: user not found → tenantId null → resolves the global platform key.
+  findFirstUser.mockResolvedValue(null)
 })
 
 describe("userQuotaService default-plan overlay (macLimit)", () => {
@@ -146,5 +157,58 @@ describe("userQuotaService default-plan overlay (macLimit)", () => {
     const quota = await userQuotaService.getForUser(USER)
 
     expect(quota).toBeNull()
+  })
+})
+
+describe("userQuotaService per-tenant default-plan resolution", () => {
+  const TENANT = "42"
+  const TENANT_KEY = `${DEFAULT_PLAN_ENTITLEMENT_KEY}:${TENANT}`
+  /** Reseller's own default — distinct macLimit so we can tell which key won. */
+  const resellerSnapshot = { ...snapshot, planName: "Reseller Free", macLimit: 999 }
+
+  /** Route the row cache, the global default key, and the per-tenant key. */
+  const routeStore = (opts: { global: unknown; tenant?: unknown }) => {
+    storeGet.mockImplementation(async (key: string) => {
+      if (key === TENANT_KEY) {
+        return opts.tenant ?? null
+      }
+      if (key === DEFAULT_PLAN_ENTITLEMENT_KEY) {
+        return opts.global
+      }
+      return null // row cache miss
+    })
+  }
+
+  test("sub-account prefers its reseller per-tenant snapshot over the global default", async () => {
+    findFirstQuota.mockResolvedValue(null)
+    findFirstUser.mockResolvedValue({ tenantId: TENANT })
+    routeStore({ global: snapshot, tenant: resellerSnapshot })
+
+    const quota = await userQuotaService.getForUser(USER)
+
+    expect(quota?.macLimit).toBe(999)
+    expect(quota?.planName).toBe("Reseller Free")
+  })
+
+  test("sub-account with no reseller default does not read the global default", async () => {
+    findFirstQuota.mockResolvedValue(null)
+    findFirstUser.mockResolvedValue({ tenantId: TENANT })
+    routeStore({ global: snapshot, tenant: null })
+
+    const quota = await userQuotaService.getForUser(USER)
+
+    expect(quota).toBeNull()
+    expect(storeGet).not.toHaveBeenCalledWith(DEFAULT_PLAN_ENTITLEMENT_KEY)
+  })
+
+  test("root-tenant user reads the global default and ignores any tenant key", async () => {
+    findFirstQuota.mockResolvedValue(null)
+    findFirstUser.mockResolvedValue({ tenantId: "1" })
+    routeStore({ global: snapshot, tenant: resellerSnapshot })
+
+    const quota = await userQuotaService.getForUser(USER)
+
+    expect(quota?.macLimit).toBe(100)
+    expect(quota?.planName).toBe("Free")
   })
 })

--- a/packages/business/__tests__/user-quota-default-plan.test.ts
+++ b/packages/business/__tests__/user-quota-default-plan.test.ts
@@ -164,18 +164,22 @@ describe("userQuotaService per-tenant default-plan resolution", () => {
   const TENANT = "42"
   const TENANT_KEY = `${DEFAULT_PLAN_ENTITLEMENT_KEY}:${TENANT}`
   /** Reseller's own default — distinct macLimit so we can tell which key won. */
-  const resellerSnapshot = { ...snapshot, planName: "Reseller Free", macLimit: 999 }
+  const resellerSnapshot = {
+    ...snapshot,
+    planName: "Reseller Free",
+    macLimit: 999,
+  }
 
   /** Route the row cache, the global default key, and the per-tenant key. */
   const routeStore = (opts: { global: unknown; tenant?: unknown }) => {
-    storeGet.mockImplementation(async (key: string) => {
+    storeGet.mockImplementation((key: string) => {
       if (key === TENANT_KEY) {
-        return opts.tenant ?? null
+        return Promise.resolve(opts.tenant ?? null)
       }
       if (key === DEFAULT_PLAN_ENTITLEMENT_KEY) {
-        return opts.global
+        return Promise.resolve(opts.global)
       }
-      return null // row cache miss
+      return Promise.resolve(null) // row cache miss
     })
   }
 

--- a/packages/business/src/user-quota/service.ts
+++ b/packages/business/src/user-quota/service.ts
@@ -4,6 +4,7 @@ import { userQuotaModel } from "@chatbotx.io/database/schema"
 import type { UserQuotaModel } from "@chatbotx.io/database/types"
 import { distributedStore } from "@chatbotx.io/redis"
 import { BaseService } from "../base.service"
+import { isCloud } from "../keys"
 import { logger } from "../logger"
 import {
   LiveCounterStore,
@@ -15,11 +16,22 @@ export type { QuotaMetric } from "../quota-shared/live-counter-store"
 
 /**
  * Cross-repo contract key (read-only here). The enterprise billing layer writes
- * the platform default plan's entitlements to this key; we read it as the
- * free-tier fallback for users with no per-user UserQuota row. Absent in pure
- * OSS installs → no fallback (unlimited), preserving prior behavior.
+ * the platform default plan's entitlements to this key; cloud sign-up uses it
+ * to stamp the initial bootstrap row. The legacy free-tier overlay still reads
+ * it as a secondary fallback for failed stamps and usage-only rows. Absent in
+ * pure OSS installs → no overlay fallback (unlimited), preserving prior behavior.
  */
 const DEFAULT_PLAN_ENTITLEMENT_KEY = "entitlements:default-plan"
+
+const BOOTSTRAP_TRIAL_FALLBACK = {
+  planName: "Trial",
+  trialDays: 1,
+  workspacesLimit: 1,
+  macLimit: 1,
+  channelsLimit: 1,
+  teamMembersLimit: 1,
+  contactsLimit: 100,
+} as const
 
 interface DefaultPlanSnapshot {
   channelsLimit: number | null
@@ -33,6 +45,17 @@ interface DefaultPlanSnapshot {
   whiteLabel: boolean
   workspacesLimit: number | null
 }
+
+type BootstrapPlanSnapshot = Pick<
+  DefaultPlanSnapshot,
+  | "channelsLimit"
+  | "contactsLimit"
+  | "macLimit"
+  | "planName"
+  | "teamMembersLimit"
+  | "trialDays"
+  | "workspacesLimit"
+>
 
 /**
  * Result of evaluating whether a user may access the app. `blocked` is the only
@@ -123,6 +146,78 @@ class UserQuotaService extends BaseService {
     return null
   }
 
+  private async readDefaultPlanSnapshot(): Promise<DefaultPlanSnapshot | null> {
+    try {
+      return await distributedStore.get<DefaultPlanSnapshot>(
+        DEFAULT_PLAN_ENTITLEMENT_KEY,
+      )
+    } catch (err) {
+      logger.warn({ err }, "user-quota: default-plan snapshot read failed")
+      return null
+    }
+  }
+
+  /**
+   * Stamp a real cloud sign-up quota row before the private quota-worker runs.
+   * Idempotent by `UserQuota.userId`; the worker remains authoritative and may
+   * overwrite this bootstrap row on its next `publishEntitlements` sync.
+   */
+  async ensureBootstrapPlan(userId: string): Promise<void> {
+    if (!isCloud()) {
+      return
+    }
+
+    try {
+      const snapshot: BootstrapPlanSnapshot =
+        (await this.readDefaultPlanSnapshot()) ?? BOOTSTRAP_TRIAL_FALLBACK
+      const now = new Date()
+      // Distinguish a malformed snapshot (NaN → 1-day lockdown) from an
+      // explicit `0`/negative trial length (a free-forever default plan →
+      // `active`, never expires). Only the malformed case falls back.
+      const rawTrialDays = Number(snapshot.trialDays)
+      const trialDays = Number.isFinite(rawTrialDays)
+        ? Math.max(0, rawTrialDays)
+        : BOOTSTRAP_TRIAL_FALLBACK.trialDays
+      const isTrial = trialDays > 0
+      const periodEnd = isTrial
+        ? new Date(now.getTime() + trialDays * 24 * 60 * 60 * 1000)
+        : null
+
+      const inserted = await db
+        .insert(userQuotaModel)
+        .values({
+          userId,
+          contactsLimit: snapshot.contactsLimit,
+          workspacesLimit: snapshot.workspacesLimit,
+          channelsLimit: snapshot.channelsLimit,
+          teamMembersLimit: snapshot.teamMembersLimit,
+          macLimit: snapshot.macLimit,
+          whiteLabel: false,
+          ssoSaml: false,
+          saasMode: false,
+          planName: snapshot.planName,
+          planStatus: isTrial
+            ? planStatuses.enum.trial
+            : planStatuses.enum.active,
+          periodStart: now,
+          periodEnd,
+          syncedAt: now,
+        })
+        .onConflictDoNothing({ target: userQuotaModel.userId })
+        .returning({ userId: userQuotaModel.userId })
+
+      // Only bust the cache when we actually wrote a row. On a no-op conflict
+      // (hook retry, re-signup, or the worker winning the race) there is
+      // nothing new to invalidate — and skipping it preserves any freshly
+      // cached authoritative row the worker just wrote.
+      if (inserted.length > 0) {
+        await this.store.invalidate(userId)
+      }
+    } catch (err) {
+      logger.warn({ err, userId }, "user-quota: bootstrap plan stamp failed")
+    }
+  }
+
   /**
    * Overlay the shared default-plan entitlement snapshot onto a free-tier user.
    * Fills only unset (null) limit fields and the plan identity, preserving any
@@ -132,15 +227,7 @@ class UserQuotaService extends BaseService {
     userId: string,
     quota: UserQuotaModel | null,
   ): Promise<UserQuotaModel | null> {
-    let snapshot: DefaultPlanSnapshot | null = null
-    try {
-      snapshot = await distributedStore.get<DefaultPlanSnapshot>(
-        DEFAULT_PLAN_ENTITLEMENT_KEY,
-      )
-    } catch (err) {
-      logger.warn({ err }, "user-quota: default-plan snapshot read failed")
-      return null
-    }
+    const snapshot = await this.readDefaultPlanSnapshot()
     if (!snapshot) {
       return null
     }
@@ -185,9 +272,9 @@ class UserQuotaService extends BaseService {
       ssoSaml: base.ssoSaml || snapshot.ssoSaml,
       saasMode: base.saasMode || snapshot.saasMode,
       planName: base.planName ?? snapshot.planName,
-      // Fail-open: a user with no per-user row yet (gap between sign-up and the
-      // quota-worker) is never blocked. The worker later writes the real status
-      // ("trial" + periodEnd, etc.), which getAccessState then enforces.
+      // Secondary fail-open fallback: normally cloud sign-up stamps a real
+      // bootstrap row first. If that stamp failed, or for legacy usage-only rows,
+      // the overlay still avoids blocking while the worker writes real status.
       planStatus: base.planStatus ?? planStatuses.enum.active,
     }
   }

--- a/packages/business/src/user-quota/service.ts
+++ b/packages/business/src/user-quota/service.ts
@@ -23,14 +23,19 @@ export type { QuotaMetric } from "../quota-shared/live-counter-store"
  */
 const DEFAULT_PLAN_ENTITLEMENT_KEY = "entitlements:default-plan"
 
+// Last-resort fallback used only when the default-plan snapshot is unreadable
+// (cold/flushed Redis). A 1-day `trial` keeps the user signed in but every
+// limit is `0`, so they cannot create anything until the authoritative
+// quota-worker re-anchors the row — a deliberate fail-closed-on-capacity stance
+// for the snapshot-absent window (the user can log in, but not act).
 const BOOTSTRAP_TRIAL_FALLBACK = {
   planName: "Trial",
   trialDays: 1,
-  workspacesLimit: 1,
-  macLimit: 1,
-  channelsLimit: 1,
-  teamMembersLimit: 1,
-  contactsLimit: 100,
+  workspacesLimit: 0,
+  macLimit: 0,
+  channelsLimit: 0,
+  teamMembersLimit: 0,
+  contactsLimit: 0,
 } as const
 
 interface DefaultPlanSnapshot {

--- a/packages/business/src/user-quota/service.ts
+++ b/packages/business/src/user-quota/service.ts
@@ -174,6 +174,8 @@ class UserQuotaService extends BaseService {
    * Stamp a real cloud sign-up quota row before the private quota-worker runs.
    * Idempotent by `UserQuota.userId`; the worker remains authoritative and may
    * overwrite this bootstrap row on its next `publishEntitlements` sync.
+   * Surfaces failures to the caller — the sign-up hook swallows them so a stamp
+   * failure never blocks sign-up; the worker re-anchors the row regardless.
    */
   async ensureBootstrapPlan(input: {
     tenantId?: string | null
@@ -185,55 +187,50 @@ class UserQuotaService extends BaseService {
 
     const { tenantId, userId } = input
 
-    try {
-      const snapshot: BootstrapPlanSnapshot =
-        (await this.readDefaultPlanSnapshot(tenantId)) ??
-        BOOTSTRAP_TRIAL_FALLBACK
-      const now = new Date()
-      // Distinguish a malformed snapshot (NaN → 1-day lockdown) from an
-      // explicit `0`/negative trial length (a free-forever default plan →
-      // `active`, never expires). Only the malformed case falls back.
-      const rawTrialDays = Number(snapshot.trialDays)
-      const trialDays = Number.isFinite(rawTrialDays)
-        ? Math.max(0, rawTrialDays)
-        : BOOTSTRAP_TRIAL_FALLBACK.trialDays
-      const isTrial = trialDays > 0
-      const periodEnd = isTrial
-        ? new Date(now.getTime() + trialDays * 24 * 60 * 60 * 1000)
-        : null
+    const snapshot: BootstrapPlanSnapshot =
+      (await this.readDefaultPlanSnapshot(tenantId)) ?? BOOTSTRAP_TRIAL_FALLBACK
+    const now = new Date()
+    // Distinguish a malformed snapshot (NaN → 1-day lockdown) from an
+    // explicit `0`/negative trial length (a free-forever default plan →
+    // `active`, never expires). Only the malformed case falls back.
+    const rawTrialDays = Number(snapshot.trialDays)
+    const trialDays = Number.isFinite(rawTrialDays)
+      ? Math.max(0, rawTrialDays)
+      : BOOTSTRAP_TRIAL_FALLBACK.trialDays
+    const isTrial = trialDays > 0
+    const periodEnd = isTrial
+      ? new Date(now.getTime() + trialDays * 24 * 60 * 60 * 1000)
+      : null
 
-      const inserted = await db
-        .insert(userQuotaModel)
-        .values({
-          userId,
-          contactsLimit: snapshot.contactsLimit,
-          workspacesLimit: snapshot.workspacesLimit,
-          channelsLimit: snapshot.channelsLimit,
-          teamMembersLimit: snapshot.teamMembersLimit,
-          macLimit: snapshot.macLimit,
-          whiteLabel: false,
-          ssoSaml: false,
-          saasMode: false,
-          planName: snapshot.planName,
-          planStatus: isTrial
-            ? planStatuses.enum.trial
-            : planStatuses.enum.active,
-          periodStart: now,
-          periodEnd,
-          syncedAt: now,
-        })
-        .onConflictDoNothing({ target: userQuotaModel.userId })
-        .returning({ userId: userQuotaModel.userId })
+    const inserted = await db
+      .insert(userQuotaModel)
+      .values({
+        userId,
+        contactsLimit: snapshot.contactsLimit,
+        workspacesLimit: snapshot.workspacesLimit,
+        channelsLimit: snapshot.channelsLimit,
+        teamMembersLimit: snapshot.teamMembersLimit,
+        macLimit: snapshot.macLimit,
+        whiteLabel: false,
+        ssoSaml: false,
+        saasMode: false,
+        planName: snapshot.planName,
+        planStatus: isTrial
+          ? planStatuses.enum.trial
+          : planStatuses.enum.active,
+        periodStart: now,
+        periodEnd,
+        syncedAt: now,
+      })
+      .onConflictDoNothing({ target: userQuotaModel.userId })
+      .returning({ userId: userQuotaModel.userId })
 
-      // Only bust the cache when we actually wrote a row. On a no-op conflict
-      // (hook retry, re-signup, or the worker winning the race) there is
-      // nothing new to invalidate — and skipping it preserves any freshly
-      // cached authoritative row the worker just wrote.
-      if (inserted.length > 0) {
-        await this.store.invalidate(userId)
-      }
-    } catch (err) {
-      logger.warn({ err, userId }, "user-quota: bootstrap plan stamp failed")
+    // Only bust the cache when we actually wrote a row. On a no-op conflict
+    // (hook retry, re-signup, or the worker winning the race) there is
+    // nothing new to invalidate — and skipping it preserves any freshly
+    // cached authoritative row the worker just wrote.
+    if (inserted.length > 0) {
+      await this.store.invalidate(userId)
     }
   }
 
@@ -247,18 +244,23 @@ class UserQuotaService extends BaseService {
   private async resolveDefaultPlanSnapshot(
     userId: string,
   ): Promise<DefaultPlanSnapshot | null> {
+    let tenantId: string | null = null
     try {
       const user = await db.query.userModel.findFirst({
         where: { id: userId },
         columns: { tenantId: true },
       })
-      const tenantId = user?.tenantId ?? null
-
-      return await this.readDefaultPlanSnapshot(tenantId)
+      tenantId = user?.tenantId ?? null
     } catch (err) {
-      logger.warn({ err }, "user-quota: default-plan snapshot read failed")
+      logger.warn(
+        { err, userId },
+        "user-quota: tenant lookup for default-plan failed",
+      )
       return null
     }
+
+    // Self-guarded (logs + returns null on its own Redis failure).
+    return this.readDefaultPlanSnapshot(tenantId)
   }
 
   /**

--- a/packages/business/src/user-quota/service.ts
+++ b/packages/business/src/user-quota/service.ts
@@ -1,6 +1,6 @@
 import { db, eq, sql } from "@chatbotx.io/database/client"
 import { planStatuses } from "@chatbotx.io/database/partials"
-import { userQuotaModel } from "@chatbotx.io/database/schema"
+import { ROOT_TENANT_ID, userQuotaModel } from "@chatbotx.io/database/schema"
 import type { UserQuotaModel } from "@chatbotx.io/database/types"
 import { distributedStore } from "@chatbotx.io/redis"
 import { BaseService } from "../base.service"
@@ -17,9 +17,10 @@ export type { QuotaMetric } from "../quota-shared/live-counter-store"
 /**
  * Cross-repo contract key (read-only here). The enterprise billing layer writes
  * the platform default plan's entitlements to this key; cloud sign-up uses it
- * to stamp the initial bootstrap row. The legacy free-tier overlay still reads
- * it as a secondary fallback for failed stamps and usage-only rows. Absent in
- * pure OSS installs → no overlay fallback (unlimited), preserving prior behavior.
+ * to stamp the initial bootstrap row. Reseller tenants read only their
+ * per-tenant variant `entitlements:default-plan:{tenantId}`. Absent snapshots
+ * in pure OSS installs still mean no overlay fallback (unlimited), preserving
+ * prior behavior.
  */
 const DEFAULT_PLAN_ENTITLEMENT_KEY = "entitlements:default-plan"
 
@@ -151,8 +152,15 @@ class UserQuotaService extends BaseService {
     return null
   }
 
-  private async readDefaultPlanSnapshot(): Promise<DefaultPlanSnapshot | null> {
+  private async readDefaultPlanSnapshot(
+    tenantId?: string | null,
+  ): Promise<DefaultPlanSnapshot | null> {
     try {
+      if (tenantId && tenantId !== ROOT_TENANT_ID) {
+        return await distributedStore.get<DefaultPlanSnapshot>(
+          `${DEFAULT_PLAN_ENTITLEMENT_KEY}:${tenantId}`,
+        )
+      }
       return await distributedStore.get<DefaultPlanSnapshot>(
         DEFAULT_PLAN_ENTITLEMENT_KEY,
       )
@@ -167,14 +175,20 @@ class UserQuotaService extends BaseService {
    * Idempotent by `UserQuota.userId`; the worker remains authoritative and may
    * overwrite this bootstrap row on its next `publishEntitlements` sync.
    */
-  async ensureBootstrapPlan(userId: string): Promise<void> {
+  async ensureBootstrapPlan(input: {
+    tenantId?: string | null
+    userId: string
+  }): Promise<void> {
     if (!isCloud()) {
       return
     }
 
+    const { tenantId, userId } = input
+
     try {
       const snapshot: BootstrapPlanSnapshot =
-        (await this.readDefaultPlanSnapshot()) ?? BOOTSTRAP_TRIAL_FALLBACK
+        (await this.readDefaultPlanSnapshot(tenantId)) ??
+        BOOTSTRAP_TRIAL_FALLBACK
       const now = new Date()
       // Distinguish a malformed snapshot (NaN → 1-day lockdown) from an
       // explicit `0`/negative trial length (a free-forever default plan →
@@ -224,6 +238,30 @@ class UserQuotaService extends BaseService {
   }
 
   /**
+   * Read the default-plan snapshot that governs this user, resolved by tenant. A
+   * sub-account (non-root `tenantId`) reads only its reseller's per-tenant
+   * snapshot `entitlements:default-plan:{tenantId}`; root-tenant users read the
+   * global key directly. Returns null on Redis failure or when nothing is published
+   * (pure OSS install) — the caller then leaves the user unconstrained.
+   */
+  private async resolveDefaultPlanSnapshot(
+    userId: string,
+  ): Promise<DefaultPlanSnapshot | null> {
+    try {
+      const user = await db.query.userModel.findFirst({
+        where: { id: userId },
+        columns: { tenantId: true },
+      })
+      const tenantId = user?.tenantId ?? null
+
+      return await this.readDefaultPlanSnapshot(tenantId)
+    } catch (err) {
+      logger.warn({ err }, "user-quota: default-plan snapshot read failed")
+      return null
+    }
+  }
+
+  /**
    * Overlay the shared default-plan entitlement snapshot onto a free-tier user.
    * Fills only unset (null) limit fields and the plan identity, preserving any
    * existing usage counters. Returns null when no default plan is published.
@@ -232,7 +270,7 @@ class UserQuotaService extends BaseService {
     userId: string,
     quota: UserQuotaModel | null,
   ): Promise<UserQuotaModel | null> {
-    const snapshot = await this.readDefaultPlanSnapshot()
+    const snapshot = await this.resolveDefaultPlanSnapshot(userId)
     if (!snapshot) {
       return null
     }

--- a/packages/database/src/partials/plan-status.ts
+++ b/packages/database/src/partials/plan-status.ts
@@ -2,12 +2,14 @@ import { z } from "zod"
 
 /**
  * Canonical `UserQuota.planStatus` — a small **app-facing state machine**, not a
- * mirror of Stripe's billing vocabulary. Written by the private billing portal
- * (`publishEntitlements`) and read here by the access gate
+ * mirror of Stripe's billing vocabulary. Cloud sign-up stamps the initial
+ * `trial` row in OSS, then the private billing portal (`publishEntitlements`)
+ * remains authoritative and reconciles/overwrites it. The access gate
  * (`userQuotaService.getAccessStateFromQuota`) and the builder's plan-status
- * banner. The column is plain `text()` (the portal owns it cross-repo), but every
- * reader MUST key off these constants, never an inline literal, so the two sides
- * can never drift (a mismatch silently disables the banner or the access gate).
+ * banner read it here. The column is plain `text()` (the portal owns it
+ * cross-repo), but every reader MUST key off these constants, never an inline
+ * literal, so the two sides can never drift (a mismatch silently disables the
+ * banner or the access gate).
  *
  * Four values; Stripe's ~8 subscription statuses collapse into them:
  *  - `active`   : entitled & good standing — paid `active`/`trialing`, the free

--- a/packages/database/src/schema/enterprise/user-quota.ts
+++ b/packages/database/src/schema/enterprise/user-quota.ts
@@ -25,7 +25,8 @@ export const userQuotaModel = pgTable("UserQuota", {
   whiteLabel: boolean().notNull().default(false),
   ssoSaml: boolean().notNull().default(false),
   saasMode: boolean().notNull().default(false),
-  // Plan identity, written by the enterprise billing layer (publishEntitlements).
+  // Plan identity. Cloud sign-up stamps an initial OSS trial row; the enterprise
+  // billing layer (publishEntitlements) remains authoritative and overwrites it.
   // null = free tier / not yet synced.
   planName: text(),
   planStatus: text(),

--- a/packages/ui/src/config/portal-nav.ts
+++ b/packages/ui/src/config/portal-nav.ts
@@ -64,7 +64,7 @@ export const portalSaasNavConfigs: PortalSaasNavConfig[] = [
     key: "portalPlans",
     pathSuffix: "/plans",
     icon: LayoutList,
-    requires: "saasMode",
+    requires: "whiteLabel",
   },
   {
     key: "portalUsage",

--- a/packages/worker-config/src/queues/quota/index.ts
+++ b/packages/worker-config/src/queues/quota/index.ts
@@ -8,9 +8,11 @@ import { queueNames } from "../../lib/types"
 
 /**
  * Cross-repo contract queue. The OSS app produces `publishEntitlements` jobs
- * (e.g. on sign-up); the enterprise `quota-worker` consumes them and writes the
- * user's entitlement snapshot. The contract is the queue NAME + job shape only —
- * no enterprise package is imported into OSS.
+ * (e.g. on sign-up); the enterprise `quota-worker` consumes them and reconciles
+ * the user's entitlement snapshot. Cloud sign-up may already have an
+ * OSS-stamped bootstrap trial row, which the worker overwrites and re-anchors.
+ * The contract is the queue NAME + job shape only — no enterprise package is
+ * imported into OSS.
  */
 export const QuotaJobAction = {
   publishEntitlements: "publishEntitlements",

--- a/packages/worker-config/src/queues/quota/index.ts
+++ b/packages/worker-config/src/queues/quota/index.ts
@@ -21,6 +21,10 @@ export const QuotaJobAction = {
   // the default-plan snapshot alone never reaches them). Consumed by the
   // enterprise quota-worker, which runs the backfill loop.
   backfillDefaultPlan: "backfillDefaultPlan",
+  // Reconcile only one tenant's users — produced by the enterprise portal when a
+  // reseller changes their tenant's default plan. Scopes the backfill to that
+  // reseller's sub-accounts instead of every user.
+  backfillTenantDefaultPlan: "backfillTenantDefaultPlan",
 } as const
 
 export type QuotaJobPublishEntitlements = {
@@ -33,9 +37,15 @@ export type QuotaJobBackfillDefaultPlan = {
   data: Record<string, never>
 }
 
+export type QuotaJobBackfillTenantDefaultPlan = {
+  type: typeof QuotaJobAction.backfillTenantDefaultPlan
+  data: { tenantId: string }
+}
+
 export type QuotaJobData =
   | QuotaJobPublishEntitlements
   | QuotaJobBackfillDefaultPlan
+  | QuotaJobBackfillTenantDefaultPlan
 
 export const quotaQueue =
   process.env.NEXT_PHASE === "phase-production-build"


### PR DESCRIPTION
## Summary
- On the **cloud** edition, sign-up now synchronously stamps a conservative `UserQuota` bootstrap "trial" row (`ensureBootstrapPlan`) *before* enqueuing the `publishEntitlements` job — closing the sign-up→worker gap that the fail-open default-plan overlay previously had to cover. The private `quota-worker` stays authoritative and re-anchors the row on its run.
- Makes the default-plan snapshot **tenant-aware**: a reseller sub-account (non-root `tenantId`) reads only its `entitlements:default-plan:{tenantId}` key; root-tenant users read the global key. Adds the `backfillTenantDefaultPlan` job type to the cross-repo contract for scoped reseller reconciliation.
- Error handling on the bootstrap path is owned at the sign-up boundary (no internal swallow + dead boundary catch), and the per-tenant resolution logs an accurate, distinct message.

## Changes
- `apps/builder/src/lib/auth/on-user-created.ts` — stamp bootstrap row, then enqueue; boundary owns best-effort swallow/log.
- `packages/business/src/user-quota/service.ts` — `ensureBootstrapPlan`, `readDefaultPlanSnapshot`, `resolveDefaultPlanSnapshot` (tenant-aware), `BOOTSTRAP_TRIAL_FALLBACK` lockdown; `applyDefaultPlan` now resolves per-tenant.
- `packages/worker-config/src/queues/quota/index.ts` — `backfillTenantDefaultPlan` job type + union.
- `packages/database/src/{partials/plan-status.ts,schema/enterprise/user-quota.ts}`, `packages/ui/src/config/portal-nav.ts` — doc/comment updates and `portalPlans` nav gating aligned to `whiteLabel`.
- Tests: `apps/builder/__tests__/on-user-created.test.ts`, `packages/business/__tests__/user-quota-{bootstrap,default}-plan.test.ts`.

## Test plan
- [x] `pnpm lint` (PR-scope clean; remaining hits are generated `.next/`/`en.json`, not in this diff)
- [x] `pnpm --filter @chatbotx.io/business check-types`
- [x] `vitest run user-quota` (business) — 17/17
- [x] `vitest run on-user-created` (builder) — 5/5
- [ ] Manual: cloud sign-up with cold Redis → lockdown trial row; with published default-plan → trial limits; reseller sub-account → tenant snapshot