### PR TITLE
 fix(zalo): allow incoming image-only messages without text

### DIFF
--- a/integrations/zalo/src/handlers/message/incoming-message/index.ts
+++ b/integrations/zalo/src/handlers/message/incoming-message/index.ts
@@ -128,13 +128,13 @@ const getMessageEntity = async (
       break
   }
 
-  if (!message.text) {
+  if (!message.text && (message.attachments?.length ?? 0) === 0) {
     throw new ZaloException(`No content found in message ${event.event_name}`)
   }
 
   // Detect postback action
   let postbackAction: string | null = null
-  if (message.text.startsWith("postback_")) {
+  if (message.text?.startsWith("postback_")) {
     postbackAction = message.text.replace("postback_", "")
   }
 


### PR DESCRIPTION
## Summary
- Zalo webhook handler was throwing `ZaloException: No content found` for `user_send_image` events with no caption text
- Root cause: guard `if (!message.text)` fired even when `message.attachments` was already populated
- Fix: guard now only throws when both text and attachments are empty

## Changes
- `integrations/zalo/src/handlers/message/incoming-message/index.ts`

## Test plan
- [ ] Send a Zalo image (no caption) → confirm it appears in inbox with attachment
- [ ] Send a Zalo image with caption → confirm both text and image appear
- [ ] pnpm lint
- [ ] pnpm --filter @chatbotx.io/integration-zalo check-types
