### PR TITLE
fix(webchat): prevent duplicate messages after send

### DIFF
--- a/apps/builder/src/features/integration-webchat/webchat-message-input.tsx
+++ b/apps/builder/src/features/integration-webchat/webchat-message-input.tsx
@@ -60,7 +60,7 @@ export const WebchatMessageInput = (props: WebchatMessageInputProps) => {
           textareaRef.current?.focus()
         },
         onSuccess: ({ data }) => {
-          if (data?.attachments) {
+          if (data?.attachments?.length) {
             appendMessage(data)
           }
 


### PR DESCRIPTION
Empty array returned by createWebchatMessageAction for text-only messages is truthy, causing appendMessage to be called in onSuccess for every message in addition to the optimistic append in onExecute.