### PR TITLE
fix: stop messages repeating in flows

### DIFF
--- a/apps/worker/__tests__/flow.test.ts
+++ b/apps/worker/__tests__/flow.test.ts
@@ -9,12 +9,13 @@ import { beforeEach, describe, expect, type Mock, test, vi } from "vitest"
 // --- mocks ---
 
 const integrationQueueAdd = vi.fn(async () => undefined)
+const chatQueueAdd = vi.fn(async () => undefined)
 
 vi.mock("@chatbotx.io/worker-config", () => ({
   IntegrationJobAction: { sendFlow: "sendFlow" },
   integrationQueue: { add: integrationQueueAdd },
   ChatJobAction: { sendFlowMessage: "sendFlowMessage" },
-  chatQueue: { add: vi.fn(async () => undefined) },
+  chatQueue: { add: chatQueueAdd },
 }))
 
 vi.mock("@chatbotx.io/database/client", () => ({
@@ -304,6 +305,64 @@ describe("executeMultipleSteps — loop control statuses", () => {
 
     expect(result?.status).toBe("retry")
     expect(sendSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe("executeMultipleSteps — nodeId preservation", () => {
+  beforeEach(() => {
+    chatQueueAdd.mockClear()
+    integrationQueueAdd.mockClear()
+  })
+
+  test("startAnotherNode jumps to its configured target, not the current node", async () => {
+    const step = {
+      id: "s1",
+      stepType: "startAnotherNode",
+      nodeId: "node-2",
+    } as unknown as BaseStepSchema
+
+    await executeMultipleSteps({ ...makeBaseProps(), steps: [step] })
+
+    const [action, job] = integrationQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { nodeId: string } },
+    ]
+    expect(action).toBe("sendFlow")
+    expect(job.data.nodeId).toBe("node-2")
+  })
+
+  test("startExternalNode preserves its own target node and flow", async () => {
+    const step = {
+      id: "s1",
+      stepType: "startExternalNode",
+      flowId: "external-flow",
+      nodeId: "external-node",
+    } as unknown as BaseStepSchema
+
+    await executeMultipleSteps({ ...makeBaseProps(), steps: [step] })
+
+    const [, job] = integrationQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { flowId: string; nodeId: string } },
+    ]
+    expect(job.data.flowId).toBe("external-flow")
+    expect(job.data.nodeId).toBe("external-node")
+  })
+
+  test("message steps still carry their source node id for analytics", async () => {
+    const step = {
+      id: "s1",
+      stepType: "sendText",
+      text: "hi",
+    } as unknown as BaseStepSchema
+
+    await executeMultipleSteps({ ...makeBaseProps(), steps: [step] })
+
+    const [, job] = chatQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { step: { nodeId: string } } },
+    ]
+    expect(job.data.step.nodeId).toBe("node-1")
   })
 })
 

--- a/apps/worker/src/integration/handlers/flow.ts
+++ b/apps/worker/src/integration/handlers/flow.ts
@@ -315,7 +315,10 @@ async function* executeMultipleStepsGenerator(
   const { steps, ...rest } = props
 
   for (const step of steps) {
-    const stepWithNodeId = { ...step, nodeId: props.targetNodeId || "" }
+    const stepWithNodeId = {
+      ...step,
+      nodeId: step.nodeId ?? props.targetNodeId ?? "",
+    }
 
     const rawResult = await flowStepHandlers[step.stepType as StepType]?.({
       ...rest,


### PR DESCRIPTION
## Summary

Fixes a flow bug where a **Send Message** step that sends the conversation to another node would loop forever — the message kept being re-sent and never stopped.

The node was accidentally sending the conversation back to itself instead of the node the user picked, so it ran the same message over and over.

## What changed

- The flow engine now keeps the destination node the user selected for "send to another node" actions, instead of overwriting it.
- Per-message node tracking (used for analytics) is unchanged.

## Test plan

- [x] Added unit tests covering:
  - "send to another node" jumps to the selected node, not the current one
  - external-node jumps keep their target flow and node
  - normal message steps still record their source node (analytics)
- [x] `pnpm --filter worker test flow.test.ts` — all passing
- [x] `pnpm --filter worker check-types` — clean
- [x] Lint — clean
- [ ] Manual: build a flow with a message + "send to another node" and confirm the message is sent once and then moves on

## Notes

A genuinely circular flow built by a user (node A → node B → node A) can still loop; adding an engine-level cycle guard is tracked as a separate follow-up.
