### PR TITLE
fix(auth): re-home white-label verification redirects onto branded host

### DIFF
--- a/apps/builder/__tests__/auth-redirect.test.ts
+++ b/apps/builder/__tests__/auth-redirect.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const BUILDER_URL = "https://app.example.com"
+const RESELLER_HOST = "chat.acme.com"
+
+const { mockIsAllowedOrigin } = vi.hoisted(() => ({
+  mockIsAllowedOrigin: vi.fn(),
+}))
+
+vi.mock("@/env", () => ({
+  env: { NEXT_PUBLIC_BUILDER_URL: BUILDER_URL },
+}))
+
+vi.mock("@/lib/oauth-broker", () => ({
+  getBrokerOrigin: () => BUILDER_URL,
+}))
+
+vi.mock("@/lib/oauth-referer", () => ({
+  isAllowedOrigin: mockIsAllowedOrigin,
+}))
+
+// The proxy sets these from the forwarded headers; here we derive them from the
+// request host so each case can drive the public host directly.
+vi.mock("@chatbotx.io/utils", () => ({
+  getPublicHostFromRequest: (request: Request) => new URL(request.url).host,
+  getPublicProtocolFromRequest: (request: Request) =>
+    new URL(request.url).protocol.replace(":", ""),
+}))
+
+async function loadModule() {
+  return await import("@/lib/auth-redirect")
+}
+
+function verifyRequest(host: string): Request {
+  return new Request(
+    `https://${host}/api/auth/magic-link/verify?token=abc&callbackURL=/`,
+  )
+}
+
+function redirectTo(location: string, status = 302): Response {
+  return new Response(null, {
+    status,
+    headers: { location },
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("rewriteAuthRedirectToPublicHost", () => {
+  test("re-homes a builder-origin redirect onto the branded host the user is on", async () => {
+    mockIsAllowedOrigin.mockResolvedValue(true)
+    const { rewriteAuthRedirectToPublicHost } = await loadModule()
+
+    const response = redirectTo(`${BUILDER_URL}/`)
+    const rewritten = await rewriteAuthRedirectToPublicHost(
+      verifyRequest(RESELLER_HOST),
+      response,
+    )
+
+    expect(rewritten.headers.get("location")).toBe(`https://${RESELLER_HOST}/`)
+    expect(mockIsAllowedOrigin).toHaveBeenCalledWith(
+      new URL(`https://${RESELLER_HOST}`),
+    )
+  })
+
+  test("preserves the Set-Cookie session header across the rewrite", async () => {
+    mockIsAllowedOrigin.mockResolvedValue(true)
+    const { rewriteAuthRedirectToPublicHost } = await loadModule()
+
+    const response = new Response(null, {
+      status: 302,
+      headers: {
+        location: `${BUILDER_URL}/dashboard`,
+        "set-cookie": "better-auth.session_token=secret; Path=/; HttpOnly",
+      },
+    })
+    const rewritten = await rewriteAuthRedirectToPublicHost(
+      verifyRequest(RESELLER_HOST),
+      response,
+    )
+
+    expect(rewritten.headers.get("location")).toBe(
+      `https://${RESELLER_HOST}/dashboard`,
+    )
+    expect(rewritten.headers.get("set-cookie")).toBe(
+      "better-auth.session_token=secret; Path=/; HttpOnly",
+    )
+  })
+
+  test("leaves a builder-host request untouched (single-domain no-op)", async () => {
+    const { rewriteAuthRedirectToPublicHost } = await loadModule()
+
+    const response = redirectTo(`${BUILDER_URL}/`)
+    const rewritten = await rewriteAuthRedirectToPublicHost(
+      verifyRequest(new URL(BUILDER_URL).host),
+      response,
+    )
+
+    expect(rewritten).toBe(response)
+    expect(mockIsAllowedOrigin).not.toHaveBeenCalled()
+  })
+
+  test("does not rewrite a redirect to a non-builder/broker origin", async () => {
+    const { rewriteAuthRedirectToPublicHost } = await loadModule()
+
+    const response = redirectTo("https://accounts.google.com/o/oauth2/auth")
+    const rewritten = await rewriteAuthRedirectToPublicHost(
+      verifyRequest(RESELLER_HOST),
+      response,
+    )
+
+    expect(rewritten).toBe(response)
+    expect(mockIsAllowedOrigin).not.toHaveBeenCalled()
+  })
+
+  test("does not rewrite when the public host is not a controlled origin", async () => {
+    mockIsAllowedOrigin.mockResolvedValue(false)
+    const { rewriteAuthRedirectToPublicHost } = await loadModule()
+
+    const response = redirectTo(`${BUILDER_URL}/`)
+    const rewritten = await rewriteAuthRedirectToPublicHost(
+      verifyRequest("evil.example.org"),
+      response,
+    )
+
+    expect(rewritten.headers.get("location")).toBe(`${BUILDER_URL}/`)
+    expect(mockIsAllowedOrigin).toHaveBeenCalled()
+  })
+
+  test("ignores non-redirect responses", async () => {
+    const { rewriteAuthRedirectToPublicHost } = await loadModule()
+
+    const response = new Response("ok", { status: 200 })
+    const rewritten = await rewriteAuthRedirectToPublicHost(
+      verifyRequest(RESELLER_HOST),
+      response,
+    )
+
+    expect(rewritten).toBe(response)
+    expect(mockIsAllowedOrigin).not.toHaveBeenCalled()
+  })
+
+  test("ignores a 3xx with no Location header", async () => {
+    const { rewriteAuthRedirectToPublicHost } = await loadModule()
+
+    const response = new Response(null, { status: 304 })
+    const rewritten = await rewriteAuthRedirectToPublicHost(
+      verifyRequest(RESELLER_HOST),
+      response,
+    )
+
+    expect(rewritten).toBe(response)
+  })
+})

--- a/apps/builder/__tests__/auth-route.test.ts
+++ b/apps/builder/__tests__/auth-route.test.ts
@@ -53,6 +53,13 @@ vi.mock("@/lib/oauth-referer", () => ({
   resolveRelayTarget: mockResolveRelayTarget,
 }))
 
+// Redirect re-homing is exercised in auth-redirect.test.ts; here it is a
+// pass-through so routing/relay assertions stay isolated.
+vi.mock("@/lib/auth-redirect", () => ({
+  rewriteAuthRedirectToPublicHost: (_request: Request, response: Response) =>
+    response,
+}))
+
 async function loadRoute() {
   vi.resetModules()
   return await import("@/app/api/auth/[...all]/route")

--- a/apps/builder/src/app/api/auth/[...all]/route.ts
+++ b/apps/builder/src/app/api/auth/[...all]/route.ts
@@ -8,6 +8,7 @@ import {
 import { getPublicUrlFromRequest } from "@chatbotx.io/utils"
 import { auth } from "@/lib/auth/auth"
 import { getSocialAuthForTenant } from "@/lib/auth/auth-instances"
+import { rewriteAuthRedirectToPublicHost } from "@/lib/auth-redirect"
 import { resolveRelayTarget } from "@/lib/oauth-referer"
 
 /**
@@ -41,6 +42,13 @@ import { resolveRelayTarget } from "@/lib/oauth-referer"
  *    so we dispatch the social/callback legs to a per-credential auth instance
  *    resolved for the bound tenant and provider (own app, else platform default).
  *    Every other route uses the default `auth` instance. See `auth-instances.ts`.
+ *
+ * 3. Verification redirect re-homing — better-auth resolves the post-verification
+ *    redirect (magic-link/verify, verify-email, reset-password) against its fixed
+ *    `baseURL` (the builder URL), so a user who clicked the link on a branded
+ *    domain would be bounced to the builder host — losing the brand and the
+ *    host-scoped session cookie just minted. We rewrite that redirect back onto
+ *    the originating host. See `rewriteAuthRedirectToPublicHost`.
  */
 
 /** The provider on a `/callback/<provider>` leg, or `null` if not a social callback. */
@@ -117,7 +125,10 @@ const handle = async (request: Request): Promise<Response> => {
         ? await getSocialAuthForTenant(tenantId, provider)
         : auth
 
-      return instance.handler(request)
+      // Re-home a baseURL-resolved verification redirect onto the branded host
+      // the user is on (magic-link/verify, verify-email, reset-password).
+      const response = await instance.handler(request)
+      return rewriteAuthRedirectToPublicHost(request, response)
     },
     { strictScope: isSocialPath },
   )

--- a/apps/builder/src/lib/auth-redirect.ts
+++ b/apps/builder/src/lib/auth-redirect.ts
@@ -1,0 +1,78 @@
+import {
+  getPublicHostFromRequest,
+  getPublicProtocolFromRequest,
+} from "@chatbotx.io/utils"
+import { env } from "@/env"
+import { getBrokerOrigin } from "./oauth-broker"
+import { isAllowedOrigin } from "./oauth-referer"
+
+const isRedirect = (status: number): boolean => status >= 300 && status < 400
+
+/**
+ * Re-home a better-auth verification redirect onto the white-label domain the
+ * user is actually on.
+ *
+ * better-auth resolves the post-verification redirect target (magic-link/verify,
+ * verify-email, reset-password) against its fixed `baseURL` — pinned to
+ * `BETTER_AUTH_URL` (= the builder URL). So a user who clicked the link on a
+ * reseller's custom domain is bounced to the builder host, losing the brand and,
+ * worse, the freshly-minted session cookie scoped to that host. The email link's
+ * host is already rewritten when sent (`@chatbotx.io/auth` server.ts); this is the
+ * matching fix for the *redirect* leg.
+ *
+ * Only a 3xx whose `Location` origin is the builder or broker origin (i.e. a
+ * `baseURL`-resolved callback) is rewritten, and only when the request's public
+ * host is a controlled origin (active custom domain / builder / broker). Both
+ * guards keep a spoofed `Host` / `x-forwarded-host` from driving an open
+ * redirect, and make this a no-op on single-domain deploys (public host already
+ * equals the builder host). `Set-Cookie` is preserved across the rewrite.
+ */
+export async function rewriteAuthRedirectToPublicHost(
+  request: Request,
+  response: Response,
+): Promise<Response> {
+  if (!isRedirect(response.status)) {
+    return response
+  }
+
+  const location = response.headers.get("location")
+  if (!location) {
+    return response
+  }
+
+  const builderOrigin = new URL(env.NEXT_PUBLIC_BUILDER_URL).origin
+  let target: URL
+  try {
+    // better-auth emits absolute Locations; the base only resolves a relative one
+    // (which still belongs to the builder origin and so is eligible to re-home).
+    target = new URL(location, builderOrigin)
+  } catch {
+    return response
+  }
+
+  if (target.origin !== builderOrigin && target.origin !== getBrokerOrigin()) {
+    return response
+  }
+
+  const publicHost = getPublicHostFromRequest(request)
+  if (publicHost === target.host) {
+    return response
+  }
+
+  const publicProtocol = getPublicProtocolFromRequest(request)
+  const publicOrigin = `${publicProtocol}://${publicHost}`
+  if (!(await isAllowedOrigin(new URL(publicOrigin)))) {
+    return response
+  }
+
+  target.host = publicHost
+  target.protocol = publicProtocol
+  target.port = ""
+
+  const headers = new Headers(response.headers)
+  headers.set("location", target.toString())
+  return new Response(response.body, {
+    status: response.status,
+    headers,
+  })
+}

--- a/apps/builder/src/lib/oauth-referer.ts
+++ b/apps/builder/src/lib/oauth-referer.ts
@@ -7,9 +7,10 @@ export const FALLBACK_REDIRECT = "/manage"
 /**
  * A valid relay/redirect target is any origin we control: the broker host, the
  * builder app URL, or an active white-label custom domain. Anything else is
- * rejected so an attacker-controlled `state` cannot drive an open redirect.
+ * rejected so an attacker-controlled `state` (or a spoofed `Host` /
+ * `x-forwarded-host`) cannot drive an open redirect.
  */
-async function isAllowedOrigin(targetUrl: URL): Promise<boolean> {
+export async function isAllowedOrigin(targetUrl: URL): Promise<boolean> {
   if (
     targetUrl.origin === getBrokerOrigin() ||
     targetUrl.origin === new URL(env.NEXT_PUBLIC_BUILDER_URL).origin


### PR DESCRIPTION
## Summary

- Magic-link verify (and verify-email / reset-password) on a white-label custom domain bounced the user to `NEXT_PUBLIC_BUILDER_URL`. better-auth resolves the post-verification redirect against its fixed `baseURL` (the builder URL), so the relative default `callbackURL=/` always lands on the builder host.
- Beyond the cosmetic brand loss, the session cookie minted on that verify response is host-scoped and never reaches the branded domain.
- The email link host was already rewritten on send; this is the matching fix for the redirect leg.

## Changes

- `apps/builder/src/lib/auth-redirect.ts` (new) — `rewriteAuthRedirectToPublicHost`: rewrites a 3xx whose `Location` origin is the builder/broker origin onto the request's public host. Preserves `Set-Cookie`. Two guards (builder/broker-origin only + public origin must pass the trusted-origin allowlist) prevent a spoofed `Host`/`x-forwarded-host` from driving an open redirect. No-op on single-domain deploys.
- `apps/builder/src/app/api/auth/[...all]/route.ts` — wrap `instance.handler` with the rewrite; social-callback relay still early-returns before it. Doc comment extended with concern #3.
- `apps/builder/src/lib/oauth-referer.ts` — export the existing `isAllowedOrigin` predicate for reuse.
- Tests — new `auth-redirect.test.ts` (7 cases); `auth-route.test.ts` mocks the new module as pass-through to stay isolated.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [x] `vitest run __tests__/auth-redirect.test.ts __tests__/auth-route.test.ts` (10 passed)
- [ ] Manual: click a magic link issued on a custom domain → verify lands and stays on that domain with an active session