### PR TITLE
fix: stop messages from repeating in flows

### DIFF
--- a/apps/worker/__tests__/flow.test.ts
+++ b/apps/worker/__tests__/flow.test.ts
@@ -48,8 +48,12 @@ vi.mock("@chatbotx.io/sdk", async (importOriginal) => {
 
 // --- imports after mocks ---
 
-const { executeMultipleSteps, seekConnectedNode, runStepsAndQuickReplies } =
-  await import("../src/integration/handlers/flow")
+const {
+  executeMultipleSteps,
+  MAX_NODE_EXECUTIONS,
+  seekConnectedNode,
+  runStepsAndQuickReplies,
+} = await import("../src/integration/handlers/flow")
 
 // --- helpers ---
 
@@ -743,5 +747,149 @@ describe("runStepsAndQuickReplies — per-step re-dispatch", () => {
       { data: { nodeId: string } },
     ]
     expect(job.data.nodeId).toBe("node-2")
+  })
+})
+
+describe("runStepsAndQuickReplies — node execution loop guard", () => {
+  beforeEach(() => {
+    integrationQueueAdd.mockClear()
+    chatQueueAdd.mockClear()
+  })
+
+  test("stops a node that already reached the execution limit", async () => {
+    const { logger } = await import("../src/lib/logger")
+    const step = { ...makeStep("sendText"), id: "step-1" }
+    const props = {
+      ...makeBaseProps(),
+      details: { steps: [step] },
+      nodeVisits: { "node-1": MAX_NODE_EXECUTIONS },
+    }
+
+    await runStepsAndQuickReplies(props)
+
+    expect(integrationQueueAdd).not.toHaveBeenCalled()
+    expect(chatQueueAdd).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodeId: "node-1",
+        count: MAX_NODE_EXECUTIONS + 1,
+        maxNodeExecutions: MAX_NODE_EXECUTIONS,
+        flowId: "flow-1",
+        flowVersionId: "fv-1",
+        conversationId: "conv-1",
+        contactInboxId: "ci-1",
+        nodeVisits: { "node-1": MAX_NODE_EXECUTIONS },
+      }),
+      "Flow node exceeded max executions in one run; stopping to prevent an infinite loop",
+    )
+  })
+
+  test("increments and forwards nodeVisits on the next-step re-dispatch", async () => {
+    const step1 = { ...makeStep("sendText"), id: "step-1" }
+    const step2 = { ...makeStep("sendText"), id: "step-2" }
+    const props = {
+      ...makeBaseProps(),
+      details: { steps: [step1, step2] },
+      triggerNextNode: false,
+      nodeVisits: { "node-1": 1 },
+    }
+
+    await runStepsAndQuickReplies(props)
+
+    const [, job] = integrationQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { nodeVisits: Record<string, number> } },
+    ]
+    expect(job.data.nodeVisits).toEqual({ "node-1": 2 })
+  })
+
+  test("propagates the incremented count across a startAnotherNode jump", async () => {
+    const step = {
+      id: "s1",
+      stepType: "startAnotherNode",
+      nodeId: "node-2",
+    } as unknown as BaseStepSchema
+    const props = {
+      ...makeBaseProps(),
+      details: { steps: [step] },
+      nodeVisits: { "node-1": 1 },
+    }
+
+    await runStepsAndQuickReplies(props)
+
+    const [, job] = integrationQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { nodeId: string; nodeVisits: Record<string, number> } },
+    ]
+    expect(job.data.nodeId).toBe("node-2")
+    expect(job.data.nodeVisits).toEqual({ "node-1": 2 })
+  })
+
+  test("propagates the incremented count across a splitTraffic jump", async () => {
+    const step = {
+      id: "split-1",
+      stepType: "splitTraffic",
+      cases: [{ value: 100 }],
+    } as unknown as BaseStepSchema
+    const flowVersion = makeFlowVersion(
+      [],
+      [
+        {
+          id: "edge-1",
+          source: "node-1",
+          sourceHandle: "node-1-case-0",
+          target: "node-2",
+          targetHandle: "input",
+        },
+      ],
+    )
+    const props = {
+      ...makeBaseProps(flowVersion),
+      details: { steps: [step] },
+      triggerNextNode: false,
+      nodeVisits: { "node-1": 1 },
+    }
+
+    await runStepsAndQuickReplies(props)
+
+    const [, job] = integrationQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { nodeId: string; nodeVisits: Record<string, number> } },
+    ]
+    expect(job.data.nodeId).toBe("node-2")
+    expect(job.data.nodeVisits).toEqual({ "node-1": 2 })
+  })
+
+  test("seeds the count on the first entry", async () => {
+    const step1 = { ...makeStep("sendText"), id: "step-1" }
+    const step2 = { ...makeStep("sendText"), id: "step-2" }
+    const props = {
+      ...makeBaseProps(),
+      details: { steps: [step1, step2] },
+      triggerNextNode: false,
+    }
+
+    await runStepsAndQuickReplies(props)
+
+    const [, job] = integrationQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { nodeVisits: Record<string, number> } },
+    ]
+    expect(job.data.nodeVisits).toEqual({ "node-1": 1 })
+  })
+
+  test("does not cap a mid-node resume even above the limit", async () => {
+    const step1 = { ...makeStep("sendText"), id: "step-1" }
+    const step2 = { ...makeStep("sendText"), id: "step-2" }
+    const props = {
+      ...makeBaseProps(),
+      details: { steps: [step1, step2] },
+      startFromStepId: "step-2",
+      nodeVisits: { "node-1": 5 },
+    }
+
+    await runStepsAndQuickReplies(props)
+
+    expect(chatQueueAdd).toHaveBeenCalled()
   })
 })

--- a/apps/worker/__tests__/flow.test.ts
+++ b/apps/worker/__tests__/flow.test.ts
@@ -892,4 +892,133 @@ describe("runStepsAndQuickReplies — node execution loop guard", () => {
 
     expect(chatQueueAdd).toHaveBeenCalled()
   })
+
+  test("forwards the incremented count to the next node via a default edge", async () => {
+    const nextNode: FlowNode = {
+      id: "node-2",
+      position: { x: 0, y: 0 },
+      measured: { width: 100, height: 100 },
+      data: { name: "Next", isStartNode: false, details: { steps: [] } },
+    }
+    const edges: EdgeSchema[] = [
+      {
+        id: "e1",
+        source: "node-1",
+        sourceHandle: "node-1",
+        target: "node-2",
+        targetHandle: "input",
+      },
+    ]
+    const props = {
+      ...makeBaseProps(makeFlowVersion([nextNode], edges)),
+      details: { steps: [], quickReplies: [] },
+      triggerNextNode: true,
+      nodeVisits: { "node-1": 1 },
+    }
+
+    await runStepsAndQuickReplies(props)
+
+    const [, job] = integrationQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { nodeId: string; nodeVisits: Record<string, number> } },
+    ]
+    expect(job.data.nodeId).toBe("node-2")
+    expect(job.data.nodeVisits).toEqual({ "node-1": 2 })
+  })
+
+  test("forwards the incremented count when routing via a success state", async () => {
+    const stateId = "state-ok"
+    const step1 = {
+      ...makeStep("autoAssignConversation", [
+        { id: stateId, stateType: "success" },
+      ]),
+      id: "step-1",
+    }
+    const flowVersion = makeFlowVersion(
+      [],
+      [
+        {
+          id: "e1",
+          source: "n1",
+          sourceHandle: stateId,
+          target: "success-node",
+          targetHandle: "input",
+        },
+      ],
+    )
+    const { flowStepHandlers } = await import(
+      "../src/integration/handlers/step"
+    )
+    mockSpy(flowStepHandlers, "autoAssignConversation").mockResolvedValue({
+      status: "success",
+      result: null,
+    })
+    const props = {
+      ...makeBaseProps(flowVersion),
+      details: { steps: [step1] },
+      triggerNextNode: false,
+      nodeVisits: { "node-1": 1 },
+    }
+
+    await runStepsAndQuickReplies(props)
+
+    const [, job] = integrationQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { nodeId: string; nodeVisits: Record<string, number> } },
+    ]
+    expect(job.data.nodeId).toBe("success-node")
+    expect(job.data.nodeVisits).toEqual({ "node-1": 2 })
+  })
+
+  test("propagates the count across a startExternalNode jump", async () => {
+    const step = {
+      id: "s1",
+      stepType: "startExternalNode",
+      flowId: "external-flow",
+      nodeId: "external-node",
+    } as unknown as BaseStepSchema
+    const props = {
+      ...makeBaseProps(),
+      details: { steps: [step] },
+      nodeVisits: { "node-1": 1 },
+    }
+
+    await runStepsAndQuickReplies(props)
+
+    const [, job] = integrationQueueAdd.mock.calls[0] as unknown as [
+      string,
+      {
+        data: {
+          flowId: string
+          nodeId: string
+          nodeVisits: Record<string, number>
+        }
+      },
+    ]
+    expect(job.data.flowId).toBe("external-flow")
+    expect(job.data.nodeId).toBe("external-node")
+    expect(job.data.nodeVisits).toEqual({ "node-1": 2 })
+  })
+
+  test("propagates the count across a startExternalFlow jump", async () => {
+    const step = {
+      id: "s1",
+      stepType: "startExternalFlow",
+      flowId: "external-flow",
+    } as unknown as BaseStepSchema
+    const props = {
+      ...makeBaseProps(),
+      details: { steps: [step] },
+      nodeVisits: { "node-1": 1 },
+    }
+
+    await runStepsAndQuickReplies(props)
+
+    const [, job] = integrationQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { flowId: string; nodeVisits: Record<string, number> } },
+    ]
+    expect(job.data.flowId).toBe("external-flow")
+    expect(job.data.nodeVisits).toEqual({ "node-1": 2 })
+  })
 })

--- a/apps/worker/src/integration/handlers/flow-utils.ts
+++ b/apps/worker/src/integration/handlers/flow-utils.ts
@@ -13,6 +13,7 @@ import {
   type BotResponseTrackingContext,
   IntegrationJobAction,
   integrationQueue,
+  type NodeVisits,
 } from "@chatbotx.io/worker-config"
 
 export type ExecuteMultipleStepsProps = {
@@ -30,7 +31,7 @@ export type ExecuteMultipleStepsProps = {
   trackingContext?: BotResponseTrackingContext
   metadata?: MetadataPayload
   sendFrom?: "inbox"
-  nodeVisits?: Record<string, number>
+  nodeVisits?: NodeVisits
 }
 
 export type ExecuteStepProps<T> = Omit<ExecuteMultipleStepsProps, "steps"> & {

--- a/apps/worker/src/integration/handlers/flow-utils.ts
+++ b/apps/worker/src/integration/handlers/flow-utils.ts
@@ -30,6 +30,7 @@ export type ExecuteMultipleStepsProps = {
   trackingContext?: BotResponseTrackingContext
   metadata?: MetadataPayload
   sendFrom?: "inbox"
+  nodeVisits?: Record<string, number>
 }
 
 export type ExecuteStepProps<T> = Omit<ExecuteMultipleStepsProps, "steps"> & {
@@ -80,6 +81,7 @@ export async function sendFlow(
         nodeId: connectedNodeId,
         metadata: props.metadata,
         sendFrom: props.sendFrom,
+        nodeVisits: props.nodeVisits,
       },
     })
   }

--- a/apps/worker/src/integration/handlers/flow.ts
+++ b/apps/worker/src/integration/handlers/flow.ts
@@ -358,6 +358,11 @@ async function* executeMultipleStepsGenerator(
   const { steps, ...rest } = props
 
   for (const step of steps) {
+    // `nodeId` is overloaded: startAnotherNode/startExternalNode store their own jump
+    // target in it, while every other step uses it only to tag the message with the node
+    // that produced it (flow analytics). Keep the step's own target when present; otherwise
+    // stamp the containing node id. Falling straight to `props.targetNodeId` here would make
+    // a jump step target its own node and loop forever.
     const stepWithNodeId = {
       ...step,
       nodeId: step.nodeId ?? props.targetNodeId ?? "",

--- a/apps/worker/src/integration/handlers/flow.ts
+++ b/apps/worker/src/integration/handlers/flow.ts
@@ -29,6 +29,7 @@ import {
   type IntegrationJobSendFlowPostback,
   type IntegrationJobSendFlowQuickReply,
   integrationQueue,
+  type NodeVisits,
 } from "@chatbotx.io/worker-config"
 import {
   detectConversationAndContactInbox,
@@ -86,7 +87,7 @@ type ExecuteStepsAndQuickRepliesProps = {
   trackingContext?: BotResponseTrackingContext
   metadata?: MetadataPayload
   sendFrom?: "inbox"
-  nodeVisits?: Record<string, number>
+  nodeVisits?: NodeVisits
 }
 
 export const runFlowNode = async (props: IntegrationJobRunFlowNode["data"]) => {
@@ -178,9 +179,16 @@ export async function runStepsAndQuickReplies(
     triggerNextNode = true,
   } = props
 
+  // Loop guard: cap how many times a single node runs within one uninterrupted pass.
+  // Only a real node entry is counted (no startFromStepId — mid-node re-dispatches reuse
+  // the same count). The counter rides the job payload and resets when the flow pauses for
+  // the user (wait / getUserData resume from a fresh payload), so only instant cycles add up.
   let nodeVisits = props.nodeVisits
   if (!props.startFromStepId && props.targetNodeId) {
     const count = (props.nodeVisits?.[props.targetNodeId] ?? 0) + 1
+    // This node has already run MAX_NODE_EXECUTIONS times in this pass — the flow is cyclic
+    // (e.g. node A → node B → node A). Stop here instead of sending forever, and log the
+    // cycle (the nodeVisits map) so the misconfigured flow can be found.
     if (count > MAX_NODE_EXECUTIONS) {
       logger.warn(
         {

--- a/apps/worker/src/integration/handlers/flow.ts
+++ b/apps/worker/src/integration/handlers/flow.ts
@@ -52,6 +52,12 @@ const ROUTING_STATUSES = new Set<StepRoutingStatus>([
   "skip",
 ])
 
+/**
+ * Max times a single node may execute within one uninterrupted run.
+ * The counter rides sendFlow jobs and resets on user pauses.
+ */
+export const MAX_NODE_EXECUTIONS = 3
+
 export type {
   ExecuteMultipleStepsProps,
   ExecuteStepProps,
@@ -80,6 +86,7 @@ type ExecuteStepsAndQuickRepliesProps = {
   trackingContext?: BotResponseTrackingContext
   metadata?: MetadataPayload
   sendFrom?: "inbox"
+  nodeVisits?: Record<string, number>
 }
 
 export const runFlowNode = async (props: IntegrationJobRunFlowNode["data"]) => {
@@ -132,6 +139,7 @@ export const runFlowNode = async (props: IntegrationJobRunFlowNode["data"]) => {
       trackingContext,
       metadata,
       sendFrom,
+      nodeVisits: props.nodeVisits,
     })
   } catch (error) {
     if (props.metadata?.type === BROADCAST_PAYLOAD_TYPE) {
@@ -170,6 +178,28 @@ export async function runStepsAndQuickReplies(
     triggerNextNode = true,
   } = props
 
+  let nodeVisits = props.nodeVisits
+  if (!props.startFromStepId && props.targetNodeId) {
+    const count = (props.nodeVisits?.[props.targetNodeId] ?? 0) + 1
+    if (count > MAX_NODE_EXECUTIONS) {
+      logger.warn(
+        {
+          nodeId: props.targetNodeId,
+          count,
+          maxNodeExecutions: MAX_NODE_EXECUTIONS,
+          flowId: flowVersion.flowId,
+          flowVersionId: flowVersion.id,
+          conversationId: props.conversation.id,
+          contactInboxId: props.contactInbox.id,
+          nodeVisits: props.nodeVisits,
+        },
+        "Flow node exceeded max executions in one run; stopping to prevent an infinite loop",
+      )
+      return
+    }
+    nodeVisits = { ...props.nodeVisits, [props.targetNodeId]: count }
+  }
+
   // run before step
   // Skip startAnotherNode beforeStep for buttons/quickReplies: the edge-following below
   // already navigates to the same target node, so running beforeStep would execute it twice.
@@ -180,6 +210,7 @@ export async function runStepsAndQuickReplies(
   if (details.beforeStep && !props.startFromStepId && !skipBeforeStep) {
     await executeMultipleSteps({
       ...props,
+      nodeVisits,
       steps: [details.beforeStep],
     })
   }
@@ -204,6 +235,7 @@ export async function runStepsAndQuickReplies(
     const currentStep = details.steps[startIdx]
     const result = await executeMultipleSteps({
       ...props,
+      nodeVisits,
       steps: [currentStep],
     })
 
@@ -232,6 +264,7 @@ export async function runStepsAndQuickReplies(
           metadata: props.metadata,
           trackingContext: props.trackingContext,
           sendFrom: props.sendFrom,
+          nodeVisits,
         },
       })
       return
@@ -246,6 +279,7 @@ export async function runStepsAndQuickReplies(
   ) {
     await executeMultipleSteps({
       ...props,
+      nodeVisits,
       steps: [
         {
           stepType: stepTypes.enum.sendQuickReply,
@@ -290,6 +324,7 @@ export async function runStepsAndQuickReplies(
         metadata: props.metadata,
         trackingContext: props.trackingContext,
         sendFrom: props.sendFrom,
+        nodeVisits,
       },
     })
   }
@@ -357,6 +392,7 @@ async function* executeMultipleStepsGenerator(
               metadata: props.metadata,
               trackingContext: props.trackingContext,
               sendFrom: props.sendFrom,
+              nodeVisits: props.nodeVisits,
             },
           })
           branched = true

--- a/apps/worker/src/integration/handlers/step.ts
+++ b/apps/worker/src/integration/handlers/step.ts
@@ -119,6 +119,7 @@ async function splitTraffic({
   targetId,
   useLatestFlowVersion,
   sendFrom,
+  nodeVisits,
 }: ExecuteStepProps<SplitTrafficStepSchema>) {
   if (!(targetId && step.cases.length)) {
     return
@@ -150,6 +151,7 @@ async function splitTraffic({
         flowVersionId: useLatestFlowVersion ? undefined : flowVersion.id,
         nodeId: connectedEdge.target,
         sendFrom,
+        nodeVisits,
       },
     })
   }
@@ -273,6 +275,7 @@ async function startAnotherNode(
       nodeId: props.step.nodeId,
       metadata: props.metadata,
       sendFrom: props.sendFrom,
+      nodeVisits: props.nodeVisits,
     },
   })
 }
@@ -283,6 +286,7 @@ async function startExternalFlow({
   step,
   metadata,
   sendFrom,
+  nodeVisits,
 }: ExecuteStepProps<StartExternalFlowStepSchema>) {
   await integrationQueue.add(IntegrationJobAction.sendFlow, {
     type: IntegrationJobAction.sendFlow,
@@ -292,6 +296,7 @@ async function startExternalFlow({
       flowId: step.flowId,
       metadata,
       sendFrom,
+      nodeVisits,
     },
   })
 }
@@ -302,6 +307,7 @@ async function startExternalNode({
   step,
   metadata,
   sendFrom,
+  nodeVisits,
 }: ExecuteStepProps<StartExternalNodeStepSchema>) {
   await integrationQueue.add(IntegrationJobAction.sendFlow, {
     type: IntegrationJobAction.sendFlow,
@@ -312,6 +318,7 @@ async function startExternalNode({
       nodeId: step.nodeId,
       metadata,
       sendFrom,
+      nodeVisits,
     },
   })
 }

--- a/biome.json
+++ b/biome.json
@@ -19,7 +19,8 @@
       "!**/packages/ui/src/hooks",
       "!**/packages/ui/src/components/carousel-snap.tsx",
       "!**/packages/ui/src/types/data-table.ts",
-      "!**/dist"
+      "!**/dist",
+      "!**/coverage"
     ]
   },
   "formatter": {

--- a/packages/worker-config/src/queues/integration/index.ts
+++ b/packages/worker-config/src/queues/integration/index.ts
@@ -100,6 +100,13 @@ export type IntegrationJobMessageStatus = {
   }
 }
 
+/**
+ * Per-node execution counter carried through `sendFlow` jobs to guard against
+ * infinite flow loops. Maps a node id to the number of times that node has
+ * executed within one uninterrupted run; resets when the flow pauses for the user.
+ */
+export type NodeVisits = Record<string, number>
+
 export type IntegrationJobRunFlowNode = {
   type: typeof IntegrationJobAction.sendFlow
   data: {
@@ -109,7 +116,7 @@ export type IntegrationJobRunFlowNode = {
     flowVersionId?: string
     nodeId?: string
     startFromStepId?: string
-    nodeVisits?: Record<string, number>
+    nodeVisits?: NodeVisits
     trackingContext?: BotResponseTrackingContext
     metadata?: MetadataPayload
     sendFrom?: "inbox"

--- a/packages/worker-config/src/queues/integration/index.ts
+++ b/packages/worker-config/src/queues/integration/index.ts
@@ -109,6 +109,7 @@ export type IntegrationJobRunFlowNode = {
     flowVersionId?: string
     nodeId?: string
     startFromStepId?: string
+    nodeVisits?: Record<string, number>
     trackingContext?: BotResponseTrackingContext
     metadata?: MetadataPayload
     sendFrom?: "inbox"


### PR DESCRIPTION
## What this does

Fixes a problem where a flow could send the same message over and over without stopping.

When a step hands the conversation to another node, it now continues to the node that was actually chosen — instead of accidentally looping back and repeating. As an extra safeguard, a flow can no longer get stuck sending forever: if it's set up in a circle by mistake, it stops on its own after a few repeats and records a note in the logs.

Flows that are meant to repeat on purpose — waiting for a reply or for a delay — keep working exactly as before.

## How it was checked

- Added automated tests for the affected flow behaviour
- All existing tests still pass
- Type checks and code style checks pass