### PR TITLE
Improve contact creation and analytics experience

### DIFF
--- a/apps/builder/__tests__/contacts-last-read.test.ts
+++ b/apps/builder/__tests__/contacts-last-read.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment node
+import { describe, expect, test } from "vitest"
+import { getLatestContactLastReadAt } from "@/features/contacts/utils"
+
+describe("getLatestContactLastReadAt", () => {
+  test("returns the latest contact inbox read timestamp", () => {
+    const oldest = new Date("2026-01-01T00:00:00.000Z")
+    const latest = new Date("2026-01-03T00:00:00.000Z")
+
+    expect(
+      getLatestContactLastReadAt([
+        { contactLastReadAt: oldest },
+        { contactLastReadAt: null },
+        { contactLastReadAt: latest },
+      ]),
+    ).toBe(latest)
+  })
+
+  test("returns null when no contact inbox read timestamp exists", () => {
+    expect(
+      getLatestContactLastReadAt([
+        { contactLastReadAt: null },
+        { contactLastReadAt: undefined },
+      ]),
+    ).toBeNull()
+  })
+})

--- a/apps/builder/__tests__/create-contact-action.test.ts
+++ b/apps/builder/__tests__/create-contact-action.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest"
 import { z } from "zod"
 
 const mockFindByPhone = vi.fn()
+const mockContactInboxFindLatestBySource = vi.fn()
 const mockContactInsert = vi.fn()
 const mockCreateNewContactWithMac = vi.fn()
 const mockQuotaIncrement = vi.fn()
@@ -12,6 +13,9 @@ const mockEmitContactCreated = vi.fn()
 const mockReturnValidationErrors = vi.fn((_schema, errors) => errors)
 
 vi.mock("@chatbotx.io/business", () => ({
+  contactInboxService: {
+    findLatestBySource: mockContactInboxFindLatestBySource,
+  },
   contactService: {
     findByPhone: mockFindByPhone,
     insert: mockContactInsert,
@@ -39,7 +43,6 @@ vi.mock("@chatbotx.io/database/partials", async () => {
   >("@chatbotx.io/database/partials")
   return {
     ...actual,
-    channelTypes: { enum: { webchat: "webchat" } },
     contactSources: { enum: { imported: "imported" } },
   }
 })
@@ -84,6 +87,9 @@ vi.mock("@/lib/safe-action", () => ({
 const { createContact } = await import(
   "../src/features/contacts/actions/create-contact.action"
 )
+const { createContactRequest } = await import(
+  "../src/features/contacts/schemas/action"
+)
 
 const contact = {
   id: "contact-1",
@@ -99,17 +105,57 @@ const contactInbox = {
   sourceId: "source-1",
 }
 
+type InsertedContactInboxRow = Record<string, unknown> & {
+  channel?: string
+  inboxId?: string
+  sourceId?: string
+}
+
+type CreateContactTestTx = {
+  insert: () => {
+    values: (row: InsertedContactInboxRow) => {
+      returning: () => [typeof contactInbox]
+    }
+  }
+}
+
+type CreateContactQuotaArgs = {
+  create: (tx: CreateContactTestTx) => Promise<{ value: unknown }>
+}
+
+const mockCreateWithInsertedRows = () => {
+  const insertedRows: InsertedContactInboxRow[] = []
+  mockCreateNewContactWithMac.mockImplementation(
+    async (args: CreateContactQuotaArgs) => {
+      const tx: CreateContactTestTx = {
+        insert: () => ({
+          values: (row) => {
+            insertedRows.push(row)
+            return {
+              returning: () => [contactInbox],
+            }
+          },
+        }),
+      }
+      const created = await args.create(tx)
+      return { ok: true, value: created.value }
+    },
+  )
+  return insertedRows
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   mockFindByPhone.mockResolvedValue(undefined)
+  mockContactInboxFindLatestBySource.mockResolvedValue(undefined)
   mockFindOrFail.mockResolvedValue({ id: "inbox-1", channel: "webchat" })
   mockWorkspaceFind.mockResolvedValue({ id: "ws-1", ownerId: "owner-1" })
   mockContactInsert.mockResolvedValue(contact)
   mockQuotaIncrement.mockResolvedValue(undefined)
   mockEmitContactCreated.mockResolvedValue(undefined)
   mockCreateNewContactWithMac.mockImplementation(
-    async (args: { create: (tx: unknown) => Promise<{ value: unknown }> }) => {
-      const tx = {
+    async (args: CreateContactQuotaArgs) => {
+      const tx: CreateContactTestTx = {
         insert: () => ({
           values: () => ({
             returning: () => [contactInbox],
@@ -130,7 +176,10 @@ describe("createContact", () => {
         email: "ada@example.com",
         firstName: "Ada",
         gender: "unknown",
+        inboxId: "inbox-1",
         phoneNumber: "+15551234567",
+        channel: "webchat",
+        contactId: "",
       },
     })
 
@@ -156,7 +205,10 @@ describe("createContact", () => {
         email: "ada@example.com",
         firstName: "Ada",
         gender: "unknown",
+        inboxId: "inbox-1",
         phoneNumber: "+15551234567",
+        channel: "webchat",
+        contactId: "",
       },
     })
 
@@ -165,5 +217,747 @@ describe("createContact", () => {
     })
     expect(mockContactInsert).not.toHaveBeenCalled()
     expect(mockQuotaIncrement).not.toHaveBeenCalled()
+  })
+
+  test("attaches manual contacts to the selected workspace inbox", async () => {
+    const selectedInbox = { id: "messenger-inbox-1", channel: "messenger" }
+    mockFindOrFail.mockResolvedValue(selectedInbox)
+    const insertedRows = mockCreateWithInsertedRows()
+
+    await createContact({
+      workspaceId: "ws-1",
+      parsedInput: {
+        email: "ada@example.com",
+        firstName: "Ada",
+        gender: "unknown",
+        inboxId: selectedInbox.id,
+        phoneNumber: "+15551234567",
+        channel: "messenger",
+        contactId: "psid-123",
+      },
+    })
+
+    expect(mockFindOrFail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { workspaceId: "ws-1", id: selectedInbox.id },
+      }),
+    )
+    expect(mockContactInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          email: "ada@example.com",
+          firstName: "Ada",
+          gender: "unknown",
+          phoneNumber: "+15551234567",
+        },
+      }),
+    )
+    expect(insertedRows).toContainEqual(
+      expect.objectContaining({
+        channel: selectedInbox.channel,
+        inboxId: selectedInbox.id,
+        sourceId: "psid-123",
+      }),
+    )
+  })
+
+  test("uses WhatsApp phone digits as the source id", async () => {
+    const selectedInbox = { id: "whatsapp-inbox-1", channel: "whatsapp" }
+    mockFindOrFail.mockResolvedValue(selectedInbox)
+    const insertedRows = mockCreateWithInsertedRows()
+
+    await createContact({
+      workspaceId: "ws-1",
+      parsedInput: {
+        email: "",
+        firstName: "Ada",
+        gender: "unknown",
+        inboxId: selectedInbox.id,
+        phoneNumber: "+15551234567",
+        channel: "whatsapp",
+        contactId: "",
+      },
+    })
+
+    expect(mockContactInboxFindLatestBySource).toHaveBeenCalledWith({
+      inboxId: selectedInbox.id,
+      sourceId: "15551234567",
+    })
+    expect(insertedRows).toContainEqual(
+      expect.objectContaining({
+        inboxId: selectedInbox.id,
+        sourceId: "15551234567",
+      }),
+    )
+  })
+
+  test("normalizes local WhatsApp phone numbers with the workspace target country", async () => {
+    const selectedInbox = { id: "whatsapp-inbox-1", channel: "whatsapp" }
+    mockFindOrFail.mockResolvedValue(selectedInbox)
+    mockWorkspaceFind.mockResolvedValue({
+      id: "ws-1",
+      ownerId: "owner-1",
+      targetCountry: "VN",
+    })
+    const insertedRows = mockCreateWithInsertedRows()
+
+    await createContact({
+      workspaceId: "ws-1",
+      parsedInput: {
+        email: "",
+        firstName: "Ada",
+        gender: "unknown",
+        inboxId: selectedInbox.id,
+        phoneNumber: "0901234567",
+        channel: "whatsapp",
+        contactId: "",
+      },
+    })
+
+    expect(mockFindByPhone).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      phoneNumber: "+84901234567",
+    })
+    expect(mockContactInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          phoneNumber: "+84901234567",
+        }),
+      }),
+    )
+    expect(mockContactInboxFindLatestBySource).toHaveBeenCalledWith({
+      inboxId: selectedInbox.id,
+      sourceId: "84901234567",
+    })
+    expect(insertedRows).toContainEqual(
+      expect.objectContaining({
+        inboxId: selectedInbox.id,
+        sourceId: "84901234567",
+      }),
+    )
+  })
+
+  test.each([
+    {
+      name: "unset",
+      workspace: { id: "ws-1", ownerId: "owner-1" },
+    },
+    {
+      name: "unknown",
+      workspace: { id: "ws-1", ownerId: "owner-1", targetCountry: "unknown" },
+    },
+  ])("requires a country code for local WhatsApp phone numbers when target country is $name", async ({
+    workspace,
+  }) => {
+    const selectedInbox = { id: "whatsapp-inbox-1", channel: "whatsapp" }
+    mockFindOrFail.mockResolvedValue(selectedInbox)
+    mockWorkspaceFind.mockResolvedValue(workspace)
+
+    const result = await createContact({
+      workspaceId: "ws-1",
+      parsedInput: {
+        email: "",
+        firstName: "Ada",
+        gender: "unknown",
+        inboxId: selectedInbox.id,
+        phoneNumber: "0901234567",
+        channel: "whatsapp",
+        contactId: "",
+      },
+    })
+
+    expect(result).toMatchObject({
+      phoneNumber: {
+        _errors: ["Please include the country code (e.g. +84)"],
+      },
+    })
+    expect(mockContactInsert).not.toHaveBeenCalled()
+    expect(mockCreateNewContactWithMac).not.toHaveBeenCalled()
+  })
+
+  test("uses email as the source id for SMTP contacts", async () => {
+    const selectedInbox = { id: "smtp-inbox-1", channel: "smtp" }
+    mockFindOrFail.mockResolvedValue(selectedInbox)
+    const insertedRows = mockCreateWithInsertedRows()
+
+    await createContact({
+      workspaceId: "ws-1",
+      parsedInput: {
+        email: "ada@example.com",
+        firstName: "Ada",
+        gender: "unknown",
+        inboxId: selectedInbox.id,
+        phoneNumber: "",
+        channel: "smtp",
+        contactId: "",
+      },
+    })
+
+    expect(mockContactInboxFindLatestBySource).toHaveBeenCalledWith({
+      inboxId: selectedInbox.id,
+      sourceId: "ada@example.com",
+    })
+    expect(insertedRows).toContainEqual(
+      expect.objectContaining({
+        inboxId: selectedInbox.id,
+        sourceId: "ada@example.com",
+      }),
+    )
+  })
+
+  test("uses a synthetic source id for webchat contacts", async () => {
+    const selectedInbox = { id: "webchat-inbox-1", channel: "webchat" }
+    mockFindOrFail.mockResolvedValue(selectedInbox)
+    const insertedRows = mockCreateWithInsertedRows()
+
+    await createContact({
+      workspaceId: "ws-1",
+      parsedInput: {
+        email: "",
+        firstName: "Ada",
+        gender: "unknown",
+        inboxId: selectedInbox.id,
+        phoneNumber: "",
+        channel: "webchat",
+        contactId: "",
+      },
+    })
+
+    expect(mockContactInboxFindLatestBySource).not.toHaveBeenCalled()
+    expect(insertedRows).toContainEqual(
+      expect.objectContaining({
+        inboxId: selectedInbox.id,
+        sourceId: "randomgenerated-id",
+      }),
+    )
+  })
+
+  test("rejects when the selected inbox channel does not match the requested source", async () => {
+    const selectedInbox = { id: "messenger-inbox-1", channel: "messenger" }
+    mockFindOrFail.mockResolvedValue(selectedInbox)
+
+    const result = await createContact({
+      workspaceId: "ws-1",
+      parsedInput: {
+        email: "",
+        firstName: "Ada",
+        gender: "unknown",
+        inboxId: selectedInbox.id,
+        phoneNumber: "+15551234567",
+        channel: "whatsapp",
+        contactId: "",
+      },
+    })
+
+    expect(result).toMatchObject({
+      inboxId: {
+        _errors: ["Selected inbox does not match the selected source"],
+      },
+    })
+    expect(mockContactInboxFindLatestBySource).not.toHaveBeenCalled()
+    expect(mockCreateNewContactWithMac).not.toHaveBeenCalled()
+  })
+
+  test("returns a field validation error when the selected inbox identity already exists", async () => {
+    const selectedInbox = { id: "messenger-inbox-1", channel: "messenger" }
+    mockFindOrFail.mockResolvedValue(selectedInbox)
+    mockContactInboxFindLatestBySource.mockResolvedValue({
+      id: "existing-contact-inbox-1",
+    })
+
+    const result = await createContact({
+      workspaceId: "ws-1",
+      parsedInput: {
+        email: "",
+        firstName: "Ada",
+        gender: "unknown",
+        inboxId: selectedInbox.id,
+        phoneNumber: "",
+        channel: "messenger",
+        contactId: "psid-123",
+      },
+    })
+
+    expect(result).toMatchObject({
+      contactId: {
+        _errors: ["This contact already exists on the selected inbox"],
+      },
+    })
+    expect(mockCreateNewContactWithMac).not.toHaveBeenCalled()
+  })
+
+  test("uses an already-international WhatsApp number even when a target country is set", async () => {
+    mockFindOrFail.mockResolvedValue({
+      id: "whatsapp-inbox-1",
+      channel: "whatsapp",
+    })
+    mockWorkspaceFind.mockResolvedValue({
+      id: "ws-1",
+      ownerId: "owner-1",
+      targetCountry: "VN",
+    })
+    const insertedRows = mockCreateWithInsertedRows()
+
+    await createContact({
+      workspaceId: "ws-1",
+      parsedInput: {
+        email: "",
+        firstName: "Ada",
+        gender: "unknown",
+        inboxId: "whatsapp-inbox-1",
+        phoneNumber: "+84901234567",
+        channel: "whatsapp",
+        contactId: "",
+      },
+    })
+
+    expect(insertedRows).toContainEqual(
+      expect.objectContaining({ sourceId: "84901234567" }),
+    )
+  })
+
+  test("prefers an explicit country code over the workspace target country", async () => {
+    mockFindOrFail.mockResolvedValue({
+      id: "whatsapp-inbox-1",
+      channel: "whatsapp",
+    })
+    mockWorkspaceFind.mockResolvedValue({
+      id: "ws-1",
+      ownerId: "owner-1",
+      targetCountry: "VN",
+    })
+    const insertedRows = mockCreateWithInsertedRows()
+
+    await createContact({
+      workspaceId: "ws-1",
+      parsedInput: {
+        email: "",
+        firstName: "Ada",
+        gender: "unknown",
+        inboxId: "whatsapp-inbox-1",
+        phoneNumber: "+12015550123",
+        channel: "whatsapp",
+        contactId: "",
+      },
+    })
+
+    expect(mockContactInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ phoneNumber: "+12015550123" }),
+      }),
+    )
+    expect(insertedRows).toContainEqual(
+      expect.objectContaining({ sourceId: "12015550123" }),
+    )
+  })
+
+  test("strips spaces and separators from local WhatsApp numbers", async () => {
+    mockFindOrFail.mockResolvedValue({
+      id: "whatsapp-inbox-1",
+      channel: "whatsapp",
+    })
+    mockWorkspaceFind.mockResolvedValue({
+      id: "ws-1",
+      ownerId: "owner-1",
+      targetCountry: "VN",
+    })
+    const insertedRows = mockCreateWithInsertedRows()
+
+    await createContact({
+      workspaceId: "ws-1",
+      parsedInput: {
+        email: "",
+        firstName: "Ada",
+        gender: "unknown",
+        inboxId: "whatsapp-inbox-1",
+        phoneNumber: "090 123 4567",
+        channel: "whatsapp",
+        contactId: "",
+      },
+    })
+
+    expect(insertedRows).toContainEqual(
+      expect.objectContaining({ sourceId: "84901234567" }),
+    )
+  })
+
+  test("requires a country code when the WhatsApp phone is empty", async () => {
+    mockFindOrFail.mockResolvedValue({
+      id: "whatsapp-inbox-1",
+      channel: "whatsapp",
+    })
+    mockWorkspaceFind.mockResolvedValue({
+      id: "ws-1",
+      ownerId: "owner-1",
+      targetCountry: "VN",
+    })
+
+    const result = await createContact({
+      workspaceId: "ws-1",
+      parsedInput: {
+        email: "",
+        firstName: "Ada",
+        gender: "unknown",
+        inboxId: "whatsapp-inbox-1",
+        phoneNumber: "",
+        channel: "whatsapp",
+        contactId: "",
+      },
+    })
+
+    expect(result).toMatchObject({
+      phoneNumber: { _errors: ["Please include the country code (e.g. +84)"] },
+    })
+    expect(mockCreateNewContactWithMac).not.toHaveBeenCalled()
+  })
+
+  test("dedups WhatsApp by the normalized phone number", async () => {
+    mockFindOrFail.mockResolvedValue({
+      id: "whatsapp-inbox-1",
+      channel: "whatsapp",
+    })
+    mockWorkspaceFind.mockResolvedValue({
+      id: "ws-1",
+      ownerId: "owner-1",
+      targetCountry: "VN",
+    })
+    mockFindByPhone.mockResolvedValue({ id: "existing-contact" })
+
+    const result = await createContact({
+      workspaceId: "ws-1",
+      parsedInput: {
+        email: "",
+        firstName: "Ada",
+        gender: "unknown",
+        inboxId: "whatsapp-inbox-1",
+        phoneNumber: "0901234567",
+        channel: "whatsapp",
+        contactId: "",
+      },
+    })
+
+    expect(mockFindByPhone).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      phoneNumber: "+84901234567",
+    })
+    expect(result).toMatchObject({
+      phoneNumber: { _errors: ["Phone number is exists"] },
+    })
+    expect(mockCreateNewContactWithMac).not.toHaveBeenCalled()
+  })
+
+  test("maps a duplicate WhatsApp wa_id to the phoneNumber field", async () => {
+    mockFindOrFail.mockResolvedValue({
+      id: "whatsapp-inbox-1",
+      channel: "whatsapp",
+    })
+    mockWorkspaceFind.mockResolvedValue({
+      id: "ws-1",
+      ownerId: "owner-1",
+      targetCountry: "VN",
+    })
+    mockContactInboxFindLatestBySource.mockResolvedValue({ id: "existing-ci" })
+
+    const result = await createContact({
+      workspaceId: "ws-1",
+      parsedInput: {
+        email: "",
+        firstName: "Ada",
+        gender: "unknown",
+        inboxId: "whatsapp-inbox-1",
+        phoneNumber: "0901234567",
+        channel: "whatsapp",
+        contactId: "",
+      },
+    })
+
+    expect(mockContactInboxFindLatestBySource).toHaveBeenCalledWith({
+      inboxId: "whatsapp-inbox-1",
+      sourceId: "84901234567",
+    })
+    expect(result).toMatchObject({
+      phoneNumber: {
+        _errors: ["This contact already exists on the selected inbox"],
+      },
+    })
+    expect(mockCreateNewContactWithMac).not.toHaveBeenCalled()
+  })
+
+  test("maps a duplicate SMTP identity to the email field", async () => {
+    mockFindOrFail.mockResolvedValue({ id: "smtp-inbox-1", channel: "smtp" })
+    mockContactInboxFindLatestBySource.mockResolvedValue({ id: "existing-ci" })
+
+    const result = await createContact({
+      workspaceId: "ws-1",
+      parsedInput: {
+        email: "ada@example.com",
+        firstName: "Ada",
+        gender: "unknown",
+        inboxId: "smtp-inbox-1",
+        phoneNumber: "",
+        channel: "smtp",
+        contactId: "",
+      },
+    })
+
+    expect(result).toMatchObject({
+      email: {
+        _errors: ["This contact already exists on the selected inbox"],
+      },
+    })
+    expect(mockCreateNewContactWithMac).not.toHaveBeenCalled()
+  })
+
+  test("normalizes the phone for non-WhatsApp channels too", async () => {
+    mockFindOrFail.mockResolvedValue({
+      id: "messenger-inbox-1",
+      channel: "messenger",
+    })
+    mockWorkspaceFind.mockResolvedValue({
+      id: "ws-1",
+      ownerId: "owner-1",
+      targetCountry: "VN",
+    })
+    const insertedRows = mockCreateWithInsertedRows()
+
+    await createContact({
+      workspaceId: "ws-1",
+      parsedInput: {
+        email: "",
+        firstName: "Ada",
+        gender: "unknown",
+        inboxId: "messenger-inbox-1",
+        phoneNumber: "0901234567",
+        channel: "messenger",
+        contactId: "psid-9",
+      },
+    })
+
+    // Phone is normalized to E.164 even though the identity (sourceId) is the PSID.
+    expect(mockContactInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ phoneNumber: "+84901234567" }),
+      }),
+    )
+    expect(insertedRows).toContainEqual(
+      expect.objectContaining({ sourceId: "psid-9" }),
+    )
+  })
+
+  test("requires a country code for a non-WhatsApp phone that cannot be resolved", async () => {
+    mockFindOrFail.mockResolvedValue({
+      id: "messenger-inbox-1",
+      channel: "messenger",
+    })
+    // beforeEach workspace has no targetCountry → a local number cannot be resolved.
+
+    const result = await createContact({
+      workspaceId: "ws-1",
+      parsedInput: {
+        email: "",
+        firstName: "Ada",
+        gender: "unknown",
+        inboxId: "messenger-inbox-1",
+        phoneNumber: "0901234567",
+        channel: "messenger",
+        contactId: "psid-9",
+      },
+    })
+
+    expect(result).toMatchObject({
+      phoneNumber: { _errors: ["Please include the country code (e.g. +84)"] },
+    })
+    expect(mockCreateNewContactWithMac).not.toHaveBeenCalled()
+  })
+
+  test("skips the phone dedup when no phone is provided", async () => {
+    mockFindOrFail.mockResolvedValue({ id: "smtp-inbox-1", channel: "smtp" })
+    mockCreateWithInsertedRows()
+
+    await createContact({
+      workspaceId: "ws-1",
+      parsedInput: {
+        email: "ada@example.com",
+        firstName: "Ada",
+        gender: "unknown",
+        inboxId: "smtp-inbox-1",
+        phoneNumber: "",
+        channel: "smtp",
+        contactId: "",
+      },
+    })
+
+    expect(mockFindByPhone).not.toHaveBeenCalled()
+  })
+
+  test("emits contact-created and analytics events on success", async () => {
+    mockFindOrFail.mockResolvedValue({
+      id: "webchat-inbox-1",
+      channel: "webchat",
+    })
+    mockCreateWithInsertedRows()
+
+    await createContact({
+      workspaceId: "ws-1",
+      parsedInput: {
+        email: "ada@example.com",
+        firstName: "Ada",
+        gender: "unknown",
+        inboxId: "webchat-inbox-1",
+        phoneNumber: "",
+        channel: "webchat",
+        contactId: "",
+      },
+    })
+
+    expect(mockEmitContactCreated).toHaveBeenCalledWith(
+      "ws-1",
+      "contact-1",
+      "Ada",
+      "+15551234567",
+      "ada@example.com",
+    )
+    expect(mockEmit).toHaveBeenCalledWith(
+      "analytics:dashboard",
+      expect.objectContaining({
+        eventType: "contact:created",
+        workspaceId: "ws-1",
+        channel: "webchat",
+      }),
+    )
+  })
+})
+
+describe("createContactRequest", () => {
+  const baseInput = {
+    email: "",
+    firstName: "Ada",
+    gender: "unknown",
+    inboxId: "1",
+    phoneNumber: "",
+    contactId: "",
+  } as const
+
+  test("requires phone number for WhatsApp", () => {
+    const result = createContactRequest.safeParse({
+      ...baseInput,
+      channel: "whatsapp",
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues).toContainEqual(
+      expect.objectContaining({
+        path: ["phoneNumber"],
+        message: "Phone number is required for WhatsApp",
+      }),
+    )
+  })
+
+  test("requires email for SMTP", () => {
+    const result = createContactRequest.safeParse({
+      ...baseInput,
+      channel: "smtp",
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues).toContainEqual(
+      expect.objectContaining({
+        path: ["email"],
+        message: "Email is required for the Email channel",
+      }),
+    )
+  })
+
+  test("requires contact id for social channels", () => {
+    const result = createContactRequest.safeParse({
+      ...baseInput,
+      channel: "messenger",
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues).toContainEqual(
+      expect.objectContaining({
+        path: ["contactId"],
+        message: "User ID is required for this channel",
+      }),
+    )
+  })
+
+  test("allows webchat without a channel identity", () => {
+    const result = createContactRequest.safeParse({
+      ...baseInput,
+      channel: "webchat",
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  test("accepts WhatsApp with a phone number", () => {
+    expect(
+      createContactRequest.safeParse({
+        ...baseInput,
+        channel: "whatsapp",
+        phoneNumber: "+84901234567",
+      }).success,
+    ).toBe(true)
+  })
+
+  test("accepts SMTP with an email", () => {
+    expect(
+      createContactRequest.safeParse({
+        ...baseInput,
+        channel: "smtp",
+        email: "ada@example.com",
+      }).success,
+    ).toBe(true)
+  })
+
+  test("accepts a social channel with a contact id", () => {
+    expect(
+      createContactRequest.safeParse({
+        ...baseInput,
+        channel: "messenger",
+        contactId: "psid-1",
+      }).success,
+    ).toBe(true)
+  })
+
+  test("rejects an invalid email format", () => {
+    const result = createContactRequest.safeParse({
+      ...baseInput,
+      channel: "webchat",
+      email: "not-an-email",
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues).toContainEqual(
+      expect.objectContaining({ path: ["email"] }),
+    )
+  })
+
+  test("rejects a contact id longer than 255 chars", () => {
+    const result = createContactRequest.safeParse({
+      ...baseInput,
+      channel: "messenger",
+      contactId: "x".repeat(256),
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues).toContainEqual(
+      expect.objectContaining({ path: ["contactId"] }),
+    )
+  })
+
+  test("rejects a too-short WhatsApp phone number", () => {
+    const result = createContactRequest.safeParse({
+      ...baseInput,
+      channel: "whatsapp",
+      phoneNumber: "123",
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues).toContainEqual(
+      expect.objectContaining({ path: ["phoneNumber"] }),
+    )
   })
 })

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -208,6 +208,22 @@
     "newContactsByCountry": "New contacts by country",
     "date": "Date",
     "total": "Total",
+    "messagesSent": "Messages Sent",
+    "selectRange": "Select range",
+    "dateFilterPreset": "Date filter preset",
+    "noResults": "No results.",
+    "noData": "No data",
+    "comingSoon": "Coming soon",
+    "unknown": "Unknown",
+    "pagination": {
+      "selectedRows": "{selected} of {total} row(s) selected.",
+      "rowsPerPage": "Rows per page",
+      "pageOf": "Page {page} of {pageCount}",
+      "firstPage": "Go to first page",
+      "previousPage": "Go to previous page",
+      "nextPage": "Go to next page",
+      "lastPage": "Go to last page"
+    },
     "sessionsThroughTheRef": "Sessions through the Ref \"{ref}\" per day",
     "sessionsThroughTheMagicLink": "Sessions through the Magic Link \"{ref}\" per day"
   },
@@ -781,7 +797,8 @@
       "label": "Show Message Input"
     },
     "inbox": {
-      "label": "Inbox"
+      "label": "Inbox",
+      "placeholder": "Select an inbox"
     },
     "inboxTeam": {
       "label": "Inbox Team"
@@ -1129,7 +1146,14 @@
       "placeholder": "Enter URL"
     },
     "userId": {
-      "label": "User ID"
+      "label": "User ID",
+      "placeholders": {
+        "instagram": "Instagram user ID",
+        "messenger": "Messenger PSID",
+        "telegram": "Telegram chat ID",
+        "tiktok": "TikTok user ID",
+        "zalo": "Zalo user ID"
+      }
     },
     "userTags": {
       "label": "User Tags"
@@ -1271,7 +1295,8 @@
       "label": "Spreadsheet"
     },
     "source": {
-      "label": "Source"
+      "label": "Source",
+      "placeholder": "Select a source"
     },
     "password": {
       "label": "Password",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -208,8 +208,24 @@
     "newContactsByCountry": "Liên hệ mới theo quốc gia",
     "date": "Ngày",
     "total": "Tổng",
-    "sessionsThroughTheRef": "Phiên qua Ref '{ref}' mỗi ngày",
-    "sessionsThroughTheMagicLink": "Phiên qua Magic Link '{ref}' mỗi ngày"
+    "messagesSent": "Tin nhắn đã gửi",
+    "selectRange": "Chọn khoảng thời gian",
+    "dateFilterPreset": "Bộ lọc ngày đặt sẵn",
+    "noResults": "Không có kết quả.",
+    "noData": "Không có dữ liệu",
+    "comingSoon": "Sắp ra mắt",
+    "unknown": "Không xác định",
+    "pagination": {
+      "selectedRows": "{selected} / {total} hàng đã chọn.",
+      "rowsPerPage": "Số hàng mỗi trang",
+      "pageOf": "Trang {page} / {pageCount}",
+      "firstPage": "Đi tới trang đầu",
+      "previousPage": "Đi tới trang trước",
+      "nextPage": "Đi tới trang sau",
+      "lastPage": "Đi tới trang cuối"
+    },
+    "sessionsThroughTheRef": "Phiên qua Ref \"{ref}\" mỗi ngày",
+    "sessionsThroughTheMagicLink": "Phiên qua Magic Link \"{ref}\" mỗi ngày"
   },
   "autoAssignConversation": {
     "rule": {
@@ -788,7 +804,8 @@
       "label": "Hiển thị ô nhập tin nhắn"
     },
     "inbox": {
-      "label": "Hộp thư"
+      "label": "Hộp thư",
+      "placeholder": "Chọn hộp thư"
     },
     "inboxTeam": {
       "label": "Nhóm hộp thư"
@@ -1112,7 +1129,14 @@
       "placeholder": "Nhập URL"
     },
     "userId": {
-      "label": "ID Người dùng"
+      "label": "ID Người dùng",
+      "placeholders": {
+        "instagram": "ID người dùng Instagram",
+        "messenger": "PSID Messenger",
+        "telegram": "Chat ID Telegram",
+        "tiktok": "ID người dùng TikTok",
+        "zalo": "ID người dùng Zalo"
+      }
     },
     "userTags": {
       "label": "Nhãn người dùng"
@@ -1251,7 +1275,8 @@
       "label": "Bảng tính"
     },
     "source": {
-      "label": "Nguồn"
+      "label": "Nguồn",
+      "placeholder": "Chọn nguồn"
     },
     "password": {
       "label": "Mật khẩu",
@@ -2065,7 +2090,7 @@
     "deleteSuccess": "{feature} deleted successfully",
     "error": "Error",
     "moveFolderDescription": "Move {feature} to folder",
-    "noData": "No data",
+    "noData": "Không có dữ liệu",
     "featureNotFound": "Không tìm thấy {feature}",
     "enableSuccess": "Đã bật {feature} thành công",
     "userInactive": "Người dùng không hoạt động hơn 7 ngày",

--- a/apps/builder/src/features/contact-inboxes/schema/resource.ts
+++ b/apps/builder/src/features/contact-inboxes/schema/resource.ts
@@ -9,11 +9,13 @@ export const contactInboxResource = createSelectSchema(contactInboxModel, {
   contactId: z.string(),
   inboxId: z.string(),
   channel: z.string(),
+  contactLastReadAt: z.date().nullable().optional(),
 }).pick({
   id: true,
   contactId: true,
   inboxId: true,
   channel: true,
   lastIncomingMessageAt: true,
+  contactLastReadAt: true,
 })
 export type ContactInboxResource = z.infer<typeof contactInboxResource>

--- a/apps/builder/src/features/contacts/actions/create-contact.action.ts
+++ b/apps/builder/src/features/contacts/actions/create-contact.action.ts
@@ -1,13 +1,18 @@
 "use server"
 
 import {
+  contactInboxService,
   contactService,
   quotaEnforcementService,
   workspaceService,
 } from "@chatbotx.io/business"
 import { ChatbotXException } from "@chatbotx.io/business/errors"
 import { findOrFail } from "@chatbotx.io/database/client"
-import { channelTypes, contactSources } from "@chatbotx.io/database/partials"
+import {
+  type ChannelType,
+  channelTypes,
+  contactSources,
+} from "@chatbotx.io/database/partials"
 import {
   contactInboxModel,
   conversationModel,
@@ -16,6 +21,7 @@ import {
 import { emit } from "@chatbotx.io/event-bus"
 import { emitContactCreated } from "@chatbotx.io/events"
 import { createId } from "@chatbotx.io/utils"
+import { type CountryCode, parsePhoneNumberFromString } from "libphonenumber-js"
 import { returnValidationErrors } from "next-safe-action"
 import { randomString } from "remeda"
 import {
@@ -28,6 +34,56 @@ import {
   type CreateContactResponse,
   createContactRequest,
 } from "../schemas/action"
+
+type CreateContactValidationField =
+  | "contactId"
+  | "email"
+  | "inboxId"
+  | "phoneNumber"
+type CreateContactValidationFieldError = { _errors: string[] }
+type CreateContactValidationFieldErrors = Partial<
+  Record<CreateContactValidationField, CreateContactValidationFieldError>
+>
+
+const UNKNOWN_TARGET_COUNTRY = "unknown"
+const E164_PREFIX_PATTERN = /^\+/
+
+// No workspace country means local-format WhatsApp numbers must include "+".
+const resolveDefaultRegion = (
+  targetCountry: string | null | undefined,
+): CountryCode | undefined =>
+  targetCountry && targetCountry !== UNKNOWN_TARGET_COUNTRY
+    ? (targetCountry as CountryCode)
+    : undefined
+
+const resolveContactSourceId = ({
+  channel,
+  parsedInput,
+}: {
+  channel: ChannelType
+  parsedInput: CreateContactRequest
+}) => {
+  if (channel === channelTypes.enum.smtp) {
+    return parsedInput.email ?? ""
+  }
+  if (channel === channelTypes.enum.webchat) {
+    return `${randomString()}${createId()}`
+  }
+  return parsedInput.contactId ?? ""
+}
+
+const duplicateIdentityErrorForChannel = (
+  channel: ChannelType,
+  error: CreateContactValidationFieldError,
+): CreateContactValidationFieldErrors => {
+  if (channel === channelTypes.enum.whatsapp) {
+    return { phoneNumber: error }
+  }
+  if (channel === channelTypes.enum.smtp) {
+    return { email: error }
+  }
+  return { contactId: error }
+}
 
 export const createContactAction = workspaceActionClient
   .bindArgsSchemas(workspaceIdrequestParams)
@@ -51,10 +107,63 @@ export const createContact = async ({
   workspaceId: string
   parsedInput: CreateContactRequest
 }): Promise<CreateContactResponse> => {
-  const existedContact = parsedInput.phoneNumber
+  const inbox = await findOrFail({
+    table: inboxModel,
+    where: { workspaceId, id: parsedInput.inboxId },
+    message: "Inbox not found",
+  })
+  const inboxChannel = inbox.channel as ChannelType
+
+  if (parsedInput.channel !== inboxChannel) {
+    return returnValidationErrors(createContactRequest, {
+      _errors: ["Validation Exception"],
+      inboxId: {
+        _errors: ["Selected inbox does not match the selected source"],
+      },
+    })
+  }
+
+  const workspace = await workspaceService.find({ where: { id: workspaceId } })
+  if (!workspace) {
+    return returnValidationErrors(createContactRequest, {
+      _errors: ["Workspace not found"],
+      phoneNumber: { _errors: [] },
+    })
+  }
+
+  // Normalize any provided phone to E.164 (with country code) so it is stored and
+  // deduped consistently across every channel — not just WhatsApp. WhatsApp always
+  // needs one (it is the wa_id); other channels normalize only when a phone is given.
+  let normalizedPhone = parsedInput.phoneNumber
+  if (inboxChannel === channelTypes.enum.whatsapp || parsedInput.phoneNumber) {
+    const parsed = parsePhoneNumberFromString(
+      parsedInput.phoneNumber ?? "",
+      resolveDefaultRegion(workspace.targetCountry),
+    )
+    // Do not use isValid(); it rejects well-formed but unassigned numbers.
+    if (!parsed) {
+      return returnValidationErrors(createContactRequest, {
+        _errors: ["Validation Exception"],
+        phoneNumber: {
+          _errors: ["Please include the country code (e.g. +84)"],
+        },
+      })
+    }
+    normalizedPhone = parsed.number
+  }
+
+  // WhatsApp `wa_id` is the E.164 digits without "+"; other channels key on their own id.
+  let sourceId: string
+  if (inboxChannel === channelTypes.enum.whatsapp) {
+    sourceId = (normalizedPhone ?? "").replace(E164_PREFIX_PATTERN, "")
+  } else {
+    sourceId = resolveContactSourceId({ channel: inboxChannel, parsedInput })
+  }
+
+  const existedContact = normalizedPhone
     ? await contactService.findByPhone({
         workspaceId,
-        phoneNumber: parsedInput.phoneNumber,
+        phoneNumber: normalizedPhone,
       })
     : undefined
   if (existedContact) {
@@ -66,19 +175,30 @@ export const createContact = async ({
     })
   }
 
-  const inbox = await findOrFail({
-    table: inboxModel,
-    where: { workspaceId, channel: channelTypes.enum.webchat },
-    message: "Inbox not found",
-  })
-
-  const workspace = await workspaceService.find({ where: { id: workspaceId } })
-  if (!workspace) {
-    return returnValidationErrors(createContactRequest, {
-      _errors: ["Workspace not found"],
-      phoneNumber: { _errors: [] },
+  if (inboxChannel !== channelTypes.enum.webchat) {
+    const existing = await contactInboxService.findLatestBySource({
+      inboxId: inbox.id,
+      sourceId,
     })
+    if (existing) {
+      const dup = {
+        _errors: ["This contact already exists on the selected inbox"],
+      }
+      return returnValidationErrors(createContactRequest, {
+        _errors: ["Validation Exception"],
+        ...duplicateIdentityErrorForChannel(inboxChannel, dup),
+      })
+    }
   }
+
+  // Store the normalized WhatsApp phone, but keep other contact fields unchanged.
+  const {
+    channel: _channel,
+    inboxId: _inboxId,
+    contactId: _contactId,
+    ...rest
+  } = parsedInput
+  const contactData = { ...rest, phoneNumber: normalizedPhone }
 
   const result = await quotaEnforcementService.createNewContactWithMac({
     ownerId: workspace.ownerId,
@@ -86,7 +206,7 @@ export const createContact = async ({
     create: async (tx) => {
       const contact = await contactService.insert({
         workspaceId,
-        data: parsedInput,
+        data: contactData,
         tx,
       })
 
@@ -96,9 +216,9 @@ export const createContact = async ({
           originalContactId: contact.id,
           contactId: contact.id,
           inboxId: inbox.id,
-          channel: channelTypes.enum.webchat,
+          channel: inboxChannel,
           source: contactSources.enum.imported,
-          sourceId: `${randomString()}${createId()}`,
+          sourceId,
         })
         .returning()
       if (!contactInbox) {

--- a/apps/builder/src/features/contacts/contacts-table.tsx
+++ b/apps/builder/src/features/contacts/contacts-table.tsx
@@ -17,7 +17,7 @@ import {
 } from "@chatbotx.io/ui/components/ui/tooltip"
 import { useDataTable } from "@chatbotx.io/ui/hooks/use-data-table"
 import type { Column, ColumnDef } from "@tanstack/react-table"
-import { format, formatDistance } from "date-fns"
+import { format, formatDistanceToNow } from "date-fns"
 import Link from "next/link"
 import { useTranslations } from "next-intl"
 import { use, useMemo } from "react"
@@ -29,7 +29,7 @@ import type { listContacts } from "./queries/list-contacts.queries"
 import type { ExportContactsFilter } from "./schemas/action"
 import type { ListContactsResponse } from "./schemas/query"
 import type { ContactResource } from "./schemas/resource"
-import { useAvatarUrl } from "./utils"
+import { getLatestContactLastReadAt, useAvatarUrl } from "./utils"
 
 function NameCell({
   contact,
@@ -39,21 +39,21 @@ function NameCell({
   workspaceId: string
 }) {
   const avatarUrl = useAvatarUrl(contact)
+  const inboxHref = `/space/${workspaceId}/inbox?conversationId=${contact.conversation?.id}`
+
   return (
     <div className="flex max-w-50 items-center gap-2">
-      <Avatar className="size-6 shrink-0">
-        <AvatarImage alt={contact.fullName ?? ""} src={avatarUrl} />
-        <AvatarFallback className="text-xs">
-          {contact.fullName?.charAt(0)?.toUpperCase() ?? "?"}
-        </AvatarFallback>
-      </Avatar>
+      <Link href={inboxHref} target="_blank">
+        <Avatar className="size-6 shrink-0">
+          <AvatarImage alt={contact.fullName ?? ""} src={avatarUrl} />
+          <AvatarFallback className="text-xs">
+            {contact.fullName?.charAt(0)?.toUpperCase() ?? "?"}
+          </AvatarFallback>
+        </Avatar>
+      </Link>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Link
-            className="truncate"
-            href={`/space/${workspaceId}/inbox?conversationId=${contact.conversation?.id}`}
-            target="_blank"
-          >
+          <Link className="truncate" href={inboxHref} target="_blank">
             {contact.fullName}
           </Link>
         </TooltipTrigger>
@@ -185,30 +185,29 @@ export function ContactsTable({
       },
       {
         id: "lastReadAt",
-        accessorKey: "lastReadAt",
         header: ({ column }) => (
           <DataTableColumnHeader
             column={column}
             title={t("fields.lastRead.label")}
           />
         ),
-        cell: ({ row }) => (
-          <div>
-            {row.original.conversation?.contactLastReadAt
-              ? formatDistance(
-                  new Date(),
-                  row.original.conversation.contactLastReadAt,
-                  {
-                    addSuffix: true,
-                  },
-                )
-              : null}
-          </div>
-        ),
+        cell: ({ row }) => {
+          const lastReadAt = getLatestContactLastReadAt(
+            row.original.contactInboxes,
+          )
+
+          return (
+            <div>
+              {lastReadAt
+                ? formatDistanceToNow(lastReadAt, { addSuffix: true })
+                : null}
+            </div>
+          )
+        },
         meta: {
           label: t("fields.lastRead.label"),
         },
-        enableSorting: true,
+        enableSorting: false,
         enableHiding: false,
       },
       {

--- a/apps/builder/src/features/contacts/create-contact-dialog.tsx
+++ b/apps/builder/src/features/contacts/create-contact-dialog.tsx
@@ -12,6 +12,7 @@ import {
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { type ReactNode, useState } from "react"
+import { InboxStoreProvider } from "@/features/inboxes/provider/inbox-store-context"
 import { CreateContactForm } from "./create-contact-form"
 
 export function CreateContactDialog({
@@ -51,11 +52,13 @@ export function CreateContactDialog({
           <DialogDescription />
         </DialogHeader>
         <div className="flex items-center space-x-2">
-          <CreateContactForm
-            onCancelled={() => setOpen(false)}
-            onSubmmited={onSubmmited}
-            workspaceId={workspaceId}
-          />
+          <InboxStoreProvider workspaceId={workspaceId}>
+            <CreateContactForm
+              onCancelled={() => setOpen(false)}
+              onSubmmited={onSubmmited}
+              workspaceId={workspaceId}
+            />
+          </InboxStoreProvider>
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/builder/src/features/contacts/create-contact-form.tsx
+++ b/apps/builder/src/features/contacts/create-contact-form.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { type ChannelType, channelTypes } from "@chatbotx.io/database/partials"
 import { InputField } from "@chatbotx.io/ui/components/form/input-field"
 import { SelectField } from "@chatbotx.io/ui/components/form/select-field"
 import { Button } from "@chatbotx.io/ui/components/ui/button"
@@ -8,9 +9,41 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hooks"
 import { Loader2Icon } from "lucide-react"
 import { useTranslations } from "next-intl"
+import { useMemo, useState } from "react"
 import { toast } from "sonner"
+import {
+  allInboxConfigs,
+  useInboxOptionsByChannel,
+} from "@/features/inboxes/provider/inbox-hook"
+import { useInboxStore } from "@/features/inboxes/provider/inbox-store-context"
 import { createContactAction } from "./actions/create-contact.action"
 import { createContactRequest } from "./schemas/action"
+
+const isChannelType = (channelValue: string): channelValue is ChannelType =>
+  channelTypes.options.includes(channelValue as ChannelType)
+
+const channelLabel = (channelValue: ChannelType) =>
+  channelValue === channelTypes.enum.smtp
+    ? "Email"
+    : (allInboxConfigs[channelValue as keyof typeof allInboxConfigs]?.label ??
+      channelValue)
+
+const userIdPlaceholderKey = (channel: ChannelType) => {
+  switch (channel) {
+    case channelTypes.enum.instagram:
+      return "fields.userId.placeholders.instagram"
+    case channelTypes.enum.messenger:
+      return "fields.userId.placeholders.messenger"
+    case channelTypes.enum.telegram:
+      return "fields.userId.placeholders.telegram"
+    case channelTypes.enum.tiktok:
+      return "fields.userId.placeholders.tiktok"
+    case channelTypes.enum.zalo:
+      return "fields.userId.placeholders.zalo"
+    default:
+      return
+  }
+}
 
 export function CreateContactForm({
   workspaceId,
@@ -22,6 +55,33 @@ export function CreateContactForm({
   onCancelled?: () => void
 }) {
   const t = useTranslations()
+  const [channel, setChannel] = useState<ChannelType | undefined>(undefined)
+  const inboxes = useInboxStore((state) => state.inboxes)
+  const channelOptions = useMemo(
+    () =>
+      [...new Set(inboxes.map((inbox) => inbox.channel))]
+        .filter(isChannelType)
+        .filter(
+          (channelValue) => channelValue !== channelTypes.enum.omnichannel,
+        )
+        .map((channelValue) => ({
+          value: channelValue,
+          label: channelLabel(channelValue),
+        })),
+    [inboxes],
+  )
+  const inboxOptions = useInboxOptionsByChannel(channel)
+  const isWhatsapp = channel === channelTypes.enum.whatsapp
+  const isEmail = channel === channelTypes.enum.smtp
+  const isSocial =
+    !!channel &&
+    !isWhatsapp &&
+    !isEmail &&
+    channel !== channelTypes.enum.webchat &&
+    channel !== channelTypes.enum.omnichannel
+  const placeholderKey = channel ? userIdPlaceholderKey(channel) : undefined
+  const userIdPlaceholder =
+    placeholderKey === undefined ? undefined : t(placeholderKey)
 
   const { form, handleSubmitWithAction, resetFormAndAction } =
     useHookFormAction(
@@ -52,6 +112,8 @@ export function CreateContactForm({
             firstName: "",
             lastName: "",
             gender: "unknown",
+            inboxId: "",
+            contactId: "",
           },
         },
         errorMapProps: {},
@@ -76,17 +138,47 @@ export function CreateContactForm({
   return (
     <Form {...form}>
       <form className="flex-1 space-y-4" onSubmit={handleSubmitWithAction}>
+        <SelectField
+          label={t("fields.source.label")}
+          name="channel"
+          options={channelOptions}
+          placeholder={t("fields.source.placeholder")}
+          required
+          triggerValueChange={(value) => {
+            setChannel(value && isChannelType(value) ? value : undefined)
+            form.setValue("inboxId", "")
+          }}
+        />
+
+        <SelectField
+          label={t("fields.inbox.label")}
+          name="inboxId"
+          options={inboxOptions}
+          placeholder={t("fields.inbox.placeholder")}
+          required
+        />
+
+        {isSocial && (
+          <InputField
+            label={`${channelLabel(channel)} ${t("fields.userId.label")}`}
+            name="contactId"
+            placeholder={userIdPlaceholder}
+            required
+          />
+        )}
+
         <InputField
           label={t("fields.phoneNumber.label")}
           name="phoneNumber"
           placeholder="090xxxxxxx"
-          required
+          required={isWhatsapp}
         />
 
         <InputField
           label={t("fields.email.label")}
           name="email"
           placeholder="email@chatbotx.io"
+          required={isEmail}
         />
 
         <InputField

--- a/apps/builder/src/features/contacts/schemas/action.ts
+++ b/apps/builder/src/features/contacts/schemas/action.ts
@@ -1,4 +1,4 @@
-import { genderTypes } from "@chatbotx.io/database/partials"
+import { channelTypes, genderTypes } from "@chatbotx.io/database/partials"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { z } from "zod"
 import { contactFilterCriteriaSchema } from "./contact-filter"
@@ -7,17 +7,56 @@ export const contactPrefix = "sys"
 export const contactFieldPrefix = "cus"
 export const contactTagPrefix = "tag"
 
-export const createContactRequest = z.object({
-  phoneNumber: z
-    .string()
-    .min(10)
-    .max(20)
-    .regex(/\+?\d{10,20}/),
-  email: z.union([z.literal(""), z.email().max(100)]),
-  firstName: z.optional(z.string().trim().max(100)),
-  lastName: z.optional(z.string().trim().max(100)),
-  gender: genderTypes,
-})
+export const createContactRequest = z
+  .object({
+    phoneNumber: z
+      .union([
+        z.literal(""),
+        z
+          .string()
+          .min(10)
+          .max(20)
+          .regex(/\+?\d{10,20}/),
+      ])
+      .optional(),
+    email: z.union([z.literal(""), z.email().max(100)]),
+    contactId: z.string().max(255).optional(),
+    firstName: z.optional(z.string().trim().max(100)),
+    lastName: z.optional(z.string().trim().max(100)),
+    gender: genderTypes,
+    channel: channelTypes,
+    inboxId: zodBigintAsString("Please select an inbox"),
+  })
+  .superRefine((data, ctx) => {
+    const ch = data.channel
+    if (ch === channelTypes.enum.whatsapp) {
+      if (!data.phoneNumber) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["phoneNumber"],
+          message: "Phone number is required for WhatsApp",
+        })
+      }
+    } else if (ch === channelTypes.enum.smtp) {
+      if (!data.email) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["email"],
+          message: "Email is required for the Email channel",
+        })
+      }
+    } else if (
+      ch !== channelTypes.enum.webchat &&
+      ch !== channelTypes.enum.omnichannel &&
+      !data.contactId
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["contactId"],
+        message: "User ID is required for this channel",
+      })
+    }
+  })
 export type CreateContactRequest = z.infer<typeof createContactRequest>
 
 export const createContactResponse = z.object({

--- a/apps/builder/src/features/contacts/utils.ts
+++ b/apps/builder/src/features/contacts/utils.ts
@@ -1,6 +1,21 @@
 import { useTenantSettings } from "@/features/tenant"
 import type { ContactResource } from "./schemas/resource"
 
+type ContactInboxReadTimestamp = {
+  contactLastReadAt?: Date | null
+}
+
+export function getLatestContactLastReadAt(
+  contactInboxes?: ContactInboxReadTimestamp[] | null,
+): Date | null {
+  return (
+    contactInboxes
+      ?.map((contactInbox) => contactInbox.contactLastReadAt)
+      .filter((date): date is Date => Boolean(date))
+      .sort((a, b) => b.getTime() - a.getTime())[0] ?? null
+  )
+}
+
 export function useAvatarUrl(
   contact?: ContactResource | null,
 ): string | undefined {

--- a/packages/analytics-nextjs/src/components/charts/admins-analysis.tsx
+++ b/packages/analytics-nextjs/src/components/charts/admins-analysis.tsx
@@ -29,7 +29,10 @@ export function AdminsAnalysis() {
         id: "name",
         accessorKey: "userName",
         header: ({ column }) => (
-          <DataTableColumnHeader column={column} title="Name" />
+          <DataTableColumnHeader
+            column={column}
+            title={t("fields.name.label")}
+          />
         ),
         cell: ({ row }) => (
           <div>
@@ -45,7 +48,10 @@ export function AdminsAnalysis() {
         id: "messagesSent",
         accessorKey: "messagesSent",
         header: ({ column }) => (
-          <DataTableColumnHeader column={column} title="Messages Sent" />
+          <DataTableColumnHeader
+            column={column}
+            title={t("analytics.messagesSent")}
+          />
         ),
         enableSorting: true,
         enableHiding: false,
@@ -54,7 +60,10 @@ export function AdminsAnalysis() {
         id: "uniqueContacts",
         accessorKey: "uniqueContacts",
         header: ({ column }) => (
-          <DataTableColumnHeader column={column} title="Contacts" />
+          <DataTableColumnHeader
+            column={column}
+            title={t("analytics.contacts")}
+          />
         ),
         enableSorting: true,
         enableHiding: false,
@@ -89,14 +98,14 @@ export function AdminsAnalysis() {
         header: ({ column }) => (
           <DataTableColumnHeader
             column={column}
-            title="Assigned Conversations"
+            title={t("analytics.assignedConversations.title")}
           />
         ),
         enableSorting: true,
         enableHiding: false,
       },
     ],
-    [],
+    [t],
   )
 
   const { table } = useDataTable({
@@ -118,7 +127,21 @@ export function AdminsAnalysis() {
         <CardTitle>{t("analytics.admins")}</CardTitle>
       </CardHeader>
       <CardContent>
-        <DataTable table={table} />
+        <DataTable
+          labels={{
+            firstPage: t("analytics.pagination.firstPage"),
+            lastPage: t("analytics.pagination.lastPage"),
+            nextPage: t("analytics.pagination.nextPage"),
+            noResults: t("fields.noResults.label"),
+            pageOf: (page, pageCount) =>
+              t("analytics.pagination.pageOf", { page, pageCount }),
+            previousPage: t("analytics.pagination.previousPage"),
+            rowsPerPage: t("analytics.pagination.rowsPerPage"),
+            selectedRows: (selected, total) =>
+              t("analytics.pagination.selectedRows", { selected, total }),
+          }}
+          table={table}
+        />
       </CardContent>
     </Card>
   )

--- a/packages/analytics-nextjs/src/components/charts/all-contacts-by-channel-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/all-contacts-by-channel-chart.tsx
@@ -12,15 +12,16 @@ export function AllContactsByChannelChart() {
   const data = useMemo(
     () =>
       contactsByChannel.map((item) => ({
-        name: item.dimension || "Unknown",
+        name: item.dimension || t("analytics.unknown"),
         value: item.uniqueContacts,
       })),
-    [contactsByChannel],
+    [contactsByChannel, t],
   )
 
   return (
     <DonutChart
       data={data}
+      noDataLabel={t("analytics.noData")}
       title={t("analytics.allContactsByChannel")}
       valueLabel={t("analytics.contacts")}
     />

--- a/packages/analytics-nextjs/src/components/charts/archived-conversation-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/archived-conversation-chart.tsx
@@ -2,12 +2,14 @@
 
 import BarChart from "@chatbotx.io/ui/components/charts/bar-chart"
 import { eachDayOfInterval, format } from "date-fns"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useMemo } from "react"
 import { useAnalysisStore } from "../../provider/analysis-store-context"
+import { formatDateWithYear } from "../../utils/date-format"
 
 export function ArchivedConversationChart() {
   const t = useTranslations()
+  const locale = useLocale()
   const conversationArchived = useAnalysisStore(
     (state) => state.conversationArchived,
   )
@@ -18,7 +20,7 @@ export function ArchivedConversationChart() {
     const groupedByDate = new Map<string, number>()
 
     for (const stat of conversationArchived) {
-      const dateKey = format(new Date(stat.timestamp), "MMM d, yyyy")
+      const dateKey = format(new Date(stat.timestamp), "yyyy-MM-dd")
       const existing = groupedByDate.get(dateKey) || 0
       groupedByDate.set(dateKey, existing + stat.count)
     }
@@ -26,10 +28,10 @@ export function ArchivedConversationChart() {
     const allDates = eachDayOfInterval({ start: from, end: to })
 
     return allDates.map((date) => {
-      const dateKey = format(date, "MMM d, yyyy")
+      const dateKey = format(date, "yyyy-MM-dd")
       const count = groupedByDate.get(dateKey) || 0
       return {
-        name: dateKey,
+        name: formatDateWithYear(date, locale),
         value: [
           {
             label: t("analytics.conversations"),
@@ -38,7 +40,7 @@ export function ArchivedConversationChart() {
         ],
       }
     })
-  }, [conversationArchived, from, to, t])
+  }, [conversationArchived, from, to, locale, t])
 
   return <BarChart data={data} title={t("analytics.archivedConversations")} />
 }

--- a/packages/analytics-nextjs/src/components/charts/assigned-conversations-by-admin-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/assigned-conversations-by-admin-chart.tsx
@@ -24,6 +24,7 @@ export function AssignedConversationsByAdminChart() {
     <DonutChart
       data={data}
       helpText={t("analytics.assignedConversationsByAdminsHelp")}
+      noDataLabel={t("analytics.noData")}
       title={t("analytics.assignedConversationsByAdmins")}
       valueLabel={t("analytics.conversations")}
     />

--- a/packages/analytics-nextjs/src/components/charts/assigned-conversations-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/assigned-conversations-chart.tsx
@@ -2,12 +2,14 @@
 
 import BarChart from "@chatbotx.io/ui/components/charts/bar-chart"
 import { eachDayOfInterval, format } from "date-fns"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useMemo } from "react"
 import { useAnalysisStore } from "../../provider/analysis-store-context"
+import { formatDateWithYear } from "../../utils/date-format"
 
 export function AssignedConversationsChart() {
   const t = useTranslations()
+  const locale = useLocale()
   const conversationAssigned = useAnalysisStore(
     (state) => state.conversationAssigned,
   )
@@ -18,7 +20,7 @@ export function AssignedConversationsChart() {
     const groupedByDate = new Map<string, number>()
 
     for (const stat of conversationAssigned) {
-      const dateKey = format(new Date(stat.timestamp), "MMM d, yyyy")
+      const dateKey = format(new Date(stat.timestamp), "yyyy-MM-dd")
       const existing = groupedByDate.get(dateKey) || 0
       groupedByDate.set(dateKey, existing + stat.count)
     }
@@ -26,10 +28,10 @@ export function AssignedConversationsChart() {
     const allDates = eachDayOfInterval({ start: from, end: to })
 
     return allDates.map((date) => {
-      const dateKey = format(date, "MMM d, yyyy")
+      const dateKey = format(date, "yyyy-MM-dd")
       const count = groupedByDate.get(dateKey) || 0
       return {
-        name: dateKey,
+        name: formatDateWithYear(date, locale),
         value: [
           {
             label: t("analytics.conversations"),
@@ -38,7 +40,7 @@ export function AssignedConversationsChart() {
         ],
       }
     })
-  }, [conversationAssigned, from, to, t])
+  }, [conversationAssigned, from, to, locale, t])
 
   return (
     <BarChart

--- a/packages/analytics-nextjs/src/components/charts/avg-conversation-duration-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/avg-conversation-duration-chart.tsx
@@ -13,7 +13,7 @@ export function AvgConversationDurationChart() {
           name: "Jan 7",
           value: [
             {
-              label: "Value",
+              label: t("fields.value.label"),
               value: 4000,
             },
           ],
@@ -22,7 +22,7 @@ export function AvgConversationDurationChart() {
           name: "Jan 8",
           value: [
             {
-              label: "Value",
+              label: t("fields.value.label"),
               value: 3000,
             },
           ],
@@ -31,7 +31,7 @@ export function AvgConversationDurationChart() {
           name: "Jan 9",
           value: [
             {
-              label: "Value",
+              label: t("fields.value.label"),
               value: 2000,
             },
           ],
@@ -40,7 +40,7 @@ export function AvgConversationDurationChart() {
           name: "Jan 10",
           value: [
             {
-              label: "Value",
+              label: t("fields.value.label"),
               value: 2780,
             },
           ],
@@ -49,7 +49,7 @@ export function AvgConversationDurationChart() {
           name: "Jan 11",
           value: [
             {
-              label: "Value",
+              label: t("fields.value.label"),
               value: 1890,
             },
           ],

--- a/packages/analytics-nextjs/src/components/charts/avg-first-response-minutes-by-admin-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/avg-first-response-minutes-by-admin-chart.tsx
@@ -18,7 +18,7 @@ export function AvgFirstResponseMinutesByAdminChart() {
       ]}
       helpText={t("analytics.averageFirstResponseTimeByAdminHelp")}
       title={t("analytics.averageFirstResponseTimeByAdmin")}
-      valueLabel="Value"
+      valueLabel={t("fields.value.label")}
     />
   )
 }

--- a/packages/analytics-nextjs/src/components/charts/avg-response-minutes-by-admin-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/avg-response-minutes-by-admin-chart.tsx
@@ -27,7 +27,7 @@ export function AvgResponseMinutesByAdminChart() {
       ]}
       helpText={t("analytics.averageResponseTimeHelp")}
       title={t("analytics.averageResponseTimeByAdmin")}
-      valueLabel="Minutes"
+      valueLabel={t("fields.delayUnit.minutes")}
     />
   )
 }

--- a/packages/analytics-nextjs/src/components/charts/blocked-contacts-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/blocked-contacts-chart.tsx
@@ -1,20 +1,19 @@
 "use client"
 
 import BarChart from "@chatbotx.io/ui/components/charts/bar-chart"
-import { format } from "date-fns"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useAnalysisStore } from "../../provider/analysis-store-context"
-import { getTimeRangeDateFormat } from "../../utils/date-format"
+import { formatTimeRangeDate } from "../../utils/date-format"
 
 export function BlockedContactsChart() {
   const t = useTranslations()
+  const locale = useLocale()
   const { blockedContactCounts, from, to } = useAnalysisStore((state) => state)
-  const dateFormat = getTimeRangeDateFormat(from, to)
 
   return (
     <BarChart
       data={blockedContactCounts.map((count) => ({
-        name: format(count.date, dateFormat),
+        name: formatTimeRangeDate(count.date, from, to, locale),
         value: [
           {
             label: t("analytics.blockedContacts"),

--- a/packages/analytics-nextjs/src/components/charts/bot-messages-ai-providers-table.tsx
+++ b/packages/analytics-nextjs/src/components/charts/bot-messages-ai-providers-table.tsx
@@ -31,7 +31,7 @@ export function BotMessagesAIProvidersTable() {
                 className="px-4 py-8 text-center text-muted-foreground text-sm"
                 colSpan={3}
               >
-                No data
+                {t("analytics.noData")}
               </td>
             </tr>
           ) : (

--- a/packages/analytics-nextjs/src/components/charts/bot-messages-by-result-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/bot-messages-by-result-chart.tsx
@@ -2,13 +2,14 @@
 
 import { botMessageResults } from "@chatbotx.io/analytics/schemas"
 import BarChart from "@chatbotx.io/ui/components/charts/bar-chart"
-import { format } from "date-fns"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useMemo } from "react"
 import { useAnalysisStore } from "../../provider/analysis-store-context"
+import { formatShortDate } from "../../utils/date-format"
 
 export function BotMessagesByResultChart() {
   const t = useTranslations()
+  const locale = useLocale()
   const { botMessagesByResult } = useAnalysisStore((state) => state)
 
   const data = useMemo(() => {
@@ -28,7 +29,7 @@ export function BotMessagesByResultChart() {
     for (const item of botMessagesByResult) {
       const date = new Date(item.timestamp)
       const timestampMs = date.getTime()
-      const name = format(date, "MMM d")
+      const name = formatShortDate(date, locale)
 
       const existing = groupedByDate.get(name)
       if (!existing) {
@@ -70,7 +71,7 @@ export function BotMessagesByResultChart() {
           },
         ],
       }))
-  }, [botMessagesByResult, t])
+  }, [botMessagesByResult, locale, t])
 
   return <BarChart data={data} title={t("analytics.botMessagesByResult")} />
 }

--- a/packages/analytics-nextjs/src/components/charts/bot-messages-no-response-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/bot-messages-no-response-chart.tsx
@@ -1,13 +1,14 @@
 "use client"
 
 import BarChart from "@chatbotx.io/ui/components/charts/bar-chart"
-import { format } from "date-fns"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useMemo } from "react"
 import { useAnalysisStore } from "../../provider/analysis-store-context"
+import { formatShortDate } from "../../utils/date-format"
 
 export function BotMessagesNoResponseChart() {
   const t = useTranslations()
+  const locale = useLocale()
 
   const botMessagesNoResponse = useAnalysisStore(
     (state) => state.botMessagesNoResponse,
@@ -26,7 +27,7 @@ export function BotMessagesNoResponseChart() {
     for (const item of botMessagesNoResponse) {
       const date = new Date(item.timestamp)
       const timestampMs = date.getTime()
-      const name = format(date, "MMM d")
+      const name = formatShortDate(date, locale)
 
       const existing = groupedByDate.get(name)
       if (!existing) {
@@ -57,7 +58,7 @@ export function BotMessagesNoResponseChart() {
           },
         ],
       }))
-  }, [botMessagesNoResponse, t])
+  }, [botMessagesNoResponse, locale, t])
 
   return <BarChart data={data} title={t("analytics.botMessagesNoResponse")} />
 }

--- a/packages/analytics-nextjs/src/components/charts/bot-messages-with-response-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/bot-messages-with-response-chart.tsx
@@ -1,13 +1,14 @@
 "use client"
 
 import BarChart from "@chatbotx.io/ui/components/charts/bar-chart"
-import { format } from "date-fns"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useMemo } from "react"
 import { useAnalysisStore } from "../../provider/analysis-store-context"
+import { formatShortDate } from "../../utils/date-format"
 
 export function BotMessagesWithResponseChart() {
   const t = useTranslations()
+  const locale = useLocale()
 
   const botMessagesWithResponse = useAnalysisStore(
     (state) => state.botMessagesWithResponse,
@@ -26,7 +27,7 @@ export function BotMessagesWithResponseChart() {
     for (const item of botMessagesWithResponse) {
       const date = new Date(item.timestamp)
       const timestampMs = date.getTime()
-      const name = format(date, "MMM d")
+      const name = formatShortDate(date, locale)
 
       const existing = groupedByDate.get(name)
       if (!existing) {
@@ -57,7 +58,7 @@ export function BotMessagesWithResponseChart() {
           },
         ],
       }))
-  }, [botMessagesWithResponse, t])
+  }, [botMessagesWithResponse, locale, t])
 
   return <BarChart data={data} title={t("analytics.botMessagesWithResponse")} />
 }

--- a/packages/analytics-nextjs/src/components/charts/contact-counts-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/contact-counts-chart.tsx
@@ -1,21 +1,20 @@
 "use client"
 
 import AreaChart from "@chatbotx.io/ui/components/charts/area-chart"
-import { format } from "date-fns"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useAnalysisStore } from "../../provider/analysis-store-context"
-import { getTimeRangeDateFormat } from "../../utils/date-format"
+import { formatTimeRangeDate } from "../../utils/date-format"
 
 export function ContactCountsChart() {
   const t = useTranslations()
+  const locale = useLocale()
 
   const { contactCounts, from, to } = useAnalysisStore((state) => state)
-  const dateFormat = getTimeRangeDateFormat(from, to)
 
   return (
     <AreaChart
       data={contactCounts.map((count) => ({
-        label: format(count.date, dateFormat),
+        label: formatTimeRangeDate(count.date, from, to, locale),
         value: count.count,
       }))}
       title={t("analytics.totalContacts")}

--- a/packages/analytics-nextjs/src/components/charts/contacts-by-channel-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/contacts-by-channel-chart.tsx
@@ -12,15 +12,16 @@ export function ContactsByChannelChart() {
   const data = useMemo(
     () =>
       contactsByChannel.map((item) => ({
-        name: item.dimension || "Unknown",
+        name: item.dimension || t("analytics.unknown"),
         value: item.uniqueContacts,
       })),
-    [contactsByChannel],
+    [contactsByChannel, t],
   )
 
   return (
     <DonutChart
       data={data}
+      noDataLabel={t("analytics.noData")}
       title={t("analytics.newContactsByChannel")}
       valueLabel={t("analytics.contacts")}
     />

--- a/packages/analytics-nextjs/src/components/charts/contacts-by-country-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/contacts-by-country-chart.tsx
@@ -12,15 +12,16 @@ export function ContactsByCountryChart() {
   const data = useMemo(
     () =>
       contactsByCountry.map((item) => ({
-        name: item.dimension || "Unknown",
+        name: item.dimension || t("analytics.unknown"),
         value: item.uniqueContacts,
       })),
-    [contactsByCountry],
+    [contactsByCountry, t],
   )
 
   return (
     <DonutChart
       data={data}
+      noDataLabel={t("analytics.noData")}
       title={t("analytics.newContactsByCountry")}
       valueLabel={t("analytics.contacts")}
     />

--- a/packages/analytics-nextjs/src/components/charts/contacts-by-source-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/contacts-by-source-chart.tsx
@@ -12,15 +12,16 @@ export function ContactsBySourceChart() {
   const data = useMemo(
     () =>
       contactsBySource.map((item) => ({
-        name: item.dimension || "Unknown",
+        name: item.dimension || t("analytics.unknown"),
         value: item.uniqueContacts,
       })),
-    [contactsBySource],
+    [contactsBySource, t],
   )
 
   return (
     <DonutChart
       data={data}
+      noDataLabel={t("analytics.noData")}
       title={t("analytics.newContactsBySource")}
       valueLabel={t("analytics.contacts")}
     />

--- a/packages/analytics-nextjs/src/components/charts/conversations-moved-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/conversations-moved-chart.tsx
@@ -2,12 +2,14 @@
 
 import BarChart from "@chatbotx.io/ui/components/charts/bar-chart"
 import { eachDayOfInterval, format } from "date-fns"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useMemo } from "react"
 import { useAnalysisStore } from "../../provider/analysis-store-context"
+import { formatDateWithYear } from "../../utils/date-format"
 
 export function ConversationsMovedChart() {
   const t = useTranslations()
+  const locale = useLocale()
   const conversationHandoffs = useAnalysisStore(
     (state) => state.conversationHandoffs,
   )
@@ -24,7 +26,7 @@ export function ConversationsMovedChart() {
     >()
 
     for (const item of conversationHandoffs) {
-      const dateKey = format(new Date(item.timestamp), "MMM d, yyyy")
+      const dateKey = format(new Date(item.timestamp), "yyyy-MM-dd")
       const existing = groupedByDate.get(dateKey) || {
         to_human: 0,
         to_bot: 0,
@@ -42,20 +44,20 @@ export function ConversationsMovedChart() {
     const allDates = eachDayOfInterval({ start: from, end: to })
 
     return allDates.map((date) => {
-      const dateKey = format(date, "MMM d, yyyy")
+      const dateKey = format(date, "yyyy-MM-dd")
       const counts = groupedByDate.get(dateKey) || {
         to_human: 0,
         to_bot: 0,
       }
       return {
-        name: dateKey,
+        name: formatDateWithYear(date, locale),
         value: [
           { label: t("analytics.human"), value: counts.to_human },
           { label: t("analytics.bot"), value: counts.to_bot },
         ],
       }
     })
-  }, [conversationHandoffs, from, to, t])
+  }, [conversationHandoffs, from, to, locale, t])
 
   return (
     <BarChart

--- a/packages/analytics-nextjs/src/components/charts/follow-up-conversations.tsx
+++ b/packages/analytics-nextjs/src/components/charts/follow-up-conversations.tsx
@@ -2,12 +2,14 @@
 
 import BarChart from "@chatbotx.io/ui/components/charts/bar-chart"
 import { eachDayOfInterval, format } from "date-fns"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useMemo } from "react"
 import { useAnalysisStore } from "../../provider/analysis-store-context"
+import { formatDateWithYear } from "../../utils/date-format"
 
 export function FollowUpConversations() {
   const t = useTranslations()
+  const locale = useLocale()
   const conversationFollowUps = useAnalysisStore(
     (state) => state.conversationFollowUps,
   )
@@ -18,7 +20,7 @@ export function FollowUpConversations() {
     const groupedByDate = new Map<string, number>()
 
     for (const stat of conversationFollowUps) {
-      const dateKey = format(new Date(stat.timestamp), "MMM d, yyyy")
+      const dateKey = format(new Date(stat.timestamp), "yyyy-MM-dd")
       const existing = groupedByDate.get(dateKey) || 0
       groupedByDate.set(dateKey, existing + stat.count)
     }
@@ -26,10 +28,10 @@ export function FollowUpConversations() {
     const allDates = eachDayOfInterval({ start: from, end: to })
 
     return allDates.map((date) => {
-      const dateKey = format(date, "MMM d, yyyy")
+      const dateKey = format(date, "yyyy-MM-dd")
       const count = groupedByDate.get(dateKey) || 0
       return {
-        name: dateKey,
+        name: formatDateWithYear(date, locale),
         value: [
           {
             label: t("analytics.conversations"),
@@ -38,7 +40,7 @@ export function FollowUpConversations() {
         ],
       }
     })
-  }, [conversationFollowUps, from, to, t])
+  }, [conversationFollowUps, from, to, locale, t])
 
   return (
     <BarChart

--- a/packages/analytics-nextjs/src/components/charts/magic-link-contacts-table.tsx
+++ b/packages/analytics-nextjs/src/components/charts/magic-link-contacts-table.tsx
@@ -21,9 +21,9 @@ import {
   TableHeader,
   TableRow,
 } from "@chatbotx.io/ui/components/ui/table"
-import { format } from "date-fns"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useAnalysisStore } from "../../provider/analysis-store-context"
+import { formatDateWithYear } from "../../utils/date-format"
 
 function getFullName(contact: FlowNodeContactData): string {
   if (contact.firstName || contact.lastName) {
@@ -38,6 +38,7 @@ function getInitial(contact: FlowNodeContactData): string {
 
 export function MagicLinkContactsTable() {
   const t = useTranslations()
+  const locale = useLocale()
   const {
     magicLinkContacts: contacts,
     magicLinkContactsPage: page,
@@ -72,7 +73,7 @@ export function MagicLinkContactsTable() {
                     {getFullName(contact)}
                   </TableCell>
                   <TableCell>
-                    {format(new Date(contact.occurredAt), "MMM d, yyyy")}
+                    {formatDateWithYear(new Date(contact.occurredAt), locale)}
                   </TableCell>
                   <TableCell>{contact.sourceId ?? "-"}</TableCell>
                 </TableRow>
@@ -80,7 +81,7 @@ export function MagicLinkContactsTable() {
             ) : (
               <TableRow>
                 <TableCell className="h-24 text-center" colSpan={4}>
-                  No results.
+                  {t("fields.noResults.label")}
                 </TableCell>
               </TableRow>
             )}

--- a/packages/analytics-nextjs/src/components/charts/magic-link-stats-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/magic-link-stats-chart.tsx
@@ -1,12 +1,13 @@
 "use client"
 
 import AreaChart from "@chatbotx.io/ui/components/charts/area-chart"
-import { format } from "date-fns"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useAnalysisStore } from "../../provider/analysis-store-context"
+import { formatShortDate } from "../../utils/date-format"
 
 export function MagicLinkStatsChart() {
   const t = useTranslations()
+  const locale = useLocale()
 
   const magicLinkStats = useAnalysisStore((state) => state.magicLinkStats)
   const linkName = useAnalysisStore(
@@ -16,7 +17,7 @@ export function MagicLinkStatsChart() {
   return (
     <AreaChart
       data={magicLinkStats.map((row) => ({
-        label: format(new Date(row.dateReport), "MMM d"),
+        label: formatShortDate(new Date(row.dateReport), locale),
         value: row.count,
       }))}
       title={t("analytics.sessionsThroughTheMagicLink", { ref: linkName })}

--- a/packages/analytics-nextjs/src/components/charts/magic-link-stats-table.tsx
+++ b/packages/analytics-nextjs/src/components/charts/magic-link-stats-table.tsx
@@ -8,12 +8,13 @@ import {
   TableHeader,
   TableRow,
 } from "@chatbotx.io/ui/components/ui/table"
-import { format } from "date-fns"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useAnalysisStore } from "../../provider/analysis-store-context"
+import { formatDateWithYear } from "../../utils/date-format"
 
 export function MagicLinkStatsTable() {
   const t = useTranslations("analytics")
+  const locale = useLocale()
   const magicLinkStats = useAnalysisStore((state) => state.magicLinkStats)
 
   return (
@@ -30,7 +31,7 @@ export function MagicLinkStatsTable() {
             magicLinkStats.map((row) => (
               <TableRow key={row.dateReport}>
                 <TableCell>
-                  {format(new Date(row.dateReport), "MMM d, yyyy")}
+                  {formatDateWithYear(new Date(row.dateReport), locale)}
                 </TableCell>
                 <TableCell>{row.count}</TableCell>
               </TableRow>
@@ -38,7 +39,7 @@ export function MagicLinkStatsTable() {
           ) : (
             <TableRow>
               <TableCell className="h-24 text-center" colSpan={2}>
-                No results.
+                {t("noResults")}
               </TableCell>
             </TableRow>
           )}

--- a/packages/analytics-nextjs/src/components/charts/messages-by-sender-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/messages-by-sender-chart.tsx
@@ -40,6 +40,7 @@ export function MessagesBySenderChart() {
   return (
     <DonutChart
       data={data}
+      noDataLabel={t("analytics.noData")}
       title={t("analytics.messagesSentByHumanOrBot")}
       valueLabel={t("analytics.messages")}
     />

--- a/packages/analytics-nextjs/src/components/charts/new-contact-counts-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/new-contact-counts-chart.tsx
@@ -1,20 +1,19 @@
 "use client"
 
 import BarChart from "@chatbotx.io/ui/components/charts/bar-chart"
-import { format } from "date-fns"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useAnalysisStore } from "../../provider/analysis-store-context"
-import { getTimeRangeDateFormat } from "../../utils/date-format"
+import { formatTimeRangeDate } from "../../utils/date-format"
 
 export function NewContactCountsChart() {
   const t = useTranslations()
+  const locale = useLocale()
   const { newContactCounts, from, to } = useAnalysisStore((state) => state)
-  const dateFormat = getTimeRangeDateFormat(from, to)
 
   return (
     <BarChart
       data={newContactCounts.map((count) => ({
-        name: format(count.date, dateFormat),
+        name: formatTimeRangeDate(count.date, from, to, locale),
         value: [
           {
             label: t("analytics.newContacts"),

--- a/packages/analytics-nextjs/src/components/charts/reflink-contacts-table.tsx
+++ b/packages/analytics-nextjs/src/components/charts/reflink-contacts-table.tsx
@@ -21,9 +21,9 @@ import {
   TableHeader,
   TableRow,
 } from "@chatbotx.io/ui/components/ui/table"
-import { format } from "date-fns"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useAnalysisStore } from "../../provider/analysis-store-context"
+import { formatDateWithYear } from "../../utils/date-format"
 
 function getFullName(contact: FlowNodeContactData): string {
   if (contact.firstName || contact.lastName) {
@@ -38,6 +38,7 @@ function getInitial(contact: FlowNodeContactData): string {
 
 export function ReflinkContactsTable() {
   const t = useTranslations()
+  const locale = useLocale()
   const {
     reflinkContacts: contacts,
     reflinkContactsPage: page,
@@ -72,7 +73,7 @@ export function ReflinkContactsTable() {
                     {getFullName(contact)}
                   </TableCell>
                   <TableCell>
-                    {format(new Date(contact.occurredAt), "MMM d, yyyy")}
+                    {formatDateWithYear(new Date(contact.occurredAt), locale)}
                   </TableCell>
                   <TableCell>{contact.sourceId ?? "-"}</TableCell>
                 </TableRow>
@@ -80,7 +81,7 @@ export function ReflinkContactsTable() {
             ) : (
               <TableRow>
                 <TableCell className="h-24 text-center" colSpan={4}>
-                  No results.
+                  {t("fields.noResults.label")}
                 </TableCell>
               </TableRow>
             )}

--- a/packages/analytics-nextjs/src/components/charts/reflink-stats-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/reflink-stats-chart.tsx
@@ -1,12 +1,13 @@
 "use client"
 
 import AreaChart from "@chatbotx.io/ui/components/charts/area-chart"
-import { format } from "date-fns"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useAnalysisStore } from "../../provider/analysis-store-context"
+import { formatShortDate } from "../../utils/date-format"
 
 export function ReflinkStatsChart() {
   const t = useTranslations()
+  const locale = useLocale()
 
   const refLinkStats = useAnalysisStore((state) => state.refLinkStats)
   const linkName = useAnalysisStore(
@@ -16,7 +17,7 @@ export function ReflinkStatsChart() {
   return (
     <AreaChart
       data={refLinkStats.map((row) => ({
-        label: format(new Date(row.dateReport), "MMM d"),
+        label: formatShortDate(new Date(row.dateReport), locale),
         value: row.count,
       }))}
       title={t("analytics.sessionsThroughTheRef", { ref: linkName })}

--- a/packages/analytics-nextjs/src/components/charts/reflink-stats-table.tsx
+++ b/packages/analytics-nextjs/src/components/charts/reflink-stats-table.tsx
@@ -8,12 +8,13 @@ import {
   TableHeader,
   TableRow,
 } from "@chatbotx.io/ui/components/ui/table"
-import { format } from "date-fns"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useAnalysisStore } from "../../provider/analysis-store-context"
+import { formatDateWithYear } from "../../utils/date-format"
 
 export function ReflinkStatsTable() {
   const t = useTranslations("analytics")
+  const locale = useLocale()
   const refLinkStats = useAnalysisStore((state) => state.refLinkStats)
 
   return (
@@ -30,7 +31,7 @@ export function ReflinkStatsTable() {
             refLinkStats.map((row) => (
               <TableRow key={row.dateReport}>
                 <TableCell>
-                  {format(new Date(row.dateReport), "MMM d, yyyy")}
+                  {formatDateWithYear(new Date(row.dateReport), locale)}
                 </TableCell>
                 <TableCell>{row.count}</TableCell>
               </TableRow>
@@ -38,7 +39,7 @@ export function ReflinkStatsTable() {
           ) : (
             <TableRow>
               <TableCell className="h-24 text-center" colSpan={2}>
-                No results.
+                {t("noResults")}
               </TableCell>
             </TableRow>
           )}

--- a/packages/analytics-nextjs/src/components/charts/unique-conversations-by-admin-chart.tsx
+++ b/packages/analytics-nextjs/src/components/charts/unique-conversations-by-admin-chart.tsx
@@ -24,6 +24,7 @@ export function UniqueConversationsByAdminChart() {
     <DonutChart
       data={data}
       helpText={t("analytics.uniqueConversationsByAdminsHelp")}
+      noDataLabel={t("analytics.noData")}
       title={t("analytics.uniqueConversationsByAdmins")}
       valueLabel={t("analytics.conversations")}
     />

--- a/packages/analytics-nextjs/src/components/filter-form.tsx
+++ b/packages/analytics-nextjs/src/components/filter-form.tsx
@@ -28,7 +28,7 @@ import {
   subMonths,
 } from "date-fns"
 import { Calendar1Icon, RotateCwIcon } from "lucide-react"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useMemo, useState } from "react"
 import { useForm } from "react-hook-form"
 import { useAnalysisStore } from "../provider/analysis-store-context"
@@ -115,6 +115,7 @@ export default function AnalysisFilterForm({
   onChange,
 }: AnalysisFilterFormProps) {
   const t = useTranslations()
+  const locale = useLocale()
 
   const { setRange: setAnalysisRange } = useAnalysisStore((state) => state)
 
@@ -160,7 +161,7 @@ export default function AnalysisFilterForm({
 
   const rangeText = useMemo(() => {
     if (!range) {
-      return "Select range"
+      return t("analytics.selectRange")
     }
     const fromDate = new Date(range.from)
     const toDate = new Date(range.to)
@@ -170,13 +171,13 @@ export default function AnalysisFilterForm({
       year: "numeric",
     }
     if (fromDate.toDateString() === toDate.toDateString()) {
-      return fromDate.toLocaleDateString(undefined, options)
+      return fromDate.toLocaleDateString(locale, options)
     }
     return `${fromDate.toLocaleDateString(
-      undefined,
+      locale,
       options,
-    )} - ${toDate.toLocaleDateString(undefined, options)}`
-  }, [range])
+    )} - ${toDate.toLocaleDateString(locale, options)}`
+  }, [locale, range, t])
 
   const applyRange = (r: DateRangeResult) => {
     setRange(r)
@@ -240,7 +241,7 @@ export default function AnalysisFilterForm({
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
-              aria-label="Date filter preset"
+              aria-label={t("analytics.dateFilterPreset")}
               id="date-range-preset"
               onClick={(e) => {
                 if (preset === "custom") {

--- a/packages/analytics-nextjs/src/components/inbox-stats-list.tsx
+++ b/packages/analytics-nextjs/src/components/inbox-stats-list.tsx
@@ -43,14 +43,14 @@ export default function InboxStatsList() {
       {/* <Card className="flex-1 py-4">
         <CardContent className="flex flex-col items-center justify-center gap-2 px-4">
           <h3 className="text-sm">{t("analytics.responseTime")}</h3>
-          <p className="font-bold text-sm">Coming soon</p>
+          <p className="font-bold text-sm">{t("analytics.comingSoon")}</p>
         </CardContent>
       </Card>
 
       <Card className="flex-1 py-4">
         <CardContent className="flex flex-col items-center justify-center gap-2 px-4">
           <h3 className="text-sm">{t("analytics.firstResponseTime")}</h3>
-          <p className="font-bold text-sm">Coming soon</p>
+          <p className="font-bold text-sm">{t("analytics.comingSoon")}</p>
         </CardContent>
       </Card> */}
     </div>

--- a/packages/analytics-nextjs/src/utils/date-format.ts
+++ b/packages/analytics-nextjs/src/utils/date-format.ts
@@ -1,5 +1,61 @@
 import { differenceInDays } from "date-fns"
 
-export function getTimeRangeDateFormat(from: Date, to: Date): string {
-  return differenceInDays(to, from) > 60 ? "MMM yyyy" : "MMM d"
+type DateInput = Date | string | number | null | undefined
+
+function toValidDate(value: DateInput): Date | null {
+  if (value === null || value === undefined || value === "") {
+    return null
+  }
+
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+export function formatShortDate(value: DateInput, locale: string): string {
+  const date = toValidDate(value)
+  if (!date) {
+    return ""
+  }
+
+  return new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "short",
+  }).format(date)
+}
+
+export function formatDateWithYear(value: DateInput, locale: string): string {
+  const date = toValidDate(value)
+  if (!date) {
+    return ""
+  }
+
+  return new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(date)
+}
+
+export function formatTimeRangeDate(
+  value: DateInput,
+  fromValue: DateInput,
+  toValue: DateInput,
+  locale: string,
+): string {
+  const date = toValidDate(value)
+  if (!date) {
+    return ""
+  }
+
+  const from = toValidDate(fromValue)
+  const to = toValidDate(toValue)
+
+  if (from && to && differenceInDays(to, from) > 60) {
+    return new Intl.DateTimeFormat(locale, {
+      month: "short",
+      year: "numeric",
+    }).format(date)
+  }
+
+  return formatShortDate(date, locale)
 }

--- a/packages/ui/__tests__/tags-input-field.test.tsx
+++ b/packages/ui/__tests__/tags-input-field.test.tsx
@@ -1,0 +1,96 @@
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { FormProvider, useForm } from "react-hook-form"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { TagsInputField } from "../src/components/ui/muhammada86/tags-input-field"
+
+type TagsForm = {
+  tags: string[]
+}
+
+const TagsInputHarness = ({ tags = [] }: { tags?: string[] }) => {
+  const form = useForm<TagsForm>({
+    defaultValues: {
+      tags,
+    },
+  })
+
+  return (
+    <FormProvider {...form}>
+      <TagsInputField<TagsForm>
+        label="Tags"
+        name="tags"
+        suggestions={["alpha", "beta", "gamma"]}
+      />
+    </FormProvider>
+  )
+}
+
+describe("TagsInputField", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement("div")
+    document.body.append(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+  })
+
+  test("shows every suggestion when the right-side dropdown button is clicked", () => {
+    act(() => {
+      root.render(<TagsInputHarness />)
+    })
+
+    expect(container.textContent).not.toContain("alpha")
+    expect(container.textContent).not.toContain("beta")
+    expect(container.textContent).not.toContain("gamma")
+
+    const dropdownButton = container.querySelector("button")
+    expect(dropdownButton).not.toBeNull()
+
+    act(() => {
+      dropdownButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+    })
+
+    expect(container.textContent).toContain("alpha")
+    expect(container.textContent).toContain("beta")
+    expect(container.textContent).toContain("gamma")
+  })
+
+  test("disables suggestions that are already selected", () => {
+    act(() => {
+      root.render(<TagsInputHarness tags={["alpha"]} />)
+    })
+
+    const dropdownButton = Array.from(container.querySelectorAll("button")).at(
+      -1,
+    )
+    expect(dropdownButton).not.toBeUndefined()
+
+    act(() => {
+      dropdownButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+    })
+
+    const suggestionButtons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>("button.w-full"),
+    )
+    const selectedSuggestion = suggestionButtons.find((button) =>
+      button.textContent?.includes("alpha"),
+    )
+    const availableSuggestion = suggestionButtons.find((button) =>
+      button.textContent?.includes("beta"),
+    )
+
+    expect(selectedSuggestion?.disabled).toBe(true)
+    expect(selectedSuggestion?.className).toContain("disabled:opacity-50")
+    expect(availableSuggestion?.disabled).toBe(false)
+  })
+})

--- a/packages/ui/src/components/charts/donut-chart.tsx
+++ b/packages/ui/src/components/charts/donut-chart.tsx
@@ -14,6 +14,7 @@ import { COLORS } from "./constants"
 export interface DonutChartProps {
   data: Array<{ name: string; value: number; color?: string }>
   helpText?: string
+  noDataLabel?: string
   title: string
   valueLabel: string
 }
@@ -23,9 +24,12 @@ export function DonutChart({
   valueLabel,
   data,
   helpText,
+  noDataLabel = "No data",
 }: DonutChartProps) {
   const chartData =
-    data.length === 0 ? [{ name: "No data", value: 0, color: "#e5e7eb" }] : data
+    data.length === 0
+      ? [{ name: noDataLabel, value: 0, color: "#e5e7eb" }]
+      : data
 
   return (
     <Card className="flex-1">

--- a/packages/ui/src/components/data-table/data-table-pagination.tsx
+++ b/packages/ui/src/components/data-table/data-table-pagination.tsx
@@ -19,14 +19,31 @@ import { cn } from "@chatbotx.io/ui/lib/utils"
 interface DataTablePaginationProps<TData> extends React.ComponentProps<"div"> {
   table: Table<TData>
   pageSizeOptions?: number[]
+  labels?: DataTablePaginationLabels
+}
+
+export type DataTablePaginationLabels = {
+  selectedRows?: (selected: number, total: number) => string
+  rowsPerPage?: string
+  pageOf?: (page: number, pageCount: number) => string
+  firstPage?: string
+  previousPage?: string
+  nextPage?: string
+  lastPage?: string
 }
 
 export function DataTablePagination<TData>({
   table,
   pageSizeOptions = [10, 20, 30, 40, 50],
+  labels,
   className,
   ...props
 }: DataTablePaginationProps<TData>) {
+  const selectedRows = table.getFilteredSelectedRowModel().rows.length
+  const totalRows = table.getFilteredRowModel().rows.length
+  const page = table.getState().pagination.pageIndex + 1
+  const pageCount = table.getPageCount()
+
   return (
     <div
       className={cn(
@@ -36,12 +53,14 @@ export function DataTablePagination<TData>({
       {...props}
     >
       <div className="flex-1 whitespace-nowrap text-muted-foreground text-sm">
-        {table.getFilteredSelectedRowModel().rows.length} of{" "}
-        {table.getFilteredRowModel().rows.length} row(s) selected.
+        {labels?.selectedRows?.(selectedRows, totalRows) ??
+          `${selectedRows} of ${totalRows} row(s) selected.`}
       </div>
       <div className="flex flex-col-reverse items-center gap-4 sm:flex-row sm:gap-6 lg:gap-8">
         <div className="flex items-center space-x-2">
-          <p className="whitespace-nowrap font-medium text-sm">Rows per page</p>
+          <p className="whitespace-nowrap font-medium text-sm">
+            {labels?.rowsPerPage ?? "Rows per page"}
+          </p>
           <Select
             value={`${table.getState().pagination.pageSize}`}
             onValueChange={(value) => {
@@ -61,12 +80,11 @@ export function DataTablePagination<TData>({
           </Select>
         </div>
         <div className="flex items-center justify-center font-medium text-sm">
-          Page {table.getState().pagination.pageIndex + 1} of{" "}
-          {table.getPageCount()}
+          {labels?.pageOf?.(page, pageCount) ?? `Page ${page} of ${pageCount}`}
         </div>
         <div className="flex items-center space-x-2">
           <Button
-            aria-label="Go to first page"
+            aria-label={labels?.firstPage ?? "Go to first page"}
             variant="outline"
             size="icon"
             className="hidden size-8 lg:flex"
@@ -76,7 +94,7 @@ export function DataTablePagination<TData>({
             <ChevronsLeft />
           </Button>
           <Button
-            aria-label="Go to previous page"
+            aria-label={labels?.previousPage ?? "Go to previous page"}
             variant="outline"
             size="icon"
             className="size-8"
@@ -86,7 +104,7 @@ export function DataTablePagination<TData>({
             <ChevronLeft />
           </Button>
           <Button
-            aria-label="Go to next page"
+            aria-label={labels?.nextPage ?? "Go to next page"}
             variant="outline"
             size="icon"
             className="size-8"
@@ -96,7 +114,7 @@ export function DataTablePagination<TData>({
             <ChevronRight />
           </Button>
           <Button
-            aria-label="Go to last page"
+            aria-label={labels?.lastPage ?? "Go to last page"}
             variant="outline"
             size="icon"
             className="hidden size-8 lg:flex"

--- a/packages/ui/src/components/data-table/data-table.tsx
+++ b/packages/ui/src/components/data-table/data-table.tsx
@@ -2,6 +2,7 @@ import { flexRender, type Table as TanstackTable } from "@tanstack/react-table"
 import type * as React from "react"
 
 import { DataTablePagination } from "@chatbotx.io/ui/components/data-table/data-table-pagination"
+import type { DataTablePaginationLabels } from "@chatbotx.io/ui/components/data-table/data-table-pagination"
 import {
   Table,
   TableBody,
@@ -16,11 +17,15 @@ import { cn } from "@chatbotx.io/ui/lib/utils"
 interface DataTableProps<TData> extends React.ComponentProps<"div"> {
   table: TanstackTable<TData>
   actionBar?: React.ReactNode
+  labels?: DataTablePaginationLabels & {
+    noResults?: string
+  }
 }
 
 export function DataTable<TData>({
   table,
   actionBar,
+  labels,
   children,
   className,
   ...props
@@ -91,7 +96,7 @@ export function DataTable<TData>({
                   colSpan={table.getAllColumns().length}
                   className="h-24 text-center"
                 >
-                  No results.
+                  {labels?.noResults ?? "No results."}
                 </TableCell>
               </TableRow>
             )}
@@ -99,7 +104,7 @@ export function DataTable<TData>({
         </Table>
       </div>
       <div className="flex flex-col gap-2.5">
-        <DataTablePagination table={table} />
+        <DataTablePagination labels={labels} table={table} />
         {actionBar &&
           table.getFilteredSelectedRowModel().rows.length > 0 &&
           actionBar}

--- a/packages/ui/src/components/ui/muhammada86/tags-input-field.tsx
+++ b/packages/ui/src/components/ui/muhammada86/tags-input-field.tsx
@@ -20,7 +20,7 @@ import {
   memo,
 } from "react";
 import { type FieldValues, type Path, useFormContext } from "react-hook-form";
-import { X, Plus, Tag } from "lucide-react";
+import { ChevronDown, X, Tag } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 
 interface TagsInputFieldProps<TFieldValues extends FieldValues> {
@@ -65,6 +65,7 @@ const TagsInputFieldBase = <TFieldValues extends FieldValues>({
   const { control } = useFormContext();
   const [inputValue, setInputValue] = useState("");
   const [showSuggestions, setShowSuggestions] = useState(false);
+  const [showAllSuggestions, setShowAllSuggestions] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -81,6 +82,7 @@ const TagsInputFieldBase = <TFieldValues extends FieldValues>({
         !containerRef.current.contains(event.target as Node)
       ) {
         setShowSuggestions(false);
+        setShowAllSuggestions(false);
       }
     };
 
@@ -103,6 +105,7 @@ const TagsInputFieldBase = <TFieldValues extends FieldValues>({
     onChange([...currentTags, trimmedTag]);
     setInputValue("");
     setShowSuggestions(false);
+    setShowAllSuggestions(false);
     onSelect && onSelect([...currentTags, trimmedTag])
   };
 
@@ -130,6 +133,7 @@ const TagsInputFieldBase = <TFieldValues extends FieldValues>({
       removeTag(currentTags.length - 1, currentTags, onChange);
     } else if (e.key === "Escape") {
       setShowSuggestions(false);
+      setShowAllSuggestions(false);
     }
   };
 
@@ -168,7 +172,10 @@ const TagsInputFieldBase = <TFieldValues extends FieldValues>({
       control={control}
       name={name}
       render={({ field }) => {
-        const tags = field.value || [];
+        const tags = (field.value || []) as string[];
+        const visibleSuggestions = showAllSuggestions
+          ? suggestions
+          : filteredSuggestions;
 
         return (
           <FormItem className={cn("space-y-2", className)}>
@@ -238,16 +245,18 @@ const TagsInputFieldBase = <TFieldValues extends FieldValues>({
                       value={inputValue}
                       onChange={(e) => {
                         setInputValue(e.target.value);
+                        setShowAllSuggestions(false);
                         setShowSuggestions(
                           e.target.value.length > 0 && suggestions.length > 0
                         );
                       }}
                       onKeyDown={(e) => handleKeyDown(e, tags, field.onChange)}
-                      onFocus={() =>
+                      onFocus={() => {
+                        setShowAllSuggestions(false);
                         setShowSuggestions(
                           inputValue.length > 0 && suggestions.length > 0
-                        )
-                      }
+                        );
+                      }}
                       placeholder={
                         tags.length === 0
                           ? placeholder ??
@@ -273,54 +282,73 @@ const TagsInputFieldBase = <TFieldValues extends FieldValues>({
                     <button
                       type="button"
                       onClick={() => {
-                        if (inputValue.trim()) {
-                          addTag(inputValue, tags, field.onChange);
-                        }
                         inputRef.current?.focus();
+                        setShowAllSuggestions(true);
+                        setShowSuggestions(
+                          suggestions.length > 0 &&
+                            !(showSuggestions && showAllSuggestions)
+                        );
                       }}
                       className="p-1 hover:bg-muted rounded transition-colors"
                       disabled={
-                        !inputValue.trim() ||
+                        suggestions.length === 0 ||
                         (maxTags ? tags.length >= maxTags : false)
                       }
                     >
-                      <Plus className="w-4 h-4 text-muted-foreground" />
+                      <ChevronDown className="w-4 h-4 text-muted-foreground" />
                     </button>
                   )}
                 </div>
 
                 {/* Suggestions Dropdown */}
                 <AnimatePresence>
-                  {showSuggestions && filteredSuggestions.length > 0 && (
+                  {showSuggestions && visibleSuggestions.length > 0 && (
                     <motion.div
                       initial={{ opacity: 0, y: -10 }}
                       animate={{ opacity: 1, y: 0 }}
                       exit={{ opacity: 0, y: -10 }}
                       transition={{ duration: 0.2 }}
                       className={cn(
-                        "absolute z-50 w-full mt-1 rounded-md overflow-auto",
+                        "absolute z-50 w-full mt-1 rounded-md max-h-60 overflow-auto",
                         styles.suggestions
                       )}
                     >
-                      {filteredSuggestions.map((suggestion) => (
-                        <button
-                          key={suggestion}
-                          type="button"
-                          onClick={() =>
-                            addTag(suggestion, tags, field.onChange)
-                          }
-                          className="w-full px-3 py-2 text-left hover:bg-muted transition-colors text-sm"
-                        >
-                          <div className="flex items-center gap-2">
-                            {startIcon ? (
-                              startIcon
-                            ) : (
-                              <Tag className="w-3 h-3 text-muted-foreground" />
+                      {visibleSuggestions.map((suggestion) => {
+                        const isSelected =
+                          !allowDuplicates && tags.includes(suggestion);
+
+                        return (
+                          <button
+                            key={suggestion}
+                            type="button"
+                            onClick={() =>
+                              addTag(suggestion, tags, field.onChange)
+                            }
+                            className={cn(
+                              "w-full px-3 py-2 text-left hover:bg-muted transition-colors text-sm disabled:cursor-not-allowed disabled:text-muted-foreground disabled:opacity-50 disabled:hover:bg-transparent",
+                              isSelected &&
+                                "cursor-not-allowed text-muted-foreground hover:bg-transparent"
                             )}
-                            {suggestion}
-                          </div>
-                        </button>
-                      ))}
+                            disabled={isSelected}
+                          >
+                            <div className="flex items-center gap-2">
+                              <span
+                                className={cn(
+                                  "text-muted-foreground",
+                                  isSelected && "text-muted-foreground"
+                                )}
+                              >
+                                {startIcon ? (
+                                  startIcon
+                                ) : (
+                                  <Tag className="w-3 h-3" />
+                                )}
+                              </span>
+                              <span>{suggestion}</span>
+                            </div>
+                          </button>
+                        );
+                      })}
                     </motion.div>
                   )}
                 </AnimatePresence>

--- a/packages/utils/src/zod.ts
+++ b/packages/utils/src/zod.ts
@@ -2,4 +2,5 @@ import z from "zod"
 
 const DIGITS_REGEX = /\d+/
 
-export const zodBigintAsString = () => z.string().regex(DIGITS_REGEX)
+export const zodBigintAsString = (message?: string) =>
+  z.string().regex(DIGITS_REGEX, message ? { message } : undefined)


### PR DESCRIPTION
## Summary

This PR groups several improvements: a redesigned contact creation flow, a localized
analytics dashboard, and a few shared UI enhancements.

## Contact creation

- Choose the **Source** (channel) and **Inbox** when creating a contact; the channel-specific
  identity field (phone / email / user ID) now appears right below the inbox.
- Phone numbers are normalized to full international format (with country code), using the
  workspace target country as the default. When a country code cannot be determined, a clear
  message asks the user to include one.
- Friendlier validation messages and field placeholders.
- Added tests covering the contact creation flow.

## Analytics dashboard

- Chart labels are now translatable (e.g. "Unknown", "No data") instead of hardcoded text.
- Locale-aware date formatting for the selected date ranges.

## Tags input

- Added a dropdown to browse all available tag suggestions, with proper open/close behavior.
- Added tests for the tags input field.

## Other shared UI

- Data table: pagination improvements.
- Donut chart: configurable "no data" label.

## Contacts list

- Show the most recent "last read" time derived from a contact's inboxes.
