### PR TITLE
fix(builder): use webpack for production build

### DIFF
--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "SKIP_ENV_CHECK=true dotenv  -e ../../.env -- next build",
+    "build": "SKIP_ENV_CHECK=true dotenv  -e ../../.env -- next build --webpack",
     "check-types": "tsc --noEmit",
     "dev": "dotenv -e .env -e ../../.env -- next dev -p 3123 | pino-pretty",
     "https": "dotenv -e .env -e ../../.env -- next dev -p 3123 --experimental-https",

--- a/apps/builder/src/app/api/[[...rest]]/route.ts
+++ b/apps/builder/src/app/api/[[...rest]]/route.ts
@@ -71,7 +71,7 @@ const openAPIHandler = new OpenAPIHandler(router, {
   ],
 })
 
-export async function handleRequest(request: Request) {
+async function handleRequest(request: Request) {
   const { response } = await openAPIHandler.handle(request, {
     prefix: "/api",
     context: { headers: request.headers, url: request.url },


### PR DESCRIPTION
## What

Switch the `builder` production build from Turbopack (Next.js 16 default) to Webpack by adding the `--webpack` flag to the `build` script.

## Why

Next.js 16.2.x Turbopack uses a "compressed chunk naming format" that emits static asset filenames containing `..` and `~` (e.g. `_next/static/chunks/171mb27t57vc..css`). Some CDNs / reverse proxies / WAFs normalize URLs or treat `..` as path traversal and `~` as suspicious, returning an HTML error instead of the asset. The browser then refuses to execute it (MIME mismatch) and the app breaks.

Webpack emits clean hex content-hash filenames (`static/css/<hash>.css`) with no special characters, so they are served normally everywhere. This is the workaround currently recommended by the Next.js team — Turbopack does not yet expose any option to customize chunk filenames (see upstream issue below).

Upstream reference: vercel/next.js#92711

## Trade-off

- Runtime performance / bundle size: unchanged.
- CI / Docker build time: slightly slower (Webpack is slower to compile than Turbopack).
- `dev` script is unchanged — local dev still uses Turbopack.

## Test plan

- [ ] `pnpm --filter builder build` completes successfully
- [ ] Built assets under `.next/static/` contain no filenames with `..` or `~`
- [ ] Deploy and confirm CSS/JS load correctly (no 4xx on `_next/static/*`)