### PR TITLE
Fix flow builder: quick reply button bugs

### DIFF
--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -1506,6 +1506,9 @@
   },
   "flows": {
     "title": "Flows",
+    "quickReplies": {
+      "requiresTextCarrier": "Quick replies require a text message in this node."
+    },
     "aiGenerateText": {
       "label": "{name}: Generate Text"
     },

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -1515,6 +1515,9 @@
   },
   "flows": {
     "title": "Luồng",
+    "quickReplies": {
+      "requiresTextCarrier": "Trả lời nhanh cần có một tin nhắn văn bản trong node này."
+    },
     "aiGenerateText": {
       "label": "{name}: Tạo văn bản"
     },

--- a/apps/builder/src/features/flows/react-flow/nodes/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/nodes/editor.tsx
@@ -4,6 +4,7 @@ import {
   disabledCopyActionTypes,
   hiddenActionsStepTypes,
   MAX_QUICK_REPLIES,
+  QUICK_REPLIES_REQUIRE_TEXT_CARRIER_MESSAGE,
   stepTypes,
 } from "@chatbotx.io/flow-config"
 import { TriggerFormInitially } from "@chatbotx.io/ui/components/form/form-trigger-initially"
@@ -66,6 +67,16 @@ const collectErrorMessages = (node: unknown): string[] => {
   }
 
   return messages
+}
+
+const translateErrorMessage = (
+  t: ReturnType<typeof useTranslations>,
+  message: string,
+) => {
+  if (message === QUICK_REPLIES_REQUIRE_TEXT_CARRIER_MESSAGE) {
+    return t(QUICK_REPLIES_REQUIRE_TEXT_CARRIER_MESSAGE)
+  }
+  return message
 }
 
 type NodeEditorProps = {
@@ -364,7 +375,7 @@ export const NodeEditor = memo((props: NodeEditorProps) => {
                       const messages = collectErrorMessages(
                         // biome-ignore lint/suspicious/noExplicitAny: wip - dynamic form errors
                         (form.formState.errors as any).steps?.[index],
-                      )
+                      ).map((message) => translateErrorMessage(t, message))
                       return messages.length > 0 ? (
                         <ErrorAlert message={messages.join(", ")} />
                       ) : (
@@ -428,7 +439,18 @@ export const NodeEditor = memo((props: NodeEditorProps) => {
       </div>
 
       {"quickReplies" in nodeDetails && nodeDetails.quickReplies && (
-        <NodeEditorQuickReplies />
+        <>
+          {(() => {
+            const messages = collectErrorMessages(
+              // biome-ignore lint/suspicious/noExplicitAny: wip - dynamic form errors
+              (form.formState.errors as any).quickReplies,
+            ).map((message) => translateErrorMessage(t, message))
+            return messages.length > 0 ? (
+              <ErrorAlert message={messages.join(", ")} />
+            ) : null
+          })()}
+          <NodeEditorQuickReplies />
+        </>
       )}
 
       <NodeEditorMenu nodeType={nodeType} onClick={onAddStep} />

--- a/apps/worker/__tests__/flow.test.ts
+++ b/apps/worker/__tests__/flow.test.ts
@@ -1,6 +1,7 @@
 import type { FlowVersionModel } from "@chatbotx.io/database/types"
 import type {
   BaseStepSchema,
+  ButtonStepProps,
   EdgeSchema,
   FlowNode,
 } from "@chatbotx.io/flow-config"
@@ -103,6 +104,10 @@ function makeStep(
   states: BaseStepSchema["states"] = [],
 ): BaseStepSchema {
   return { id: "step-1", stepType: stepType as never, states } as BaseStepSchema
+}
+
+function makeQuickReply(id = "qr-1", label = "Yes"): ButtonStepProps {
+  return { id, label, buttonType: null, beforeStep: null, steps: [] }
 }
 
 function mockSpy(obj: unknown, name: string): Mock {
@@ -416,7 +421,10 @@ describe("runStepsAndQuickReplies — default edge enqueues a new job (Part 1)",
 })
 
 describe("runStepsAndQuickReplies — per-step re-dispatch", () => {
-  beforeEach(() => integrationQueueAdd.mockClear())
+  beforeEach(() => {
+    chatQueueAdd.mockClear()
+    integrationQueueAdd.mockClear()
+  })
 
   test("runs only the first step and enqueues a sendFlow job for the next step", async () => {
     const step1 = { ...makeStep("sendText"), id: "step-1" }
@@ -543,6 +551,114 @@ describe("runStepsAndQuickReplies — per-step re-dispatch", () => {
 
     expect(result?.status).toBe("retry")
     expect(integrationQueueAdd).not.toHaveBeenCalled()
+  })
+
+  test("attaches quick replies to the current carrier step without synthesizing sendQuickReply", async () => {
+    const quickReplies = [makeQuickReply()]
+    const step1 = { ...makeStep("sendText"), id: "step-1", text: "Choose" }
+    const props = {
+      ...makeBaseProps(),
+      details: { steps: [step1], quickReplies },
+      triggerNextNode: false,
+    }
+
+    await runStepsAndQuickReplies(props)
+
+    expect(chatQueueAdd).toHaveBeenCalledOnce()
+    const [, job] = chatQueueAdd.mock.calls[0] as unknown as [
+      string,
+      {
+        data: { step: { stepType: string }; quickReplies?: ButtonStepProps[] }
+      },
+    ]
+    expect(job.data.step.stepType).toBe("sendText")
+    expect(job.data.quickReplies).toEqual(quickReplies)
+  })
+
+  test("uses the active channel when selecting the quick reply carrier", async () => {
+    const quickReplies = [makeQuickReply()]
+    const textStep = {
+      ...makeStep("sendText"),
+      id: "step-1",
+      text: "Choose",
+      buttons: [],
+    }
+    const imageStep = {
+      ...makeStep("sendImage"),
+      id: "step-2",
+      url: "https://example.com/image.png",
+      buttons: [],
+    }
+    const props = {
+      ...makeBaseProps(),
+      contactInbox: {
+        ...makeContactInbox(),
+        channel: "tiktok",
+      },
+      details: { steps: [textStep, imageStep], quickReplies },
+      triggerNextNode: false,
+    }
+
+    await runStepsAndQuickReplies(props)
+
+    expect(chatQueueAdd).toHaveBeenCalledOnce()
+    const [, job] = chatQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { step: { id: string }; quickReplies?: ButtonStepProps[] } },
+    ]
+    expect(job.data.step.id).toBe("step-1")
+    expect(job.data.quickReplies).toEqual(quickReplies)
+    expect(integrationQueueAdd).toHaveBeenCalledOnce()
+    const [, nextJob] = integrationQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { startFromStepId: string } },
+    ]
+    expect(nextJob.data.startFromStepId).toBe("step-2")
+  })
+
+  test("warns and skips quick replies when the active channel has no carrier", async () => {
+    const { logger } = await import("../src/lib/logger")
+    const quickReplies = [makeQuickReply()]
+    const stepWithButtons = {
+      ...makeStep("sendText"),
+      id: "step-1",
+      text: "Choose",
+      buttons: [
+        {
+          id: "btn-1",
+          label: "Existing",
+          buttonType: null,
+          beforeStep: null,
+          steps: [],
+        },
+      ],
+    }
+    const props = {
+      ...makeBaseProps(),
+      contactInbox: {
+        ...makeContactInbox(),
+        channel: "messenger",
+      },
+      details: { steps: [stepWithButtons], quickReplies },
+      triggerNextNode: false,
+    }
+
+    await runStepsAndQuickReplies(props)
+
+    expect(chatQueueAdd).toHaveBeenCalledOnce()
+    const [, job] = chatQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { quickReplies?: ButtonStepProps[] } },
+    ]
+    expect(job.data.quickReplies).toBeUndefined()
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "messenger",
+        flowId: "flow-1",
+        targetNodeId: "node-1",
+      }),
+      expect.stringContaining("no attachable carrier"),
+    )
   })
 
   test("executes quickReplies and next-node dispatch on the final step", async () => {

--- a/apps/worker/__tests__/send-flow-step.test.ts
+++ b/apps/worker/__tests__/send-flow-step.test.ts
@@ -380,6 +380,54 @@ describe("sendFlowStep", () => {
     )
   })
 
+  test("forwards and persists quick replies on the carrier message", async () => {
+    const quickReplies = [
+      {
+        id: "qr-1",
+        label: "Yes",
+        buttonType: null,
+        beforeStep: null,
+        steps: [],
+      },
+    ]
+    const stepWithButtons = {
+      ...sendTextStep,
+      buttons: [
+        {
+          id: "btn-1",
+          label: "Existing",
+          buttonType: null,
+          beforeStep: null,
+          steps: [],
+        },
+      ],
+    }
+
+    await sendFlowStep({
+      ...baseParams,
+      step: stepWithButtons,
+      quickReplies,
+    } as SendFlowStepData & { quickReplies: typeof quickReplies })
+
+    expect(mockSendFlowStepToChannel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        quickReplies,
+      }),
+    )
+    expect(mockRepositoryCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contentAttributes: expect.objectContaining({
+          payload: expect.objectContaining({
+            buttons: expect.arrayContaining([
+              expect.objectContaining({ id: "btn-1", label: "Existing" }),
+              expect.objectContaining({ id: "qr-1", label: "Yes" }),
+            ]),
+          }),
+        }),
+      }),
+    )
+  })
+
   test("calls repository.createWithAttachments() for step with url (sendImage)", async () => {
     await sendFlowStep({ ...baseParams, step: sendImageStep })
 

--- a/apps/worker/src/chat/handlers/send-flow-step.ts
+++ b/apps/worker/src/chat/handlers/send-flow-step.ts
@@ -130,6 +130,7 @@ export async function sendFlowStep({
   step,
   trackingContext,
   metadata,
+  quickReplies,
   sendFrom,
 }: ChatJobSendFlowStep["data"]) {
   const conversation = await db.query.conversationModel.findFirst({
@@ -261,7 +262,12 @@ export async function sendFlowStep({
         flowVersionId,
       }
 
-    if ("buttons" in resolvedStep && resolvedStep.buttons.length > 0) {
+    const displayButtons =
+      "buttons" in resolvedStep
+        ? [...resolvedStep.buttons, ...(quickReplies ?? [])]
+        : (quickReplies ?? [])
+
+    if (displayButtons.length > 0) {
       contentAttributes = {
         type: "template",
         payload: {
@@ -269,7 +275,7 @@ export async function sendFlowStep({
           buttons: convertButtonsToTemplate({
             flowId,
             flowVersionId,
-            buttons: resolvedStep.buttons,
+            buttons: displayButtons,
             metadata,
             contactInboxId: targetContactInbox.id,
           }),
@@ -360,6 +366,7 @@ export async function sendFlowStep({
         flowVersionId,
         step: resolvedStep as SendFlowStepData,
         metadata,
+        quickReplies,
         messageId: message?.id,
         sendFrom,
       }),

--- a/apps/worker/src/chat/handlers/send-message.ts
+++ b/apps/worker/src/chat/handlers/send-message.ts
@@ -7,6 +7,7 @@ import type {
 } from "@chatbotx.io/database/types"
 import { emit } from "@chatbotx.io/event-bus"
 import {
+  type ButtonStepProps,
   type MetadataPayload,
   messageEventTypeSchema,
   stepTypes,
@@ -316,6 +317,7 @@ export async function sendFlowStepToChannel({
   flowId,
   flowVersionId,
   step,
+  quickReplies,
   metadata,
   messageId,
   sendFrom,
@@ -325,6 +327,7 @@ export async function sendFlowStepToChannel({
   flowId: string
   flowVersionId?: string
   step: SendFlowStepData
+  quickReplies?: ButtonStepProps[]
   metadata?: MetadataPayload
   messageId?: string
   sendFrom?: "inbox"
@@ -368,6 +371,7 @@ export async function sendFlowStepToChannel({
         flowId,
         flowVersionId,
         step: resolvedStep,
+        quickReplies,
         metadata,
         sendFrom,
       },

--- a/apps/worker/src/integration/handlers/flow-utils.ts
+++ b/apps/worker/src/integration/handlers/flow-utils.ts
@@ -5,6 +5,7 @@ import type {
 } from "@chatbotx.io/database/types"
 import type {
   BaseStepSchema,
+  ButtonStepProps,
   EdgeSchema,
   MetadataPayload,
 } from "@chatbotx.io/flow-config"
@@ -30,6 +31,7 @@ export type ExecuteMultipleStepsProps = {
   steps: BaseStepSchema[]
   trackingContext?: BotResponseTrackingContext
   metadata?: MetadataPayload
+  quickReplies?: ButtonStepProps[]
   sendFrom?: "inbox"
   nodeVisits?: NodeVisits
 }

--- a/apps/worker/src/integration/handlers/flow.ts
+++ b/apps/worker/src/integration/handlers/flow.ts
@@ -17,7 +17,6 @@ import {
   flowEventTypeSchema,
   getNodeFromButton,
   type MetadataPayload,
-  type SendQuickReplyStepSchema,
   type StepType,
   stepTypes,
 } from "@chatbotx.io/flow-config"
@@ -52,6 +51,51 @@ const ROUTING_STATUSES = new Set<StepRoutingStatus>([
   "error",
   "skip",
 ])
+
+const hasButtons = (step: BaseStepSchema) =>
+  "buttons" in step &&
+  Array.isArray((step as BaseStepSchema & { buttons?: unknown }).buttons) &&
+  ((step as BaseStepSchema & { buttons: unknown[] }).buttons?.length ?? 0) > 0
+
+export function isQuickReplyCarrierStep(
+  channel: string | null | undefined,
+  step: BaseStepSchema,
+) {
+  switch (channel) {
+    case "messenger":
+    case "instagram":
+      return step.stepType === stepTypes.enum.sendText && !hasButtons(step)
+    case "telegram":
+      return (
+        step.stepType === stepTypes.enum.sendText ||
+        step.stepType === stepTypes.enum.sendImage ||
+        step.stepType === stepTypes.enum.sendVideo ||
+        step.stepType === stepTypes.enum.sendAudio ||
+        step.stepType === stepTypes.enum.sendFile ||
+        step.stepType === stepTypes.enum.sendGif
+      )
+    case "whatsapp":
+    case "zalo":
+      return (
+        step.stepType === stepTypes.enum.sendText ||
+        step.stepType === stepTypes.enum.sendImage
+      )
+    default:
+      return step.stepType === stepTypes.enum.sendText
+  }
+}
+
+function findQuickReplyCarrierStep(props: {
+  channel: string | null | undefined
+  steps: BaseStepSchema[]
+}) {
+  for (let index = props.steps.length - 1; index >= 0; index--) {
+    const step = props.steps[index]
+    if (step && isQuickReplyCarrierStep(props.channel, step)) {
+      return step
+    }
+  }
+}
 
 /**
  * Max times a single node may execute within one uninterrupted run.
@@ -178,6 +222,30 @@ export async function runStepsAndQuickReplies(
     flowVersion,
     triggerNextNode = true,
   } = props
+  const quickReplies =
+    "quickReplies" in details && details.quickReplies
+      ? details.quickReplies
+      : []
+  const quickReplyCarrier = details.steps
+    ? findQuickReplyCarrierStep({
+        channel: props.contactInbox.channel,
+        steps: details.steps,
+      })
+    : undefined
+
+  if (quickReplies.length > 0 && !quickReplyCarrier && !props.startFromStepId) {
+    logger.warn(
+      {
+        flowId: flowVersion.flowId,
+        flowVersionId: flowVersion.id,
+        conversationId: props.conversation.id,
+        contactInboxId: props.contactInbox.id,
+        channel: props.contactInbox.channel,
+        targetNodeId: props.targetNodeId,
+      },
+      "Flow node has quick replies but no attachable carrier step for this channel; skipping quick replies",
+    )
+  }
 
   // Loop guard: cap how many times a single node runs within one uninterrupted pass.
   // Only a real node entry is counted (no startFromStepId — mid-node re-dispatches reuse
@@ -244,6 +312,8 @@ export async function runStepsAndQuickReplies(
     const result = await executeMultipleSteps({
       ...props,
       nodeVisits,
+      quickReplies:
+        quickReplyCarrier?.id === currentStep.id ? quickReplies : undefined,
       steps: [currentStep],
     })
 
@@ -278,24 +348,6 @@ export async function runStepsAndQuickReplies(
       return
     }
     // Last step — fall through to quickReplies + next-node dispatch
-  }
-
-  if (
-    "quickReplies" in details &&
-    details.quickReplies &&
-    details.quickReplies.length > 0
-  ) {
-    await executeMultipleSteps({
-      ...props,
-      nodeVisits,
-      steps: [
-        {
-          stepType: stepTypes.enum.sendQuickReply,
-          message: "Please select an option",
-          buttons: details.quickReplies,
-        } as SendQuickReplyStepSchema,
-      ],
-    })
   }
 
   if (!triggerNextNode) {

--- a/apps/worker/src/integration/handlers/step.ts
+++ b/apps/worker/src/integration/handlers/step.ts
@@ -95,6 +95,7 @@ export async function sendFlowMessage(
     step,
     trackingContext,
     metadata,
+    quickReplies,
     sendFrom,
   } = props
   await chatQueue.add(ChatJobAction.sendFlowMessage, {
@@ -106,6 +107,7 @@ export async function sendFlowMessage(
       step,
       trackingContext,
       metadata,
+      quickReplies,
       sendFrom,
     },
   })

--- a/integrations/instagram/__tests__/quick-replies-attachment.test.ts
+++ b/integrations/instagram/__tests__/quick-replies-attachment.test.ts
@@ -1,0 +1,74 @@
+import type { ButtonStepProps } from "@chatbotx.io/flow-config"
+import { describe, expect, test } from "vitest"
+import { convertFlowStepText } from "../src/handlers/message/outgoing-message/send-text"
+
+const quickReplies: ButtonStepProps[] = [
+  { id: "qr-1", label: "Yes", buttonType: null, beforeStep: null, steps: [] },
+]
+
+describe("instagram quick replies attachment", () => {
+  test("attaches node quick replies to plain text as quick reply chips", () => {
+    const [payload] = Array.from(
+      convertFlowStepText({
+        data: {
+          contact: { id: "ci-1" },
+          flowId: "flow-1",
+          step: {
+            id: "step-1",
+            stepType: "sendText",
+            text: "Choose",
+            buttons: [],
+          },
+          quickReplies,
+        },
+      } as never),
+    )
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        text: "Choose",
+        quick_replies: [
+          expect.objectContaining({ title: "Yes", content_type: "text" }),
+        ],
+      }),
+    )
+  })
+
+  test("does not attach node quick replies when text already renders a button template", () => {
+    const [payload] = Array.from(
+      convertFlowStepText({
+        data: {
+          contact: { id: "ci-1" },
+          flowId: "flow-1",
+          step: {
+            id: "step-1",
+            stepType: "sendText",
+            text: "Choose",
+            buttons: [
+              {
+                id: "btn-1",
+                label: "Existing",
+                buttonType: null,
+                beforeStep: null,
+                steps: [],
+              },
+            ],
+          },
+          quickReplies,
+        },
+      } as never),
+    )
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        attachment: expect.objectContaining({
+          payload: expect.objectContaining({
+            template_type: "button",
+            buttons: [expect.objectContaining({ title: "Existing" })],
+          }),
+        }),
+      }),
+    )
+    expect(payload).not.toHaveProperty("quick_replies")
+  })
+})

--- a/integrations/instagram/src/handlers/message/outgoing-message/send-text.ts
+++ b/integrations/instagram/src/handlers/message/outgoing-message/send-text.ts
@@ -6,6 +6,7 @@ import type {
   InstagramSendMessage,
 } from "../../../schemas"
 import { convertInstagramButtons } from "./send-button"
+import { convertInstagramQuickReplies } from "./send-quick-reply"
 
 export function* convertFlowStepText(
   props: SendFlowStepProps<InstagramAuthValue, SendTextStepSchema>,
@@ -14,6 +15,18 @@ export function* convertFlowStepText(
     data: { step },
   } = props
   if (step.buttons.length === 0) {
+    const quickReplies = props.data.quickReplies ?? []
+    if (quickReplies.length > 0) {
+      yield {
+        text: step.text,
+        quick_replies: convertInstagramQuickReplies({
+          flowId: props.data.flowId,
+          flowVersionId: props.data.flowVersionId,
+          buttons: quickReplies,
+        }),
+      }
+      return
+    }
     yield {
       text: step.text,
     }

--- a/integrations/messenger/__tests__/quick-replies-attachment.test.ts
+++ b/integrations/messenger/__tests__/quick-replies-attachment.test.ts
@@ -1,0 +1,74 @@
+import type { ButtonStepProps } from "@chatbotx.io/flow-config"
+import { describe, expect, test } from "vitest"
+import { convertFlowStepText } from "../src/handlers/message/outgoing-message/send-text"
+
+const quickReplies: ButtonStepProps[] = [
+  { id: "qr-1", label: "Yes", buttonType: null, beforeStep: null, steps: [] },
+]
+
+describe("messenger quick replies attachment", () => {
+  test("attaches node quick replies to plain text as quick reply chips", () => {
+    const [payload] = Array.from(
+      convertFlowStepText({
+        data: {
+          contact: { id: "ci-1" },
+          flowId: "flow-1",
+          step: {
+            id: "step-1",
+            stepType: "sendText",
+            text: "Choose",
+            buttons: [],
+          },
+          quickReplies,
+        },
+      } as never),
+    )
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        text: "Choose",
+        quick_replies: [
+          expect.objectContaining({ title: "Yes", content_type: "text" }),
+        ],
+      }),
+    )
+  })
+
+  test("does not attach node quick replies when text already renders a button template", () => {
+    const [payload] = Array.from(
+      convertFlowStepText({
+        data: {
+          contact: { id: "ci-1" },
+          flowId: "flow-1",
+          step: {
+            id: "step-1",
+            stepType: "sendText",
+            text: "Choose",
+            buttons: [
+              {
+                id: "btn-1",
+                label: "Existing",
+                buttonType: null,
+                beforeStep: null,
+                steps: [],
+              },
+            ],
+          },
+          quickReplies,
+        },
+      } as never),
+    )
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        attachment: expect.objectContaining({
+          payload: expect.objectContaining({
+            template_type: "button",
+            buttons: [expect.objectContaining({ title: "Existing" })],
+          }),
+        }),
+      }),
+    )
+    expect(payload).not.toHaveProperty("quick_replies")
+  })
+})

--- a/integrations/messenger/src/handlers/message/outgoing-message/send-text.ts
+++ b/integrations/messenger/src/handlers/message/outgoing-message/send-text.ts
@@ -6,6 +6,7 @@ import type {
   MessengerAuthValue,
 } from "../../../schema"
 import { convertFacebookButtons } from "./send-button"
+import { convertFacebookQuickReplies } from "./send-quick-reply"
 
 export function* convertFlowStepText(
   props: SendFlowStepProps<MessengerAuthValue, SendTextStepSchema>,
@@ -14,6 +15,19 @@ export function* convertFlowStepText(
     data: { step },
   } = props
   if (step.buttons.length === 0) {
+    const quickReplies = props.data.quickReplies ?? []
+    if (quickReplies.length > 0) {
+      yield {
+        text: step.text,
+        quick_replies: convertFacebookQuickReplies({
+          flowId: props.data.flowId,
+          flowVersionId: props.data.flowVersionId,
+          buttons: quickReplies,
+          metadata: props.data.metadata,
+        }),
+      }
+      return
+    }
     yield {
       text: step.text,
     }

--- a/integrations/telegram/__tests__/quick-replies-attachment.test.ts
+++ b/integrations/telegram/__tests__/quick-replies-attachment.test.ts
@@ -1,0 +1,68 @@
+import type { ButtonStepProps } from "@chatbotx.io/flow-config"
+import { describe, expect, test } from "vitest"
+import { convertFlowStepImage } from "../src/handlers/message/outgoing-message/send-attachment"
+import { convertFlowStepText } from "../src/handlers/message/outgoing-message/send-text"
+
+const quickReplies: ButtonStepProps[] = [
+  { id: "qr-1", label: "Yes", buttonType: null, beforeStep: null, steps: [] },
+]
+
+describe("telegram quick replies attachment", () => {
+  test("merges node quick replies into the inline keyboard", () => {
+    const [payload] = Array.from(
+      convertFlowStepText({
+        data: {
+          contact: { sourceId: "chat-1" },
+          flowId: "flow-1",
+          step: {
+            id: "step-1",
+            stepType: "sendText",
+            text: "Choose",
+            buttons: [
+              {
+                id: "btn-1",
+                label: "Existing",
+                buttonType: null,
+                beforeStep: null,
+                steps: [],
+              },
+            ],
+          },
+          quickReplies,
+        },
+      } as never),
+    )
+
+    expect(payload.reply_markup?.inline_keyboard.flat()).toEqual([
+      expect.objectContaining({ text: "Existing" }),
+      expect.objectContaining({ text: "Yes" }),
+    ])
+  })
+
+  test("adds node quick replies to image payload inline keyboard", () => {
+    const [payload] = Array.from(
+      convertFlowStepImage({
+        data: {
+          contact: { sourceId: "chat-1" },
+          flowId: "flow-1",
+          step: {
+            id: "step-1",
+            stepType: "sendImage",
+            url: "https://example.com/image.png",
+            buttons: [],
+          },
+          quickReplies,
+        },
+      } as never),
+    )
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        photo: "https://example.com/image.png",
+        reply_markup: {
+          inline_keyboard: [[expect.objectContaining({ text: "Yes" })]],
+        },
+      }),
+    )
+  })
+})

--- a/integrations/telegram/src/handlers/message/outgoing-message/index.ts
+++ b/integrations/telegram/src/handlers/message/outgoing-message/index.ts
@@ -20,6 +20,7 @@ import {
   sendTelegramPhoto,
   sendTelegramVideo,
 } from "../../../apis/bot"
+import { MAX_INLINE_BUTTONS_PER_ROW } from "../../../constants"
 import { mapToChannelError } from "../../../lib/error-mapper"
 import { logger } from "../../../lib/logger"
 import type { TelegramAuthValue } from "../../../schema"
@@ -29,6 +30,7 @@ import {
   convertFlowStepImage,
   convertFlowStepVideo,
 } from "./send-attachment"
+import { buildInlineKeyboard } from "./send-button"
 import { convertFlowStepCarousel } from "./send-carousel"
 import { convertFlowStepQuickReply } from "./send-quick-reply"
 import { convertFlowStepText } from "./send-text"
@@ -191,6 +193,14 @@ export const sendFlowStep: MessageHandlers<TelegramAuthValue>["sendFlowStep"] =
             const messageId = await sendTelegramDocument(ctx.auth, {
               chat_id: props.data.contact.sourceId,
               document: step.url as string,
+              reply_markup:
+                props.data.quickReplies && props.data.quickReplies.length > 0
+                  ? buildInlineKeyboard({
+                      flowId: props.data.flowId,
+                      buttons: props.data.quickReplies,
+                      buttonsPerRow: MAX_INLINE_BUTTONS_PER_ROW,
+                    })
+                  : undefined,
             })
             messageIds.push(String(messageId))
           }

--- a/integrations/telegram/src/handlers/message/outgoing-message/send-attachment.ts
+++ b/integrations/telegram/src/handlers/message/outgoing-message/send-attachment.ts
@@ -28,15 +28,16 @@ export function* convertFlowStepImage(
   if (!chatId) {
     return
   }
+  const buttons = [...step.buttons, ...(props.data.quickReplies ?? [])]
 
-  if (step.buttons.length === 0) {
+  if (buttons.length === 0) {
     yield { chat_id: chatId, photo: step.url }
     return
   }
 
   const keyboard = buildInlineKeyboard({
     flowId,
-    buttons: step.buttons,
+    buttons,
     buttonsPerRow: MAX_INLINE_BUTTONS_PER_ROW,
   })
 
@@ -53,17 +54,28 @@ export function* convertFlowStepVideo(
   >[0],
 ): Generator<TelegramSendVideoRequest> {
   const {
-    data: { step, contact },
+    data: { step, contact, flowId },
   } = props
 
   const chatId = contact.sourceId
   if (!chatId) {
     return
   }
+  const buttons = [...step.buttons, ...(props.data.quickReplies ?? [])]
+
+  const keyboard =
+    buttons.length > 0
+      ? buildInlineKeyboard({
+          flowId,
+          buttons,
+          buttonsPerRow: MAX_INLINE_BUTTONS_PER_ROW,
+        })
+      : undefined
 
   yield {
     chat_id: chatId,
     video: step.url,
+    reply_markup: keyboard,
   }
 }
 
@@ -80,15 +92,16 @@ export function* convertFlowStepAudio(
   if (!chatId) {
     return
   }
+  const buttons = [...step.buttons, ...(props.data.quickReplies ?? [])]
 
-  if (step.buttons.length === 0) {
+  if (buttons.length === 0) {
     yield { chat_id: chatId, audio: step.url }
     return
   }
 
   const keyboard = buildInlineKeyboard({
     flowId,
-    buttons: step.buttons,
+    buttons,
     buttonsPerRow: MAX_INLINE_BUTTONS_PER_ROW,
   })
 
@@ -112,15 +125,16 @@ export function* convertFlowStepFile(
   if (!chatId) {
     return
   }
+  const buttons = [...step.buttons, ...(props.data.quickReplies ?? [])]
 
-  if (step.buttons.length === 0) {
+  if (buttons.length === 0) {
     yield { chat_id: chatId, document: step.url }
     return
   }
 
   const keyboard = buildInlineKeyboard({
     flowId,
-    buttons: step.buttons,
+    buttons,
     buttonsPerRow: MAX_INLINE_BUTTONS_PER_ROW,
   })
 

--- a/integrations/telegram/src/handlers/message/outgoing-message/send-text.ts
+++ b/integrations/telegram/src/handlers/message/outgoing-message/send-text.ts
@@ -15,15 +15,16 @@ export function* convertFlowStepText(
   const {
     data: { step, contact },
   } = props
+  const buttons = [...step.buttons, ...(props.data.quickReplies ?? [])]
 
-  if (step.buttons.length === 0) {
+  if (buttons.length === 0) {
     yield { chat_id: contact.sourceId, text: step.text }
     return
   }
 
   const keyboard = buildInlineKeyboard({
     flowId: props.data.flowId,
-    buttons: step.buttons,
+    buttons,
     buttonsPerRow: MAX_INLINE_BUTTONS_PER_ROW,
   })
 

--- a/integrations/telegram/src/schema.ts
+++ b/integrations/telegram/src/schema.ts
@@ -146,6 +146,7 @@ export type TelegramSendVideoRequest = {
   chat_id: number | string
   video: string
   caption?: string
+  reply_markup?: TelegramInlineKeyboardMarkup
 }
 
 export type TelegramSendChatActionRequest = {

--- a/integrations/tiktok/__tests__/quick-replies-attachment.test.ts
+++ b/integrations/tiktok/__tests__/quick-replies-attachment.test.ts
@@ -1,0 +1,69 @@
+import type { ButtonStepProps } from "@chatbotx.io/flow-config"
+import { describe, expect, test } from "vitest"
+import { convertFlowStepText } from "../src/handlers/message/outgoing-message/send-text"
+
+const quickReplies: ButtonStepProps[] = [
+  { id: "qr-1", label: "Yes", buttonType: null, beforeStep: null, steps: [] },
+]
+
+describe("tiktok quick replies attachment", () => {
+  test("turns text plus node quick replies into template cards", () => {
+    const [payload] = Array.from(
+      convertFlowStepText("business-1", {
+        data: {
+          contact: { id: "ci-1", sourceConversationId: "conv-1" },
+          flowId: "flow-1",
+          step: {
+            id: "step-1",
+            stepType: "sendText",
+            text: "Choose",
+            buttons: [],
+          },
+          quickReplies,
+        },
+      } as never),
+    )
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        message_type: "TEMPLATE",
+        template: expect.objectContaining({
+          type: "QA_BUTTON_CARD",
+          title: "Choose",
+          buttons: [expect.objectContaining({ title: "Yes" })],
+        }),
+      }),
+    )
+  })
+
+  test("merges existing text buttons with node quick replies", () => {
+    const [payload] = Array.from(
+      convertFlowStepText("business-1", {
+        data: {
+          contact: { id: "ci-1", sourceConversationId: "conv-1" },
+          flowId: "flow-1",
+          step: {
+            id: "step-1",
+            stepType: "sendText",
+            text: "Choose",
+            buttons: [
+              {
+                id: "btn-1",
+                label: "Existing",
+                buttonType: null,
+                beforeStep: null,
+                steps: [],
+              },
+            ],
+          },
+          quickReplies,
+        },
+      } as never),
+    )
+
+    expect(payload.template?.buttons).toEqual([
+      expect.objectContaining({ title: "Existing" }),
+      expect.objectContaining({ title: "Yes" }),
+    ])
+  })
+})

--- a/integrations/tiktok/src/handlers/message/outgoing-message/send-text.ts
+++ b/integrations/tiktok/src/handlers/message/outgoing-message/send-text.ts
@@ -10,8 +10,9 @@ export function* convertFlowStepText(
   const {
     data: { step, contact, flowId, flowVersionId, metadata },
   } = props
+  const buttons = [...step.buttons, ...(props.data.quickReplies ?? [])]
 
-  if (step.buttons.length === 0) {
+  if (buttons.length === 0) {
     yield {
       business_id: businessId,
       recipient_type: "CONVERSATION",
@@ -26,7 +27,7 @@ export function* convertFlowStepText(
     title: step.text,
     flowId,
     flowVersionId,
-    buttons: step.buttons,
+    buttons,
     metadata,
     contactInboxId: contact.id,
   })) {

--- a/integrations/whatsapp/__tests__/quick-replies-attachment.test.ts
+++ b/integrations/whatsapp/__tests__/quick-replies-attachment.test.ts
@@ -1,0 +1,86 @@
+import type { ButtonStepProps } from "@chatbotx.io/flow-config"
+import { describe, expect, test } from "vitest"
+import { convertFlowStepText } from "../src/handlers/message/outgoing-message/send-text"
+
+const quickReplies: ButtonStepProps[] = [
+  { id: "qr-1", label: "One", buttonType: null, beforeStep: null, steps: [] },
+  { id: "qr-2", label: "Two", buttonType: null, beforeStep: null, steps: [] },
+  { id: "qr-3", label: "Three", buttonType: null, beforeStep: null, steps: [] },
+]
+
+describe("whatsapp quick replies attachment", () => {
+  test("uses reply buttons when merged buttons are at most three", () => {
+    const [payload] = Array.from(
+      convertFlowStepText({
+        data: {
+          flowId: "flow-1",
+          step: {
+            id: "step-1",
+            stepType: "sendText",
+            text: "Choose",
+            buttons: [],
+          },
+          quickReplies: quickReplies.slice(0, 2),
+        },
+      } as never),
+    )
+
+    expect(payload).toMatchObject({
+      _type: "interactive",
+      type: "button",
+      action: {
+        buttons: [
+          expect.objectContaining({
+            reply: expect.objectContaining({ title: "One" }),
+          }),
+          expect.objectContaining({
+            reply: expect.objectContaining({ title: "Two" }),
+          }),
+        ],
+      },
+    })
+  })
+
+  test("uses an interactive list when merged buttons exceed three", () => {
+    const [payload] = Array.from(
+      convertFlowStepText({
+        data: {
+          flowId: "flow-1",
+          step: {
+            id: "step-1",
+            stepType: "sendText",
+            text: "Choose",
+            buttons: [
+              {
+                id: "btn-1",
+                label: "Existing",
+                buttonType: null,
+                beforeStep: null,
+                steps: [],
+              },
+            ],
+          },
+          quickReplies,
+        },
+      } as never),
+    )
+
+    expect(payload).toMatchObject({
+      _type: "interactive",
+      type: "list",
+      action: {
+        button: "Options",
+        sections: [
+          {
+            rows: [
+              expect.objectContaining({ title: "Existing" }),
+              expect.objectContaining({ title: "One" }),
+              expect.objectContaining({ title: "Two" }),
+              expect.objectContaining({ title: "Three" }),
+            ],
+          },
+        ],
+      },
+    })
+  })
+})

--- a/integrations/whatsapp/src/handlers/message/outgoing-message/send-image.ts
+++ b/integrations/whatsapp/src/handlers/message/outgoing-message/send-image.ts
@@ -1,20 +1,8 @@
-import {
-  encodeButtonPayload,
-  extractMetadata,
-  type SendImageStepSchema,
-} from "@chatbotx.io/flow-config"
+import type { SendImageStepSchema } from "@chatbotx.io/flow-config"
 import type { MessageHandlers } from "@chatbotx.io/sdk"
-import { chunk } from "remeda"
-import {
-  ActionButtons,
-  Body,
-  Button,
-  Header,
-  Image,
-  Interactive,
-} from "whatsapp-api-js/messages"
+import { Header, Image } from "whatsapp-api-js/messages"
 import type { WhatsappAuthValue } from "../../../schema"
-import { MAX_BUTTONS } from "./shared"
+import { buildWhatsappButtonMessages } from "./shared"
 
 export function* convertFlowStepImage(
   props: Parameters<
@@ -24,31 +12,20 @@ export function* convertFlowStepImage(
   const {
     data: { step },
   } = props
-  if (step.buttons.length === 0) {
+  const buttons = [...step.buttons, ...(props.data.quickReplies ?? [])]
+  if (buttons.length === 0) {
     yield new Image(step.url)
-  } else {
-    const chunks = chunk(step.buttons, MAX_BUTTONS)
+    return
+  }
 
-    for (const c1 of chunks) {
-      const buttons = c1.map((button) => {
-        const buttonId = encodeButtonPayload({
-          flowId: props.data.flowId,
-          flowVersionId: props.data.flowVersionId,
-          buttonId: button.id,
-          broadcastId: extractMetadata("broadcastId", props.data.metadata),
-          sequenceStepId: extractMetadata(
-            "sequenceStepId",
-            props.data.metadata,
-          ),
-        })
-        return new Button(buttonId, button.label)
-      })
-
-      yield new Interactive(
-        new ActionButtons(...(buttons as [Button, ...Button[]])),
-        new Body(""),
-        new Header(new Image(step.url)),
-      )
-    }
+  for (const message of buildWhatsappButtonMessages({
+    flowId: props.data.flowId,
+    flowVersionId: props.data.flowVersionId,
+    buttons,
+    metadata: props.data.metadata,
+    bodyText: "",
+    header: buttons.length <= 3 ? new Header(new Image(step.url)) : undefined,
+  })) {
+    yield message
   }
 }

--- a/integrations/whatsapp/src/handlers/message/outgoing-message/send-text.ts
+++ b/integrations/whatsapp/src/handlers/message/outgoing-message/send-text.ts
@@ -1,19 +1,8 @@
-import {
-  encodeButtonPayload,
-  extractMetadata,
-  type SendTextStepSchema,
-} from "@chatbotx.io/flow-config"
+import type { SendTextStepSchema } from "@chatbotx.io/flow-config"
 import type { MessageHandlers } from "@chatbotx.io/sdk"
-import { chunk } from "remeda"
-import {
-  ActionButtons,
-  Body,
-  Button,
-  Interactive,
-  Text,
-} from "whatsapp-api-js/messages"
+import { Text } from "whatsapp-api-js/messages"
 import type { WhatsappAuthValue } from "../../../schema"
-import { MAX_BUTTONS } from "./shared"
+import { buildWhatsappButtonMessages } from "./shared"
 
 export function* convertFlowStepText(
   props: Parameters<
@@ -23,30 +12,19 @@ export function* convertFlowStepText(
   const {
     data: { step },
   } = props
-  if (step.buttons.length === 0) {
+  const buttons = [...step.buttons, ...(props.data.quickReplies ?? [])]
+  if (buttons.length === 0) {
     yield new Text(step.text)
-  } else {
-    const chunks = chunk(step.buttons, MAX_BUTTONS)
+    return
+  }
 
-    for (const c1 of chunks) {
-      const buttons = c1.map((button) => {
-        const buttonId = encodeButtonPayload({
-          flowId: props.data.flowId,
-          flowVersionId: props.data.flowVersionId,
-          buttonId: button.id,
-          broadcastId: extractMetadata("broadcastId", props.data.metadata),
-          sequenceStepId: extractMetadata(
-            "sequenceStepId",
-            props.data.metadata,
-          ),
-        })
-        return new Button(buttonId, button.label)
-      })
-
-      yield new Interactive(
-        new ActionButtons(...(buttons as [Button, ...Button[]])),
-        new Body(step.text),
-      )
-    }
+  for (const message of buildWhatsappButtonMessages({
+    flowId: props.data.flowId,
+    flowVersionId: props.data.flowVersionId,
+    buttons,
+    metadata: props.data.metadata,
+    bodyText: step.text,
+  })) {
+    yield message
   }
 }

--- a/integrations/whatsapp/src/handlers/message/outgoing-message/shared.ts
+++ b/integrations/whatsapp/src/handlers/message/outgoing-message/shared.ts
@@ -1,1 +1,89 @@
+import {
+  type ButtonStepProps,
+  encodeButtonPayload,
+  extractMetadata,
+  type MetadataPayload,
+} from "@chatbotx.io/flow-config"
+import {
+  ActionButtons,
+  ActionList,
+  Body,
+  Button,
+  type Header,
+  Interactive,
+  ListSection,
+  Row,
+} from "whatsapp-api-js/messages"
+
 export const MAX_BUTTONS = 3
+export const MAX_LIST_ROWS = 10
+export const DEFAULT_LIST_BUTTON_LABEL = "Options"
+
+const ROW_ID_MAX_LENGTH = 200
+
+export function buildWhatsappButtonMessages(props: {
+  flowId: string
+  flowVersionId?: string
+  buttons: ButtonStepProps[]
+  metadata?: MetadataPayload
+  bodyText: string
+  header?: Header
+}) {
+  const { buttons, flowId, flowVersionId, metadata } = props
+
+  if (buttons.length === 0) {
+    return []
+  }
+
+  if (buttons.length <= MAX_BUTTONS) {
+    const actionButtons = buttons.map((button) => {
+      const buttonId = encodeButtonPayload({
+        flowId,
+        flowVersionId,
+        buttonId: button.id,
+        broadcastId: extractMetadata("broadcastId", metadata),
+        sequenceStepId: extractMetadata("sequenceStepId", metadata),
+      })
+      return new Button(buttonId, button.label)
+    })
+
+    return [
+      new Interactive(
+        new ActionButtons(...(actionButtons as [Button, ...Button[]])),
+        new Body(props.bodyText),
+        props.header,
+      ),
+    ]
+  }
+
+  if (buttons.length > MAX_LIST_ROWS) {
+    throw new Error(
+      `WhatsApp interactive lists support at most ${MAX_LIST_ROWS} quick reply rows`,
+    )
+  }
+
+  const rows = buttons.map((button) => {
+    const buttonId = encodeButtonPayload({
+      flowId,
+      flowVersionId,
+      buttonId: button.id,
+      broadcastId: extractMetadata("broadcastId", metadata),
+      sequenceStepId: extractMetadata("sequenceStepId", metadata),
+    })
+    return new Row(
+      buttonId.slice(0, ROW_ID_MAX_LENGTH),
+      button.label.slice(0, 24),
+    )
+  })
+  const [firstRow, ...restRows] = rows
+
+  return [
+    new Interactive(
+      new ActionList(
+        DEFAULT_LIST_BUTTON_LABEL,
+        new ListSection(undefined, firstRow, ...restRows),
+      ),
+      new Body(props.bodyText),
+    ),
+  ]
+}

--- a/integrations/zalo/__tests__/quick-replies-attachment.test.ts
+++ b/integrations/zalo/__tests__/quick-replies-attachment.test.ts
@@ -1,0 +1,74 @@
+import type { ButtonStepProps } from "@chatbotx.io/flow-config"
+import { describe, expect, test } from "vitest"
+import { convertFlowStepText } from "../src/handlers/message/outgoing-message/send-text"
+
+const quickReplies: ButtonStepProps[] = [
+  { id: "qr-1", label: "Yes", buttonType: null, beforeStep: null, steps: [] },
+]
+
+describe("zalo quick replies attachment", () => {
+  test("merges node quick replies into the text template buttons", () => {
+    const [payload] = Array.from(
+      convertFlowStepText({
+        data: {
+          contact: { id: "ci-1" },
+          flowId: "flow-1",
+          step: {
+            id: "step-1",
+            stepType: "sendText",
+            text: "Choose",
+            buttons: [
+              {
+                id: "btn-1",
+                label: "Existing",
+                buttonType: null,
+                beforeStep: null,
+                steps: [],
+              },
+            ],
+          },
+          quickReplies,
+        },
+      } as never),
+    )
+
+    expect(payload.attachment?.payload.buttons).toEqual([
+      expect.objectContaining({ title: "Existing" }),
+      expect.objectContaining({ title: "Yes" }),
+    ])
+  })
+
+  test("throws instead of silently truncating when merged buttons exceed Zalo max", () => {
+    expect(() =>
+      Array.from(
+        convertFlowStepText({
+          data: {
+            contact: { id: "ci-1" },
+            flowId: "flow-1",
+            step: {
+              id: "step-1",
+              stepType: "sendText",
+              text: "Choose",
+              buttons: [
+                {
+                  id: "btn-1",
+                  label: "Existing",
+                  buttonType: null,
+                  beforeStep: null,
+                  steps: [],
+                },
+              ],
+            },
+            quickReplies: Array.from({ length: 5 }, (_, index) => ({
+              id: `qr-${index}`,
+              label: `QR ${index}`,
+              buttonType: null,
+              beforeStep: null,
+              steps: [],
+            })),
+          },
+        } as never),
+      ),
+    ).toThrow("Zalo template buttons support at most 5")
+  })
+})

--- a/integrations/zalo/src/handlers/message/outgoing-message/send-image.ts
+++ b/integrations/zalo/src/handlers/message/outgoing-message/send-image.ts
@@ -5,6 +5,7 @@ import {
 } from "@chatbotx.io/flow-config"
 import type { SendFlowStepProps } from "@chatbotx.io/sdk"
 import { uploadAttachment } from "../../../api/message"
+import { MAX_BUTTONS } from "../../../constants"
 import { logger } from "../../../lib/logger"
 import type { ZaloAuthValue } from "../../../schema/definition"
 import type { MessageTemplate } from "../../../schema/webhook"
@@ -33,12 +34,19 @@ export async function* convertFlowStepImage(
       throw new Error("Failed to upload image: No attachment ID received")
     }
 
-    const buttons =
+    const buttonsToSend =
       step.stepType === stepTypes.enum.sendImage
+        ? [...step.buttons, ...(props.data.quickReplies ?? [])]
+        : []
+    if (buttonsToSend.length > MAX_BUTTONS) {
+      throw new Error(`Zalo template buttons support at most ${MAX_BUTTONS}`)
+    }
+    const buttons =
+      buttonsToSend.length > 0
         ? await convertZaloButtons({
             flowId: props.data.flowId,
             flowVersionId: props.data.flowVersionId,
-            buttons: step.buttons,
+            buttons: buttonsToSend,
             metadata: props.data.metadata,
             contactInboxId: props.data.contact.id,
           })

--- a/integrations/zalo/src/handlers/message/outgoing-message/send-text.ts
+++ b/integrations/zalo/src/handlers/message/outgoing-message/send-text.ts
@@ -1,5 +1,6 @@
 import type { SendTextStepSchema } from "@chatbotx.io/flow-config"
 import type { SendFlowStepProps } from "@chatbotx.io/sdk"
+import { MAX_BUTTONS } from "../../../constants"
 import type { ZaloAuthValue } from "../../../schema/definition"
 import type { ButtonPayload, MessageTemplate } from "../../../schema/webhook"
 import { convertZaloButtons } from "./send-button"
@@ -10,15 +11,19 @@ export function* convertFlowStepText(
   const {
     data: { step },
   } = props
-  if (step.buttons.length === 0) {
+  const buttonsToSend = [...step.buttons, ...(props.data.quickReplies ?? [])]
+  if (buttonsToSend.length === 0) {
     yield {
       text: step.text,
     }
   } else {
+    if (buttonsToSend.length > MAX_BUTTONS) {
+      throw new Error(`Zalo template buttons support at most ${MAX_BUTTONS}`)
+    }
     const buttons: ButtonPayload[] | undefined = convertZaloButtons({
       flowId: props.data.flowId,
       flowVersionId: props.data.flowVersionId,
-      buttons: step.buttons,
+      buttons: buttonsToSend,
       metadata: props.data.metadata,
       contactInboxId: props.data.contact.id,
     })

--- a/packages/flow-config/__tests__/quick-replies-carrier.test.ts
+++ b/packages/flow-config/__tests__/quick-replies-carrier.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest"
+import {
+  buttonStepDefaultFn,
+  sendImageStepDefaultFn,
+  sendMessageNodeDefaultFn,
+  sendMessageNodeSchema,
+  sendQuickReplyStepDefaultFn,
+  sendTextStepDefaultFn,
+} from "../src"
+
+describe("sendMessage quick reply carrier validation", () => {
+  test("rejects quick replies when the node has no text carrier", () => {
+    const node = sendMessageNodeDefaultFn({
+      nodeProps: {},
+      detailProps: {
+        steps: [
+          {
+            ...sendImageStepDefaultFn(),
+            url: "https://example.com/image.png",
+          },
+        ],
+        quickReplies: [buttonStepDefaultFn({ label: "Yes" })],
+      },
+    })
+
+    const result = sendMessageNodeSchema.safeParse(node)
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: ["data", "details", "quickReplies"],
+          message: "flows.quickReplies.requiresTextCarrier",
+        }),
+      ]),
+    )
+  })
+
+  test("accepts quick replies when the node has a text carrier", () => {
+    const node = sendMessageNodeDefaultFn({
+      nodeProps: {},
+      detailProps: {
+        steps: [
+          sendTextStepDefaultFn({
+            text: "Choose one",
+          }),
+        ],
+        quickReplies: [buttonStepDefaultFn({ label: "Yes" })],
+      },
+    })
+
+    const result = sendMessageNodeSchema.safeParse(node)
+
+    expect(result.success).toBe(true)
+  })
+
+  test("does not default legacy sendQuickReply steps to a hardcoded prompt", () => {
+    const step = sendQuickReplyStepDefaultFn()
+
+    expect(step.message).not.toBe("Please select an option")
+    expect(step.message).toBe("")
+  })
+})

--- a/packages/flow-config/src/nodes/send-message.ts
+++ b/packages/flow-config/src/nodes/send-message.ts
@@ -27,32 +27,48 @@ import {
   nodeTypeSchema,
 } from "./base"
 
+export const QUICK_REPLIES_REQUIRE_TEXT_CARRIER_MESSAGE =
+  "flows.quickReplies.requiresTextCarrier"
+
 export const sendMessageNodeSchema = baseNodeSchema.extend({
   type: z.literal(nodeTypeSchema.enum.sendMessage),
   data: baseNodeDataSchema.extend({
-    details: z.object({
-      beforeStep: chooseChannelStepSchema,
-      steps: z.array(
-        z.discriminatedUnion("stepType", [
-          sendAudioStepSchema,
-          sendFileStepSchema,
-          sendImageStepSchema,
-          sendTextStepSchema,
-          sendVideoStepSchema,
-          // sendCardStepSchema,
-          sendCarouselStepSchema,
-          getUserDataStepSchema,
-          sendGifStepSchema,
-          typingStepSchema,
-          sendWaTemplateMessageStepSchema,
-          sendMessengerTemplateMessageStepSchema,
-          whatsappOptionListStepSchema,
-          whatsappFlowStepSchema,
-          ...actionSteps,
-        ]),
-      ),
-      quickReplies: z.array(buttonStepSchema).max(MAX_QUICK_REPLIES),
-    }),
+    details: z
+      .object({
+        beforeStep: chooseChannelStepSchema,
+        steps: z.array(
+          z.discriminatedUnion("stepType", [
+            sendAudioStepSchema,
+            sendFileStepSchema,
+            sendImageStepSchema,
+            sendTextStepSchema,
+            sendVideoStepSchema,
+            // sendCardStepSchema,
+            sendCarouselStepSchema,
+            getUserDataStepSchema,
+            sendGifStepSchema,
+            typingStepSchema,
+            sendWaTemplateMessageStepSchema,
+            sendMessengerTemplateMessageStepSchema,
+            whatsappOptionListStepSchema,
+            whatsappFlowStepSchema,
+            ...actionSteps,
+          ]),
+        ),
+        quickReplies: z.array(buttonStepSchema).max(MAX_QUICK_REPLIES),
+      })
+      .superRefine((details, ctx) => {
+        if (
+          details.quickReplies.length > 0 &&
+          !details.steps.some((step) => step.stepType === "sendText")
+        ) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["quickReplies"],
+            message: QUICK_REPLIES_REQUIRE_TEXT_CARRIER_MESSAGE,
+          })
+        }
+      }),
   }),
 })
 export type SendMessageNodeSchema = z.infer<typeof sendMessageNodeSchema>

--- a/packages/flow-config/src/steps/send-quick-reply.ts
+++ b/packages/flow-config/src/steps/send-quick-reply.ts
@@ -17,7 +17,7 @@ export type SendQuickReplyStepSchema = z.infer<typeof sendQuickReplyStepSchema>
 export const sendQuickReplyStepDefaultFn = (
   props: Partial<SendQuickReplyStepSchema> = {},
 ): SendQuickReplyStepSchema => ({
-  message: "Please select an option",
+  message: "",
   buttons: [],
   ...props,
   id: createId(),

--- a/packages/sdk/src/lib/integration.ts
+++ b/packages/sdk/src/lib/integration.ts
@@ -1,4 +1,4 @@
-import type { MetadataPayload } from "@chatbotx.io/flow-config"
+import type { ButtonStepProps, MetadataPayload } from "@chatbotx.io/flow-config"
 import type { AuthValue, Oauth2AuthValue } from "./auth"
 import {
   AuthException,
@@ -48,6 +48,7 @@ export type ChannelSendFlowStepProps<IAuth extends AuthValue> = {
     flowId: string
     flowVersionId?: string
     step: SendFlowStepData
+    quickReplies?: ButtonStepProps[]
     metadata?: MetadataPayload
     sendFrom?: "inbox"
   }
@@ -90,6 +91,7 @@ export type MessageHandlers<
         flowId: string
         flowVersionId?: string
         step: TStep
+        quickReplies?: ButtonStepProps[]
         metadata?: MetadataPayload
         sendFrom?: "inbox"
       }

--- a/packages/worker-config/src/queues/chat/index.ts
+++ b/packages/worker-config/src/queues/chat/index.ts
@@ -4,6 +4,7 @@ import type {
   MessageModel,
 } from "@chatbotx.io/database/types"
 import type {
+  ButtonStepProps,
   MessengerTemplateParams,
   MetadataPayload,
   SendAudioStepSchema,
@@ -76,6 +77,7 @@ export type ChatJobSendFlowStep = {
       | SendMessengerTemplateMessageStepSchema
     trackingContext?: BotResponseTrackingContext
     metadata?: MetadataPayload
+    quickReplies?: ButtonStepProps[]
     sendFrom?: "inbox"
   }
 }


### PR DESCRIPTION
## Overview

This update fixes several bugs with **Quick Reply buttons** in the flow builder. Quick replies now behave consistently and correctly across every messaging channel.

## Bugs fixed

- **Removed the unwanted "Please select an option" message.** Adding a quick reply used to send an extra English sentence that could not be translated or edited. That automatic message is now gone.

- **Quick replies now stay attached to your message.** The buttons appear together with the text or image you actually send, instead of showing up as a separate empty bubble.

- **Quick replies now work on WhatsApp, Zalo, and TikTok.** They previously did nothing on these channels — the buttons simply never appeared. They now show up correctly, alongside Messenger, Instagram, and Telegram.

- **Clearer guidance in the builder.** If you add quick replies without a message for them to attach to, the builder now warns you — so you no longer accidentally publish a flow where the buttons can't be delivered.
