### PR TITLE
Fix: new contacts missing from hourly activity reports

### DIFF
--- a/packages/analytics/__tests__/mac-tracking.service.test.ts
+++ b/packages/analytics/__tests__/mac-tracking.service.test.ts
@@ -526,6 +526,39 @@ describe("MacTrackingService.claimNewActiveContact", () => {
     )
   })
 
+  test("also records the paired hourly presence row for a brand-new contact", async () => {
+    macRepository.upsertMonthlyPresence.mockResolvedValueOnce([
+      { workspaceMacId: "wm-1", count: 1 },
+    ])
+    const tx = {} as never
+
+    await newService().claimNewActiveContact(input, tx)
+
+    expect(macRepository.upsertHourlyPresence).toHaveBeenCalledTimes(1)
+    expect(macRepository.upsertHourlyPresence).toHaveBeenCalledWith(
+      [
+        {
+          workspaceId: WORKSPACE_ID,
+          contactId: "c-1",
+          contactInboxId: "ci-1",
+          inboxId: "ib-1",
+          hourBucket: new Date("2026-05-01T10:00:00.000Z"),
+        },
+      ],
+      tx,
+    )
+  })
+
+  test("still records the hourly presence row when the monthly row already exists (dedup)", async () => {
+    macRepository.upsertMonthlyPresence.mockResolvedValueOnce([])
+
+    const result = await newService().claimNewActiveContact(input, {} as never)
+
+    expect(result).toEqual({ counted: false })
+    expect(macRepository.addWorkspaceMacCount).not.toHaveBeenCalled()
+    expect(macRepository.upsertHourlyPresence).toHaveBeenCalledTimes(1)
+  })
+
   test("reports not counted when the presence row already exists (dedup)", async () => {
     macRepository.upsertMonthlyPresence.mockResolvedValueOnce([])
 
@@ -542,6 +575,7 @@ describe("MacTrackingService.claimNewActiveContact", () => {
 
     expect(result).toEqual({ counted: false })
     expect(macRepository.upsertMonthlyPresence).not.toHaveBeenCalled()
+    expect(macRepository.upsertHourlyPresence).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/analytics/src/services/mac-tracking.service.ts
+++ b/packages/analytics/src/services/mac-tracking.service.ts
@@ -178,10 +178,11 @@ export class MacTrackingService {
    * Synchronously claim one monthly-active-contact slot for a *brand-new*
    * contact at creation time, inside the caller's transaction. This is the
    * write-time half of MAC enforcement: it records the same
-   * `ContactActiveMonthly` presence row and `WorkspaceMac` rollup that the
-   * async `trackMessageIn`/`trackMessageOut` path would, so a later
-   * `message:received`/`message:sent` event for this same contact dedups via
-   * `onConflictDoNothing` and does NOT double-count.
+   * `ContactActiveMonthly` + `ContactActiveHourly` presence rows and
+   * `WorkspaceMac` rollup that the async `trackMessageIn`/`trackMessageOut`
+   * (+ hourly) path would, so a later `message:received`/`message:sent`
+   * event for this same contact dedups via `onConflictDoNothing` and does
+   * NOT double-count.
    *
    * Returns `{ counted: true }` only when a presence row was newly inserted.
    * Because the contact (and its `contactInbox`) is brand-new, a conflict
@@ -218,12 +219,13 @@ export class MacTrackingService {
 
   /**
    * Batch variant of {@link claimNewActiveContact} for bulk creation (e.g.
-   * contact import): records the `ContactActiveMonthly` presence rows + the
-   * `WorkspaceMac` rollup for many brand-new contacts of one workspace in a
-   * single round-trip, inside the caller's transaction. Returns the number of
-   * presence rows newly inserted (`onConflictDoNothing` dedups any already
-   * active this period). Keeps the import-created contacts in the same ledger
-   * the quota reconcile derives `macUsed` from.
+   * contact import): records the `ContactActiveMonthly` + `ContactActiveHourly`
+   * presence rows and the `WorkspaceMac` rollup for many brand-new contacts of
+   * one workspace in a single round-trip, inside the caller's transaction.
+   * Returns the number of monthly presence rows newly inserted
+   * (`onConflictDoNothing` dedups any already active this period). Keeps the
+   * import-created contacts in the same ledger the quota reconcile derives
+   * `macUsed` from.
    */
   async claimNewActiveContacts(
     input: {
@@ -272,6 +274,18 @@ export class MacTrackingService {
       })),
       tx,
     )
+
+    await macRepository.upsertHourlyPresence(
+      input.contacts.map((contact) => ({
+        workspaceId: input.workspaceId,
+        contactId: contact.contactId,
+        contactInboxId: contact.contactInboxId,
+        inboxId: input.inboxId,
+        hourBucket,
+      })),
+      tx,
+    )
+
     if (deltas.length === 0) {
       return { counted: 0 }
     }


### PR DESCRIPTION
## Summary

This fixes a data-consistency bug in contact activity tracking.

**Bug fixed:** When a brand-new contact reached out for the first time, the system correctly counted them toward the monthly active-contacts total (used for billing), but it failed to also log that activity in the hourly activity records. As a result, hourly/time-based activity reports could undercount new contacts, even though the monthly totals were correct.

This affected new contacts created through:
- A first message on webchat
- A first message on any connected channel (WhatsApp, Messenger, Instagram, Telegram, etc.)
- Manually creating a contact in the dashboard

After this fix, every time a contact is counted as active for the month, the matching hourly record is also created — keeping monthly totals and hourly reports consistent with each other.

## Impact

- No change to billing numbers (the monthly count was already correct).
- Hourly/time-based active-contact reporting will now be complete and consistent going forward.

## Test plan

- [x] Added automated tests confirming the hourly record is created alongside the monthly record for new contacts
- [x] Full existing test suite passes with no regressions
- [x] Type checking and lint checks pass