### PR TITLE
fix(tenancy): resolve integration webhooks via broker host for white-label

### DIFF
--- a/apps/builder/src/app/integrations/[...integration]/webhook.ts
+++ b/apps/builder/src/app/integrations/[...integration]/webhook.ts
@@ -12,11 +12,12 @@ import type {
 } from "@chatbotx.io/integration-tiktok"
 import { integrationQueue } from "@chatbotx.io/worker-config"
 import type { NextRequest } from "next/server"
-import { env, isCloud } from "@/env"
+import { isCloud } from "@/env"
 import { findIntegrationTelegramByBotId } from "@/features/integration-telegram/queries"
 import { findIntegrationTiktokByOpenId } from "@/features/integration-tiktok/queries"
 import { type IntegrationKey, integrations } from "@/integration"
 import { logger } from "@/lib/log"
+import { isBrokerHost } from "@/lib/oauth-broker"
 
 type CredentialType = Parameters<
   typeof platformCredentialService.resolveForOwner
@@ -46,10 +47,9 @@ export const handleWebhook = async (
 
   if (isCloud()) {
     const domain = req.headers.get("x-domain") ?? ""
-    const defaultDomain = new URL(env.NEXT_PUBLIC_BUILDER_URL).hostname
 
-    if (domain === defaultDomain) {
-      // Default platform domain: use global platform credential
+    if (isBrokerHost(domain)) {
+      // Broker (platform) domain: use global platform credential
       credential = await platformCredentialService.findDecryptedPlatform({
         type,
       })

--- a/apps/builder/src/lib/oauth-broker.ts
+++ b/apps/builder/src/lib/oauth-broker.ts
@@ -24,7 +24,7 @@ export function buildBrokerCallbackUrl(path: string): string {
   return new URL(path, getBrokerOrigin()).toString()
 }
 
-/** Whether the given request host is the broker host. */
+/** Whether the given request hostname is the broker host. */
 export function isBrokerHost(host: string): boolean {
-  return host === new URL(getBrokerOrigin()).host
+  return host === new URL(getBrokerOrigin()).hostname
 }


### PR DESCRIPTION
## Summary
- Route cloud integration webhook credential lookup through the shared `isBrokerHost` helper instead of comparing against `NEXT_PUBLIC_BUILDER_URL`, so provider callbacks on the registered broker origin resolve to platform credentials correctly in white-label deployments.
- Align `isBrokerHost` to compare `.hostname` (matching the proxy's `x-domain` header) instead of `.host`.

## Test plan
- [x] `pnpm --filter builder check-types`
- [x] `pnpm lint`
- [x] `pnpm --filter builder test oauth-broker`
- [ ] Verify integration webhook on broker host resolves global platform credential in cloud mode
- [ ] Verify integration webhook on a reseller custom domain resolves tenant-specific credential


Made with [Cursor](https://cursor.com)