### PR TITLE
fix(integrations): harden channel schemas, add null guards, and register TikTok webhook

### DIFF
--- a/apps/builder/src/features/messages/components/message-input.tsx
+++ b/apps/builder/src/features/messages/components/message-input.tsx
@@ -272,6 +272,12 @@ export const MessageInput = () => {
 
   const channel = conversation?.contactInboxes[0]?.channel
 
+  // Meta DM = messenger or instagram that is NOT a post comment.
+  // sourceId != null on the conversation means it's a post comment for both channels.
+  const isMetaDm =
+    (channel === "messenger" || channel === "instagram") &&
+    conversation?.sourceId == null
+
   // Parse lastIncomingMessageAt into a numeric timestamp once. Using a scalar
   // as a memo dependency is more stable than the whole contactInboxes array.
   // Returns null if the field is absent or not a valid date (NaN guard).
@@ -302,10 +308,7 @@ export const MessageInput = () => {
     if (windowSeconds) {
       deadlines.push(lastIncomingTs + windowSeconds * 1000)
     }
-    if (
-      channel === "messenger" ||
-      (channel === "instagram" && !isInstagramPostComment)
-    ) {
+    if (isMetaDm) {
       deadlines.push(
         lastIncomingTs + MESSENGER_HUMAN_AGENT_WINDOW_SECONDS * 1000,
       )
@@ -321,7 +324,7 @@ export const MessageInput = () => {
       next - Date.now(),
     )
     return () => clearTimeout(timeout)
-  }, [lastIncomingTs, channel, isInstagramPostComment, clockTick])
+  }, [lastIncomingTs, channel, isMetaDm, clockTick])
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: clockTick forces recompute at window boundary
   const isWindowExpired = useMemo(() => {
@@ -336,25 +339,19 @@ export const MessageInput = () => {
   }, [channel, lastIncomingTs, clockTick])
 
   const isMessengerWindowClosed = useMemo(
-    () =>
-      (channel === "messenger" ||
-        (channel === "instagram" && !isInstagramPostComment)) &&
-      isWindowExpired,
-    [channel, isInstagramPostComment, isWindowExpired],
+    () => isMetaDm && isWindowExpired,
+    [isMetaDm, isWindowExpired],
   )
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: clockTick forces recompute at window boundary
   const isMessengerHumanAgentWindowExpired = useMemo(() => {
-    const isMetaDm =
-      channel === "messenger" ||
-      (channel === "instagram" && !isInstagramPostComment)
     if (!(isMetaDm && lastIncomingTs)) {
       return false
     }
     return (
       Date.now() - lastIncomingTs > MESSENGER_HUMAN_AGENT_WINDOW_SECONDS * 1000
     )
-  }, [channel, lastIncomingTs, isInstagramPostComment, clockTick])
+  }, [isMetaDm, lastIncomingTs, clockTick])
 
   const isWhatsappWindowClosed = useMemo(
     () => channel === "whatsapp" && isWindowExpired,

--- a/apps/builder/src/features/platform-credentials/tiktok/update-tiktok-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/tiktok/update-tiktok-settings.action.ts
@@ -5,7 +5,9 @@ import {
   type TiktokCredential,
   tiktokCredentialUpdateSchema,
 } from "@chatbotx.io/database/partials"
+import { subscribeWebhook } from "@chatbotx.io/integration-tiktok"
 import { getTranslations } from "next-intl/server"
+import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { authActionClient } from "@/lib/safe-action"
 import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
 
@@ -31,6 +33,11 @@ export const updateTiktokSettingAction = authActionClient
       clientId: parsedInput.clientId,
       clientSecret,
     }
+
+    await subscribeWebhook(
+      { clientId: config.clientId, clientSecret },
+      buildBrokerCallbackUrl("/integrations/tiktok/webhook"),
+    )
 
     await platformCredentialService.upsert({
       userId: scopedUserId,

--- a/integrations/instagram/src/apis/page.ts
+++ b/integrations/instagram/src/apis/page.ts
@@ -10,8 +10,8 @@ import { DEFAULT_API_VERSION } from "../constants"
 import { rescue } from "../exception"
 import { instagramBusinessClient } from "../lib/http-client"
 import type {
+  InstagramAttachment,
   InstagramAuthValue,
-  InstagramMessageAttachment,
   InstagramProfileRequest,
   InstagramSendMessageRequest,
   InstagramSendMessageResponse,
@@ -126,7 +126,7 @@ export const getMessageAttachmentEntity = async ({
   attachment,
 }: {
   ctx: Context<InstagramAuthValue>
-  attachment: InstagramMessageAttachment
+  attachment: InstagramAttachment
 }): Promise<IncomingAttachment | undefined> => {
   if (!attachment.payload.url) {
     throw new Error("No attachment URL found")
@@ -141,7 +141,7 @@ export const getMessageAttachmentEntity = async ({
     const originPath = `${ctx.storagePrefix}/${createId()}`
     const bytes = await response.arrayBuffer()
     const mimeType = response.headers.get("content-type") ?? "image/png"
-    const fileType = guessFileTypeFromMimeType(attachment.type)
+    const fileType = guessFileTypeFromMimeType(mimeType)
 
     await ctx.uploader?.putObject(originPath, Buffer.from(bytes), {
       ACL: "public-read",

--- a/integrations/instagram/src/handlers/webhook.ts
+++ b/integrations/instagram/src/handlers/webhook.ts
@@ -65,6 +65,9 @@ const handleWebhookEvent = async (
     }
 
     const entry = webhookData.entry[0]
+    if (!entry) {
+      return
+    }
 
     // Handle Instagram post comment events (changes.comments).
     // Instagram only sends webhooks for new comments — no edit/delete events.

--- a/integrations/instagram/src/schemas.ts
+++ b/integrations/instagram/src/schemas.ts
@@ -27,12 +27,21 @@ export type InstagramActions = {
   }) => Promise<import("./apis/post").InstagramMediaDetails>
 }
 
-// Common attachment types
-const attachmentTypeSchema = z.enum(["image", "video", "audio", "file"])
+// Common attachment types — includes all types Instagram may send in a webhook
+const attachmentTypeSchema = z.enum([
+  "image",
+  "video",
+  "audio",
+  "file",
+  "sticker",
+  "location",
+  "share",
+  "fallback",
+])
 
-// Base attachment payload
+// Base attachment payload — url optional because location/share have no url
 const baseAttachmentPayloadSchema = z.object({
-  url: z.url(),
+  url: z.url().optional(),
 })
 
 // Common ID schemas

--- a/integrations/messenger/src/apis/attachment.ts
+++ b/integrations/messenger/src/apis/attachment.ts
@@ -12,6 +12,7 @@ import { facebookAttachmentClient } from "../lib/http-client"
 import type {
   FacebookMessageAttachment,
   FacebookSendMessageResponse,
+  MessengerAttachment,
   MessengerAuthValue,
 } from "../schema"
 
@@ -47,7 +48,7 @@ export const getMessageAttachmentEntity = async ({
   attachment,
 }: {
   ctx: Context<MessengerAuthValue>
-  attachment: FacebookMessageAttachment
+  attachment: MessengerAttachment
 }): Promise<IncomingAttachment | undefined> => {
   if (!attachment.payload.url) {
     throw new Error("No attachment URL found")
@@ -62,7 +63,7 @@ export const getMessageAttachmentEntity = async ({
     const originPath = `${ctx.storagePrefix}/${createId()}`
     const bytes = await response.arrayBuffer()
     const mimeType = response.headers.get("content-type") ?? "image/png"
-    const fileType = guessFileTypeFromMimeType(attachment.type)
+    const fileType = guessFileTypeFromMimeType(mimeType)
 
     await ctx.uploader?.putObject(originPath, Buffer.from(bytes), {
       ACL: "public-read",

--- a/integrations/messenger/src/handlers/webhook.ts
+++ b/integrations/messenger/src/handlers/webhook.ts
@@ -64,6 +64,9 @@ const handleWebhookEvent = async (
     }
 
     const entry = webhookData.entry[0]
+    if (!entry) {
+      return
+    }
 
     const labelChange = entry.changes?.find(
       (c: { field: string }) => c.field === "inbox_labels",

--- a/integrations/messenger/src/schema.ts
+++ b/integrations/messenger/src/schema.ts
@@ -56,13 +56,17 @@ export type MessengerActions<
   >
 }
 
-// Common attachment types
+// Common attachment types — includes all types Facebook may send in a webhook
 const attachmentTypeSchema = z.enum([
   "image",
   "video",
   "audio",
   "file",
   "template",
+  "sticker",
+  "location",
+  "share",
+  "fallback",
 ])
 
 // Base attachment payload — url optional because template attachments have no url

--- a/integrations/telegram/src/handlers/message/incoming-message.ts
+++ b/integrations/telegram/src/handlers/message/incoming-message.ts
@@ -227,8 +227,8 @@ const getLargestPhoto = (
     if (!largest) {
       return photo
     }
-    return photo.file_size &&
-      largest.file_size &&
+    return typeof photo.file_size === "number" &&
+      typeof largest.file_size === "number" &&
       photo.file_size > largest.file_size
       ? photo
       : largest

--- a/integrations/telegram/src/schema.ts
+++ b/integrations/telegram/src/schema.ts
@@ -36,7 +36,7 @@ export type TelegramUser = z.infer<typeof telegramUserSchema>
 
 export const telegramChatSchema = z.object({
   id: z.number(),
-  type: z.enum(["private", "group", "supergroup", "channel"]),
+  type: z.enum(["private", "group", "supergroup", "channel"]).or(z.string()),
   title: z.string().optional(),
   username: z.string().optional(),
   first_name: z.string().optional(),

--- a/integrations/tiktok/src/apis/webhook.ts
+++ b/integrations/tiktok/src/apis/webhook.ts
@@ -1,0 +1,32 @@
+import ky from "ky"
+import { BUSINESS_API_BASE_URL } from "../constants"
+import { rescue, TiktokAPIException } from "../exception"
+
+type WebhookUpdateResponse = {
+  code: number
+  message?: string
+}
+
+export const subscribeWebhook = (
+  { clientId, clientSecret }: { clientId: string; clientSecret: string },
+  callbackUrl: string,
+): Promise<void> =>
+  rescue("business/webhook/update", async () => {
+    const response = await ky
+      .post(`${BUSINESS_API_BASE_URL}business/webhook/update/`, {
+        json: {
+          app_id: clientId,
+          secret: clientSecret,
+          event_type: "DIRECT_MESSAGE",
+          callback_url: callbackUrl,
+        },
+        headers: { "Content-Type": "application/json" },
+      })
+      .json<WebhookUpdateResponse>()
+
+    if (response.code !== 0) {
+      throw new TiktokAPIException(
+        response.message ?? "Webhook subscription failed",
+      )
+    }
+  })

--- a/integrations/tiktok/src/handlers/message/incoming-message.ts
+++ b/integrations/tiktok/src/handlers/message/incoming-message.ts
@@ -98,7 +98,7 @@ export const receiveMessage = async ({
     message: incomingMessage,
     contact,
     postbackAction:
-      content.reply_source_payload &&
+      content.reply_source_payload?.reply_source_unique_id &&
       !content.reply_source_payload.reply_source_unique_id.startsWith("http")
         ? content.reply_source_payload.reply_source_unique_id
         : null,

--- a/integrations/tiktok/src/handlers/message/outgoing-message/index.ts
+++ b/integrations/tiktok/src/handlers/message/outgoing-message/index.ts
@@ -56,6 +56,9 @@ export const sendMessage: MessageHandlers<TiktokAuthValue>["sendMessage"] =
 
       for (const attachment of message.attachments ?? []) {
         if (attachment.fileType === "image") {
+          if (!attachment.url) {
+            continue
+          }
           const payload = await uploadAndBuildImagePayload(
             ctx.auth.tokens.accessToken,
             businessId,

--- a/integrations/tiktok/src/index.ts
+++ b/integrations/tiktok/src/index.ts
@@ -1,4 +1,5 @@
 export { generateAuthUrl } from "./apis/auth"
+export { subscribeWebhook } from "./apis/webhook"
 export * from "./integration"
 export { isRevokedTokenError, mapToChannelError } from "./lib/error-mapper"
 export type {

--- a/integrations/zalo/src/schema/webhook.ts
+++ b/integrations/zalo/src/schema/webhook.ts
@@ -64,7 +64,9 @@ export const messageTemplate = z.object({
 export type MessageTemplate = z.infer<typeof messageTemplate>
 
 export const messageAttachmentSchema = z.object({
-  type: z.enum(["image", "video", "audio", "file", "sticker", "location"]),
+  type: z
+    .enum(["image", "video", "audio", "file", "sticker", "location"])
+    .or(z.string()),
   payload: z.object({
     url: z.url().optional(),
     thumbnail: z.url().optional(),
@@ -113,27 +115,28 @@ export const zaloWebhookEventSchema = z.object({
   app_id: z.string(),
   // OA id — present on tag events; absent on message events.
   oa_id: z.string().optional(),
-  event_name: z.enum([
-    "user_send_text",
-    "user_send_image",
-    "user_send_sticker",
-    "user_send_location",
-    "user_send_sticker",
-    "user_send_file",
-    "user_send_audio",
-    "user_seen_message",
-    "oa_send_msg",
-    "oa_send_text",
-    "oa_send_image",
-    "oa_send_sticker",
-    "oa_send_file",
-    "oa_send_link",
-    "oa_send_video",
-    "oa_send_carousel",
-    "oa_send_list",
-    "oa_send_action",
-    ...TAG_EVENT_NAMES,
-  ]),
+  event_name: z
+    .enum([
+      "user_send_text",
+      "user_send_image",
+      "user_send_sticker",
+      "user_send_location",
+      "user_send_file",
+      "user_send_audio",
+      "user_seen_message",
+      "oa_send_msg",
+      "oa_send_text",
+      "oa_send_image",
+      "oa_send_sticker",
+      "oa_send_file",
+      "oa_send_link",
+      "oa_send_video",
+      "oa_send_carousel",
+      "oa_send_list",
+      "oa_send_action",
+      ...TAG_EVENT_NAMES,
+    ])
+    .or(z.string()),
   timestamp: z.string().optional(),
   // Present on message events; absent on tag events.
   sender: z


### PR DESCRIPTION

### Summary
- Expanded attachment type enums for Messenger, Instagram, and Zalo to cover all real webhook types (`sticker`, `location`, `share`, `fallback`) — prevents hard parse crashes on unknown attachment types
- Added `.or(z.string())` to enums that may grow on the channel side (Telegram `chat.type`, Zalo `event_name`) for forward compatibility
- Fixed several null-safety bugs across multiple integrations
- Added TikTok webhook subscription API; webhook is now registered automatically when credentials are saved

### Changes

#### Instagram
- `schemas.ts` — expanded `attachmentTypeSchema` with `sticker`, `location`, `share`, `fallback`; `payload.url` made optional
- `apis/page.ts` — `getMessageAttachmentEntity` now accepts `InstagramAttachment` (incoming) instead of `InstagramMessageAttachment` (outgoing) to match actual call sites
- `handlers/webhook.ts` — added null guard on `entry[0]`

#### Messenger
- `schema.ts` — added `sticker`, `location`, `share`, `fallback` to attachment type enum
- `apis/attachment.ts` — file type detection now reads from `Content-Type` response header instead of `attachment.type` field
- `handlers/webhook.ts` — added null guard on `entry[0]`

#### Telegram
- `schema.ts` — `chat.type` uses `.or(z.string())` to accept unknown chat types without crashing
- `handlers/message/incoming-message.ts` — `getLargestPhoto` uses `typeof === 'number'` instead of truthiness so `file_size === 0` still participates in the comparison

#### TikTok
- `apis/webhook.ts` *(new)* — calls `POST business/webhook/update/` to register a DIRECT_MESSAGE webhook
- `index.ts` — exports `subscribeWebhook`
- `handlers/message/incoming-message.ts` — optional-chains `reply_source_payload?.reply_source_unique_id` before calling `.startsWith()`
- `handlers/message/outgoing-message/index.ts` — skips upload when `attachment.url` is absent

#### Zalo
- `schema/webhook.ts` — `event_name` and `messageAttachmentSchema.type` use `.or(z.string())`; removed duplicate `user_send_sticker` entry

#### Builder
- `platform-credentials/tiktok/update-tiktok-settings.action.ts` — calls `subscribeWebhook` on credential save
- `messages/components/message-input.tsx` — extracted `isMetaDm` as a shared top-level variable instead of recomputing it inside each `useMemo`

### Test plan
- [ ] `pnpm lint`
- [ ] `pnpm check-types` — verified 49/49 packages pass locally
- [ ] Save TikTok credentials and confirm webhook registration is triggered
- [ ] Send a sticker/location/share message from Instagram or Messenger — should process without a parse error
- [ ] Verify Messenger attachment uploads use the correct file type derived from the `Content-Type` header
