### PR TITLE
fix(worker): skip lastIncomingMessageAt update for post comments

### DIFF
--- a/apps/worker/src/integration/handlers/received-message.ts
+++ b/apps/worker/src/integration/handlers/received-message.ts
@@ -277,7 +277,10 @@ const saveAndBroadcastMessage = async (props: {
       lastMessageAt: newMessage.createdAt,
     }
 
-    if (incomingMessage.messageType !== "outgoing") {
+    if (
+      incomingMessage.messageType !== "outgoing" &&
+      messageInput.type === "message"
+    ) {
       lastMessageUpdate.lastIncomingMessageAt = newMessage.createdAt
     }
 


### PR DESCRIPTION
## Summary

- `ContactInbox.lastIncomingMessageAt` powers the 24-hour messaging window check in `message-input.tsx` — it should only advance when a contact sends a **direct message**, not when they comment on a post
- The previous guard (`messageType !== "outgoing"`) was too broad: it updated the timestamp for both DMs and post comments, which could falsely extend or open the messaging window based on comment activity
- Fixed by adding `&& messageInput.type === "message"` to the condition in `saveAndBroadcastMessage`

## Why `messageInput.type` instead of `incomingMessage.type`

`incomingMessage.type` is optional — DMs never set it explicitly, so it is `undefined`. Checking `incomingMessage.type === "message"` would silently exclude DMs. `messageInput.type` is safe because it already carries the coerced value (`incomingMessage.type ?? "message"`), ensuring:

| Interaction | `messageInput.type` | Updates `lastIncomingMessageAt` |
|---|---|---|
| Direct message | `"message"` | ✅ Yes |
| Post comment | `"comment"` | ❌ No |
| Outgoing (agent/bot) | any | ❌ No (`messageType !== "outgoing"` guard) |

## Changes

- `apps/worker/src/integration/handlers/received-message.ts` — tighten the `lastIncomingMessageAt` guard in `saveAndBroadcastMessage`

## Test plan

- [ ] Send a DM → `ContactInbox.lastIncomingMessageAt` is updated
- [ ] Contact comments on a post → `ContactInbox.lastIncomingMessageAt` does **not** change
- [ ] View a DM conversation where the contact has commented recently but not DMed in >24h → messaging window correctly shows as **expired**
- [ ] `pnpm --filter worker check-types`
