### PR TITLE
fix(integrations): allow non-owner workspace members through oauth callback

### DIFF
--- a/apps/builder/src/app/integrations/[...integration]/callback.ts
+++ b/apps/builder/src/app/integrations/[...integration]/callback.ts
@@ -1,5 +1,6 @@
 import {
   platformCredentialService,
+  workspaceMemberService,
   workspaceService,
 } from "@chatbotx.io/business"
 import { db } from "@chatbotx.io/database/client"
@@ -97,10 +98,16 @@ export const handleCallback = async (
         createdBy: userId,
       })
 
-  if (stateParams.workspaceId && workspace.ownerId !== userId) {
+  if (
+    stateParams.workspaceId &&
+    !(await workspaceMemberService.isMember({
+      workspaceId: stateParams.workspaceId,
+      userId,
+    }))
+  ) {
     logger.warn(
       { userId, workspaceId: stateParams.workspaceId },
-      "workspace ownership mismatch in OAuth callback",
+      "user is not a member of workspace in OAuth callback",
     )
     return notFound()
   }

--- a/apps/builder/src/middlewares/auth.ts
+++ b/apps/builder/src/middlewares/auth.ts
@@ -1,4 +1,4 @@
-import { db } from "@chatbotx.io/database/client"
+import { workspaceMemberService } from "@chatbotx.io/business"
 import { ORPCError } from "@orpc/server"
 import { auth } from "@/lib/auth/auth"
 import { base } from "./context"
@@ -43,14 +43,9 @@ export const workspaceAuthorizedMidddleware = base.middleware(
       throw new ORPCError("UNAUTHORIZED")
     }
 
-    const workspaceMember = await db.query.workspaceMemberModel.findFirst({
-      where: {
-        workspaceId,
-        userId: context.user.id,
-      },
-      with: {
-        workspace: true,
-      },
+    const workspaceMember = await workspaceMemberService.findMembership({
+      workspaceId,
+      userId: context.user.id,
     })
 
     if (!workspaceMember) {

--- a/packages/business/src/workspace-member/service.ts
+++ b/packages/business/src/workspace-member/service.ts
@@ -89,6 +89,39 @@ export class WorkspaceMemberService extends BaseService {
     )
   }
 
+  async findMembership(props: {
+    tx?: DatabaseClient
+    workspaceId: string
+    userId: string
+  }): Promise<WorkspaceMemberWithWorkspace | undefined> {
+    const { tx = db, workspaceId, userId } = props
+    return await tx.query.workspaceMemberModel.findFirst({
+      where: { workspaceId, userId },
+      with: { workspace: true },
+    })
+  }
+
+  // Auth gate — membership must take effect immediately on revoke, so this
+  // intentionally skips withCache (unlike the list methods above).
+  async isMember(props: {
+    tx?: DatabaseClient
+    workspaceId: string
+    userId: string
+  }): Promise<boolean> {
+    const { tx = db, workspaceId, userId } = props
+    const [row] = await tx
+      .select({ userId: workspaceMemberModel.userId })
+      .from(workspaceMemberModel)
+      .where(
+        and(
+          eq(workspaceMemberModel.workspaceId, workspaceId),
+          eq(workspaceMemberModel.userId, userId),
+        ),
+      )
+      .limit(1)
+    return !!row
+  }
+
   async listByWorkspaceId(props: {
     tx?: DatabaseClient
     workspaceId: string


### PR DESCRIPTION
## Summary
- The OAuth callback for Instagram/Messenger/TikTok/Zalo/Google Sheets rejected any non-owner workspace member with a 404, so invited Admins couldn't complete integration connects.
- Replaced the `workspace.ownerId !== userId` ownership check with a membership check (`workspaceMemberService.isMember`), matching how `workspaceAuthorizedMidddleware` already authorizes workspace access.

## Changes
- `packages/business/src/workspace-member/service.ts` — added `isMember({ workspaceId, userId })`.
- `apps/builder/src/app/integrations/[...integration]/callback.ts` — swapped ownership check for membership check; credential resolution still keys off `workspace.ownerId`, unchanged.

## Test plan
- [x] `pnpm --filter builder check-types`
- [x] `pnpm lint` (pre-commit hook)
- [ ] Manual verification: A invites B as Admin, B connects Instagram/Messenger from that workspace → should reach the account picker instead of 404
- [ ] Negative case: non-member hitting the callback with that workspaceId still gets 404
