### PR TITLE
Fix: analytics dashboard reliability & accuracy, contact re-engagement

### DIFF
--- a/apps/builder/__tests__/create-webchat-message-action.test.ts
+++ b/apps/builder/__tests__/create-webchat-message-action.test.ts
@@ -7,6 +7,7 @@ const {
   mockAutomatedResponseEnqueue,
   mockChatQueueAdd,
   mockContactFindById,
+  mockContactUnblockIfBlocked,
   mockContactInboxFindLatest,
   mockConversationEnsureActive,
   mockConversationFindBy,
@@ -46,6 +47,7 @@ const {
     insertBuilder,
     mockAutomatedResponseEnqueue: vi.fn().mockResolvedValue(undefined),
     mockContactFindById: vi.fn(),
+    mockContactUnblockIfBlocked: vi.fn().mockResolvedValue(null),
     mockContactInboxFindLatest: vi.fn(),
     mockConversationFindBy: vi.fn(),
     mockChatQueueAdd: vi.fn().mockResolvedValue(undefined),
@@ -92,7 +94,10 @@ vi.mock("@chatbotx.io/automated-response", () => ({
 
 vi.mock("@chatbotx.io/business", () => ({
   contactInboxService: { findLatestBySource: mockContactInboxFindLatest },
-  contactService: { findById: mockContactFindById },
+  contactService: {
+    findById: mockContactFindById,
+    unblockIfBlocked: mockContactUnblockIfBlocked,
+  },
   conversationService: {
     ensureActive: mockConversationEnsureActive,
     findBy: mockConversationFindBy,
@@ -105,6 +110,10 @@ vi.mock("@chatbotx.io/business", () => ({
     .fn()
     .mockResolvedValue({ storageUrl: "https://storage.example.com" }),
   workspaceService: { find: mockWorkspaceFind },
+}))
+
+vi.mock("@/lib/log", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }))
 
 vi.mock("@chatbotx.io/business/errors", () => ({
@@ -213,6 +222,7 @@ const resetCommonMocks = () => {
   mockFindOrFail.mockResolvedValue({ inboxId: "inbox-1" })
   mockConversationFindBy.mockResolvedValue(conversation)
   mockContactFindById.mockResolvedValue(contact)
+  mockContactUnblockIfBlocked.mockResolvedValue(null)
   mockRepositoryCreate.mockImplementation((input) =>
     Promise.resolve({
       id: "msg-1",
@@ -283,6 +293,22 @@ describe("handleCreateWebchatMessage", () => {
       lastMessageAt: messageInput.createdAt,
       lastIncomingMessageAt: messageInput.createdAt,
     })
+  })
+
+  test("auto-unblocks using the resolved contact row after creating an inbound message", async () => {
+    await handleCreateWebchatMessage({
+      parsedInput: {
+        text: "hello",
+        workspaceId: "ws-1",
+        webchatId: "webchat-1",
+        guestConversationId: "guest-1",
+      },
+    })
+
+    expect(mockContactUnblockIfBlocked).toHaveBeenCalledWith(
+      { workspaceId: "ws-1", id: "contact-1" },
+      contact,
+    )
   })
 })
 

--- a/apps/builder/src/features/messages/actions/create-webchat-message.action.ts
+++ b/apps/builder/src/features/messages/actions/create-webchat-message.action.ts
@@ -36,6 +36,7 @@ import {
   integrationQueue,
 } from "@chatbotx.io/worker-config"
 import { randomString } from "remeda"
+import { logger } from "@/lib/log"
 import { actionClient } from "@/lib/safe-action"
 import {
   type CreateWebchatMessageRequest,
@@ -156,6 +157,18 @@ export async function handleCreateWebchatMessage({
         lastIncomingMessageAt: message.createdAt,
       })
       .where(eq(contactInboxModel.id, contactInbox.id))
+
+    try {
+      await contactService.unblockIfBlocked(
+        { workspaceId: conversation.workspaceId, id: contactInbox.contactId },
+        contact,
+      )
+    } catch (error) {
+      logger.warn(
+        { error, contactId: contactInbox.contactId, channel: "webchat" },
+        "Auto-unblock on webchat inbound message failed",
+      )
+    }
 
     emit(messageEventTypeSchema.enum["message:received"], {
       workspaceId: conversation.workspaceId,

--- a/apps/worker/__tests__/analytics-dashboard-listener.test.ts
+++ b/apps/worker/__tests__/analytics-dashboard-listener.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  handleBotMessageSent: vi.fn(async () => undefined),
+  handleContactBlocked: vi.fn(async () => undefined),
+  handleContactCreated: vi.fn(async () => undefined),
+  handleContactDeleted: vi.fn(async () => undefined),
+  handleConversationArchived: vi.fn(async () => undefined),
+  handleConversationAssigned: vi.fn(async () => undefined),
+  handleConversationCreated: vi.fn(async () => undefined),
+  handleConversationFollowed: vi.fn(async () => undefined),
+  handleConversationTransferredToBot: vi.fn(async () => undefined),
+  handleConversationTransferredToHuman: vi.fn(async () => undefined),
+  handleConversationUnarchived: vi.fn(async () => undefined),
+  handleConversationUnassigned: vi.fn(async () => undefined),
+  handleConversationUnfollowed: vi.fn(async () => undefined),
+  handleHumanMessageSent: vi.fn(async () => undefined),
+  handleMessageBotReceived: vi.fn(async () => undefined),
+  loggerDebug: vi.fn(),
+  loggerError: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/event-bus", () => ({
+  EVENT_BUS_MESSAGE_ID: "__eventBusMessageId",
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: {
+    debug: mocks.loggerDebug,
+    error: mocks.loggerError,
+  },
+}))
+
+vi.mock("../src/events/analytics/contact", () => ({
+  handleContactBlocked: mocks.handleContactBlocked,
+  handleContactCreated: mocks.handleContactCreated,
+  handleContactDeleted: mocks.handleContactDeleted,
+}))
+
+vi.mock("../src/events/analytics/conversation", () => ({
+  handleConversationArchived: mocks.handleConversationArchived,
+  handleConversationAssigned: mocks.handleConversationAssigned,
+  handleConversationCreated: mocks.handleConversationCreated,
+  handleConversationFollowed: mocks.handleConversationFollowed,
+  handleConversationTransferredToBot: mocks.handleConversationTransferredToBot,
+  handleConversationTransferredToHuman:
+    mocks.handleConversationTransferredToHuman,
+  handleConversationUnarchived: mocks.handleConversationUnarchived,
+  handleConversationUnassigned: mocks.handleConversationUnassigned,
+  handleConversationUnfollowed: mocks.handleConversationUnfollowed,
+}))
+
+vi.mock("../src/events/analytics/message", () => ({
+  handleBotMessageSent: mocks.handleBotMessageSent,
+  handleHumanMessageSent: mocks.handleHumanMessageSent,
+}))
+
+vi.mock("../src/events/analytics/bot-message", () => ({
+  handleMessageBotReceived: mocks.handleMessageBotReceived,
+}))
+
+const { analyticsDashboardListeners } = await import(
+  "../src/events/analytics/listener"
+)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.handleContactCreated.mockResolvedValue(undefined)
+})
+
+describe("analyticsDashboardListeners", () => {
+  test("logs sub-handler timing and returns failed stream ids when a grouped handler fails", async () => {
+    mocks.handleContactCreated.mockRejectedValueOnce(new Error("insert failed"))
+    const listener = analyticsDashboardListeners["analytics:dashboard"]?.[0]
+
+    const result = await listener?.handler?.([
+      {
+        __eventBusMessageId: "1-0",
+        eventType: "contact:created",
+      } as never,
+    ])
+
+    expect(result).toEqual({ failedMessageIds: ["1-0"] })
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      { err: expect.any(Error), eventType: "contact:created", count: 1 },
+      "[analytics] dashboard handler failed",
+    )
+    expect(mocks.loggerDebug).toHaveBeenCalledWith(
+      {
+        count: 1,
+        durationMs: expect.any(Number),
+        eventType: "contact:created",
+        success: false,
+      },
+      "[analytics] dashboard sub-handler processed",
+    )
+  })
+
+  test("returns only the failed sub-handler stream ids from a mixed batch", async () => {
+    mocks.handleContactCreated.mockRejectedValueOnce(new Error("insert failed"))
+    const listener = analyticsDashboardListeners["analytics:dashboard"]?.[0]
+
+    const result = await listener?.handler?.([
+      {
+        __eventBusMessageId: "1-0",
+        eventType: "contact:created",
+      } as never,
+      {
+        __eventBusMessageId: "2-0",
+        eventType: "message:human_sent",
+      } as never,
+    ])
+
+    expect(result).toEqual({ failedMessageIds: ["1-0"] })
+    expect(mocks.handleContactCreated).toHaveBeenCalledTimes(1)
+    expect(mocks.handleHumanMessageSent).toHaveBeenCalledTimes(1)
+  })
+
+  test("observes an already-aborted signal before starting a sub-handler", async () => {
+    const abortController = new AbortController()
+    abortController.abort()
+    const listener = analyticsDashboardListeners["analytics:dashboard"]?.[0]
+
+    const result = await listener?.handler?.(
+      [
+        {
+          __eventBusMessageId: "3-0",
+          eventType: "contact:created",
+        } as never,
+      ],
+      abortController.signal,
+    )
+
+    expect(result).toEqual({ failedMessageIds: ["3-0"] })
+    expect(mocks.handleContactCreated).not.toHaveBeenCalled()
+  })
+})

--- a/apps/worker/__tests__/received-message.test.ts
+++ b/apps/worker/__tests__/received-message.test.ts
@@ -18,6 +18,8 @@ const {
   mockBuildContext,
   mockresolveTenantSettings,
   mockUpdateContactFromMessage,
+  mockContactUnblockIfBlocked,
+  mockConversationFindOrCreate,
   mockIntegrationQueueAdd,
   mockDbSet,
   mockDbTransaction,
@@ -61,6 +63,8 @@ const {
     mockBuildContext: vi.fn().mockResolvedValue({ workspaceId: "ws-1" }),
     mockresolveTenantSettings: vi.fn().mockResolvedValue({}),
     mockUpdateContactFromMessage: vi.fn().mockResolvedValue(undefined),
+    mockContactUnblockIfBlocked: vi.fn().mockResolvedValue(null),
+    mockConversationFindOrCreate: vi.fn(),
     mockIntegrationQueueAdd: vi.fn().mockResolvedValue(undefined),
     mockDbSet,
     mockDbTransaction,
@@ -105,6 +109,8 @@ vi.mock("@chatbotx.io/business", () => ({
   buildContext: mockBuildContext,
   resolveTenantSettings: mockresolveTenantSettings,
   updateContactFromMessage: mockUpdateContactFromMessage,
+  contactService: { unblockIfBlocked: mockContactUnblockIfBlocked },
+  conversationService: { findOrCreate: mockConversationFindOrCreate },
   workspaceService: { find: mockWorkspaceFind },
   quotaEnforcementService: {
     increment: mockQuotaIncrement,
@@ -202,6 +208,12 @@ const fakeContactInbox = {
   source: "messenger",
 } as unknown as import("@chatbotx.io/database/types").ContactInboxModel
 
+const fakeContact = {
+  id: "contact-1",
+  workspaceId: "ws-1",
+  blockedAt: new Date("2026-01-01T00:00:00Z"),
+} as unknown as import("@chatbotx.io/database/types").ContactModel
+
 const fakeConversation = {
   id: "conv-1",
   workspaceId: "ws-1",
@@ -247,8 +259,12 @@ describe("receiveMessage — message repository branch", () => {
     vi.clearAllMocks()
 
     // Setup: existing contact inbox → skip transaction contact creation
-    mockFindContactInbox.mockResolvedValue(fakeContactInbox)
+    mockFindContactInbox.mockResolvedValue({
+      ...fakeContactInbox,
+      contact: fakeContact,
+    })
     mockFindOrFail.mockResolvedValue(fakeConversation)
+    mockConversationFindOrCreate.mockResolvedValue(fakeConversation)
 
     vi.mocked(
       integrationService.identifyInboxAndIntegrationAuthFromIdentifier,
@@ -289,6 +305,23 @@ describe("receiveMessage — message repository branch", () => {
 
     expect(mockCreateOrUpdate).toHaveBeenCalledTimes(1)
     expect(mockCreateOrUpdateWithAttachments).not.toHaveBeenCalled()
+  })
+
+  test("auto-unblocks on inbound messages using the loaded contact", async () => {
+    mockRunChannelHandler.mockResolvedValue({
+      message: { ...baseIncomingMessage, attachments: [] },
+      contact: { sourceId: "psid-123", firstName: "Test" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+
+    await receiveMessage(baseProps)
+
+    expect(mockContactUnblockIfBlocked).toHaveBeenCalledWith(
+      { workspaceId: "ws-1", id: "contact-1" },
+      fakeContact,
+    )
   })
 
   test("calls repository.createOrUpdateWithAttachments() when message has attachments", async () => {
@@ -360,6 +393,7 @@ describe("receiveMessage — message repository branch", () => {
 
     await receiveMessage(baseProps)
 
+    expect(mockContactUnblockIfBlocked).not.toHaveBeenCalled()
     expect(mockDbSet).toHaveBeenCalledWith({
       lastMessageAt: fakeCreatedMessage.createdAt,
     })
@@ -422,6 +456,7 @@ describe("receiveMessage — new contact MAC gate", () => {
     // No existing contact inbox → new-contact creation path.
     mockFindContactInbox.mockResolvedValue(undefined)
     mockFindOrFail.mockResolvedValue(fakeConversation)
+    mockConversationFindOrCreate.mockResolvedValue(fakeConversation)
     mockWorkspaceFind.mockResolvedValue({ ownerId: "owner-1" })
     vi.mocked(
       integrationService.identifyInboxAndIntegrationAuthFromIdentifier,
@@ -467,6 +502,7 @@ describe("receiveMessage — new contact MAC gate", () => {
       firstName: "Test",
       phoneNumber: null,
       email: null,
+      blockedAt: null,
       createdAt: new Date("2026-06-21T00:00:00Z"),
     }
     const contactInbox = {
@@ -481,6 +517,10 @@ describe("receiveMessage — new contact MAC gate", () => {
 
     await receiveMessage(baseProps)
 
+    expect(mockContactUnblockIfBlocked).toHaveBeenCalledWith(
+      { workspaceId: "ws-1", id: "contact-new" },
+      newContact,
+    )
     expect(mockCreateNewContactWithMac).toHaveBeenCalledWith(
       expect.objectContaining({ ownerId: "owner-1", workspaceId: "ws-1" }),
     )

--- a/apps/worker/__tests__/send-message-handler.test.ts
+++ b/apps/worker/__tests__/send-message-handler.test.ts
@@ -7,6 +7,7 @@ const {
   mockDbUpdate,
   mockUpdateSourceId,
   mockCreateMessageRepository,
+  mockContactUnblockIfBlocked,
 } = vi.hoisted(() => {
   const updateChain = {
     set: vi.fn().mockReturnThis(),
@@ -25,8 +26,13 @@ const {
       updateSourceId,
       findById: vi.fn().mockResolvedValue(null),
     }),
+    mockContactUnblockIfBlocked: vi.fn().mockResolvedValue(null),
   }
 })
+
+vi.mock("@chatbotx.io/business", () => ({
+  contactService: { unblockIfBlocked: mockContactUnblockIfBlocked },
+}))
 
 vi.mock("@chatbotx.io/database/client", () => ({
   db: {
@@ -90,6 +96,7 @@ describe("chat send-message handlers", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockRunChannelHandler.mockResolvedValue({ messageIds: ["mid-1"] })
+    mockContactUnblockIfBlocked.mockResolvedValue(null)
     mockResolveIntegrationContextFromContactInbox.mockResolvedValue({
       ctx: { workspaceId: "ws-1" },
       integration: {
@@ -155,6 +162,48 @@ describe("chat send-message handlers", () => {
       "wamid.echo-1",
       "ws-1",
     )
+  })
+
+  test("auto-unblocks after a successful non-comment send", async () => {
+    await sendMessageToChannel({
+      conversation: conversation as never,
+      contactInbox: contactInbox as never,
+      message: {
+        id: "msg-1",
+        workspaceId: "ws-1",
+        conversationId: "conv-1",
+        contactInboxId: "ci-1",
+        contentType: "text",
+        messageType: "outgoing",
+        senderType: "user",
+        text: "hello",
+      } as never,
+    })
+
+    expect(mockContactUnblockIfBlocked).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      id: "contact-1",
+    })
+  })
+
+  test("does not auto-unblock after a comment reply send", async () => {
+    await sendMessageToChannel({
+      conversation: conversation as never,
+      contactInbox: contactInbox as never,
+      message: {
+        id: "msg-comment-1",
+        workspaceId: "ws-1",
+        conversationId: "conv-1",
+        contactInboxId: "ci-1",
+        contentType: "text",
+        messageType: "outgoing",
+        senderType: "user",
+        text: "comment reply",
+        type: "comment",
+      } as never,
+    })
+
+    expect(mockContactUnblockIfBlocked).not.toHaveBeenCalled()
   })
 
   test("does not update sourceId when the channel returns no provider id", async () => {

--- a/apps/worker/src/chat/handlers/send-message.ts
+++ b/apps/worker/src/chat/handlers/send-message.ts
@@ -1,3 +1,4 @@
+import { contactService } from "@chatbotx.io/business"
 import { db, eq } from "@chatbotx.io/database/client"
 import { createMessageRepository } from "@chatbotx.io/database/repositories"
 import { whatsappFlowModel } from "@chatbotx.io/database/schema"
@@ -114,6 +115,14 @@ export async function sendMessageToChannel(
       // sourceId here, bot/agent outgoing rows stay sourceId=null, the echo
       // lookup misses, and a duplicate row is inserted as senderType=user.
       await updateMessageSourceId(message.id, conversation.workspaceId, result)
+      try {
+        await contactService.unblockIfBlocked({
+          workspaceId: conversation.workspaceId,
+          id: conversation.contactId,
+        })
+      } catch (error) {
+        logger.warn(error, "Auto-unblock on successful send failed")
+      }
     }
   } catch (error) {
     logger.error(error, "An error occurred while sending the message")

--- a/apps/worker/src/events/analytics/listener.ts
+++ b/apps/worker/src/events/analytics/listener.ts
@@ -2,7 +2,9 @@ import type {
   AnalyticsDashboardEvent,
   AnalyticsDashboardEventMap,
   BaseEventListener,
+  EventBusMessageMetadata,
 } from "@chatbotx.io/event-bus"
+import { EVENT_BUS_MESSAGE_ID } from "@chatbotx.io/event-bus"
 import { logger } from "../../lib/logger"
 import { handleMessageBotReceived } from "./bot-message"
 import {
@@ -23,30 +25,60 @@ import {
 } from "./conversation"
 import { handleBotMessageSent, handleHumanMessageSent } from "./message"
 
-function runHandler<T extends AnalyticsDashboardEvent>(
+type DashboardPayload = AnalyticsDashboardEvent & EventBusMessageMetadata
+
+function getEventBusMessageIds(events: DashboardPayload[]): string[] {
+  return events.flatMap((event) => {
+    const messageId = event[EVENT_BUS_MESSAGE_ID]
+    return typeof messageId === "string" ? [messageId] : []
+  })
+}
+
+async function runHandler<T extends DashboardPayload>(
   eventType: AnalyticsDashboardEvent["eventType"],
   handler: (events: T[]) => Promise<unknown>,
   events: T[] | undefined,
-): Promise<unknown> {
+  signal?: AbortSignal,
+): Promise<string[]> {
   if (!events || events.length === 0) {
-    return Promise.resolve()
+    return []
   }
-  return handler(events).catch((error) => {
+  const startedAt = Date.now()
+  let success = false
+  try {
+    if (signal?.aborted) {
+      return getEventBusMessageIds(events)
+    }
+    await handler(events)
+    success = true
+    return []
+  } catch (error) {
     logger.error(
       { err: error, eventType, count: events.length },
       "[analytics] dashboard handler failed",
     )
-  })
+    return getEventBusMessageIds(events)
+  } finally {
+    logger.debug(
+      {
+        count: events.length,
+        durationMs: Date.now() - startedAt,
+        eventType,
+        success,
+      },
+      "[analytics] dashboard sub-handler processed",
+    )
+  }
 }
 
-type DashboardListener = BaseEventListener<AnalyticsDashboardEvent>
+type DashboardListener = BaseEventListener<DashboardPayload>
 
 function groupByEventType(
-  payloads: AnalyticsDashboardEvent[],
-): Map<AnalyticsDashboardEvent["eventType"], AnalyticsDashboardEvent[]> {
+  payloads: DashboardPayload[],
+): Map<AnalyticsDashboardEvent["eventType"], DashboardPayload[]> {
   const map = new Map<
     AnalyticsDashboardEvent["eventType"],
-    AnalyticsDashboardEvent[]
+    DashboardPayload[]
   >()
   for (const p of payloads) {
     const existing = map.get(p.eventType) ?? []
@@ -62,20 +94,21 @@ export const analyticsDashboardListeners: Partial<
   "analytics:dashboard": [
     {
       name: "analytics-dashboard",
-      handler: async (payloads: AnalyticsDashboardEvent[]) => {
+      handler: async (payloads: DashboardPayload[], signal?: AbortSignal) => {
         if (payloads.length === 0) {
           return
         }
 
         const grouped = groupByEventType(payloads)
 
-        await Promise.all([
+        const results = await Promise.all([
           runHandler(
             "contact:created",
             handleContactCreated,
             grouped.get("contact:created") as Parameters<
               typeof handleContactCreated
             >[0],
+            signal,
           ),
           runHandler(
             "contact:deleted",
@@ -83,6 +116,7 @@ export const analyticsDashboardListeners: Partial<
             grouped.get("contact:deleted") as Parameters<
               typeof handleContactDeleted
             >[0],
+            signal,
           ),
           runHandler(
             "contact:blocked",
@@ -90,6 +124,7 @@ export const analyticsDashboardListeners: Partial<
             grouped.get("contact:blocked") as Parameters<
               typeof handleContactBlocked
             >[0],
+            signal,
           ),
           runHandler(
             "message:human_sent",
@@ -97,6 +132,7 @@ export const analyticsDashboardListeners: Partial<
             grouped.get("message:human_sent") as Parameters<
               typeof handleHumanMessageSent
             >[0],
+            signal,
           ),
           runHandler(
             "message:bot_sent",
@@ -104,6 +140,7 @@ export const analyticsDashboardListeners: Partial<
             grouped.get("message:bot_sent") as Parameters<
               typeof handleBotMessageSent
             >[0],
+            signal,
           ),
           runHandler(
             "conversation:created",
@@ -111,6 +148,7 @@ export const analyticsDashboardListeners: Partial<
             grouped.get("conversation:created") as Parameters<
               typeof handleConversationCreated
             >[0],
+            signal,
           ),
           runHandler(
             "conversation:assigned",
@@ -118,6 +156,7 @@ export const analyticsDashboardListeners: Partial<
             grouped.get("conversation:assigned") as Parameters<
               typeof handleConversationAssigned
             >[0],
+            signal,
           ),
           runHandler(
             "conversation:unassigned",
@@ -125,6 +164,7 @@ export const analyticsDashboardListeners: Partial<
             grouped.get("conversation:unassigned") as Parameters<
               typeof handleConversationUnassigned
             >[0],
+            signal,
           ),
           runHandler(
             "conversation:transferred_to_human",
@@ -132,6 +172,7 @@ export const analyticsDashboardListeners: Partial<
             grouped.get("conversation:transferred_to_human") as Parameters<
               typeof handleConversationTransferredToHuman
             >[0],
+            signal,
           ),
           runHandler(
             "conversation:transferred_to_bot",
@@ -139,6 +180,7 @@ export const analyticsDashboardListeners: Partial<
             grouped.get("conversation:transferred_to_bot") as Parameters<
               typeof handleConversationTransferredToBot
             >[0],
+            signal,
           ),
           runHandler(
             "conversation:followed",
@@ -146,6 +188,7 @@ export const analyticsDashboardListeners: Partial<
             grouped.get("conversation:followed") as Parameters<
               typeof handleConversationFollowed
             >[0],
+            signal,
           ),
           runHandler(
             "conversation:unfollowed",
@@ -153,6 +196,7 @@ export const analyticsDashboardListeners: Partial<
             grouped.get("conversation:unfollowed") as Parameters<
               typeof handleConversationUnfollowed
             >[0],
+            signal,
           ),
           runHandler(
             "conversation:archived",
@@ -160,6 +204,7 @@ export const analyticsDashboardListeners: Partial<
             grouped.get("conversation:archived") as Parameters<
               typeof handleConversationArchived
             >[0],
+            signal,
           ),
           runHandler(
             "conversation:unarchived",
@@ -167,6 +212,7 @@ export const analyticsDashboardListeners: Partial<
             grouped.get("conversation:unarchived") as Parameters<
               typeof handleConversationUnarchived
             >[0],
+            signal,
           ),
           runHandler(
             "message:bot_received",
@@ -174,8 +220,12 @@ export const analyticsDashboardListeners: Partial<
             grouped.get("message:bot_received") as Parameters<
               typeof handleMessageBotReceived
             >[0],
+            signal,
           ),
         ])
+
+        const failedMessageIds = results.flat()
+        return failedMessageIds.length > 0 ? { failedMessageIds } : undefined
       },
     },
   ],

--- a/apps/worker/src/integration/handlers/received-message.ts
+++ b/apps/worker/src/integration/handlers/received-message.ts
@@ -1,6 +1,7 @@
 import {
   broadcastToWorkspaceParty,
   buildContext,
+  contactService,
   conversationService,
   quotaEnforcementService,
   resolveTenantSettings,
@@ -17,6 +18,7 @@ import {
 } from "@chatbotx.io/database/schema"
 import type {
   ContactInboxModel,
+  ContactModel,
   ConversationModel,
   InboxModel,
   MessageModel,
@@ -117,7 +119,7 @@ export const receiveMessage = async (
   if (!detected) {
     throw new SdkException("Unable to resolve contact and conversation")
   }
-  const { contactInbox, conversation } = detected
+  const { contactInbox, conversation, contact } = detected
 
   // Overwrite Contact.phoneNumber/email from message text — every inbound
   // channel. Unconditional: the customer just typed the value, so it's
@@ -137,6 +139,20 @@ export const receiveMessage = async (
       logger.warn(
         { error, contactId: contactInbox.contactId, channel: inbox.channel },
         "Contact update from message text failed",
+      )
+    }
+  }
+
+  if (incomingMessage && incomingMessage.messageType !== "outgoing") {
+    try {
+      await contactService.unblockIfBlocked(
+        { workspaceId: inbox.workspaceId, id: contactInbox.contactId },
+        contact,
+      )
+    } catch (error) {
+      logger.warn(
+        { error, contactId: contactInbox.contactId, channel: inbox.channel },
+        "Auto-unblock on inbound message failed",
       )
     }
   }
@@ -469,6 +485,7 @@ const detectContactAndConversation = async (props: {
   }
 }): Promise<{
   contactInbox: ContactInboxModel
+  contact: ContactModel
   conversation: ConversationModel
 }> => {
   const { incomingContact, inbox, integrationRow } = props
@@ -479,6 +496,7 @@ const detectContactAndConversation = async (props: {
       channel: inbox.channel,
       sourceId: incomingContact.sourceId,
     },
+    with: { contact: true },
   })
 
   // The conversation source id (e.g. a Facebook post id for comments) keys the
@@ -495,7 +513,11 @@ const detectContactAndConversation = async (props: {
       contactId: existingContactInbox.contactId,
       sourceId: conversationSourceId,
     })
-    return { contactInbox: existingContactInbox, conversation }
+    return {
+      contactInbox: existingContactInbox,
+      contact: existingContactInbox.contact,
+      conversation,
+    }
   }
 
   let contactData: typeof contactModel.$inferInsert = {
@@ -626,7 +648,7 @@ const detectContactAndConversation = async (props: {
     })
   }
 
-  return { contactInbox, conversation }
+  return { contactInbox, contact: newContact, conversation }
 }
 
 const canGetUserProfileIfNeeded = (integrationType: string) =>

--- a/packages/analytics/__tests__/event-bus-idempotency.test.ts
+++ b/packages/analytics/__tests__/event-bus-idempotency.test.ts
@@ -1,0 +1,165 @@
+import { EVENT_BUS_MESSAGE_ID } from "@chatbotx.io/flow-config"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const capturedInsertValues: unknown[] = []
+
+const insertChain = {
+  onConflictDoNothing: vi.fn(async () => undefined),
+  values: vi.fn((values: unknown) => {
+    capturedInsertValues.push(values)
+    return insertChain
+  }),
+}
+
+const dbInsert = vi.fn(() => insertChain)
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    execute: vi.fn(async () => ({ rows: [] })),
+    insert: dbInsert,
+  },
+  sql: Object.assign((...args: unknown[]) => ({ sql: args }), {
+    join: (...args: unknown[]) => ({ join: args }),
+  }),
+}))
+
+vi.mock("@chatbotx.io/database/schema", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@chatbotx.io/database/schema")>()
+  return {
+    ...actual,
+    analyticsBotMessageEventModel: { name: "AnalyticsBotMessageEvent" },
+    analyticsContactEventModel: { name: "AnalyticsContactEvent" },
+    analyticsConversationEventModel: { name: "AnalyticsConversationEvent" },
+    analyticsMessageEventModel: { name: "AnalyticsMessageEvent" },
+  }
+})
+
+vi.mock("@chatbotx.io/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@chatbotx.io/utils")>()
+  return {
+    ...actual,
+    createId: vi.fn(() => "generated-id"),
+  }
+})
+
+const { botMessageStatsRepository } = await import(
+  "../src/repositories/postgres/bot-message-stats.repository"
+)
+const { contactStatsRepository } = await import(
+  "../src/repositories/postgres/contact-stats.repository"
+)
+const { contactAnalyticsService } = await import(
+  "../src/services/contact-analytics.service"
+)
+const { conversationStatsRepository } = await import(
+  "../src/repositories/postgres/conversation-stats.repository"
+)
+const { messageStatsRepository } = await import(
+  "../src/repositories/postgres/message-stats.repository"
+)
+
+beforeEach(() => {
+  capturedInsertValues.length = 0
+  dbInsert.mockClear()
+  insertChain.values.mockClear()
+  insertChain.onConflictDoNothing.mockClear()
+})
+
+describe("analytics event-bus idempotency", () => {
+  test("uses the event-bus stream id as contact eventId", async () => {
+    await contactStatsRepository.insertEvents(
+      [
+        {
+          workspaceId: "ws-1",
+          contactId: "contact-1",
+          occurredAt: "2026-07-01T00:00:00.000Z",
+          [EVENT_BUS_MESSAGE_ID]: "stream-1-0",
+        },
+      ],
+      "contact_created",
+    )
+
+    expect(capturedInsertValues[0]).toMatchObject([{ eventId: "stream-1-0" }])
+  })
+
+  test("uses the event-bus stream id as conversation eventId", async () => {
+    await conversationStatsRepository.insertEvents(
+      [
+        {
+          workspaceId: "ws-1",
+          conversationId: "conversation-1",
+          occurredAt: "2026-07-01T00:00:00.000Z",
+          [EVENT_BUS_MESSAGE_ID]: "stream-2-0",
+        },
+      ],
+      "conversation_created",
+    )
+
+    expect(capturedInsertValues[0]).toMatchObject([{ eventId: "stream-2-0" }])
+  })
+
+  test("uses the event-bus stream id as message eventId", async () => {
+    await messageStatsRepository.insertEvents(
+      [
+        {
+          workspaceId: "ws-1",
+          contactId: "contact-1",
+          occurredAt: "2026-07-01T00:00:00.000Z",
+          [EVENT_BUS_MESSAGE_ID]: "stream-3-0",
+        },
+      ],
+      "message_human_sent",
+    )
+
+    expect(capturedInsertValues[0]).toMatchObject([{ eventId: "stream-3-0" }])
+  })
+
+  test("uses the event-bus stream id as bot-message eventId", async () => {
+    await botMessageStatsRepository.insertEvents([
+      {
+        workspaceId: "ws-1",
+        messageId: "message-1",
+        conversationId: "conversation-1",
+        occurredAt: "2026-07-01T00:00:00.000Z",
+        hasResponse: true,
+        [EVENT_BUS_MESSAGE_ID]: "stream-4-0",
+      },
+    ])
+
+    expect(capturedInsertValues[0]).toMatchObject([{ eventId: "stream-4-0" }])
+  })
+
+  test("falls back to generated ids when stream id metadata is absent", async () => {
+    await contactStatsRepository.insertEvents(
+      [
+        {
+          workspaceId: "ws-1",
+          contactId: "contact-1",
+          occurredAt: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+      "contact_created",
+    )
+
+    expect(capturedInsertValues[0]).toMatchObject([{ eventId: "generated-id" }])
+  })
+
+  test("preserves stream id metadata through the contact analytics service", async () => {
+    await contactAnalyticsService.recordEvents(
+      [
+        {
+          workspaceId: "ws-1",
+          contactId: "contact-1",
+          occurredAt: "2026-07-01T00:00:00.000Z",
+          [EVENT_BUS_MESSAGE_ID]: "stream-service-1-0",
+        },
+      ],
+      "contact_created",
+    )
+
+    expect(capturedInsertValues[0]).toMatchObject([
+      { eventId: "stream-service-1-0" },
+    ])
+  })
+})

--- a/packages/analytics/__tests__/mac-tracking.service.test.ts
+++ b/packages/analytics/__tests__/mac-tracking.service.test.ts
@@ -526,6 +526,39 @@ describe("MacTrackingService.claimNewActiveContact", () => {
     )
   })
 
+  test("also records the paired hourly presence row for a brand-new contact", async () => {
+    macRepository.upsertMonthlyPresence.mockResolvedValueOnce([
+      { workspaceMacId: "wm-1", count: 1 },
+    ])
+    const tx = {} as never
+
+    await newService().claimNewActiveContact(input, tx)
+
+    expect(macRepository.upsertHourlyPresence).toHaveBeenCalledTimes(1)
+    expect(macRepository.upsertHourlyPresence).toHaveBeenCalledWith(
+      [
+        {
+          workspaceId: WORKSPACE_ID,
+          contactId: "c-1",
+          contactInboxId: "ci-1",
+          inboxId: "ib-1",
+          hourBucket: new Date("2026-05-01T10:00:00.000Z"),
+        },
+      ],
+      tx,
+    )
+  })
+
+  test("still records the hourly presence row when the monthly row already exists (dedup)", async () => {
+    macRepository.upsertMonthlyPresence.mockResolvedValueOnce([])
+
+    const result = await newService().claimNewActiveContact(input, {} as never)
+
+    expect(result).toEqual({ counted: false })
+    expect(macRepository.addWorkspaceMacCount).not.toHaveBeenCalled()
+    expect(macRepository.upsertHourlyPresence).toHaveBeenCalledTimes(1)
+  })
+
   test("reports not counted when the presence row already exists (dedup)", async () => {
     macRepository.upsertMonthlyPresence.mockResolvedValueOnce([])
 
@@ -542,6 +575,7 @@ describe("MacTrackingService.claimNewActiveContact", () => {
 
     expect(result).toEqual({ counted: false })
     expect(macRepository.upsertMonthlyPresence).not.toHaveBeenCalled()
+    expect(macRepository.upsertHourlyPresence).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/analytics/src/repositories/postgres/bot-message-stats.repository.ts
+++ b/packages/analytics/src/repositories/postgres/bot-message-stats.repository.ts
@@ -1,5 +1,6 @@
 import { db, sql } from "@chatbotx.io/database/client"
 import { analyticsBotMessageEventModel } from "@chatbotx.io/database/schema"
+import type { EventBusMessageMetadata } from "@chatbotx.io/flow-config"
 import { createId } from "@chatbotx.io/utils"
 import { logger } from "../../lib/logger"
 import {
@@ -17,8 +18,9 @@ import type {
   TimeRangeQuery,
 } from "../../schemas"
 import { BaseRepository } from "./base.repository"
+import { getEventBusEventId } from "./event-bus-idempotency"
 
-export type InsertBotMessageEventRow = {
+export type InsertBotMessageEventRow = EventBusMessageMetadata & {
   workspaceId: string
   messageId: string
   conversationId: string
@@ -58,7 +60,7 @@ export class BotMessageStatsRepository extends BaseRepository {
       return
     }
     const rows = validPayloads.map((p) => ({
-      eventId: createId(),
+      eventId: getEventBusEventId(p) ?? createId(),
       workspaceId: p.workspaceId,
       messageId: p.messageId,
       conversationId: p.conversationId,

--- a/packages/analytics/src/repositories/postgres/contact-stats.repository.ts
+++ b/packages/analytics/src/repositories/postgres/contact-stats.repository.ts
@@ -1,5 +1,6 @@
 import { db, sql } from "@chatbotx.io/database/client"
 import { analyticsContactEventModel } from "@chatbotx.io/database/schema"
+import type { EventBusMessageMetadata } from "@chatbotx.io/flow-config"
 import { createId } from "@chatbotx.io/utils"
 import {
   fillContactStatsMonthlySeries,
@@ -19,8 +20,9 @@ import type {
   TimeRangeQuery,
 } from "../../schemas"
 import { BaseRepository } from "./base.repository"
+import { getEventBusEventId } from "./event-bus-idempotency"
 
-export type InsertContactEventRow = {
+export type InsertContactEventRow = EventBusMessageMetadata & {
   workspaceId: string
   contactId: string
   occurredAt: Date | string | number
@@ -40,7 +42,7 @@ export class ContactStatsRepository extends BaseRepository {
       return
     }
     const rows = payloads.map((p) => ({
-      eventId: createId(),
+      eventId: getEventBusEventId(p) ?? createId(),
       workspaceId: p.workspaceId,
       contactId: p.contactId,
       eventType,

--- a/packages/analytics/src/repositories/postgres/conversation-stats.repository.ts
+++ b/packages/analytics/src/repositories/postgres/conversation-stats.repository.ts
@@ -1,5 +1,6 @@
 import { db, sql } from "@chatbotx.io/database/client"
 import { analyticsConversationEventModel } from "@chatbotx.io/database/schema"
+import type { EventBusMessageMetadata } from "@chatbotx.io/flow-config"
 import { createId } from "@chatbotx.io/utils"
 import { shouldUseCagg } from "../../lib/time-series"
 import type {
@@ -13,8 +14,9 @@ import type {
 } from "../../schemas"
 import type { ConversationEventType } from "../../schemas/conversation-event"
 import { BaseRepository } from "./base.repository"
+import { getEventBusEventId } from "./event-bus-idempotency"
 
-export type InsertConversationEventRow = {
+export type InsertConversationEventRow = EventBusMessageMetadata & {
   workspaceId: string
   conversationId: string
   occurredAt: Date | string | number
@@ -33,7 +35,7 @@ export class ConversationStatsRepository extends BaseRepository {
       return
     }
     const rows = payloads.map((p) => ({
-      eventId: createId(),
+      eventId: getEventBusEventId(p) ?? createId(),
       workspaceId: p.workspaceId,
       conversationId: p.conversationId,
       eventType,

--- a/packages/analytics/src/repositories/postgres/event-bus-idempotency.ts
+++ b/packages/analytics/src/repositories/postgres/event-bus-idempotency.ts
@@ -1,0 +1,15 @@
+import {
+  EVENT_BUS_MESSAGE_ID,
+  type EventBusMessageMetadata,
+} from "@chatbotx.io/flow-config"
+
+export function getEventBusEventId(
+  row: EventBusMessageMetadata,
+): string | undefined {
+  const eventBusMessageId = row[EVENT_BUS_MESSAGE_ID]
+  if (typeof eventBusMessageId === "string" && eventBusMessageId.length > 0) {
+    return eventBusMessageId
+  }
+
+  return
+}

--- a/packages/analytics/src/repositories/postgres/message-stats.repository.ts
+++ b/packages/analytics/src/repositories/postgres/message-stats.repository.ts
@@ -1,5 +1,6 @@
 import { db, sql } from "@chatbotx.io/database/client"
 import { analyticsMessageEventModel } from "@chatbotx.io/database/schema"
+import type { EventBusMessageMetadata } from "@chatbotx.io/flow-config"
 import { createId } from "@chatbotx.io/utils"
 import {
   fillDailyMessageStats,
@@ -20,8 +21,9 @@ import type {
 } from "../../schemas/message-event"
 import { BaseRepository } from "./base.repository"
 import { conversationStatsRepository } from "./conversation-stats.repository"
+import { getEventBusEventId } from "./event-bus-idempotency"
 
-export type InsertMessageEventRow = {
+export type InsertMessageEventRow = EventBusMessageMetadata & {
   workspaceId: string
   contactId: string
   occurredAt: Date | string | number
@@ -42,7 +44,7 @@ export class MessageStatsRepository extends BaseRepository {
       return
     }
     const rows = payloads.map((p) => ({
-      eventId: createId(),
+      eventId: getEventBusEventId(p) ?? createId(),
       workspaceId: p.workspaceId,
       contactId: p.contactId,
       eventType,

--- a/packages/analytics/src/services/mac-tracking.service.ts
+++ b/packages/analytics/src/services/mac-tracking.service.ts
@@ -178,10 +178,11 @@ export class MacTrackingService {
    * Synchronously claim one monthly-active-contact slot for a *brand-new*
    * contact at creation time, inside the caller's transaction. This is the
    * write-time half of MAC enforcement: it records the same
-   * `ContactActiveMonthly` presence row and `WorkspaceMac` rollup that the
-   * async `trackMessageIn`/`trackMessageOut` path would, so a later
-   * `message:received`/`message:sent` event for this same contact dedups via
-   * `onConflictDoNothing` and does NOT double-count.
+   * `ContactActiveMonthly` + `ContactActiveHourly` presence rows and
+   * `WorkspaceMac` rollup that the async `trackMessageIn`/`trackMessageOut`
+   * (+ hourly) path would, so a later `message:received`/`message:sent`
+   * event for this same contact dedups via `onConflictDoNothing` and does
+   * NOT double-count.
    *
    * Returns `{ counted: true }` only when a presence row was newly inserted.
    * Because the contact (and its `contactInbox`) is brand-new, a conflict
@@ -218,12 +219,13 @@ export class MacTrackingService {
 
   /**
    * Batch variant of {@link claimNewActiveContact} for bulk creation (e.g.
-   * contact import): records the `ContactActiveMonthly` presence rows + the
-   * `WorkspaceMac` rollup for many brand-new contacts of one workspace in a
-   * single round-trip, inside the caller's transaction. Returns the number of
-   * presence rows newly inserted (`onConflictDoNothing` dedups any already
-   * active this period). Keeps the import-created contacts in the same ledger
-   * the quota reconcile derives `macUsed` from.
+   * contact import): records the `ContactActiveMonthly` + `ContactActiveHourly`
+   * presence rows and the `WorkspaceMac` rollup for many brand-new contacts of
+   * one workspace in a single round-trip, inside the caller's transaction.
+   * Returns the number of monthly presence rows newly inserted
+   * (`onConflictDoNothing` dedups any already active this period). Keeps the
+   * import-created contacts in the same ledger the quota reconcile derives
+   * `macUsed` from.
    */
   async claimNewActiveContacts(
     input: {
@@ -272,6 +274,18 @@ export class MacTrackingService {
       })),
       tx,
     )
+
+    await macRepository.upsertHourlyPresence(
+      input.contacts.map((contact) => ({
+        workspaceId: input.workspaceId,
+        contactId: contact.contactId,
+        contactInboxId: contact.contactInboxId,
+        inboxId: input.inboxId,
+        hourBucket,
+      })),
+      tx,
+    )
+
     if (deltas.length === 0) {
       return { counted: 0 }
     }

--- a/packages/business/__tests__/contact-service.test.ts
+++ b/packages/business/__tests__/contact-service.test.ts
@@ -1,0 +1,98 @@
+import type { ContactModel } from "@chatbotx.io/database/types"
+import { afterEach, describe, expect, test, vi } from "vitest"
+import { contactService } from "../src/contact"
+
+const contact = (data: Partial<ContactModel>): ContactModel =>
+  data as ContactModel
+
+describe("contactService.unblockIfBlocked", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test("unblocks a preloaded blocked contact without reading it again", async () => {
+    const blocked = contact({
+      id: "contact-1",
+      workspaceId: "ws-1",
+      blockedAt: new Date("2026-01-01T00:00:00Z"),
+    })
+    const updated = contact({ ...blocked, blockedAt: null })
+    const findById = vi.spyOn(contactService, "findById")
+    const unblock = vi
+      .spyOn(contactService, "unblock")
+      .mockResolvedValue(updated)
+
+    await expect(
+      contactService.unblockIfBlocked(
+        { workspaceId: "ws-1", id: "contact-1" },
+        blocked,
+      ),
+    ).resolves.toBe(updated)
+
+    expect(findById).not.toHaveBeenCalled()
+    expect(unblock).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      id: "contact-1",
+    })
+  })
+
+  test("does not update a preloaded unblocked contact", async () => {
+    const findById = vi.spyOn(contactService, "findById")
+    const unblock = vi.spyOn(contactService, "unblock")
+
+    await expect(
+      contactService.unblockIfBlocked(
+        { workspaceId: "ws-1", id: "contact-1" },
+        contact({ id: "contact-1", workspaceId: "ws-1", blockedAt: null }),
+      ),
+    ).resolves.toBeNull()
+
+    expect(findById).not.toHaveBeenCalled()
+    expect(unblock).not.toHaveBeenCalled()
+  })
+
+  test("reads by id when no preloaded contact is supplied", async () => {
+    const blocked = contact({
+      id: "contact-1",
+      workspaceId: "ws-1",
+      blockedAt: new Date("2026-01-01T00:00:00Z"),
+    })
+    const updated = contact({ ...blocked, blockedAt: null })
+    const findById = vi
+      .spyOn(contactService, "findById")
+      .mockResolvedValue(blocked)
+    const unblock = vi
+      .spyOn(contactService, "unblock")
+      .mockResolvedValue(updated)
+
+    await expect(
+      contactService.unblockIfBlocked({ workspaceId: "ws-1", id: "contact-1" }),
+    ).resolves.toBe(updated)
+
+    expect(findById).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      id: "contact-1",
+    })
+    expect(unblock).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      id: "contact-1",
+    })
+  })
+
+  test("does not update when the fallback read finds no blocked contact", async () => {
+    const findById = vi
+      .spyOn(contactService, "findById")
+      .mockResolvedValue(undefined)
+    const unblock = vi.spyOn(contactService, "unblock")
+
+    await expect(
+      contactService.unblockIfBlocked({ workspaceId: "ws-1", id: "contact-1" }),
+    ).resolves.toBeNull()
+
+    expect(findById).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      id: "contact-1",
+    })
+    expect(unblock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/business/src/contact/service.ts
+++ b/packages/business/src/contact/service.ts
@@ -74,19 +74,19 @@ class ContactService extends BaseService {
     tx?: DatabaseClient
   }): Promise<ContactModel | undefined> {
     const { workspaceId, id, tx = db } = props
-    return await withCache(
-      `contacts:${workspaceId}:${id}`,
-      async () =>
-        await tx.query.contactModel.findFirst({
-          where: { id, workspaceId },
-        }),
-      {
-        dynamicTags: (result) =>
-          result
-            ? ["contacts", `contacts:${workspaceId}`, `contacts:${result.id}`]
-            : undefined,
-      },
-    )
+    // return await withCache(
+    //   `contacts:${workspaceId}:${id}`,
+    //   async () =>
+    return await tx.query.contactModel.findFirst({
+      where: { id, workspaceId },
+    })
+    // {
+    //   dynamicTags: (result) =>
+    //     result
+    //       ? ["contacts", `contacts:${workspaceId}`, `contacts:${result.id}`]
+    //       : undefined,
+    // },
+    // )
   }
 
   async findByIdOrFail(props: {
@@ -163,6 +163,17 @@ class ContactService extends BaseService {
     id: string
   }): Promise<ContactModel> {
     return await this.update(ctx, { blockedAt: null })
+  }
+
+  async unblockIfBlocked(
+    ctx: { workspaceId: string; id: string },
+    contact?: ContactModel | null,
+  ): Promise<ContactModel | null> {
+    const current = contact ?? (await this.findById(ctx))
+    if (!current?.blockedAt) {
+      return null
+    }
+    return await this.unblock(ctx)
   }
 
   async delete(props: {

--- a/packages/event-bus/__tests__/configured-buses.test.ts
+++ b/packages/event-bus/__tests__/configured-buses.test.ts
@@ -1,0 +1,63 @@
+import {
+  flowEventTypeSchema,
+  messageEventTypeSchema,
+} from "@chatbotx.io/flow-config"
+import { describe, expect, test, vi } from "vitest"
+
+const workerConfigMock = vi.hoisted(() => {
+  const redis = {}
+  return {
+    getRedisConnection: vi.fn(() => redis),
+  }
+})
+
+vi.mock("@chatbotx.io/worker-config", () => ({
+  getRedisConnection: workerConfigMock.getRedisConnection,
+}))
+
+import { dashboardEventBus } from "../src/dashboard/event-bus"
+import { FlowEventBusByType, flowEventBus } from "../src/flow/event-bus"
+import {
+  MessageEventBusByType,
+  messageEventBus,
+} from "../src/message/event-bus"
+
+describe("configured event buses", () => {
+  test("configures stream keys, groups, retention, and schemas", () => {
+    expect(messageEventBus.getConfig()).toMatchObject({
+      consumerGroup: "message-events-group",
+      maxLen: 100_000,
+      streamKey: "events:message",
+    })
+    expect(flowEventBus.getConfig()).toMatchObject({
+      consumerGroup: "flow-events-group",
+      maxLen: 100_000,
+      streamKey: "flow:events",
+    })
+    expect(dashboardEventBus.getConfig()).toMatchObject({
+      consumerGroup: "analytics-dashboard-events-group",
+      maxLen: 500_000,
+      streamKey: "events:analytics-dashboard",
+    })
+  })
+
+  test("enables selective retry only for the idempotent analytics dashboard stream", () => {
+    expect(dashboardEventBus.getConfig()).toMatchObject({
+      deadLetterMaxLen: 100_000,
+      deadLetterStreamKey: "events:analytics-dashboard:dead",
+      enableSelectiveRetry: true,
+      maxDeliveries: 5,
+    })
+    expect(messageEventBus.getConfig().enableSelectiveRetry).toBeUndefined()
+    expect(flowEventBus.getConfig().enableSelectiveRetry).toBeUndefined()
+  })
+
+  test("maps every message and flow event type to its bus", () => {
+    for (const type of messageEventTypeSchema.options) {
+      expect(MessageEventBusByType[type]).toBe(messageEventBus)
+    }
+    for (const type of flowEventTypeSchema.options) {
+      expect(FlowEventBusByType[type]).toBe(flowEventBus)
+    }
+  })
+})

--- a/packages/event-bus/__tests__/event-bus.test.ts
+++ b/packages/event-bus/__tests__/event-bus.test.ts
@@ -1,0 +1,737 @@
+import {
+  type BaseEventListener,
+  EVENT_BUS_MESSAGE_ID,
+} from "@chatbotx.io/flow-config"
+import type { Redis } from "@chatbotx.io/redis"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import { z } from "zod"
+import { BaseEventBus, type EventBusConfig } from "../src/event-bus"
+
+type TestEventMap = {
+  "test:event": { value: string }
+}
+
+type TestListener = BaseEventListener<TestEventMap[keyof TestEventMap]>
+
+type FakeRedis = Redis & {
+  call: ReturnType<typeof vi.fn>
+  disconnect: ReturnType<typeof vi.fn>
+  duplicate: ReturnType<typeof vi.fn>
+  quit: ReturnType<typeof vi.fn>
+  xack: ReturnType<typeof vi.fn>
+  xadd: ReturnType<typeof vi.fn>
+  xautoclaim: ReturnType<typeof vi.fn>
+  xgroup: ReturnType<typeof vi.fn>
+}
+
+const streamEntry = (id: string, payload: TestEventMap["test:event"]) =>
+  [id, ["type", "test:event", "payload", JSON.stringify(payload)]] as [
+    string,
+    string[],
+  ]
+
+function createFakeRedis(): FakeRedis {
+  return {
+    call: vi.fn().mockResolvedValue(null),
+    disconnect: vi.fn(),
+    duplicate: vi.fn(),
+    quit: vi.fn().mockResolvedValue("OK"),
+    xack: vi.fn().mockResolvedValue(1),
+    xadd: vi.fn().mockResolvedValue("1-0"),
+    xautoclaim: vi.fn().mockResolvedValue(["0-0", [], []]),
+    xgroup: vi.fn().mockResolvedValue("OK"),
+  } as unknown as FakeRedis
+}
+
+function createBus(
+  redis: FakeRedis,
+  config: Partial<EventBusConfig<TestEventMap>> = {},
+) {
+  class TestEventBus extends BaseEventBus<TestEventMap, TestListener> {
+    consumeOnceForTest(
+      consumerName = "consumer-1",
+      listeners: Partial<Record<keyof TestEventMap, TestListener[]>> = {},
+    ) {
+      return this.consumeOnce(consumerName, listeners)
+    }
+
+    getBlockingRedisForTest() {
+      return this.blockingRedis
+    }
+  }
+
+  return new TestEventBus(redis, {
+    consumerGroup: "test-group",
+    schemas: {
+      "test:event": z.object({ value: z.string() }),
+    },
+    streamKey: "events:test",
+    ...config,
+  })
+}
+
+describe("BaseEventBus consumer reliability", () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test("uses a dedicated duplicate connection for blocking reads and closes it on deregister", async () => {
+    const sharedRedis = createFakeRedis()
+    const blockingRedis = createFakeRedis()
+    sharedRedis.duplicate.mockReturnValue(blockingRedis)
+
+    const bus = createBus(sharedRedis, {
+      claimIntervalMs: Number.POSITIVE_INFINITY,
+    })
+    sharedRedis.call.mockResolvedValue([])
+    blockingRedis.call.mockImplementation(() => {
+      bus.stop()
+      return Promise.resolve(null)
+    })
+
+    await bus.startConsuming("consumer-1", {})
+    await bus.deregister()
+
+    expect(sharedRedis.duplicate).toHaveBeenCalledTimes(1)
+    expect(blockingRedis.call).toHaveBeenCalledWith(
+      "XREADGROUP",
+      "GROUP",
+      "test-group",
+      "consumer-1",
+      "BLOCK",
+      5000,
+      "COUNT",
+      500,
+      "STREAMS",
+      "events:test",
+      ">",
+    )
+    expect(sharedRedis.call).toHaveBeenCalledWith(
+      "XPENDING",
+      "events:test",
+      "test-group",
+      "-",
+      "+",
+      1,
+      "consumer-1",
+    )
+    expect(sharedRedis.xgroup).toHaveBeenCalledWith(
+      "DELCONSUMER",
+      "events:test",
+      "test-group",
+      "consumer-1",
+    )
+    expect(blockingRedis.quit).toHaveBeenCalledTimes(1)
+  })
+
+  test("keeps the consumer registered when pending messages remain", async () => {
+    const sharedRedis = createFakeRedis()
+    const blockingRedis = createFakeRedis()
+    sharedRedis.duplicate.mockReturnValue(blockingRedis)
+    sharedRedis.call.mockResolvedValue([["1-0", "consumer-1", 1000, 1]])
+    blockingRedis.call.mockImplementation(() => {
+      bus.stop()
+      return Promise.resolve(null)
+    })
+    const logger = await import("../src/logger")
+    const warnSpy = vi.spyOn(logger.logger, "warn").mockImplementation(vi.fn())
+    const bus = createBus(sharedRedis, {
+      claimIntervalMs: Number.POSITIVE_INFINITY,
+    })
+
+    await bus.startConsuming("consumer-1", {})
+    await bus.deregister()
+
+    expect(sharedRedis.call).toHaveBeenCalledWith(
+      "XPENDING",
+      "events:test",
+      "test-group",
+      "-",
+      "+",
+      1,
+      "consumer-1",
+    )
+    expect(sharedRedis.xgroup).not.toHaveBeenCalledWith(
+      "DELCONSUMER",
+      "events:test",
+      "test-group",
+      "consumer-1",
+    )
+    expect(warnSpy).toHaveBeenCalledWith(
+      {
+        pending: 1,
+        stream: "events:test",
+        consumerName: "consumer-1",
+      },
+      "[EventBus] skipping DELCONSUMER because messages are still pending",
+    )
+  })
+
+  test("keeps the consumer registered when pending inspection fails", async () => {
+    const sharedRedis = createFakeRedis()
+    const blockingRedis = createFakeRedis()
+    sharedRedis.duplicate.mockReturnValue(blockingRedis)
+    sharedRedis.call.mockRejectedValue(new Error("pending check failed"))
+    blockingRedis.call.mockImplementation(() => {
+      bus.stop()
+      return Promise.resolve(null)
+    })
+    const logger = await import("../src/logger")
+    const errorSpy = vi
+      .spyOn(logger.logger, "error")
+      .mockImplementation(vi.fn())
+    const bus = createBus(sharedRedis, {
+      claimIntervalMs: Number.POSITIVE_INFINITY,
+    })
+
+    await bus.startConsuming("consumer-1", {})
+    await bus.deregister()
+
+    expect(sharedRedis.xgroup).not.toHaveBeenCalledWith(
+      "DELCONSUMER",
+      "events:test",
+      "test-group",
+      "consumer-1",
+    )
+    expect(errorSpy).toHaveBeenCalledWith(
+      {
+        err: expect.any(Error),
+        stream: "events:test",
+        consumerName: "consumer-1",
+      },
+      "[EventBus] skipping DELCONSUMER after XPENDING failed",
+    )
+  })
+
+  test("initializes a consumer group once and ignores existing groups", async () => {
+    const redis = createFakeRedis()
+    const bus = createBus(redis)
+
+    await expect(bus.initialize()).resolves.toBe(bus)
+    await expect(bus.initialize()).resolves.toBe(bus)
+
+    expect(redis.xgroup).toHaveBeenCalledTimes(1)
+    expect(redis.xgroup).toHaveBeenCalledWith(
+      "CREATE",
+      "events:test",
+      "test-group",
+      "0",
+      "MKSTREAM",
+    )
+
+    const existingGroupRedis = createFakeRedis()
+    existingGroupRedis.xgroup.mockRejectedValue(new Error("BUSYGROUP exists"))
+    const existingGroupBus = createBus(existingGroupRedis)
+    await expect(existingGroupBus.initialize()).resolves.toBe(existingGroupBus)
+  })
+
+  test("throws initialization errors that are not BUSYGROUP", async () => {
+    const redis = createFakeRedis()
+    redis.xgroup.mockRejectedValue(new Error("redis down"))
+
+    await expect(createBus(redis).initialize()).rejects.toThrow("redis down")
+  })
+
+  test("emits transformed payloads with maxlen and rejects invalid payloads", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1234)
+    const redis = createFakeRedis()
+    redis.xadd.mockResolvedValue("1-0")
+    const bus = createBus(redis, { maxLen: 42 }).setPayloadHandler(
+      (_eventType, payload) => ({ value: payload.value.toUpperCase() }),
+    )
+
+    await expect(bus.emit("test:event", { value: "ok" })).resolves.toBe("1-0")
+    const validatingBus = createBus(redis)
+    await expect(
+      validatingBus.emit("test:event", {
+        value: 123,
+      } as unknown as { value: string }),
+    ).resolves.toBe("")
+
+    expect(redis.xadd).toHaveBeenCalledWith(
+      "events:test",
+      "MAXLEN",
+      "~",
+      42,
+      "*",
+      "type",
+      "test:event",
+      "payload",
+      JSON.stringify({ value: "OK" }),
+      "timestamp",
+      "1234",
+    )
+  })
+
+  test("clones a bus with a different consumer group", () => {
+    const redis = createFakeRedis()
+    const clone = createBus(redis, { readBatchSize: 25 }).cloneForGroup(
+      "other-group",
+    )
+
+    expect(clone.getConfig()).toMatchObject({
+      consumerGroup: "other-group",
+      readBatchSize: 25,
+      streamKey: "events:test",
+    })
+  })
+
+  test("uses configured read batch size for XREADGROUP", async () => {
+    const redis = createFakeRedis()
+    const bus = createBus(redis, {
+      claimIntervalMs: Number.POSITIVE_INFINITY,
+      readBatchSize: 123,
+    })
+
+    await bus.consumeOnceForTest()
+
+    expect(redis.call).toHaveBeenCalledWith(
+      "XREADGROUP",
+      "GROUP",
+      "test-group",
+      "consumer-1",
+      "BLOCK",
+      5000,
+      "COUNT",
+      123,
+      "STREAMS",
+      "events:test",
+      ">",
+    )
+  })
+
+  test("leaves a timed-out batch unacked and allows the next read attempt", async () => {
+    const loggerModule = await import("../src/logger")
+    const warnSpy = vi
+      .spyOn(loggerModule.logger, "warn")
+      .mockImplementation(vi.fn())
+    vi.useFakeTimers()
+    const redis = createFakeRedis()
+    redis.call
+      .mockResolvedValueOnce([
+        ["events:test", [streamEntry("1-0", { value: "stuck" })]],
+      ])
+      .mockResolvedValueOnce(null)
+    const bus = createBus(redis, {
+      claimIntervalMs: Number.POSITIVE_INFINITY,
+      processTimeoutMs: 25,
+    })
+    const neverResolves = vi.fn(
+      () => new Promise<void>(() => undefined),
+    ) satisfies TestListener["handler"]
+
+    const firstRead = bus.consumeOnceForTest("consumer-1", {
+      "test:event": [{ name: "stuck-listener", handler: neverResolves }],
+    })
+    await vi.advanceTimersByTimeAsync(25)
+    await firstRead
+
+    await bus.consumeOnceForTest()
+
+    expect(redis.xack).not.toHaveBeenCalled()
+    expect(redis.call).toHaveBeenCalledTimes(2)
+    expect(warnSpy).toHaveBeenCalledWith(
+      { count: 1, stream: "events:test", timeoutMs: 25 },
+      "[EventBus] batch processing timed out; leaving unacked for reclaim",
+    )
+  })
+
+  test("passes an AbortSignal to handlers and aborts it on timeout", async () => {
+    vi.useFakeTimers()
+    const redis = createFakeRedis()
+    redis.call.mockResolvedValueOnce([
+      ["events:test", [streamEntry("1-0", { value: "stuck" })]],
+    ])
+    const bus = createBus(redis, {
+      claimIntervalMs: Number.POSITIVE_INFINITY,
+      processTimeoutMs: 25,
+    })
+    let receivedSignal: AbortSignal | undefined
+    const neverResolves = vi.fn((_payloads, signal) => {
+      receivedSignal = signal
+      return new Promise<void>(() => undefined)
+    }) satisfies TestListener["handler"]
+
+    const read = bus.consumeOnceForTest("consumer-1", {
+      "test:event": [{ name: "abort-aware-listener", handler: neverResolves }],
+    })
+    await vi.advanceTimersByTimeAsync(25)
+    await read
+
+    expect(receivedSignal).toBeDefined()
+    expect(receivedSignal?.aborted).toBe(true)
+    expect(redis.xack).not.toHaveBeenCalled()
+  })
+
+  test("rate-limits XAUTOCLAIM and processes claimed entries through ack path", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1000)
+    const redis = createFakeRedis()
+    redis.xautoclaim.mockResolvedValue([
+      "0-0",
+      [streamEntry("2-0", { value: "claimed" })],
+      [],
+    ])
+    const bus = createBus(redis, {
+      claimBatchSize: 77,
+      claimIdleMs: 180_000,
+      claimIntervalMs: 30_000,
+    })
+
+    await bus.consumeOnceForTest()
+    await bus.consumeOnceForTest()
+
+    expect(redis.xautoclaim).toHaveBeenCalledTimes(1)
+    expect(redis.xautoclaim).toHaveBeenCalledWith(
+      "events:test",
+      "test-group",
+      "consumer-1",
+      180_000,
+      "0",
+      "COUNT",
+      77,
+    )
+    expect(redis.xack).toHaveBeenCalledWith("events:test", "test-group", "2-0")
+  })
+
+  test("logs handler failures before acking a completed batch", async () => {
+    const redis = createFakeRedis()
+    redis.call.mockResolvedValueOnce([
+      ["events:test", [streamEntry("3-0", { value: "failed" })]],
+    ])
+    const bus = createBus(redis, {
+      claimIntervalMs: Number.POSITIVE_INFINITY,
+    })
+    const logger = await import("../src/logger")
+    const warnSpy = vi.spyOn(logger.logger, "warn").mockImplementation(vi.fn())
+
+    await bus.consumeOnceForTest("consumer-1", {
+      "test:event": [
+        {
+          name: "failing-listener",
+          handler: () => Promise.reject(new Error("listener failed")),
+        },
+      ],
+    })
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      { failed: 1, stream: "events:test", total: 1 },
+      "[EventBus] acking batch despite handler failures",
+    )
+    expect(redis.xack).toHaveBeenCalledWith("events:test", "test-group", "3-0")
+  })
+
+  test("attaches stream ids and selectively acks only successful messages when enabled", async () => {
+    const redis = createFakeRedis()
+    redis.call.mockResolvedValueOnce([
+      [
+        "events:test",
+        [
+          streamEntry("4-0", { value: "ok" }),
+          streamEntry("5-0", { value: "retry" }),
+        ],
+      ],
+    ])
+    const bus = createBus(redis, {
+      claimIntervalMs: Number.POSITIVE_INFINITY,
+      enableSelectiveRetry: true,
+    })
+    const handler = vi.fn((payloads) => {
+      expect(payloads).toEqual([
+        { value: "ok", [EVENT_BUS_MESSAGE_ID]: "4-0" },
+        { value: "retry", [EVENT_BUS_MESSAGE_ID]: "5-0" },
+      ])
+      return { failedMessageIds: ["5-0"] }
+    }) satisfies TestListener["handler"]
+
+    await bus.consumeOnceForTest("consumer-1", {
+      "test:event": [{ name: "partial-listener", handler }],
+    })
+
+    expect(redis.xack).toHaveBeenCalledTimes(1)
+    expect(redis.xack).toHaveBeenCalledWith("events:test", "test-group", "4-0")
+  })
+
+  test("moves reclaimed messages past max deliveries to the dead-letter stream", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-07-01T00:00:00.000Z"))
+    const redis = createFakeRedis()
+    redis.xautoclaim.mockResolvedValue([
+      "0-0",
+      [streamEntry("6-0", { value: "poison" })],
+      [],
+    ])
+    redis.call.mockImplementation((command: string) => {
+      if (command === "XPENDING") {
+        return Promise.resolve([["6-0", "consumer-1", 200_000, 3]])
+      }
+      return Promise.resolve(null)
+    })
+    const bus = createBus(redis, {
+      claimIntervalMs: 0,
+      deadLetterMaxLen: 10,
+      enableSelectiveRetry: true,
+      maxDeliveries: 2,
+    })
+    const handler = vi.fn() satisfies TestListener["handler"]
+
+    await bus.consumeOnceForTest("consumer-1", {
+      "test:event": [{ name: "not-called", handler }],
+    })
+
+    expect(handler).not.toHaveBeenCalled()
+    expect(redis.xadd).toHaveBeenCalledWith(
+      "events:test:dead",
+      "MAXLEN",
+      "~",
+      10,
+      "*",
+      "type",
+      "test:event",
+      "payload",
+      JSON.stringify({ value: "poison" }),
+      "originalId",
+      "6-0",
+      "deliveryCount",
+      "3",
+      "error",
+      expect.any(String),
+      "timestamp",
+      String(Date.now()),
+    )
+    expect(redis.xack).toHaveBeenCalledWith("events:test", "test-group", "6-0")
+  })
+
+  test("reprocesses reclaimed messages at or below max deliveries", async () => {
+    const redis = createFakeRedis()
+    redis.xautoclaim.mockResolvedValue([
+      "0-0",
+      [streamEntry("7-0", { value: "retryable" })],
+      [],
+    ])
+    redis.call.mockImplementation((command: string) => {
+      if (command === "XPENDING") {
+        return Promise.resolve([["7-0", "consumer-1", 200_000, 2]])
+      }
+      return Promise.resolve(null)
+    })
+    const bus = createBus(redis, {
+      claimIntervalMs: 0,
+      enableSelectiveRetry: true,
+      maxDeliveries: 2,
+    })
+    const handler = vi.fn() satisfies TestListener["handler"]
+
+    await bus.consumeOnceForTest("consumer-1", {
+      "test:event": [{ name: "retryable-listener", handler }],
+    })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(redis.xadd).not.toHaveBeenCalled()
+    expect(redis.xack).toHaveBeenCalledWith("events:test", "test-group", "7-0")
+  })
+
+  test("writes the stored processing error to the dead-letter stream", async () => {
+    const redis = createFakeRedis()
+    redis.xautoclaim
+      .mockResolvedValueOnce(["0-0", [], []])
+      .mockResolvedValue(["0-0", [streamEntry("8-0", { value: "poison" })], []])
+    redis.call
+      .mockResolvedValueOnce([
+        ["events:test", [streamEntry("8-0", { value: "poison" })]],
+      ])
+      .mockImplementation((command: string) => {
+        if (command === "XPENDING") {
+          return Promise.resolve([["8-0", "consumer-1", 200_000, 3]])
+        }
+        return Promise.resolve(null)
+      })
+    const bus = createBus(redis, {
+      claimIntervalMs: 0,
+      enableSelectiveRetry: true,
+      maxDeliveries: 2,
+    })
+
+    await bus.consumeOnceForTest("consumer-1", {
+      "test:event": [
+        {
+          name: "poison-listener",
+          handler: () => {
+            throw new Error("database unavailable")
+          },
+        },
+      ],
+    })
+    await bus.consumeOnceForTest("consumer-1", {})
+
+    expect(redis.xadd).toHaveBeenCalledWith(
+      expect.any(String),
+      "MAXLEN",
+      "~",
+      expect.any(Number),
+      "*",
+      "type",
+      "test:event",
+      "payload",
+      expect.any(String),
+      "originalId",
+      "8-0",
+      "deliveryCount",
+      "3",
+      "error",
+      "database unavailable",
+      "timestamp",
+      expect.any(String),
+    )
+  })
+
+  test("writes a max-deliveries fallback error after restart-like empty error memory", async () => {
+    const redis = createFakeRedis()
+    redis.xautoclaim.mockResolvedValue([
+      "0-0",
+      [streamEntry("9-0", { value: "poison" })],
+      [],
+    ])
+    redis.call.mockImplementation((command: string) => {
+      if (command === "XPENDING") {
+        return Promise.resolve([["9-0", "consumer-1", 200_000, 6]])
+      }
+      return Promise.resolve(null)
+    })
+    const logger = await import("../src/logger")
+    const deadLetterErrorSpy = vi
+      .spyOn(logger.deadLetterLogger, "error")
+      .mockImplementation(vi.fn())
+    const bus = createBus(redis, {
+      claimIntervalMs: 0,
+      enableSelectiveRetry: true,
+      maxDeliveries: 5,
+    })
+
+    await bus.consumeOnceForTest("consumer-1", {})
+
+    expect(redis.xadd).toHaveBeenCalledWith(
+      expect.any(String),
+      "MAXLEN",
+      "~",
+      expect.any(Number),
+      "*",
+      "type",
+      "test:event",
+      "payload",
+      expect.any(String),
+      "originalId",
+      "9-0",
+      "deliveryCount",
+      "6",
+      "error",
+      "max deliveries exceeded",
+      "timestamp",
+      expect.any(String),
+    )
+    expect(deadLetterErrorSpy).toHaveBeenCalledWith(
+      {
+        deadLetterStreamKey: "events:test:dead",
+        deliveryCount: 6,
+        messageId: "9-0",
+        stream: "events:test",
+      },
+      "[EventBus] moved message to dead-letter stream",
+    )
+  })
+
+  test("logs reclaim failures and continues with the normal read", async () => {
+    const redis = createFakeRedis()
+    redis.xautoclaim.mockRejectedValue(new Error("claim failed"))
+    const logger = await import("../src/logger")
+    const errorSpy = vi
+      .spyOn(logger.logger, "error")
+      .mockImplementation(vi.fn())
+    const bus = createBus(redis)
+
+    await bus.consumeOnceForTest()
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      { err: expect.any(Error), stream: "events:test" },
+      "[EventBus] reclaim failed",
+    )
+    expect(redis.call).toHaveBeenCalledWith(
+      "XREADGROUP",
+      "GROUP",
+      "test-group",
+      "consumer-1",
+      "BLOCK",
+      5000,
+      "COUNT",
+      500,
+      "STREAMS",
+      "events:test",
+      ">",
+    )
+  })
+
+  test("falls back to disconnect when closing a duplicate connection fails", async () => {
+    const sharedRedis = createFakeRedis()
+    const blockingRedis = createFakeRedis()
+    blockingRedis.quit.mockRejectedValue(new Error("quit failed"))
+    sharedRedis.duplicate.mockReturnValue(blockingRedis)
+
+    const bus = createBus(sharedRedis, {
+      claimIntervalMs: Number.POSITIVE_INFINITY,
+    })
+    blockingRedis.call.mockImplementation(() => {
+      bus.stop()
+      return Promise.resolve(null)
+    })
+
+    await bus.startConsuming("consumer-1", {})
+
+    expect(blockingRedis.quit).toHaveBeenCalledTimes(1)
+    expect(blockingRedis.disconnect).toHaveBeenCalledTimes(1)
+  })
+
+  test("logs consume loop errors and retries while running", async () => {
+    vi.useFakeTimers()
+    const redis = createFakeRedis()
+    const blockingRedis = createFakeRedis()
+    redis.duplicate.mockReturnValue(blockingRedis)
+    const logger = await import("../src/logger")
+    const errorSpy = vi
+      .spyOn(logger.logger, "error")
+      .mockImplementation(vi.fn())
+
+    class RetryingBus extends BaseEventBus<TestEventMap, TestListener> {
+      private attempts = 0
+
+      protected override consumeOnce() {
+        this.attempts += 1
+        if (this.attempts === 1) {
+          return Promise.reject(new Error("read failed"))
+        }
+        this.stop()
+        return Promise.resolve()
+      }
+    }
+
+    const bus = new RetryingBus(redis, {
+      consumerGroup: "test-group",
+      schemas: {
+        "test:event": z.object({ value: z.string() }),
+      },
+      streamKey: "events:test",
+    })
+
+    const consuming = bus.startConsuming("consumer-1", {})
+    await vi.advanceTimersByTimeAsync(1000)
+    await consuming
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      { err: expect.any(Error), stream: "events:test" },
+      "[EventBus] consume loop error",
+    )
+  })
+})

--- a/packages/event-bus/__tests__/index.test.ts
+++ b/packages/event-bus/__tests__/index.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test, vi } from "vitest"
+
+const workerConfigMock = vi.hoisted(() => {
+  const redis = {}
+  return {
+    getRedisConnection: vi.fn(() => redis),
+  }
+})
+
+vi.mock("@chatbotx.io/worker-config", () => ({
+  getRedisConnection: workerConfigMock.getRedisConnection,
+}))
+
+import { dashboardEventBus, emit, flowEventBus, messageEventBus } from "../src"
+import { logger } from "../src/logger"
+
+describe("emit", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test("routes known event types to their owning bus", async () => {
+    const messageEmit = vi
+      .spyOn(messageEventBus, "emit")
+      .mockResolvedValue("message-id")
+    const flowEmit = vi.spyOn(flowEventBus, "emit").mockResolvedValue("flow-id")
+    const dashboardEmit = vi
+      .spyOn(dashboardEventBus, "emit")
+      .mockResolvedValue("dashboard-id")
+
+    await expect(emit("message:sent" as never, {} as never)).resolves.toBe(
+      "message-id",
+    )
+    await expect(emit("flow:clicked" as never, {} as never)).resolves.toBe(
+      "flow-id",
+    )
+    await expect(
+      emit("analytics:dashboard" as never, {} as never),
+    ).resolves.toBe("dashboard-id")
+    await expect(emit("unknown:event" as never, {} as never)).resolves.toBe("")
+
+    expect(messageEmit).toHaveBeenCalledTimes(1)
+    expect(flowEmit).toHaveBeenCalledTimes(1)
+    expect(dashboardEmit).toHaveBeenCalledTimes(1)
+  })
+
+  test("logs synchronous emit routing failures", () => {
+    vi.spyOn(messageEventBus, "emit").mockImplementation(() => {
+      throw new Error("emit failed")
+    })
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(vi.fn())
+
+    expect(emit("message:sent" as never, {} as never)).toBeUndefined()
+    expect(errorSpy).toHaveBeenCalledWith(
+      { err: expect.any(Error), payload: {} },
+      "Failed to emit event: message:sent",
+    )
+  })
+})

--- a/packages/event-bus/__tests__/worker.test.ts
+++ b/packages/event-bus/__tests__/worker.test.ts
@@ -1,0 +1,91 @@
+import type { BaseEventListener } from "@chatbotx.io/flow-config"
+import { afterEach, describe, expect, test, vi } from "vitest"
+import type { EventModule } from "../src/event-bus"
+import { startWorker, stopWorker } from "../src/worker"
+
+type TestEventMap = {
+  "test:event": { value: string }
+}
+
+const TIMESTAMPED_WORKER_NAME = /^worker-worker-host-\d+-\d+$/
+
+function createModule(): EventModule<
+  TestEventMap,
+  BaseEventListener<TestEventMap[keyof TestEventMap]>
+> {
+  return {
+    bus: {
+      deregister: vi.fn().mockResolvedValue(undefined),
+      initialize: vi.fn().mockResolvedValue(undefined),
+      startConsuming: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn(),
+    } as unknown as EventModule<TestEventMap>["bus"],
+    listeners: {},
+  }
+}
+
+describe("event worker lifecycle", () => {
+  afterEach(async () => {
+    await stopWorker()
+    vi.restoreAllMocks()
+  })
+
+  test("uses a stable default consumer name without a timestamp segment", async () => {
+    const originalHostname = process.env.HOSTNAME
+    try {
+      process.env.HOSTNAME = "worker-host"
+      const mod = createModule()
+
+      await startWorker([mod])
+
+      expect(mod.bus.startConsuming).toHaveBeenCalledWith(
+        `worker-worker-host-${process.pid}`,
+        {},
+      )
+      expect(mod.bus.startConsuming).not.toHaveBeenCalledWith(
+        expect.stringMatching(TIMESTAMPED_WORKER_NAME),
+        {},
+      )
+    } finally {
+      if (originalHostname === undefined) {
+        delete process.env.HOSTNAME
+      } else {
+        process.env.HOSTNAME = originalHostname
+      }
+    }
+  })
+
+  test("stops consumers before deregistering them on shutdown", async () => {
+    const mod = createModule()
+    await startWorker([mod], "consumer-1")
+
+    const stopped = stopWorker()
+
+    expect(mod.bus.stop).toHaveBeenCalledTimes(1)
+    expect(mod.bus.deregister).not.toHaveBeenCalled()
+
+    await stopped
+
+    expect(mod.bus.deregister).toHaveBeenCalledTimes(1)
+  })
+
+  test("waits for consume loops to drain before deregistering", async () => {
+    const mod = createModule()
+    let resolveLoop: () => void = () => undefined
+    const loop = new Promise<void>((resolve) => {
+      resolveLoop = resolve
+    })
+    const startConsuming = mod.bus.startConsuming as ReturnType<typeof vi.fn>
+    const stop = mod.bus.stop as ReturnType<typeof vi.fn>
+    startConsuming.mockReturnValue(loop)
+    stop.mockImplementation(() => {
+      resolveLoop()
+    })
+
+    await startWorker([mod], "consumer-1")
+    await stopWorker()
+
+    expect(stop).toHaveBeenCalledTimes(1)
+    expect(mod.bus.deregister).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/event-bus/src/dashboard/event-bus.ts
+++ b/packages/event-bus/src/dashboard/event-bus.ts
@@ -8,6 +8,7 @@ import { getRedisConnection } from "@chatbotx.io/worker-config"
 import { BaseEventBus } from "../event-bus"
 
 const MAX_DASHBOARD_EVENTS = 500_000
+const MAX_DASHBOARD_DLQ_EVENTS = 100_000
 
 export const dashboardEventBus = new BaseEventBus<
   AnalyticsDashboardEventMap,
@@ -15,6 +16,10 @@ export const dashboardEventBus = new BaseEventBus<
 >(getRedisConnection(), {
   streamKey: "events:analytics-dashboard",
   consumerGroup: "analytics-dashboard-events-group",
+  deadLetterMaxLen: MAX_DASHBOARD_DLQ_EVENTS,
+  deadLetterStreamKey: "events:analytics-dashboard:dead",
+  enableSelectiveRetry: true,
   maxLen: MAX_DASHBOARD_EVENTS,
+  maxDeliveries: 5,
   schemas: analyticsDashboardEventSchemas,
 })

--- a/packages/event-bus/src/event-bus.ts
+++ b/packages/event-bus/src/event-bus.ts
@@ -1,12 +1,26 @@
-import type { BaseEventListener } from "@chatbotx.io/flow-config"
+import {
+  type BaseEventListener,
+  EVENT_BUS_MESSAGE_ID,
+} from "@chatbotx.io/flow-config"
 import type { Redis } from "@chatbotx.io/redis"
 import type { z } from "zod"
+import { deadLetterLogger, logger } from "./logger"
 
 type EventMap = Record<string, unknown>
+type StreamMessage = { messageId: string; type: string; payload: unknown }
 
 export interface EventBusConfig<TEventMap extends EventMap> {
+  claimBatchSize?: number
+  claimIdleMs?: number
+  claimIntervalMs?: number
   consumerGroup: string
+  deadLetterMaxLen?: number
+  deadLetterStreamKey?: string
+  enableSelectiveRetry?: boolean
+  maxDeliveries?: number
   maxLen?: number
+  processTimeoutMs?: number
+  readBatchSize?: number
   schemas: { [K in keyof TEventMap]: z.ZodType<TEventMap[K]> }
   streamKey: string
 }
@@ -131,58 +145,72 @@ export class BaseEventBus<
   }
 
   private running = false
+  protected blockingRedis?: Redis
+  private currentConsumerName?: string
+  private lastClaimAt = Number.NEGATIVE_INFINITY
+  private readonly lastProcessingErrors = new Map<string, string>()
 
   async startConsuming(
     consumerName: string,
     listeners: Partial<Record<keyof TEventMap, TListener[]>>,
   ): Promise<void> {
     this.running = true
+    this.currentConsumerName = consumerName
+    this.blockingRedis = this.redis.duplicate()
 
-    while (this.running) {
-      try {
-        const results = (await this.redis.call(
-          "XREADGROUP",
-          "GROUP",
-          this.config.consumerGroup,
-          consumerName,
-          "BLOCK",
-          5000,
-          "COUNT",
-          10,
-          "STREAMS",
-          this.config.streamKey,
-          ">",
-        )) as [string, [string, string[]][]][] | null
-
-        if (!results) {
-          continue
-        }
-
-        for (const [, messages] of results) {
-          const parsedMessages = messages.map(([messageId, fields]) => ({
-            messageId,
-            ...this.parseStreamMessage(fields),
-          }))
-
-          const _processResults = await this.processEvents(
-            parsedMessages,
-            listeners,
+    try {
+      while (this.running) {
+        try {
+          await this.consumeOnce(consumerName, listeners)
+        } catch (error) {
+          logger.error(
+            { err: error, stream: this.config.streamKey },
+            "[EventBus] consume loop error",
           )
-
-          const messageIds = parsedMessages.map((m) => m.messageId)
-          await this.redis.xack(
-            this.config.streamKey,
-            this.config.consumerGroup,
-            ...messageIds,
-          )
-
-          // XDEL intentionally omitted: stream entries are retained until
-          // evicted by MAXLEN so multiple consumer groups can read each message.
+          if (this.running) {
+            await sleep(1000)
+          }
         }
-      } catch (error) {
-        console.error("[EventBus] Consumer error:", error)
-        await new Promise((r) => setTimeout(r, 1000))
       }
+    } finally {
+      await this.closeBlockingRedis()
+    }
+  }
+
+  protected async consumeOnce(
+    consumerName: string,
+    listeners: Partial<Record<keyof TEventMap, TListener[]>>,
+  ): Promise<void> {
+    const redis = this.blockingRedis ?? this.redis
+    await this.reclaimStaleEntries(consumerName, listeners)
+
+    const results = (await redis.call(
+      "XREADGROUP",
+      "GROUP",
+      this.config.consumerGroup,
+      consumerName,
+      "BLOCK",
+      5000,
+      "COUNT",
+      this.config.readBatchSize ?? 500,
+      "STREAMS",
+      this.config.streamKey,
+      ">",
+    )) as [string, [string, string[]][]][] | null
+
+    if (!results) {
+      return
+    }
+
+    for (const [, messages] of results) {
+      const parsedMessages = messages.map(([messageId, fields]) => ({
+        messageId,
+        ...this.parseStreamMessage(fields),
+      }))
+      await this.processAndAck(parsedMessages, listeners)
+
+      // XDEL intentionally omitted: stream entries are retained until
+      // evicted by MAXLEN so multiple consumer groups can read each message.
     }
   }
 
@@ -197,9 +225,65 @@ export class BaseEventBus<
     this.running = false
   }
 
+  async deregister(): Promise<void> {
+    try {
+      if (
+        this.currentConsumerName &&
+        (await this.canDeleteConsumer(this.currentConsumerName))
+      ) {
+        await this.redis.xgroup(
+          "DELCONSUMER",
+          this.config.streamKey,
+          this.config.consumerGroup,
+          this.currentConsumerName,
+        )
+      }
+    } catch (error) {
+      logger.error({ err: error }, "[EventBus] DELCONSUMER failed")
+    }
+    // Note: the blocking connection is owned and closed by startConsuming's
+    // finally when the consume loop exits — closing it here would race a loop
+    // that may still be mid-command during shutdown.
+  }
+
+  private async canDeleteConsumer(consumerName: string): Promise<boolean> {
+    try {
+      const pendingEntries = (await this.redis.call(
+        "XPENDING",
+        this.config.streamKey,
+        this.config.consumerGroup,
+        "-",
+        "+",
+        1,
+        consumerName,
+      )) as unknown[]
+
+      if (pendingEntries.length === 0) {
+        return true
+      }
+
+      logger.warn(
+        {
+          consumerName,
+          pending: pendingEntries.length,
+          stream: this.config.streamKey,
+        },
+        "[EventBus] skipping DELCONSUMER because messages are still pending",
+      )
+      return false
+    } catch (error) {
+      logger.error(
+        { err: error, stream: this.config.streamKey, consumerName },
+        "[EventBus] skipping DELCONSUMER after XPENDING failed",
+      )
+      return false
+    }
+  }
+
   protected async processEvents(
-    messages: Array<{ messageId: string; type: string; payload: unknown }>,
+    messages: StreamMessage[],
     listeners: Partial<Record<keyof TEventMap, TListener[]>>,
+    signal?: AbortSignal,
   ): Promise<Array<{ messageId: string; success: boolean }>> {
     const messagesByType = new Map<string, typeof messages>()
     for (const msg of messages) {
@@ -224,35 +308,70 @@ export class BaseEventBus<
           return
         }
 
-        const payloads = typeMessages.map(
-          (m) => m.payload as TEventMap[keyof TEventMap],
+        const payloads = typeMessages.map((m) =>
+          this.attachEventBusMetadata(m.payload, m.messageId),
+        ) as TEventMap[keyof TEventMap][]
+        const knownMessageIds = new Set(
+          typeMessages.map((msg) => msg.messageId),
         )
+        const failedMessageIds = new Set<string>()
 
-        const handlerResults = await Promise.allSettled(
+        await Promise.all(
           applicableListeners.map(async (listener) => {
+            const startedAt = Date.now()
+            let success = false
             try {
-              await listener.handler?.(payloads)
+              const handlerResult = await listener.handler?.(payloads, signal)
+              const listenerFailedIds = getFailedMessageIds(
+                handlerResult,
+                knownMessageIds,
+              )
+              if (listenerFailedIds.length > 0) {
+                for (const messageId of listenerFailedIds) {
+                  failedMessageIds.add(messageId)
+                }
+                this.rememberProcessingError(
+                  listenerFailedIds,
+                  `listener ${listener.name} reported failedMessageIds`,
+                )
+              }
+              success = listenerFailedIds.length === 0
             } catch (error) {
-              console.error("[EventBus] Listener handler failed", {
-                streamKey: this.config.streamKey,
-                eventType: type,
-                listener: listener.name,
-                count: payloads.length,
-                error,
-              })
-              throw error
+              const listenerMessageIds = typeMessages.map(
+                (msg) => msg.messageId,
+              )
+              for (const messageId of listenerMessageIds) {
+                failedMessageIds.add(messageId)
+              }
+              this.rememberProcessingError(listenerMessageIds, error)
+              logger.error(
+                {
+                  err: error,
+                  streamKey: this.config.streamKey,
+                  eventType: type,
+                  listener: listener.name,
+                  count: payloads.length,
+                },
+                "[EventBus] listener handler failed",
+              )
+            } finally {
+              logger.debug(
+                {
+                  count: payloads.length,
+                  durationMs: Date.now() - startedAt,
+                  eventType: type,
+                  listener: listener.name,
+                  stream: this.config.streamKey,
+                  success,
+                },
+                "[EventBus] listener processed",
+              )
             }
           }),
         )
 
-        const failed = handlerResults.filter(
-          (r) => r.status === "rejected",
-        ).length
-
-        const success = failed === 0
-
         for (const msg of typeMessages) {
-          resultMap.set(msg.messageId, success)
+          resultMap.set(msg.messageId, !failedMessageIds.has(msg.messageId))
         }
       }),
     )
@@ -261,6 +380,17 @@ export class BaseEventBus<
       messageId: msg.messageId,
       success: resultMap.get(msg.messageId) ?? true,
     }))
+  }
+
+  private attachEventBusMetadata(payload: unknown, messageId: string): unknown {
+    if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+      return {
+        ...(payload as Record<string, unknown>),
+        [EVENT_BUS_MESSAGE_ID]: messageId,
+      }
+    }
+
+    return payload
   }
 
   private parseStreamMessage(fields: string[]): {
@@ -274,4 +404,281 @@ export class BaseEventBus<
 
     return { type: data.type, payload: JSON.parse(data.payload) }
   }
+
+  private async processAndAck(
+    messages: StreamMessage[],
+    listeners: Partial<Record<keyof TEventMap, TListener[]>>,
+  ): Promise<void> {
+    const timeoutMs = this.config.processTimeoutMs ?? 120_000
+    const startedAt = Date.now()
+    const abortController = new AbortController()
+    let timer: NodeJS.Timeout | undefined
+    const watchdog = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        abortController.abort()
+        reject(new ProcessTimeoutError(timeoutMs))
+      }, timeoutMs)
+    })
+
+    try {
+      const results = await Promise.race([
+        this.processEvents(messages, listeners, abortController.signal),
+        watchdog,
+      ])
+      const failed = results.filter((result) => !result.success).length
+      const selectiveRetry = this.config.enableSelectiveRetry === true
+      if (failed > 0) {
+        if (selectiveRetry) {
+          logger.warn(
+            { failed, stream: this.config.streamKey, total: results.length },
+            "[EventBus] leaving failed messages unacked for retry",
+          )
+        } else {
+          logger.warn(
+            { failed, stream: this.config.streamKey, total: results.length },
+            "[EventBus] acking batch despite handler failures",
+          )
+        }
+      }
+
+      const ackMessageIds = selectiveRetry
+        ? results
+            .filter((result) => result.success)
+            .map((result) => result.messageId)
+        : messages.map((message) => message.messageId)
+
+      if (ackMessageIds.length > 0) {
+        await (this.blockingRedis ?? this.redis).xack(
+          this.config.streamKey,
+          this.config.consumerGroup,
+          ...ackMessageIds,
+        )
+        this.forgetProcessingErrors(ackMessageIds)
+      }
+
+      logger.debug(
+        {
+          acked: ackMessageIds.length,
+          durationMs: Date.now() - startedAt,
+          failed,
+          stream: this.config.streamKey,
+          total: messages.length,
+        },
+        "[EventBus] batch processed",
+      )
+    } catch (error) {
+      // A watchdog timeout is expected/handled: leave the batch unacked so it
+      // stays in the PEL and gets retried via reclaim. Re-throw anything else.
+      if (error instanceof ProcessTimeoutError) {
+        this.rememberProcessingError(
+          messages.map((message) => message.messageId),
+          error,
+        )
+        logger.warn(
+          {
+            count: messages.length,
+            stream: this.config.streamKey,
+            timeoutMs,
+          },
+          "[EventBus] batch processing timed out; leaving unacked for reclaim",
+        )
+        return
+      }
+      throw error
+    } finally {
+      if (timer) {
+        clearTimeout(timer)
+      }
+    }
+  }
+
+  private async reclaimStaleEntries(
+    consumerName: string,
+    listeners: Partial<Record<keyof TEventMap, TListener[]>>,
+  ): Promise<void> {
+    const now = Date.now()
+    if (now - this.lastClaimAt < (this.config.claimIntervalMs ?? 30_000)) {
+      return
+    }
+
+    this.lastClaimAt = now
+    try {
+      const redis = this.blockingRedis ?? this.redis
+      const [, claimed] = (await redis.xautoclaim(
+        this.config.streamKey,
+        this.config.consumerGroup,
+        consumerName,
+        this.config.claimIdleMs ?? 180_000,
+        "0",
+        "COUNT",
+        this.config.claimBatchSize ?? this.config.readBatchSize ?? 500,
+      )) as [string, [string, string[]][], string[]]
+
+      if (!claimed?.length) {
+        return
+      }
+
+      const parsedMessages = claimed.map(([messageId, fields]) => ({
+        messageId,
+        ...this.parseStreamMessage(fields),
+      }))
+      const retryableMessages: StreamMessage[] = []
+      for (const message of parsedMessages) {
+        const deliveryCount = await this.getDeliveryCount(
+          message.messageId,
+          consumerName,
+        )
+        if (deliveryCount > (this.config.maxDeliveries ?? 5)) {
+          await this.moveToDeadLetter(message, deliveryCount)
+        } else {
+          retryableMessages.push(message)
+        }
+      }
+
+      if (retryableMessages.length > 0) {
+        await this.processAndAck(retryableMessages, listeners)
+      }
+    } catch (error) {
+      logger.error(
+        { err: error, stream: this.config.streamKey },
+        "[EventBus] reclaim failed",
+      )
+    }
+  }
+
+  private async getDeliveryCount(
+    messageId: string,
+    consumerName: string,
+  ): Promise<number> {
+    const pending = (await this.redis.call(
+      "XPENDING",
+      this.config.streamKey,
+      this.config.consumerGroup,
+      messageId,
+      messageId,
+      1,
+      consumerName,
+    )) as unknown
+    if (!Array.isArray(pending)) {
+      return 1
+    }
+    const firstEntry = pending[0]
+
+    if (Array.isArray(firstEntry)) {
+      const deliveryCount = Number(firstEntry[3])
+      if (Number.isFinite(deliveryCount) && deliveryCount > 0) {
+        return deliveryCount
+      }
+    }
+
+    return 1
+  }
+
+  private async moveToDeadLetter(
+    message: StreamMessage,
+    deliveryCount: number,
+  ): Promise<void> {
+    const deadLetterStreamKey =
+      this.config.deadLetterStreamKey ?? `${this.config.streamKey}:dead`
+    const error =
+      this.lastProcessingErrors.get(message.messageId) ??
+      "max deliveries exceeded"
+
+    await this.redis.xadd(
+      deadLetterStreamKey,
+      "MAXLEN",
+      "~",
+      this.config.deadLetterMaxLen ?? 100_000,
+      "*",
+      "type",
+      message.type,
+      "payload",
+      JSON.stringify(message.payload),
+      "originalId",
+      message.messageId,
+      "deliveryCount",
+      String(deliveryCount),
+      "error",
+      error,
+      "timestamp",
+      Date.now().toString(),
+    )
+    await this.redis.xack(
+      this.config.streamKey,
+      this.config.consumerGroup,
+      message.messageId,
+    )
+    this.forgetProcessingErrors([message.messageId])
+
+    deadLetterLogger.error(
+      {
+        deadLetterStreamKey,
+        deliveryCount,
+        messageId: message.messageId,
+        stream: this.config.streamKey,
+      },
+      "[EventBus] moved message to dead-letter stream",
+    )
+  }
+
+  private rememberProcessingError(messageIds: string[], error: unknown): void {
+    const message = getErrorMessage(error)
+    for (const messageId of messageIds) {
+      this.lastProcessingErrors.set(messageId, message)
+    }
+  }
+
+  private forgetProcessingErrors(messageIds: string[]): void {
+    for (const messageId of messageIds) {
+      this.lastProcessingErrors.delete(messageId)
+    }
+  }
+
+  private async closeBlockingRedis(): Promise<void> {
+    const redis = this.blockingRedis
+    this.blockingRedis = undefined
+    if (!redis) {
+      return
+    }
+
+    await redis.quit().catch(() => redis.disconnect())
+  }
+}
+
+class ProcessTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`processEvents timed out after ${timeoutMs}ms`)
+    this.name = "ProcessTimeoutError"
+  }
+}
+
+function getFailedMessageIds(
+  result: unknown,
+  knownMessageIds: Set<string>,
+): string[] {
+  if (!result || typeof result !== "object") {
+    return []
+  }
+
+  const failedMessageIds = (result as { failedMessageIds?: unknown })
+    .failedMessageIds
+  if (!Array.isArray(failedMessageIds)) {
+    return []
+  }
+
+  return failedMessageIds.filter((messageId) => knownMessageIds.has(messageId))
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+  if (typeof error === "string") {
+    return error
+  }
+  return "unknown processing error"
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/packages/event-bus/src/index.ts
+++ b/packages/event-bus/src/index.ts
@@ -11,9 +11,12 @@ import { flowEventBus } from "./flow"
 import { logger } from "./logger"
 import { messageEventBus } from "./message"
 
-export type {
-  BaseEventListener,
-  InferEventMap,
+export {
+  type BaseEventListener,
+  EVENT_BUS_MESSAGE_ID,
+  type EventBusMessageMetadata,
+  type EventHandlerResult,
+  type InferEventMap,
 } from "@chatbotx.io/flow-config"
 export * from "./dashboard"
 export * from "./event-bus"

--- a/packages/event-bus/src/logger.ts
+++ b/packages/event-bus/src/logger.ts
@@ -1,3 +1,4 @@
 import { getChildLogger } from "@chatbotx.io/logger"
 
 export const logger = getChildLogger("EventBus")
+export const deadLetterLogger = getChildLogger("EventBus:DeadLetter")

--- a/packages/event-bus/src/worker.ts
+++ b/packages/event-bus/src/worker.ts
@@ -2,6 +2,11 @@ import type { EventModule } from "./event-bus"
 
 // biome-ignore lint/suspicious/noExplicitAny: Required for generic module storage
 const activeModules: EventModule<any, any>[] = []
+let consumingPromises: Promise<unknown>[] = []
+
+// Cap how long shutdown waits for in-flight consume loops to exit before
+// deregistering, so a batch stuck in processing can't hang shutdown forever.
+const SHUTDOWN_DRAIN_TIMEOUT_MS = 6000
 
 export async function startWorker(
   // biome-ignore lint/suspicious/noExplicitAny: Required for generic module types
@@ -14,7 +19,7 @@ export async function startWorker(
 
   const name =
     consumerName ??
-    `worker-${process.env.HOSTNAME || "chatbotx"}-${process.pid}-${Date.now()}`
+    `worker-${process.env.HOSTNAME || "chatbotx"}-${process.pid}`
 
   for (const mod of modules) {
     activeModules.push(mod)
@@ -22,7 +27,9 @@ export async function startWorker(
     if (mod.init) {
       await mod.init()
     }
-    mod.bus.startConsuming(name, mod.listeners)
+    consumingPromises.push(
+      Promise.resolve(mod.bus.startConsuming(name, mod.listeners)),
+    )
   }
 }
 
@@ -31,6 +38,28 @@ export async function stopWorker(): Promise<void> {
     mod.bus.stop()
   }
 
-  await new Promise((resolve) => setTimeout(resolve, 2000))
+  // Let the consume loops exit on their own (bounded) so the blocking Redis
+  // connection is never closed mid-command; only then deregister each consumer.
+  await drainConsumeLoops(consumingPromises, SHUTDOWN_DRAIN_TIMEOUT_MS)
+  await Promise.allSettled(activeModules.map((mod) => mod.bus.deregister()))
   activeModules.length = 0
+  consumingPromises = []
+}
+
+async function drainConsumeLoops(
+  promises: Promise<unknown>[],
+  timeoutMs: number,
+): Promise<void> {
+  let timer: NodeJS.Timeout | undefined
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, timeoutMs)
+  })
+
+  try {
+    await Promise.race([Promise.allSettled(promises), timeout])
+  } finally {
+    if (timer) {
+      clearTimeout(timer)
+    }
+  }
 }

--- a/packages/flow-config/src/event/type.ts
+++ b/packages/flow-config/src/event/type.ts
@@ -16,8 +16,26 @@ export type InferEventMap<T extends Record<string, z.ZodType>> = {
   [K in keyof T]: z.infer<T[K]>
 }
 
+export const EVENT_BUS_MESSAGE_ID = "__eventBusMessageId" as const
+
+export type EventBusMessageMetadata = {
+  [EVENT_BUS_MESSAGE_ID]?: string
+}
+
+export type EventHandlerResult = {
+  failedMessageIds?: string[]
+}
+
 export interface BaseEventListener<TPayload = never> {
-  handler?(payloads: TPayload[]): Promise<void> | void
+  handler?(
+    payloads: TPayload[],
+    signal?: AbortSignal,
+  ):
+    | EventHandlerResult
+    | Promise<EventHandlerResult | undefined>
+    | Promise<void>
+    | undefined
+    | void
   name: string
   priority?: number
 }


### PR DESCRIPTION
## Bugs fixed

### Analytics dashboard
- **The dashboard could fall hours behind or stop updating.** Under load, analytics events piled up in a large backlog and were processed very slowly (or not at all), so charts and numbers went stale.
- **Dashboard numbers could be inflated (double-counted).** When events were reprocessed, metrics such as message counts, conversation stats, and the running contact total were counted more than once — and the contact total could drift permanently.
- **Some analytics events were silently dropped.** A temporary error while processing an event could discard it with no retry, causing under-reported numbers.
- **A single problematic event could stall or repeatedly reprocess a whole batch.** There was no way to set one bad event aside, so it could hold everything else up.
- **Hourly active-contact activity was not always recorded**, under-reporting active contacts.

### Background processing reliability
- **Analytics processing could get stuck after a restart or crash** — unfinished events were never picked back up, and repeated restarts left behind stale, unused workers that were never cleaned up.
- **Problematic events are now safely set aside for later inspection** instead of looping forever.

### Contacts
- **Blocked contacts stayed blocked after re-engaging.** A blocked contact is now automatically unblocked when they message again or when a message is successfully delivered to them.

## Testing
- Added/updated automated tests for analytics processing, duplicate prevention, failure isolation, and contact re-engagement.
- All affected package tests, type checks, and linting pass.
