### PR TITLE
feat(tenancy): anchor tenant settings URLs to custom domain

### DIFF
--- a/apps/builder/public/chat-widget/demo.html
+++ b/apps/builder/public/chat-widget/demo.html
@@ -7,18 +7,18 @@
     <h1>ChatbotX - Chat Widget Demo</h1>
     <!-- ChatbotX Chat Widget -->
     <script
-      src="http://builder.example.com:3123/chat-widget/plugin.js"
-      crossorigin="anonymous"
       async
-      type="module"
+      crossorigin="anonymous"
       onload="window.csmChatWidget?.init({
-      webchatId: 'wdd2wgu9vl8qlylq83wggci9',
-      workspaceId: 'fhrohnnmd3337cbggfae8vcc',
-      brandColor: '##007bff',
-      hideHeader: true,
-      showLogo: false,
-      hideMessageInput: true
-    });"
+        webchatId: 'wdd2wgu9vl8qlylq83wggci9',
+        workspaceId: 'fhrohnnmd3337cbggfae8vcc',
+        brandColor: '##007bff',
+        hideHeader: true,
+        showLogo: false,
+        hideMessageInput: true
+      });"
+      src="http://builder.example.com:3123/chat-widget/plugin.js"
+      type="module"
     ></script>
   </body>
 </html>

--- a/biome.json
+++ b/biome.json
@@ -20,7 +20,10 @@
       "!**/packages/ui/src/components/carousel-snap.tsx",
       "!**/packages/ui/src/types/data-table.ts",
       "!**/dist",
-      "!**/coverage"
+      "!**/coverage",
+      "!**/.github/assets/readme",
+      "!**/apps/builder/public/brand",
+      "!**/apps/builder/public/chat-widget/plugin-toggle.svg"
     ]
   },
   "formatter": {
@@ -37,7 +40,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "correctness": {
         "noUnusedImports": {
           "level": "error",
@@ -58,7 +61,8 @@
       },
       "suspicious": {
         "noUnknownAtRules": "off",
-        "noDuplicateCustomProperties": "off"
+        "noDuplicateCustomProperties": "off",
+        "noLeakedRender": "off"
       },
       "complexity": {
         "noExcessiveLinesPerFunction": "off",
@@ -66,9 +70,6 @@
       },
       "performance": {
         "noBarrelFile": "off"
-      },
-      "nursery": {
-        "noLeakedRender": "off"
       }
     }
   },

--- a/packages/analytics-nextjs/package.json
+++ b/packages/analytics-nextjs/package.json
@@ -19,7 +19,6 @@
     "@hookform/resolvers": "^5.2.2",
     "@orpc/server": "^1.14.0",
     "@t3-oss/env-nextjs": "^0.13.11",
-    "@types/node": "^24.10.4",
     "date-fns": "^4.1.0",
     "ky": "^2.0.2",
     "lucide-react": "^1.14.0",

--- a/packages/business/__tests__/tenant-settings-domain.test.ts
+++ b/packages/business/__tests__/tenant-settings-domain.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const BUILDER_URL = "https://app.chatbotx.io"
+const CUSTOM_DOMAIN = "chat.customer.com"
+const ENV_STORAGE_URL = "https://files.chatbotx.io/assets"
+const TENANT_STORAGE_URL = "https://cdn.customer.com/public"
+
+const mocks = vi.hoisted(() => ({
+  env: {
+    NEXT_PUBLIC_BUILDER_URL: "https://app.chatbotx.io",
+    NEXT_PUBLIC_STORAGE_URL: undefined as string | undefined,
+    REALTIME_BROADCAST_SECRET: "secret",
+  },
+  findActiveByDomain: vi.fn(),
+  findTenantById: vi.fn(),
+  hasEnterpriseFeatures: vi.fn(),
+  listByTenant: vi.fn(),
+}))
+
+vi.mock("../src/integration-context/keys", () => ({
+  integrationContextEnv: () => mocks.env,
+}))
+
+vi.mock("../src/enterprise/custom-domain/service", () => ({
+  customDomainService: { findActiveByDomain: mocks.findActiveByDomain },
+}))
+
+vi.mock("../src/enterprise/tenant/service", () => ({
+  tenantService: { findById: mocks.findTenantById },
+}))
+
+vi.mock("../src/enterprise/tenant-help-item/service", () => ({
+  tenantHelpItemService: { listByTenant: mocks.listByTenant },
+}))
+
+vi.mock("../src/user/entitlements", () => ({
+  hasEnterpriseFeatures: mocks.hasEnterpriseFeatures,
+}))
+
+vi.mock("../src/workspace/service", () => ({
+  workspaceService: { findById: vi.fn() },
+}))
+
+const { resolveTenantSettingsByDomain } = await import(
+  "../src/platform/settings"
+)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.env.NEXT_PUBLIC_STORAGE_URL = undefined
+  mocks.listByTenant.mockResolvedValue([])
+})
+
+describe("resolveTenantSettingsByDomain", () => {
+  test("anchors appUrl and wsUrl to the custom domain for an active white-label tenant", async () => {
+    mocks.hasEnterpriseFeatures.mockResolvedValue(true)
+    mocks.findActiveByDomain.mockResolvedValue({
+      domain: CUSTOM_DOMAIN,
+      tenantId: "tenant-1",
+    })
+    mocks.findTenantById.mockResolvedValue({
+      id: "tenant-1",
+      status: "active",
+    })
+
+    const settings = await resolveTenantSettingsByDomain(CUSTOM_DOMAIN)
+
+    expect(settings.appUrl).toBe(`https://${CUSTOM_DOMAIN}`)
+    expect(settings.wsUrl).toBe(`https://${CUSTOM_DOMAIN}/ws/`)
+    expect(settings.storageUrl).toBe(`https://${CUSTOM_DOMAIN}/storage/`)
+    expect(settings.faviconUrl).toBe(
+      `https://${CUSTOM_DOMAIN}/brand/icon_black.svg`,
+    )
+  })
+
+  test("resolves relative tenant asset paths from the custom domain storage URL", async () => {
+    mocks.hasEnterpriseFeatures.mockResolvedValue(true)
+    mocks.findActiveByDomain.mockResolvedValue({
+      domain: CUSTOM_DOMAIN,
+      tenantId: "tenant-1",
+    })
+    mocks.findTenantById.mockResolvedValue({
+      faviconPath: "brand/favicon.ico",
+      id: "tenant-1",
+      logoDarkPath: "brand/logo-dark.svg",
+      logoLightPath: "brand/logo-light.svg",
+      status: "active",
+    })
+
+    const settings = await resolveTenantSettingsByDomain(CUSTOM_DOMAIN)
+
+    expect(settings.logoLightUrl).toBe(
+      `https://${CUSTOM_DOMAIN}/storage/brand/logo-light.svg`,
+    )
+    expect(settings.logoDarkUrl).toBe(
+      `https://${CUSTOM_DOMAIN}/storage/brand/logo-dark.svg`,
+    )
+    expect(settings.faviconUrl).toBe(
+      `https://${CUSTOM_DOMAIN}/storage/brand/favicon.ico`,
+    )
+  })
+
+  test("preserves explicit env storage URL on a custom domain", async () => {
+    mocks.env.NEXT_PUBLIC_STORAGE_URL = ENV_STORAGE_URL
+    mocks.hasEnterpriseFeatures.mockResolvedValue(true)
+    mocks.findActiveByDomain.mockResolvedValue({
+      domain: CUSTOM_DOMAIN,
+      tenantId: "tenant-1",
+    })
+    mocks.findTenantById.mockResolvedValue({
+      id: "tenant-1",
+      logoLightPath: "brand/logo-light.svg",
+      status: "active",
+    })
+
+    const settings = await resolveTenantSettingsByDomain(CUSTOM_DOMAIN)
+
+    expect(settings.storageUrl).toBe(`${ENV_STORAGE_URL}/`)
+    expect(settings.logoLightUrl).toBe(
+      `${ENV_STORAGE_URL}/brand/logo-light.svg`,
+    )
+  })
+
+  test("preserves explicit tenant storage URL on a custom domain", async () => {
+    mocks.hasEnterpriseFeatures.mockResolvedValue(true)
+    mocks.findActiveByDomain.mockResolvedValue({
+      domain: CUSTOM_DOMAIN,
+      tenantId: "tenant-1",
+    })
+    mocks.findTenantById.mockResolvedValue({
+      id: "tenant-1",
+      logoLightPath: "brand/logo-light.svg",
+      status: "active",
+      storageUrl: TENANT_STORAGE_URL,
+    })
+
+    const settings = await resolveTenantSettingsByDomain(CUSTOM_DOMAIN)
+
+    expect(settings.storageUrl).toBe(`${TENANT_STORAGE_URL}/`)
+    expect(settings.logoLightUrl).toBe(
+      `${TENANT_STORAGE_URL}/brand/logo-light.svg`,
+    )
+  })
+
+  test("falls back to the builder URL when no active custom domain matches", async () => {
+    mocks.hasEnterpriseFeatures.mockResolvedValue(true)
+    mocks.findActiveByDomain.mockResolvedValue(null)
+
+    const settings = await resolveTenantSettingsByDomain(CUSTOM_DOMAIN)
+
+    expect(settings.appUrl).toBe(BUILDER_URL)
+  })
+
+  test("falls back to the builder URL on the community edition", async () => {
+    mocks.hasEnterpriseFeatures.mockResolvedValue(false)
+
+    const settings = await resolveTenantSettingsByDomain(CUSTOM_DOMAIN)
+
+    expect(settings.appUrl).toBe(BUILDER_URL)
+    expect(mocks.findActiveByDomain).not.toHaveBeenCalled()
+  })
+})

--- a/packages/business/src/platform/settings.ts
+++ b/packages/business/src/platform/settings.ts
@@ -12,6 +12,8 @@ import { hasEnterpriseFeatures } from "../user/entitlements"
 import { workspaceService } from "../workspace/service"
 import { deriveUrls } from "./derive-urls"
 
+const TRAILING_SLASH_RE = /\/$/
+
 export type EmailTemplate = { subject?: string; body?: string }
 
 export type TenantSettings = {
@@ -64,13 +66,36 @@ const getDefaultSettings = async (): Promise<TenantSettings> => {
   return buildDefaults(helpItems)
 }
 
+/**
+ * Re-anchor the URL-derived settings to a white-label custom domain.
+ * The env defaults key every URL off `NEXT_PUBLIC_BUILDER_URL`; on a custom
+ * domain those must instead point at the tenant's own host so that public
+ * artifacts (inbox links, ws, fallback brand assets) resolve on the branded
+ * domain. White-label domains are always served over HTTPS in production.
+ */
+const applyCustomDomain = (
+  defaults: TenantSettings,
+  domain: string,
+  storageBaseUrl?: string,
+): TenantSettings => {
+  const derived = deriveUrls(`https://${domain}`, storageBaseUrl)
+  return {
+    ...defaults,
+    appUrl: derived.appUrl,
+    wsUrl: derived.wsUrl,
+    storageUrl: derived.storageUrl,
+  }
+}
+
 const applyTenantSetting = (
   defaults: TenantSettings,
   setting: TenantModel,
   helpItems: TenantHelpItemModel[],
   enterpriseFeaturesEnabled: boolean,
 ): TenantSettings => {
-  const storageUrl = setting.storageUrl ?? defaults.storageUrl
+  const storageUrl = setting.storageUrl
+    ? `${setting.storageUrl.replace(TRAILING_SLASH_RE, "")}/`
+    : defaults.storageUrl
   return {
     ...defaults,
     storageUrl,
@@ -188,5 +213,15 @@ export const resolveTenantSettingsByDomain = async (
     getDefaultSettings(),
     tenantHelpItemService.listByTenant(tenant.id),
   ])
-  return applyTenantSetting(defaults, tenant, helpItems, true)
+  const env = integrationContextEnv()
+  return applyTenantSetting(
+    applyCustomDomain(
+      defaults,
+      customDomain.domain,
+      env.NEXT_PUBLIC_STORAGE_URL,
+    ),
+    tenant,
+    helpItems,
+    true,
+  )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1639,9 +1639,6 @@ importers:
       '@t3-oss/env-nextjs':
         specifier: ^0.13.11
         version: 0.13.11(typescript@5.9.3)(zod@4.4.3)
-      '@types/node':
-        specifier: 24.x
-        version: 24.13.1
       date-fns:
         specifier: ^4.1.0
         version: 4.4.0
@@ -1673,6 +1670,9 @@ importers:
       '@chatbotx.io/vitest-config':
         specifier: workspace:*
         version: link:../vitest-config
+      '@types/node':
+        specifier: 24.x
+        version: 24.13.1
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14


### PR DESCRIPTION
## Summary
- Re-anchor `appUrl`/`wsUrl`/`storageUrl` in `resolveTenantSettingsByDomain` to the white-label custom domain instead of `NEXT_PUBLIC_BUILDER_URL`, so public artifacts (inbox links, websocket, fallback brand assets) resolve on the tenant's own branded host.
- Normalize tenant-configured `storageUrl` to always end with a trailing slash.
- Incidental cleanup: biome lint config (`nursery.noLeakedRender` moved to `suspicious`, `recommended` → `preset`, added ignore globs), chat-widget demo.html formatting, and removed an unused `@types/node` dependency from `analytics-nextjs`.

## Changes
- `packages/business/src/platform/settings.ts` — new `applyCustomDomain` helper; wires it into `resolveTenantSettingsByDomain`.
- `packages/business/__tests__/tenant-settings-domain.test.ts` — new coverage for custom-domain anchoring, relative tenant asset paths, explicit env/tenant storage URL overrides, and community-edition/no-match fallbacks.
- `biome.json`, `apps/builder/public/chat-widget/demo.html`, `packages/analytics-nextjs/package.json` — incidental config/formatting/dependency cleanup.

## Test plan
- [x] `pnpm lint` (ran via pre-commit hook)
- [x] `pnpm --filter @chatbotx.io/business check-types` (ran via pre-commit hook)
- [ ] `pnpm --filter @chatbotx.io/business test tenant-settings-domain`
- [ ] Manual verification against a white-label tenant with a custom domain