### PR TITLE
fix(builder): show both super admin and platform admin nav links

### DIFF
--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -52,6 +52,7 @@
     "send": "Send",
     "loginWithMagicLink": "Login with Magic Link",
     "manage": "Manage",
+    "admin": "Admin",
     "more": "More",
     "moreOptions": "More options",
     "moreSettings": "More settings",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -52,6 +52,7 @@
     "send": "Gửi",
     "loginWithMagicLink": "Đăng nhập bằng Magic Link",
     "manage": "Quản lý",
+    "admin": "Quản trị",
     "more": "Thêm",
     "moreOptions": "Thêm tùy chọn",
     "moreSettings": "Thêm cài đặt",

--- a/apps/builder/src/app/page.tsx
+++ b/apps/builder/src/app/page.tsx
@@ -1,4 +1,6 @@
 import {
+  isPlatformAdmin,
+  isSuperAdmin,
   quotaEnforcementService,
   userQuotaService,
 } from "@chatbotx.io/business"
@@ -25,10 +27,11 @@ export default async function MainPage() {
   // Plan + usage limits only apply to the hosted cloud edition. Self-hosted
   // community/enterprise installs use every feature freely — no quota gating.
   const cloud = isCloud()
-  const [usageSummary, atLimit, quota] = await Promise.all([
+  const [usageSummary, atLimit, quota, platformAdmin] = await Promise.all([
     cloud ? quotaEnforcementService.getUsageSummary(user.id) : null,
     cloud ? quotaEnforcementService.getAtLimitMap(user.id) : null,
     cloud ? userQuotaService.getForUser(user.id) : null,
+    isPlatformAdmin(user),
   ])
 
   const ownerWorkspaceIds = allWorkspaceMembers
@@ -48,6 +51,8 @@ export default async function MainPage() {
   return (
     <div className="mx-auto flex min-h-dvh w-full max-w-6xl flex-col gap-8 px-6 py-12 md:flex-row md:py-16">
       <AccountRail
+        isPlatformAdmin={platformAdmin}
+        isSuperAdmin={isSuperAdmin(user)}
         metrics={buildQuotaMetrics(usageSummary)}
         planName={quota?.planName ?? null}
         planStatus={quota?.planStatus ?? null}

--- a/apps/builder/src/app/space/[workspaceId]/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/layout.tsx
@@ -76,12 +76,6 @@ export default async function WorkspaceLayout({
   }))
 
   const trialEndsAt = resolveTrialEndsAt(quota)
-  let managementHref: string | null = null
-  if (isSuperAdmin(user)) {
-    managementHref = "/admin"
-  } else if (platformAdmin) {
-    managementHref = "/manage"
-  }
 
   const quotaSummary: QuotaSummary = {
     planName: quota?.planName ?? null,
@@ -97,7 +91,8 @@ export default async function WorkspaceLayout({
     <SidebarProvider defaultOpen={defaultOpen}>
       <AppSidebar
         allWorkspaces={allWorkspaces}
-        managementHref={managementHref}
+        isPlatformAdmin={platformAdmin}
+        isSuperAdmin={isSuperAdmin(user)}
         quota={quotaSummary}
         workspaceId={workspaceId}
       />

--- a/apps/builder/src/components/app-sidebar.tsx
+++ b/apps/builder/src/components/app-sidebar.tsx
@@ -36,13 +36,15 @@ import { authClient } from "@/lib/auth/auth-client"
 export function AppSidebar({
   workspaceId,
   allWorkspaces,
-  managementHref,
+  isSuperAdmin,
+  isPlatformAdmin,
   quota,
   ...props
 }: ComponentProps<typeof Sidebar> & {
   workspaceId: string
   allWorkspaces: WorkspaceResource[]
-  managementHref?: string | null
+  isSuperAdmin?: boolean
+  isPlatformAdmin?: boolean
   quota: QuotaSummary
 }) {
   const t = useTranslations()
@@ -141,7 +143,8 @@ export function AppSidebar({
           trialEndsAt={quota.trialEndsAt}
         />
         <NavUser
-          managementHref={managementHref}
+          isPlatformAdmin={isPlatformAdmin}
+          isSuperAdmin={isSuperAdmin}
           planName={quota.planName}
           user={data.user}
         />

--- a/apps/builder/src/components/nav-user.tsx
+++ b/apps/builder/src/components/nav-user.tsx
@@ -20,7 +20,7 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@chatbotx.io/ui/components/ui/sidebar"
-import { ChevronsUpDown, Crown, Settings2 } from "lucide-react"
+import { ChevronsUpDown, Crown, Settings2, ShieldCheck } from "lucide-react"
 import Link from "next/link"
 import { useTranslations } from "next-intl"
 import { useState } from "react"
@@ -32,7 +32,8 @@ import { ThemeSwitcher } from "./theme-switcher"
 
 export function NavUser({
   user,
-  managementHref,
+  isSuperAdmin,
+  isPlatformAdmin,
   planName,
 }: {
   user: {
@@ -40,7 +41,8 @@ export function NavUser({
     email: string
     avatar: string
   }
-  managementHref?: string | null
+  isSuperAdmin?: boolean
+  isPlatformAdmin?: boolean
   planName?: string | null
 }) {
   const { isMobile } = useSidebar()
@@ -144,15 +146,25 @@ export function NavUser({
               </DropdownMenuItem>
             </DropdownMenuGroup>
             <DropdownMenuSeparator /> */}
-            {managementHref && (
+            {(isSuperAdmin || isPlatformAdmin) && (
               <>
                 <DropdownMenuGroup>
-                  <DropdownMenuItem asChild>
-                    <Link href={managementHref}>
-                      <Settings2 className="mr-2 h-4 w-4" />
-                      {t("actions.manage")}
-                    </Link>
-                  </DropdownMenuItem>
+                  {isSuperAdmin && (
+                    <DropdownMenuItem asChild>
+                      <Link href="/admin">
+                        <ShieldCheck className="h-4 w-4" />
+                        {t("actions.admin")}
+                      </Link>
+                    </DropdownMenuItem>
+                  )}
+                  {isPlatformAdmin && (
+                    <DropdownMenuItem asChild>
+                      <Link href="/manage">
+                        <Settings2 className="h-4 w-4" />
+                        {t("actions.manage")}
+                      </Link>
+                    </DropdownMenuItem>
+                  )}
                 </DropdownMenuGroup>
                 <DropdownMenuSeparator />
               </>

--- a/apps/builder/src/features/workspaces/components/account-rail.tsx
+++ b/apps/builder/src/features/workspaces/components/account-rail.tsx
@@ -4,7 +4,8 @@ import {
   AvatarImage,
 } from "@chatbotx.io/ui/components/ui/avatar"
 import { cn } from "@chatbotx.io/ui/lib/utils"
-import { CrownIcon } from "lucide-react"
+import { CrownIcon, Settings2Icon, ShieldCheckIcon } from "lucide-react"
+import Link from "next/link"
 import { getTranslations } from "next-intl/server"
 import type { QuotaMetric } from "@/components/usage-bars"
 import { UsageBars } from "@/components/usage-bars"
@@ -25,6 +26,8 @@ type AccountRailProps = {
   planStatus?: string | null
   /** ISO date of the self-managed trial end, or null when not on a trial. */
   trialEndsAt?: string | null
+  isSuperAdmin?: boolean
+  isPlatformAdmin?: boolean
 }
 
 export const AccountRail = async ({
@@ -33,6 +36,8 @@ export const AccountRail = async ({
   metrics = [],
   planStatus = null,
   trialEndsAt = null,
+  isSuperAdmin = false,
+  isPlatformAdmin = false,
 }: AccountRailProps) => {
   const t = await getTranslations()
   const cloud = isCloud()
@@ -43,7 +48,7 @@ export const AccountRail = async ({
   const usageLabels = buildUsageLabels(t)
 
   return (
-    <aside className="flex w-full shrink-0 flex-col gap-6 rounded-xl border bg-card p-6 md:w-72">
+    <aside className="flex w-full shrink-0 flex-col gap-2 rounded-xl border bg-card p-6 md:w-72">
       <div className="flex items-center gap-3">
         <Avatar className="size-11">
           <AvatarImage alt={displayName} src={user.image ?? ""} />
@@ -61,7 +66,7 @@ export const AccountRail = async ({
 
       {cloud && (
         <div className="flex flex-col gap-4 border-t pt-5">
-          <div className="mb-3 flex flex-col items-start justify-between gap-2">
+          <div className="mb-3 flex items-center justify-between gap-2">
             <span className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
               {t("billing.plan.label", {
                 plan: planName ?? t("billing.plan.free"),
@@ -93,8 +98,33 @@ export const AccountRail = async ({
         </div>
       )}
 
-      <div className="mt-auto border-t pt-4">
-        <SignOut />
+      <div className="mt-auto">
+        {(isSuperAdmin || isPlatformAdmin) && (
+          <div className="mt-auto flex flex-0 flex-col gap-1 border-t py-2">
+            {isSuperAdmin && (
+              <Link
+                className="flex items-center gap-2 px-2 py-1.5"
+                href="/admin"
+              >
+                <ShieldCheckIcon aria-hidden className="size-4" />
+                {t("actions.admin")}
+              </Link>
+            )}
+            {isPlatformAdmin && (
+              <Link
+                className="flex items-center gap-2 px-2 py-1.5"
+                href="/manage"
+              >
+                <Settings2Icon aria-hidden className="size-4" />
+                {t("actions.manage")}
+              </Link>
+            )}
+          </div>
+        )}
+
+        <div className="mt-auto flex flex-col gap-2 border-t pt-4">
+          <SignOut />
+        </div>
       </div>
     </aside>
   )


### PR DESCRIPTION
## Summary
- `managementHref` collapsed super admin and platform admin into a single destination, so a user who was both only ever saw `/admin` (or vice versa)
- Replaced it with separate `isSuperAdmin`/`isPlatformAdmin` booleans so both nav entries can render independently
- Mirrored the same logic in the account rail on the workspace-picker page (`apps/builder/src/app/page.tsx`), which had no admin links at all before this change

## Changes
- `apps/builder/src/app/space/[workspaceId]/layout.tsx` — drop `managementHref` derivation, pass both flags to `AppSidebar`
- `apps/builder/src/components/app-sidebar.tsx` — accept `isSuperAdmin`/`isPlatformAdmin`, forward to `NavUser`
- `apps/builder/src/components/nav-user.tsx` — render `/admin` and `/manage` links independently with distinct icons/labels
- `apps/builder/src/app/page.tsx` — compute `isPlatformAdmin`/`isSuperAdmin` and pass to `AccountRail`
- `apps/builder/src/features/workspaces/components/account-rail.tsx` — add matching admin/manage links above sign-out
- `apps/builder/messages/en.json`, `apps/builder/messages/vi.json` — add `actions.admin` translation key

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [ ] manual verification: sign in as a super admin, platform admin, and both — confirm correct link(s) appear in both the sidebar nav-user menu and the workspace-picker account rail