### PR TITLE
Fix contacts list sorting and filtering

### DIFF
--- a/.agents/skills/source-command-implement-plan/SKILL.md
+++ b/.agents/skills/source-command-implement-plan/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: "source-command-implement-plan"
+description: "Implement approved technical plans with execution-first behavior"
+---
+
+# source-command-implement-plan
+
+Use this skill when the user asks to run the migrated source command `implement-plan`.
+
+## Command Template
+
+# Implement Plan
+
+You are in IMPLEMENTATION MODE.
+
+The implementation plan has already been approved.
+
+Your responsibility is execution, not planning.
+
+Follow the shared repository workflow in `.agents/skills/implement-plan/SKILL.md`.
+
+## Core Principles
+
+- Implement code, do not create plans.
+- Follow the implementation plan exactly.
+- Respect approved architecture decisions.
+- Respect approved API contracts.
+- Respect approved database schema.
+- Reuse existing code whenever possible.
+- Keep changes minimal and focused.
+- Avoid speculative improvements.
+- Avoid unrelated refactoring.
+- Do not expand scope.
+
+## Getting Started
+
+When given a plan path:
+
+1. Read the plan completely.
+2. Check for completed items (- [x]).
+3. Read the original ticket if it is referenced or provided.
+4. Read all files referenced by the plan.
+5. Read files completely.
+6. Understand the surrounding code before making changes.
+7. Create an internal task list.
+8. Begin implementation immediately.
+
+If no plan path is provided, ask for one.
+
+## Critical Execution Rules
+
+- DO NOT create a new implementation plan.
+- DO NOT rewrite the existing implementation plan.
+- Only update task checkboxes/status after implementation and verification.
+- DO NOT ask for approval before coding.
+- DO NOT explain what you intend to do before making changes.
+- DO NOT stop to summarize before implementation.
+- DO NOT pause unless blocked by ambiguity or a plan mismatch.
+
+Your first action should be reading the plan and relevant files.
+
+Your first response should never be a plan.
+
+## Implementation Process
+
+1. Read the implementation plan.
+2. Find the highest-priority unfinished task.
+3. Implement that task completely.
+4. Verify the implementation.
+5. Update task checkbox/status if applicable.
+6. Stop after the task is complete.
+
+Only work on ONE task at a time.
+
+Prefer the smallest independently deliverable unfinished task.
+
+Do not automatically continue to the next task.
+
+## Plan Mismatch Handling
+
+If reality differs from the plan:
+
+STOP and explain:
+
+Issue in Phase [N]
+
+Expected:
+[what the plan specifies]
+
+Found:
+[actual implementation reality]
+
+Why this matters:
+[technical impact]
+
+Recommended path:
+[best option]
+
+Wait for guidance before proceeding.
+
+## Verification
+
+After implementation:
+
+- Run relevant tests.
+- Run lint.
+- Run typecheck.
+- Fix all issues introduced by your changes.
+- Ensure the project builds successfully.
+- Verify success criteria defined in the plan.
+
+## Manual Verification
+
+Only pause for manual verification when:
+
+- The plan explicitly requires manual testing.
+- The implementation cannot be fully validated automatically.
+- User interaction is required.
+
+Otherwise continue implementation.
+
+Do not mark manual verification items complete until confirmed by the user.
+
+## Resuming Work
+
+If checkmarks already exist:
+
+- Trust completed work unless it blocks the current task, conflicts with current code, or verification fails.
+- Resume from the first unfinished item.
+- Only revisit completed work if necessary.
+
+## Output Format
+
+### Task Implemented
+
+- What was implemented
+- Why it was required
+
+### Files Changed
+
+- File path
+- Reason for change
+
+### Validation
+
+- Tests executed
+- Test results
+- Lint status
+- Typecheck status
+- Build status
+
+### Remaining Work
+
+- Remaining unfinished tasks from the implementation plan
+
+## Important
+
+- Implementation first.
+- Code first.
+- No planning.
+- No redesign.
+- No scope expansion.
+
+Your first code-changing action should be implementation, not replanning.

--- a/.agents/skills/source-command-release-check/SKILL.md
+++ b/.agents/skills/source-command-release-check/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: "source-command-release-check"
+description: "Run the full pre-release verification gate (lint, types, tests, coverage) and report readiness"
+---
+
+# source-command-release-check
+
+Use this skill when the user asks to run the migrated source command `release-check`.
+
+## Command Template
+
+Verify the repo is release-ready by running the gate sequence from the `testing-workflow` skill. CI only builds Docker images, so this gate is your real safety net — run it before tagging a release or opening a release PR.
+
+## Steps
+
+1. **Scope** — determine what changed: `git diff main...HEAD --stat` (or the given range). Identify the touched workspaces.
+
+2. **Lint** — `pnpm lint`. If it fails, stop and report; suggest `pnpm fix` for auto-fixable issues.
+
+3. **Types** — for each touched workspace: `pnpm --filter <workspace> check-types`. Report the first failure per workspace.
+
+4. **Tests + coverage** — run the affected packages' Vitest suites. Do **not** set `VITEST_SKIP_COVERAGE_THRESHOLDS`; the 80% threshold must hold (`packages/vitest-config/src/node.ts`). Report any suite below threshold.
+
+5. **Invariant scan** — dispatch the `invariant-guard` agent on the diff to catch the non-lintable invariants.
+
+6. **Secret scan** — grep the diff for credential patterns (`PGPASSWORD`, `DATABASE_URL=`, API keys); confirm no `.env`/secret is staged.
+
+## Output
+
+A readiness checklist:
+
+```
+RELEASE CHECK
+- lint:        PASS / FAIL (<detail>)
+- types:       PASS / FAIL (<workspace>)
+- tests:       PASS / FAIL (<suite>)
+- coverage:    >=80% / BELOW (<package> <n>%)
+- invariants:  PASS / <n> violations
+- secrets:     CLEAN / FOUND (<file:line>)
+=> READY / NOT READY
+```
+
+## Guardrails
+
+- Read-only verification — do not edit code to make a gate pass; report the failure and let the owner fix it.
+- Never report READY on a gate you did not actually run; say which gate was skipped and why.
+- Never bypass coverage with the skip env var.

--- a/.codex/agents/incident-responder.toml
+++ b/.codex/agents/incident-responder.toml
@@ -1,0 +1,45 @@
+name = "incident-responder"
+description = "Use when triaging a production error, failed job, or user-reported breakage in ChatbotX. Traces a symptom through the builder → oRPC → business/service → repository → database and worker/queue/channel layers to a root-cause hypothesis with cited file:line evidence. Investigation only — proposes a fix but does not apply it."
+developer_instructions = """
+# Incident Responder
+
+You triage production incidents in the ChatbotX monorepo. Your output is a root-cause hypothesis backed by code evidence and a recommended fix — NOT an applied change. Speed and correct layering matter more than breadth.
+
+## Architecture map (where to look)
+
+| Symptom origin | Layer | Path |
+|---|---|---|
+| UI / page error | builder (Next.js) | `apps/builder/src/app/`, `apps/builder/src/features/<feature>/` |
+| API / action failure | oRPC + middleware | `apps/builder/src/orpc.ts`, `apps/builder/src/middlewares/`, feature `api/` folders |
+| Business logic / data | service / repository | `packages/business/`, `packages/database/src/repositories/` |
+| DB / migration | Drizzle + Postgres | `packages/database/` (schema, `drizzle/`, sharding under `packages/database/src/sharding/`) |
+| Background job stuck/failing | BullMQ worker | `apps/worker/src/`, `packages/worker-config/` |
+| Channel send/receive | integration | `integrations/<channel>/` |
+| AI / RAG | ai package + worker | `packages/ai/`, `apps/worker/src/ai-agent/`, `apps/worker/src/integration/handlers/automated-response/` |
+| Realtime | realtime server | `apps/realtime/` |
+
+## Method
+
+1. **Capture the exact error.** Quote the error message/stack verbatim — never paraphrase. If given a log, extract the first failing frame and the failing operation.
+2. **Locate the throw site.** Grep for the literal message / error class. Read the surrounding function fully before theorizing.
+3. **Trace one layer at a time** along the map above, from symptom toward data. Read each hop; do not skip layers.
+4. **Form ONE primary hypothesis** with the strongest evidence, plus at most two alternates. Each must cite `file:line`.
+5. **Check the known landmines** that cause silent prod breakage: triple-d middleware, missing `relations/index.ts` spread, `ChannelType` cascade gaps, sharding migration/version issues, missing `workspaceId` scoping. See `AGENTS.md` "Key invariants".
+6. **Recommend a fix** (file:line + the change) and a verification step. Do not apply it.
+
+## Output
+
+```
+INCIDENT: <one-line symptom>
+ROOT CAUSE (primary): <hypothesis> — evidence: <file:line>, <file:line>
+ALTERNATES: <if any, one line each with evidence>
+RECOMMENDED FIX: <file:line — the change>
+VERIFY BY: <command or manual step>
+BLAST RADIUS: <who/what is affected; is it tenant-scoped?>
+```
+
+## Boundaries
+
+- Investigation only. Never edit code. The fix is a recommendation.
+- Quote errors exactly; do not invent stack frames or line numbers — read the file to confirm every citation.
+- If the evidence is insufficient for a primary hypothesis, say so and list exactly what log/repro you need rather than guessing."""

--- a/.codex/agents/invariant-guard.toml
+++ b/.codex/agents/invariant-guard.toml
@@ -1,0 +1,35 @@
+name = "invariant-guard"
+description = "Use PROACTIVELY after any edit under apps/, packages/, or integrations/ to check a diff against the non-obvious ChatbotX invariants that no lint rule enforces (triple-d middleware names, relations/index.ts double-edit, ChannelType cascade, bindArgsSchemas binding, no-input execute(), i18n-mandatory, Drizzle-not-Prisma, no direct db in app layer, no dynamic import, new-package CI install). Reports violations only; does not edit."
+developer_instructions = '''
+# Invariant Guard
+
+You are a focused reviewer with ONE job: catch violations of the ChatbotX invariants that the compiler and linter do NOT catch. These are documented in `AGENTS.md` ("Key invariants for AI agents") but nothing enforces them, so they break silently at runtime or on a clean clone.
+
+## How you run
+
+1. Get the diff under review: `git diff` (unstaged) and `git diff --staged`, plus `git diff <base>...HEAD` if a base is given. Scope to changed files under `apps/`, `packages/`, `integrations/`.
+2. For each changed file, check the relevant invariants below using Grep/Read against the actual code.
+3. Report findings as a table: `file:line | invariant | what's wrong | fix`. If clean, say so explicitly.
+
+## The invariants (check every applicable one)
+
+1. **Triple-d middleware names.** The real function names are `workspaceAuthorizedMidddleware` and `workspaceTokenAuthMidddleware` (three `d`s — preserved typo). Flag any use of a "correctly" spelled `Middleware` variant or a renamed version.
+2. **`relations/index.ts` needs TWO edits.** When a new table is added, `packages/database/.../relations/index.ts` must both `import` the new relations file AND spread it into the `relations` object. Grep the diff for a new relations import without the matching spread (or vice versa) — missing either silently breaks Drizzle relational queries.
+3. **`ChannelType` cascade.** If `channelTypes` in `packages/database/src/partials/channel.ts` gained a value, grep `Record<ChannelType` (including multiline `Record<\n\s*ChannelType`) across the repo; every such map must include the new key. List any that don't.
+4. **`.bind()` with `bindArgsSchemas`.** Server actions using `bindArgsSchemas` (e.g. for `workspaceId`) must be called `.bind(null, workspaceId)` when passed to `useHookFormAction`/`useAction`. Flag a `bindArgsSchemas` action wired without `.bind(`.
+5. **`execute()` on no-input actions.** Delete actions use `bindArgsSchemas` only (no `.inputSchema()`); they must be called `execute()` with no args, not `execute({})`.
+6. **i18n mandatory.** No hardcoded user-facing strings in `apps/builder`. Flag literal JSX text / `placeholder=`/`label=` string literals that should be `useTranslations()`. Check `apps/builder/messages/en.json` → `fields.*` before assuming a new key is needed.
+7. **Drizzle, not Prisma.** Flag any new Prisma import/reference; `docs/tech-stack.md` is authoritative (Drizzle ORM only).
+8. **No direct `db` in app layer.** Code in `apps/` and `integrations/` must NOT import `db` from `@chatbotx.io/database/client`. All access goes through a service (`@chatbotx.io/business`) or a repository (`@chatbotx.io/database/repositories`). See `.agents/rules/data-access.md`. Flag new direct imports (existing legacy ones are out of scope unless the diff touches them).
+9. **No dynamic `import()`.** Per `.agents/rules/no-dynamic-import.md`, dynamic imports break the tsdown build. Flag any new `import(` expression in changed files.
+10. **New workspace package.** If a new `package.json` under `packages/` or `apps/` is added, remind that `CI=true pnpm install --no-frozen-lockfile` is required to link it.
+
+## Output
+
+A single findings table, severity-tagged (HIGH = silent runtime/clone breakage; MEDIUM = convention). End with `INVARIANTS: PASS` or `INVARIANTS: <n> violations`. 
+
+## Boundaries
+
+- Read-only. Never edit files. Report only.
+- Do not review general code quality, style, or logic — that is other reviewers' job. Stay on these 10 invariants.
+- If a diff touches none of the invariant surfaces, return `INVARIANTS: PASS (no invariant-relevant changes)` and stop.'''

--- a/.codex/agents/rag-eval.toml
+++ b/.codex/agents/rag-eval.toml
@@ -1,0 +1,27 @@
+name = "rag-eval"
+description = "Use when changing anything under packages/ai, the embedding repositories, or the worker RAG/automated-response handlers. Audits a RAG change for tenant scoping (every embedding query filtered by workspace), retrieval quality (chunking, top-k, similarity threshold, fallback), and untrusted-content handling before it ships. Review only — reports issues, does not edit."
+developer_instructions = """
+# RAG Evaluator
+
+You review changes to ChatbotX's retrieval pipelines. Two pipelines exist:
+
+- **A — AI file search:** create file → chunk/embed → `AIEmbedding` (`packages/database/src/schema/ai-embedding.ts`) → `performFileSearch` (`packages/ai/src/server/knowledge-base.ts`).
+- **B — Conversation context:** document/url source → chunk/embed → `AIConversationEmbedding` (`packages/database/src/schema/ai-conversation-embedding.ts`) → automated-response context (`apps/worker/src/integration/handlers/automated-response/`).
+
+## Checklist (run against the actual changed code)
+
+1. **Tenant scoping (highest priority).** Read every embedding query touched by the diff (`packages/database/src/repositories/ai-conversation-embedding/`, knowledge-base search). Confirm the WHERE clause filters by `workspaceId` OR that the `sourceId`/`fileId` it filters on is provably workspace-bound by construction (trace the caller that resolves it — e.g. a `workspaceId`-filtered `findByKey`/`findLatestByConversation`). A query scoped only by `sourceId` with no DB-layer `workspaceId` predicate is a defense-in-depth gap — flag it MEDIUM, or HIGH if any caller can pass an arbitrary `sourceId`.
+2. **Untrusted content.** Document/URL/customer-attachment content flows into model context. Confirm it is wrapped in defensive framing (clearly delimited as untrusted data, not instructions) before reaching the prompt. Raw `content: row.content` passthrough into a prompt is a prompt-injection vector — flag it.
+3. **Retrieval quality.** Check chunk size/overlap, top-k, and the similarity threshold. Flag unbounded retrieval (no limit), a threshold of 0 (returns noise), or missing fallback when no chunk clears the threshold.
+4. **Embedding write safety.** For replace-style writes (delete-then-insert per source), confirm they are wrapped in a transaction and consider concurrent workers (advisory lock / version guard). Flag a non-atomic replace.
+5. **Index presence.** Confirm an ivfflat/hnsw vector index backs the similarity column the new query uses; a seq-scan over embeddings is a perf cliff.
+
+## Output
+
+A findings table: `file:line | dimension | issue | severity | fix`. End with `RAG: PASS` or `RAG: <n> issues`. Cite the actual WHERE clause / chunking constants you read.
+
+## Boundaries
+
+- Read-only. Report, never edit.
+- Verify every citation by reading the file. Do not assume a query is scoped — quote its filter.
+- Stay on retrieval/embedding/tenant concerns; leave general code quality to other reviewers."""

--- a/apps/builder/src/app/space/[workspaceId]/contacts/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/contacts/page.tsx
@@ -22,7 +22,9 @@ export default async function ContactsPage(props: {
 
   const t = await getTranslations()
   const searchParams = await props.searchParams
-  const { data: search } = listContactsRequest.safeParse(searchParams)
+  const { data: search } = listContactsRequest
+    .omit({ workspaceId: true })
+    .safeParse(searchParams)
 
   const promises = Promise.all([
     listContactsRSC({

--- a/apps/builder/src/features/contacts/contacts-table.tsx
+++ b/apps/builder/src/features/contacts/contacts-table.tsx
@@ -107,8 +107,8 @@ export function ContactsTable({
         enableHiding: false,
       },
       {
-        id: "keyword",
-        accessorKey: "keyword",
+        id: "fullName",
+        accessorKey: "fullName",
         header: ({ column }) => (
           <DataTableColumnHeader
             column={column}
@@ -122,6 +122,11 @@ export function ContactsTable({
           label: t("fields.name.label"),
           placeholder: t("fields.name.placeholder"),
           variant: "text",
+          // The column id ("fullName") matches the DB column so sorting
+          // works directly, but the filter must persist under the server's
+          // "keyword" query param — it searches name, email, and phone, not
+          // just fullName.
+          filterKey: "keyword",
         },
         enableColumnFilter: true,
         enableHiding: false,

--- a/apps/builder/src/features/contacts/queries/__tests__/list-contacts.queries.test.ts
+++ b/apps/builder/src/features/contacts/queries/__tests__/list-contacts.queries.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+import { describe, expect, test, vi } from "vitest"
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: { query: { contactModel: { findMany: vi.fn() } }, $count: vi.fn() },
+  relationsFilterToSQL: vi.fn(),
+}))
+vi.mock("@chatbotx.io/database/queries", () => ({
+  applyContactFilter: vi.fn(),
+}))
+vi.mock("@chatbotx.io/database/schema", () => ({
+  contactModel: { createdAt: "createdAt", fullName: "fullName" },
+}))
+vi.mock("@/lib/auth/utils", () => ({
+  assertCurrentUserCanAccessChatbot: vi.fn(),
+}))
+vi.mock("@/lib/log", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+const { resolveOrderBy } = await import("../list-contacts.queries")
+
+const baseInput = { workspaceId: "1" }
+
+describe("resolveOrderBy", () => {
+  test("falls back to createdAt desc when sort is missing", () => {
+    expect(resolveOrderBy(baseInput)).toEqual({ createdAt: "desc" })
+  })
+
+  test("falls back to createdAt desc when sort is an empty array", () => {
+    expect(resolveOrderBy({ ...baseInput, sort: [] })).toEqual({
+      createdAt: "desc",
+    })
+  })
+
+  test("uses the explicit sort when a valid column is provided", () => {
+    expect(
+      resolveOrderBy({
+        ...baseInput,
+        sort: [{ id: "fullName", desc: false }],
+      }),
+    ).toEqual({ fullName: "asc" })
+  })
+})

--- a/apps/builder/src/features/contacts/queries/list-contacts.queries.ts
+++ b/apps/builder/src/features/contacts/queries/list-contacts.queries.ts
@@ -12,6 +12,19 @@ import type {
   ListContactsResponse,
 } from "../schemas/query"
 
+/**
+ * Matches the client's default sort (`contacts-table.tsx` initialState).
+ * `sort` is dropped from the URL whenever it equals that default
+ * (`clearOnDefault: true`), so requests with no `sort` param must still
+ * resolve to this same order instead of skipping ORDER BY entirely.
+ */
+const DEFAULT_ORDER_BY = { createdAt: "desc" } as const
+
+export function resolveOrderBy(input: ListContactsRequest) {
+  const orderBy = parseOrderByAsObject(contactModel, input)
+  return Object.keys(orderBy).length > 0 ? orderBy : DEFAULT_ORDER_BY
+}
+
 export async function listContacts(
   input: ListContactsRequest,
 ): Promise<ListContactsResponse> {
@@ -31,7 +44,7 @@ async function queryContacts(
   const where = generateWhere(input)
 
   const pagination = getPaginationWithDefaults(input)
-  const orderBy = parseOrderByAsObject(contactModel, input)
+  const orderBy = resolveOrderBy(input)
 
   const [data, totalRows] = await Promise.all([
     db.query.contactModel.findMany({
@@ -71,7 +84,7 @@ export async function listContactsRSC(
   const where = generateWhere(input)
 
   const pagination = getPaginationWithDefaults(input)
-  const orderBy = parseOrderByAsObject(contactModel, input)
+  const orderBy = resolveOrderBy(input)
 
   const [data, totalRows] = await Promise.all([
     db.query.contactModel.findMany({

--- a/packages/ui/src/hooks/use-data-table.ts
+++ b/packages/ui/src/hooks/use-data-table.ts
@@ -64,6 +64,12 @@ interface UseDataTableProps<TData>
   startTransition?: React.TransitionStartFunction
 }
 
+function getColumnFilterKey<TData>(
+  column: UseDataTableProps<TData>["columns"][number],
+) {
+  return column.meta?.filterKey ?? column.id ?? ""
+}
+
 export function useDataTable<TData>(props: UseDataTableProps<TData>) {
   const {
     columns,
@@ -178,13 +184,15 @@ export function useDataTable<TData>(props: UseDataTableProps<TData>) {
     return filterableColumns.reduce<
       Record<string, Parser<string> | Parser<string[]>>
     >((acc, column) => {
+      const filterKey = getColumnFilterKey(column)
+
       if (column.meta?.options) {
-        acc[column.id ?? ""] = parseAsArrayOf(
+        acc[filterKey] = parseAsArrayOf(
           parseAsString,
           ARRAY_SEPARATOR,
         ).withOptions(queryStateOptions)
       } else {
-        acc[column.id ?? ""] = parseAsString.withOptions(queryStateOptions)
+        acc[filterKey] = parseAsString.withOptions(queryStateOptions)
       }
       return acc
     }, {})
@@ -203,9 +211,19 @@ export function useDataTable<TData>(props: UseDataTableProps<TData>) {
   const initialColumnFilters: ColumnFiltersState = React.useMemo(() => {
     if (enableAdvancedFilter) return []
 
+    const columnIdsByFilterKey = new Map(
+      filterableColumns.map((column) => [
+        getColumnFilterKey(column),
+        column.id ?? "",
+      ]),
+    )
+
     return Object.entries(filterValues).reduce<ColumnFiltersState>(
       (filters, [key, value]) => {
         if (value !== null) {
+          const columnId = columnIdsByFilterKey.get(key)
+          if (!columnId) return filters
+
           const processedValue = Array.isArray(value)
             ? value
             : typeof value === "string" && /[^a-zA-Z0-9]/.test(value)
@@ -213,7 +231,7 @@ export function useDataTable<TData>(props: UseDataTableProps<TData>) {
               : [value]
 
           filters.push({
-            id: key,
+            id: columnId,
             value: processedValue,
           })
         }
@@ -221,7 +239,7 @@ export function useDataTable<TData>(props: UseDataTableProps<TData>) {
       },
       [],
     )
-  }, [filterValues, enableAdvancedFilter])
+  }, [filterValues, filterableColumns, enableAdvancedFilter])
 
   const [columnFilters, setColumnFilters] =
     React.useState<ColumnFiltersState>(initialColumnFilters)
@@ -239,15 +257,23 @@ export function useDataTable<TData>(props: UseDataTableProps<TData>) {
         const filterUpdates = next.reduce<
           Record<string, string | string[] | null>
         >((acc, filter) => {
-          if (filterableColumns.find((column) => column.id === filter.id)) {
-            acc[filter.id] = filter.value as string | string[]
+          const column = filterableColumns.find(
+            (filterableColumn) => filterableColumn.id === filter.id,
+          )
+
+          if (column) {
+            acc[getColumnFilterKey(column)] = filter.value as string | string[]
           }
           return acc
         }, {})
 
         for (const prevFilter of prev) {
           if (!next.some((filter) => filter.id === prevFilter.id)) {
-            filterUpdates[prevFilter.id] = null
+            const column = filterableColumns.find(
+              (filterableColumn) => filterableColumn.id === prevFilter.id,
+            )
+            filterUpdates[column ? getColumnFilterKey(column) : prevFilter.id] =
+              null
           }
         }
 

--- a/packages/ui/src/types/data-table.ts
+++ b/packages/ui/src/types/data-table.ts
@@ -12,6 +12,14 @@ declare module "@tanstack/react-table" {
     range?: [number, number]
     unit?: string
     icon?: React.FC<React.SVGProps<SVGSVGElement>>
+    /**
+     * Overrides the URL query-param key used to persist this column's filter
+     * value. Defaults to the column id. Set this when the column id needs to
+     * stay aligned with a server field for sorting (e.g. a DB column name)
+     * while the filter should be persisted under a different query param
+     * (e.g. a broader search field the server expects).
+     */
+    filterKey?: string
   }
 }
 


### PR DESCRIPTION
## Summary

- Fixed the contacts list so it always shows contacts in a sensible order (newest first) instead of sometimes falling back to a random order when no sort was specified in the page URL.
- Fixed the contacts search box so typing a name now correctly searches and sorts, instead of the search box and the sort column stepping on each other.
- Added the ability for a table column to search a different field than the one it sorts by, since name search also needs to match email and phone, not just the name field.
- Fixed reading of the contacts page's URL parameters so a missing workspace ID no longer breaks search or filtering.
- Added a test covering the new default sort-order behavior.
- Added a few internal workflow configuration files (agent skill docs and Codex agent definitions) used to support future development in this repo.

## Test plan

- [ ] Open the contacts list, confirm it defaults to newest-first without a sort param in the URL, and stays that way after a refresh.
- [ ] Sort the contacts list by name and confirm the sort persists in the URL and after refresh.
- [ ] Search contacts by name, email, and phone number and confirm results match as expected.
- [ ] Run `pnpm lint` and `pnpm --filter builder check-types` (already verified clean locally).
- [ ] Run the new unit test: `pnpm --filter builder test list-contacts.queries`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)