### PR TITLE
Fix contacts export to include all matching contacts, not just the current page

### DIFF
--- a/apps/builder/src/features/contacts/contacts-list-action.tsx
+++ b/apps/builder/src/features/contacts/contacts-list-action.tsx
@@ -60,7 +60,7 @@ export function ContactListAction({
   const router = useRouter()
 
   const rows = table.getFilteredSelectedRowModel().rows
-  const exportAll = false
+  const exportAll = table.getIsAllPageRowsSelected()
 
   return (
     <DropdownMenu>


### PR DESCRIPTION
## Summary

- Fixed the contacts export action: when a user selects all contacts on the current page, exporting now includes every contact matching the current search and filters, instead of only the contacts visible on that one page.

## Test plan

- [ ] Apply a search or filter on the contacts list, choose "select all" on the current page, export, and confirm the exported file includes every matching contact, not just the ones shown on that page.
- [ ] Select a few individual contacts (without using "select all") and export, confirming only those contacts are included.
- [ ] Run `pnpm lint` and `pnpm --filter builder check-types` (already verified clean locally via the commit hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)