### PR TITLE
Fix flow message ordering

### DIFF
--- a/apps/worker/__tests__/extract-data.test.ts
+++ b/apps/worker/__tests__/extract-data.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  aiFindBy: vi.fn(),
+  createAIModelInstance: vi.fn(),
+  generateObject: vi.fn(),
+  loggerError: vi.fn(),
+  sendMessageWithRender: vi.fn(),
+  waitForChatJobCompletion: vi.fn(async () => undefined),
+}))
+
+vi.mock("@chatbotx.io/ai", () => ({
+  aiTimeouts: { aiTotal: 30_000 },
+}))
+vi.mock("@chatbotx.io/ai/server", () => ({
+  aiIntegrationService: { findBy: mocks.aiFindBy },
+  createAIModelInstance: mocks.createAIModelInstance,
+}))
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      contactCustomFieldModel: {
+        findFirst: vi.fn(async () => ({ value: "field value" })),
+      },
+    },
+  },
+}))
+vi.mock("@chatbotx.io/variables", () => ({
+  contactVariableService: {
+    getAll: vi.fn(async () => ({})),
+    replaceAll: vi.fn(async ({ text }: { text: string }) => text),
+  },
+}))
+vi.mock("ai", () => ({
+  APICallError: { isInstance: vi.fn(() => false) },
+  generateObject: mocks.generateObject,
+}))
+vi.mock("../src/lib/logger", () => ({
+  logger: { error: mocks.loggerError },
+}))
+vi.mock("../src/integration/utils/contact", () => ({
+  saveResultToCustomField: vi.fn(),
+}))
+vi.mock("../src/integration/utils/message", () => ({
+  sendMessageWithRender: mocks.sendMessageWithRender,
+  waitForChatJobCompletion: mocks.waitForChatJobCompletion,
+}))
+
+const { handleAIExtractData } = await import(
+  "../src/integration/handlers/extract-data/index"
+)
+
+const makeProps = () =>
+  ({
+    conversation: {
+      id: "conv-1",
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+    },
+    step: {
+      id: "step-1",
+      stepType: "aiExtractData",
+      provider: "openai",
+      model: "gpt-test",
+      inputType: "text",
+      inputFieldId: "message body",
+      extractFields: [
+        {
+          key: "email",
+          description: "Email",
+          customFieldId: "field-1",
+        },
+      ],
+    },
+  }) as never
+
+describe("handleAIExtractData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.aiFindBy.mockResolvedValue({ id: "ai-1" })
+    mocks.createAIModelInstance.mockReturnValue("model")
+    mocks.generateObject.mockRejectedValue(new Error("ai failed"))
+    mocks.sendMessageWithRender.mockResolvedValue({
+      waitUntilFinished: vi.fn(),
+    })
+    mocks.waitForChatJobCompletion.mockResolvedValue(undefined)
+  })
+
+  test("waits for the error message delivery on extraction failure", async () => {
+    const fakeJob = { waitUntilFinished: vi.fn() }
+    let releaseWait!: () => void
+    const waitPromise = new Promise<void>((resolve) => {
+      releaseWait = resolve
+    })
+    mocks.sendMessageWithRender.mockResolvedValueOnce(fakeJob)
+    mocks.waitForChatJobCompletion.mockReturnValueOnce(waitPromise)
+
+    let resolved = false
+    const resultPromise = handleAIExtractData(makeProps()).then((result) => {
+      resolved = true
+      return result
+    })
+
+    await vi.waitFor(() =>
+      expect(mocks.sendMessageWithRender).toHaveBeenCalledWith(
+        "conv-1",
+        "Error extracting data",
+      ),
+    )
+    expect(mocks.waitForChatJobCompletion).toHaveBeenCalledWith(fakeJob, {
+      conversationId: "conv-1",
+    })
+    expect(resolved).toBe(false)
+
+    releaseWait()
+    await expect(resultPromise).resolves.toMatchObject({
+      status: "error",
+      result: null,
+    })
+  })
+})

--- a/apps/worker/__tests__/get-user-data.test.ts
+++ b/apps/worker/__tests__/get-user-data.test.ts
@@ -80,6 +80,11 @@ vi.mock("@chatbotx.io/worker-config", () => ({
   chatQueue: { add: chatQueueAdd },
 }))
 
+const waitForChatJobCompletion = vi.fn(async () => undefined)
+vi.mock("../src/integration/utils/message", () => ({
+  waitForChatJobCompletion,
+}))
+
 vi.mock("@chatbotx.io/utils", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@chatbotx.io/utils")>()
   return {
@@ -100,6 +105,8 @@ const { getUserData } = await import(
 
 beforeEach(() => {
   repositoryError.current = null
+  chatQueueAdd.mockResolvedValue(undefined)
+  waitForChatJobCompletion.mockResolvedValue(undefined)
 })
 
 type StepOverride = Partial<GetUserDataStepSchema>
@@ -325,11 +332,70 @@ describe("getUserData — auto-skip", () => {
 })
 
 describe("getUserData — first send (no challenge state)", () => {
+  beforeEach(() => {
+    chatQueueAdd.mockClear()
+    waitForChatJobCompletion.mockClear()
+    vi.mocked(dbUpdateBuilder.where as ReturnType<typeof vi.fn>).mockClear()
+  })
+
   test("sends message and returns wait when no challenge active", async () => {
     const props = makeProps(ReplyFormat.email)
     props.ctx = { variables: { conversation: {} } }
     const result = await getUserData(props)
     expect(result.status).toBe("wait")
     expect(chatQueueAdd).toHaveBeenCalledOnce()
+  })
+
+  test("writes challenge state before waiting for prompt delivery", async () => {
+    const order: string[] = []
+    const fakeJob = { waitUntilFinished: vi.fn() }
+    chatQueueAdd.mockImplementationOnce(() => {
+      order.push("enqueue")
+      return Promise.resolve(fakeJob)
+    })
+    vi.mocked(
+      dbUpdateBuilder.where as ReturnType<typeof vi.fn>,
+    ).mockImplementationOnce(() => {
+      order.push("state")
+      return dbUpdateBuilder
+    })
+    waitForChatJobCompletion.mockImplementationOnce(() => {
+      order.push("wait")
+      return Promise.resolve()
+    })
+
+    const props = makeProps(ReplyFormat.email)
+    props.ctx = { variables: { conversation: {} } }
+    const result = await getUserData(props)
+
+    expect(result.status).toBe("wait")
+    expect(order).toEqual(["enqueue", "state", "wait"])
+    expect(waitForChatJobCompletion).toHaveBeenCalledWith(fakeJob, {
+      conversationId: "conv-1",
+    })
+  })
+
+  test("does not return wait until prompt delivery wait completes", async () => {
+    let releaseWait!: () => void
+    const waitPromise = new Promise<void>((resolve) => {
+      releaseWait = resolve
+    })
+    chatQueueAdd.mockResolvedValueOnce({ waitUntilFinished: vi.fn() })
+    waitForChatJobCompletion.mockReturnValueOnce(waitPromise)
+
+    const props = makeProps(ReplyFormat.email)
+    props.ctx = { variables: { conversation: {} } }
+    let resolved = false
+    const resultPromise = getUserData(props).then((result) => {
+      resolved = true
+      return result
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+
+    releaseWait()
+    await expect(resultPromise).resolves.toMatchObject({ status: "wait" })
   })
 })

--- a/apps/worker/__tests__/send-flow-message.test.ts
+++ b/apps/worker/__tests__/send-flow-message.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  chatQueueAdd: vi.fn(async () => undefined),
+  integrationQueueAdd: vi.fn(async () => undefined),
+  loggerDebug: vi.fn(),
+  loggerError: vi.fn(),
+  loggerWarn: vi.fn(),
+  sendMessageWithRender: vi.fn(),
+  waitForChatJobCompletion: vi.fn(async () => undefined),
+}))
+
+vi.mock("@chatbotx.io/worker-config", () => ({
+  ChatJobAction: {
+    sendChatMessage: "sendChatMessage",
+    sendFlowMessage: "sendFlowMessage",
+  },
+  chatQueue: { add: mocks.chatQueueAdd },
+  IntegrationJobAction: { sendFlow: "sendFlow" },
+  integrationQueue: { add: mocks.integrationQueueAdd },
+}))
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: { query: {}, update: vi.fn(), insert: vi.fn() },
+  eq: vi.fn(),
+  findOrFail: vi.fn(),
+}))
+vi.mock("@chatbotx.io/database/schema", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@chatbotx.io/database/schema")>()
+  return { ...actual }
+})
+vi.mock("@chatbotx.io/event-bus", () => ({
+  emit: vi.fn(async () => undefined),
+}))
+vi.mock("@chatbotx.io/events", () => ({}))
+vi.mock("@chatbotx.io/sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@chatbotx.io/sdk")>()
+  return {
+    ...actual,
+    initVariables: vi.fn(() => ({ conversation: {} })),
+  }
+})
+vi.mock("../src/lib/logger", () => ({
+  logger: {
+    debug: mocks.loggerDebug,
+    error: mocks.loggerError,
+    warn: mocks.loggerWarn,
+  },
+}))
+vi.mock("../src/integration/utils/message", () => ({
+  sendMessageWithRender: mocks.sendMessageWithRender,
+  waitForChatJobCompletion: mocks.waitForChatJobCompletion,
+}))
+
+const { sendFlowMessage } = await import("../src/integration/handlers/step")
+
+const makeProps = () =>
+  ({
+    conversation: { id: "conv-1" },
+    flowVersion: { id: "fv-1", flowId: "flow-1" },
+    step: {
+      id: "step-1",
+      stepType: "sendText",
+      text: "message 1",
+    },
+    trackingContext: { messageId: "msg-1" },
+    metadata: { source: "test" },
+    quickReplies: [{ id: "qr-1", label: "Yes" }],
+    sendFrom: "inbox",
+  }) as never
+
+describe("sendFlowMessage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.chatQueueAdd.mockResolvedValue(undefined)
+    mocks.waitForChatJobCompletion.mockResolvedValue(undefined)
+  })
+
+  test("enqueues a sendFlowMessage chat job with the step payload", async () => {
+    await sendFlowMessage(makeProps())
+
+    expect(mocks.chatQueueAdd).toHaveBeenCalledOnce()
+    expect(mocks.chatQueueAdd).toHaveBeenCalledWith("sendFlowMessage", {
+      type: "sendFlowMessage",
+      data: {
+        conversationId: "conv-1",
+        flowId: "flow-1",
+        flowVersionId: "fv-1",
+        step: {
+          id: "step-1",
+          stepType: "sendText",
+          text: "message 1",
+        },
+        trackingContext: { messageId: "msg-1" },
+        metadata: { source: "test" },
+        quickReplies: [{ id: "qr-1", label: "Yes" }],
+        sendFrom: "inbox",
+      },
+    })
+  })
+
+  test("waits on the enqueued job with conversation and step context", async () => {
+    const fakeJob = { waitUntilFinished: vi.fn() }
+    mocks.chatQueueAdd.mockResolvedValueOnce(fakeJob)
+
+    await sendFlowMessage(makeProps())
+
+    expect(mocks.waitForChatJobCompletion).toHaveBeenCalledOnce()
+    expect(mocks.waitForChatJobCompletion).toHaveBeenCalledWith(fakeJob, {
+      conversationId: "conv-1",
+      stepId: "step-1",
+    })
+  })
+
+  test("does not resolve until delivery wait completes", async () => {
+    let releaseWait!: () => void
+    const waitPromise = new Promise<void>((resolve) => {
+      releaseWait = resolve
+    })
+    mocks.chatQueueAdd.mockResolvedValueOnce({ waitUntilFinished: vi.fn() })
+    mocks.waitForChatJobCompletion.mockReturnValueOnce(waitPromise)
+
+    let resolved = false
+    const resultPromise = sendFlowMessage(makeProps()).then(() => {
+      resolved = true
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+
+    releaseWait()
+    await resultPromise
+    expect(resolved).toBe(true)
+  })
+})

--- a/apps/worker/__tests__/wait-for-chat-job-completion.test.ts
+++ b/apps/worker/__tests__/wait-for-chat-job-completion.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  loggerError: vi.fn(),
+  queueEvents: vi.fn(function QueueEvents() {
+    return { close: vi.fn() }
+  }),
+}))
+
+vi.mock("@chatbotx.io/ai", () => ({
+  isImageUrl: vi.fn(() => false),
+}))
+vi.mock("@chatbotx.io/database/client", () => ({
+  findOrFail: vi.fn(),
+}))
+vi.mock("@chatbotx.io/database/schema", () => ({
+  conversationModel: {},
+}))
+vi.mock("@chatbotx.io/worker-config", () => ({
+  ChatJobAction: { sendChatMessage: "sendChatMessage" },
+  chatQueue: { add: vi.fn() },
+  getRedisConnection: () => ({ duplicate: () => ({}) }),
+  queueNames: { enum: { chat: "chat" } },
+}))
+vi.mock("bullmq", () => ({
+  QueueEvents: mocks.queueEvents,
+}))
+vi.mock("../src/lib/logger", () => ({
+  logger: { error: mocks.loggerError },
+}))
+
+const { waitForChatJobCompletion } = await import(
+  "../src/integration/utils/message"
+)
+
+describe("waitForChatJobCompletion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("awaits job.waitUntilFinished for a job-like value", async () => {
+    const job = { waitUntilFinished: vi.fn(async () => "done") }
+
+    await waitForChatJobCompletion(job as never)
+
+    expect(job.waitUntilFinished).toHaveBeenCalledOnce()
+    expect(mocks.queueEvents).toHaveBeenCalledOnce()
+  })
+
+  test("is a no-op for a non-job value", async () => {
+    await expect(waitForChatJobCompletion(undefined as never)).resolves.toBe(
+      undefined,
+    )
+
+    expect(mocks.queueEvents).not.toHaveBeenCalled()
+  })
+
+  test("swallows and logs a failed send", async () => {
+    const err = new Error("send failed")
+    const job = { waitUntilFinished: vi.fn(async () => Promise.reject(err)) }
+    const context = { conversationId: "conv-1", stepId: "step-1" }
+
+    await expect(waitForChatJobCompletion(job as never, context)).resolves.toBe(
+      undefined,
+    )
+
+    expect(mocks.loggerError).toHaveBeenCalledOnce()
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      { ...context, err },
+      "Flow message chat job failed; continuing flow",
+    )
+  })
+})

--- a/apps/worker/src/integration/handlers/extract-data/index.ts
+++ b/apps/worker/src/integration/handlers/extract-data/index.ts
@@ -11,7 +11,10 @@ import { normalizeError } from "universal-error-normalizer"
 import { z } from "zod"
 import { logger } from "../../../lib/logger"
 import { saveResultToCustomField } from "../../utils/contact"
-import { sendMessageWithRender } from "../../utils/message"
+import {
+  sendMessageWithRender,
+  waitForChatJobCompletion,
+} from "../../utils/message"
 import type { ExecuteStepProps } from "../flow"
 import type { ExecuteStepResult } from "../step"
 
@@ -240,7 +243,11 @@ ${schemaDescription}`
       "Error in handleAIExtractData",
     )
 
-    await sendMessageWithRender(conversation.id, "Error extracting data")
+    const job = await sendMessageWithRender(
+      conversation.id,
+      "Error extracting data",
+    )
+    await waitForChatJobCompletion(job, { conversationId: conversation.id })
 
     return {
       status: "error",

--- a/apps/worker/src/integration/handlers/get-user-data.ts
+++ b/apps/worker/src/integration/handlers/get-user-data.ts
@@ -19,6 +19,7 @@ import { createId } from "@chatbotx.io/utils"
 import { ChatJobAction, chatQueue } from "@chatbotx.io/worker-config"
 import { add, isBefore } from "date-fns"
 import { logger } from "../../lib/logger"
+import { waitForChatJobCompletion } from "../utils/message"
 import type { ExecuteStepProps } from "./flow"
 import type { ExecuteStepResult } from "./step"
 
@@ -252,7 +253,7 @@ async function sendMessage(
     )
   }
 
-  await chatQueue.add(ChatJobAction.sendChatMessage, {
+  const job = await chatQueue.add(ChatJobAction.sendChatMessage, {
     type: ChatJobAction.sendChatMessage,
     data: {
       contactInbox,
@@ -282,6 +283,8 @@ async function sendMessage(
       } as ConversationAttributes,
     })
     .where(eq(conversationModel.id, conversation.id))
+
+  await waitForChatJobCompletion(job, { conversationId: conversation.id })
 }
 
 function checkSkipCondition(

--- a/apps/worker/src/integration/handlers/step.ts
+++ b/apps/worker/src/integration/handlers/step.ts
@@ -26,6 +26,7 @@ import {
   integrationQueue,
 } from "@chatbotx.io/worker-config"
 import { logger } from "../../lib/logger"
+import { waitForChatJobCompletion } from "../utils/message"
 import { syncActiveCampaignContact } from "./active-campaign-handler"
 import { handleAIAnalyzeImage } from "./analyze-image"
 import {
@@ -99,7 +100,7 @@ export async function sendFlowMessage(
     quickReplies,
     sendFrom,
   } = props
-  await chatQueue.add(ChatJobAction.sendFlowMessage, {
+  const job = await chatQueue.add(ChatJobAction.sendFlowMessage, {
     type: ChatJobAction.sendFlowMessage,
     data: {
       conversationId: conversation.id,
@@ -111,6 +112,10 @@ export async function sendFlowMessage(
       quickReplies,
       sendFrom,
     },
+  })
+  await waitForChatJobCompletion(job, {
+    conversationId: conversation.id,
+    stepId: step.id,
   })
 }
 

--- a/apps/worker/src/integration/utils/message.ts
+++ b/apps/worker/src/integration/utils/message.ts
@@ -9,6 +9,7 @@ import {
   queueNames,
 } from "@chatbotx.io/worker-config"
 import { QueueEvents } from "bullmq"
+import { logger } from "../../lib/logger"
 
 let chatQueueEvents: QueueEvents | null = null
 
@@ -68,13 +69,37 @@ async function enqueueChatMessage(
   })
 }
 
-export async function sendMessageWithRender(
+export function sendMessageWithRender(
   conversationId: string,
   text: string,
   trackingContext?: BotResponseTrackingContext,
   options?: SendMessageOptions,
+) {
+  return enqueueChatMessage(conversationId, text, trackingContext, options)
+}
+
+/**
+ * Block until an enqueued chat job processor reaches a terminal state.
+ * This preserves step ordering; channel delivery failures may already be handled
+ * inside the chat worker and may not surface here. Propagated failures are
+ * logged with context and swallowed so the flow still advances in order.
+ */
+export async function waitForChatJobCompletion(
+  job: Awaited<ReturnType<typeof chatQueue.add>>,
+  context?: Record<string, unknown>,
 ): Promise<void> {
-  await enqueueChatMessage(conversationId, text, trackingContext, options)
+  if (!(typeof job === "object" && "waitUntilFinished" in job)) {
+    return
+  }
+
+  try {
+    await job.waitUntilFinished(getChatQueueEvents())
+  } catch (err) {
+    logger.error(
+      { ...context, err },
+      "Flow message chat job failed; continuing flow",
+    )
+  }
 }
 
 export async function sendMessageAndWait(


### PR DESCRIPTION
## Summary
- Wait for flow send chat jobs before advancing to the next step
- Keep get-user-data challenge state written before waiting for prompt delivery
- Add worker tests for ordering, failure tolerance, and touched handlers

## Validation
- pnpm --filter worker exec vitest run __tests__/wait-for-chat-job-completion.test.ts __tests__/send-flow-message.test.ts __tests__/get-user-data.test.ts __tests__/extract-data.test.ts
- pnpm --filter worker exec vitest run __tests__/flow.test.ts __tests__/send-flow-step.test.ts
- pnpm --filter worker check-types
- pnpm lint

Note: full pnpm --filter worker test still has existing unrelated failures in read-receipts, moosend-handler, and sendgrid-handler on current main.