### PR TITLE
feat(builder): enforce workspace permission guards and contact PII scoping

### DIFF
--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -14,6 +14,16 @@ A focused, repo-specific checklist. For OWASP-depth analysis dispatch the global
 - RAG/embedding queries: see the `rag-eval` agent. A `sourceId`-only filter with no `workspaceId` predicate is a defense-in-depth gap.
 - Repositories/services are the boundary — app/integration code must not reach `db` directly (`.agents/rules/data-access.md`).
 
+## 1b. Workspace-member permission enforcement
+
+The per-member permission jsonb (`WorkspaceMemberPermissions`: `superAdmin`, `analytics`, `flows`, `contacts`, `onlyAssignedContacts`, `emailAndPhone`, `broadcast`, `ecommerce`) is enforced server-side across three layers that MUST stay in sync — a client-only check is bypassable:
+
+- **Route guard:** `requireWorkspacePermission(workspaceId, key)` / `requireContactsAccess` / `resolveGuardedWorkspaceId` in `apps/builder/src/lib/auth/require-workspace-permission.ts` — call `notFound()` on failure. Gate every new page/layout in a mapped segment (`PERMISSION_NAV` in `lib/auth/permission-routes.ts`). Note route groups split URL-equivalent routes (`products`/`(e-commerce)/products`), so both layouts need the guard.
+- **Nav filter:** `app-sidebar.tsx` hides items via `hasWorkspacePermission` (and `canAccessContactsSection` for the compound contacts gate).
+- **Data scope:** contacts queries thread `resolveContactPermissionScope` → `onlyAssignedContacts` row filter (via `conversation.assignedUserId`) + `emailAndPhone` PII masking. The CSV export mirrors this in the worker; `canExportEmailAndPhone` is a **required** job field so it can never fail open.
+
+Invariants: `hasWorkspacePermission` treats missing jsonb keys as **denied** (fail-closed) and `superAdmin` bypasses every gate. `isCommunity()` normalizes stored permissions to full `getSuperAdminPermissions()` (no granular control in CE). `invite`/`update`/`delete` member actions require caller `superAdmin`. The workspace-token contacts surface (`listContactsForAPI`) is intentionally **unscoped** — verify new token surfaces don't leak member-scoped data.
+
 ## 2. Prompt injection (untrusted channel content → agent context)
 
 - Customer messages (WhatsApp/Messenger/webchat), uploaded documents, and fetched URLs are **untrusted**. When their content reaches an AI prompt or RAG context, it must be framed as data, not instructions (clear delimiters, "the following is user-provided content").

--- a/apps/builder/__tests__/contacts-permissions.test.ts
+++ b/apps/builder/__tests__/contacts-permissions.test.ts
@@ -47,8 +47,11 @@ const {
   canAccessContactsSection,
   canViewContactEmailAndPhone,
   getAssignedContactsUserId,
+  requireContactPermissionScope,
+  resolveContactPermissionScope,
   stripContactPIIFields,
 } = await import("../src/features/contacts/permissions")
+const { getCurrentUserAndTargetWorkspace } = await import("@/lib/auth/utils")
 const { generateWhere } = await import(
   "../src/features/contacts/queries/list-contacts.queries"
 )
@@ -123,6 +126,57 @@ describe("contact permission helpers", () => {
         false,
       ),
     ).toEqual(["sys:firstName", "tag:t1"])
+  })
+
+  test("requires contacts access for mutation scopes", async () => {
+    vi.mocked(getCurrentUserAndTargetWorkspace).mockResolvedValue({
+      user: { id: "user-1" },
+      targetWorkspaceMember: {
+        permissions: {
+          ...basePermissions,
+          contacts: false,
+          onlyAssignedContacts: false,
+        },
+      },
+    } as never)
+
+    await expect(requireContactPermissionScope("ws-1")).rejects.toThrow(
+      "User is not authorized to access contacts",
+    )
+  })
+
+  test("returns no contact permission scope without contact access", async () => {
+    vi.mocked(getCurrentUserAndTargetWorkspace).mockResolvedValue({
+      user: { id: "user-1" },
+      targetWorkspaceMember: {
+        permissions: {
+          ...basePermissions,
+          contacts: false,
+          onlyAssignedContacts: false,
+        },
+      },
+    } as never)
+
+    await expect(resolveContactPermissionScope("ws-1")).resolves.toBeNull()
+  })
+
+  test("returns assigned-only mutation scope for assigned contacts members", async () => {
+    vi.mocked(getCurrentUserAndTargetWorkspace).mockResolvedValue({
+      user: { id: "user-1" },
+      targetWorkspaceMember: {
+        permissions: {
+          ...basePermissions,
+          contacts: false,
+          onlyAssignedContacts: true,
+          emailAndPhone: true,
+        },
+      },
+    } as never)
+
+    await expect(requireContactPermissionScope("ws-1")).resolves.toEqual({
+      canViewEmailAndPhone: true,
+      restrictToAssignedUserId: "user-1",
+    })
   })
 })
 

--- a/apps/builder/__tests__/contacts-permissions.test.ts
+++ b/apps/builder/__tests__/contacts-permissions.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const applyContactFilterSpy = vi.fn<
+  (criteria: unknown) => Record<string, unknown>
+>(() => ({}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  countWithRelationsFilter: vi.fn(),
+  db: {
+    query: {
+      contactModel: {
+        findMany: vi.fn(),
+        findFirst: vi.fn(),
+      },
+      inboxModel: { findMany: vi.fn() },
+    },
+    $count: vi.fn(),
+  },
+}))
+
+vi.mock("@chatbotx.io/database/queries", () => ({
+  applyContactFilter: (criteria: unknown) => applyContactFilterSpy(criteria),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  contactModel: {},
+}))
+
+vi.mock("@chatbotx.io/database/utils", () => ({
+  getPaginationWithDefaults: () => ({ limit: 20, offset: 0 }),
+  parseOrderByAsObject: () => ({}),
+}))
+
+vi.mock("@/lib/auth/utils", () => ({
+  getCurrentUserAndTargetWorkspace: vi.fn(),
+}))
+
+vi.mock("@/lib/log", () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}))
+
+const {
+  canAccessContactsSection,
+  canViewContactEmailAndPhone,
+  getAssignedContactsUserId,
+  stripContactPIIFields,
+} = await import("../src/features/contacts/permissions")
+const { generateWhere } = await import(
+  "../src/features/contacts/queries/list-contacts.queries"
+)
+
+const basePermissions = {
+  superAdmin: false,
+  analytics: false,
+  flows: false,
+  contacts: true,
+  onlyAssignedContacts: false,
+  emailAndPhone: false,
+  broadcast: false,
+  ecommerce: false,
+}
+
+describe("contact permission helpers", () => {
+  test("allows contacts section access with full or assigned-only contact permission", () => {
+    expect(
+      canAccessContactsSection({
+        ...basePermissions,
+        contacts: true,
+        onlyAssignedContacts: false,
+      }),
+    ).toBe(true)
+    expect(
+      canAccessContactsSection({
+        ...basePermissions,
+        contacts: false,
+        onlyAssignedContacts: true,
+      }),
+    ).toBe(true)
+    expect(
+      canAccessContactsSection({
+        ...basePermissions,
+        contacts: false,
+        onlyAssignedContacts: false,
+      }),
+    ).toBe(false)
+  })
+
+  test("treats missing emailAndPhone as denied unless superAdmin is true", () => {
+    expect(canViewContactEmailAndPhone({})).toBe(false)
+    expect(canViewContactEmailAndPhone({ superAdmin: true })).toBe(true)
+  })
+
+  test("scopes assigned-only members to their own user id", () => {
+    expect(
+      getAssignedContactsUserId({
+        permissions: { ...basePermissions, onlyAssignedContacts: true },
+        userId: "user-1",
+      }),
+    ).toBe("user-1")
+  })
+
+  test("does not scope super admins even when onlyAssignedContacts is true", () => {
+    expect(
+      getAssignedContactsUserId({
+        permissions: {
+          ...basePermissions,
+          onlyAssignedContacts: true,
+          superAdmin: true,
+        },
+        userId: "user-1",
+      }),
+    ).toBeUndefined()
+  })
+
+  test("strips email and phone fields when PII is denied", () => {
+    expect(
+      stripContactPIIFields(
+        ["sys:firstName", "sys:email", "sys:phoneNumber", "tag:t1"],
+        false,
+      ),
+    ).toEqual(["sys:firstName", "tag:t1"])
+  })
+})
+
+describe("generateWhere contact permission scope", () => {
+  beforeEach(() => {
+    applyContactFilterSpy.mockReset()
+    applyContactFilterSpy.mockReturnValue({})
+  })
+
+  test("removes email and phoneNumber keyword clauses when PII is denied", () => {
+    const where = generateWhere(
+      { workspaceId: "ws-1", keyword: "Example" },
+      { canViewEmailAndPhone: false },
+    )
+
+    expect(where.OR).toEqual([
+      { firstName: { ilike: "%example%" } },
+      { lastName: { ilike: "%example%" } },
+    ])
+  })
+
+  test("keeps email and phoneNumber keyword clauses when PII is allowed", () => {
+    const where = generateWhere(
+      { workspaceId: "ws-1", keyword: "Example" },
+      { canViewEmailAndPhone: true },
+    )
+
+    expect(where.OR).toEqual([
+      { firstName: { ilike: "%example%" } },
+      { lastName: { ilike: "%example%" } },
+      { email: { ilike: "%example%" } },
+      { phoneNumber: { ilike: "%example%" } },
+    ])
+  })
+
+  test("adds assigned-user relation scope", () => {
+    const where = generateWhere(
+      { workspaceId: "ws-1" },
+      { canViewEmailAndPhone: true, restrictToAssignedUserId: "user-1" },
+    )
+
+    expect(where.conversation).toEqual({ assignedUserId: "user-1" })
+  })
+
+  test("merges assigned-user relation scope with existing conversation filters", () => {
+    applyContactFilterSpy.mockReturnValue({
+      conversation: { botEnabled: false },
+    })
+
+    const where = generateWhere(
+      {
+        workspaceId: "ws-1",
+        contactFilter: { operator: "and", conditions: [] },
+      },
+      { canViewEmailAndPhone: true, restrictToAssignedUserId: "user-1" },
+    )
+
+    expect(where.conversation).toEqual({
+      botEnabled: false,
+      assignedUserId: "user-1",
+    })
+  })
+})

--- a/apps/builder/__tests__/contacts-route-guards.test.ts
+++ b/apps/builder/__tests__/contacts-route-guards.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockGetCurrentUserAndTargetWorkspace, mockNotFound } = vi.hoisted(
+  () => ({
+    mockGetCurrentUserAndTargetWorkspace: vi.fn(),
+    mockNotFound: vi.fn(() => {
+      throw new Error("not found")
+    }),
+  }),
+)
+
+vi.mock("@/lib/auth/utils", () => ({
+  getCurrentUserAndTargetWorkspace: mockGetCurrentUserAndTargetWorkspace,
+}))
+
+vi.mock("next/navigation", () => ({
+  notFound: mockNotFound,
+}))
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: vi.fn(async () => (key: string) => key),
+}))
+
+vi.mock("@/features/contacts/queries/list-contacts.queries", () => ({
+  listContactsRSC: vi.fn(async () => ({ data: [], pageCount: 0 })),
+}))
+
+vi.mock("@/features/contacts/schemas/query", () => ({
+  listContactsRequest: {
+    omit: () => ({
+      safeParse: () => ({ data: {} }),
+    }),
+  },
+}))
+
+vi.mock("@/features/import/queries/list-imports.queries", () => ({
+  listImports: vi.fn(async () => ({ data: [], pageCount: 0 })),
+}))
+
+vi.mock("@/features/import/schemas/query", () => ({
+  listImportsSearchParamsCache: {
+    parse: () => ({}),
+  },
+}))
+
+vi.mock("@/features/contacts/contacts-table", () => ({
+  ContactsTable: () => null,
+}))
+
+vi.mock("@/features/contacts/import-contact-form", () => ({
+  ImportContactsForm: () => null,
+}))
+
+vi.mock("@/features/import/components/import-form", () => ({
+  ImportForm: ({ children }: { children: unknown }) => children,
+}))
+
+vi.mock("@/features/import/components/import-history-table", () => ({
+  ImportHistoryTable: () => null,
+}))
+
+vi.mock("@/features/custom-fields/provider/custom-field-store-context", () => ({
+  CustomFieldStoreProvider: ({ children }: { children: unknown }) => children,
+}))
+
+vi.mock("@/features/inboxes/provider/inbox-store-context", () => ({
+  InboxStoreProvider: ({ children }: { children: unknown }) => children,
+}))
+
+vi.mock("@/features/tags/provider/tag-store-context", () => ({
+  TagStoreProvider: ({ children }: { children: unknown }) => children,
+}))
+
+vi.mock("@/features/users/provider/user-store-context", () => ({
+  UserStoreProvider: ({ children }: { children: unknown }) => children,
+}))
+
+const { default: ContactsPage } = await import(
+  "../src/app/space/[workspaceId]/contacts/page"
+)
+const { default: ImportContactsPage } = await import(
+  "../src/app/(no-sidebar)/space/[workspaceId]/contacts/import/page"
+)
+const { default: ImportContactsHistoriesPage } = await import(
+  "../src/app/(no-sidebar)/space/[workspaceId]/contacts/import/histories/page"
+)
+
+const basePermissions = {
+  superAdmin: false,
+  analytics: false,
+  flows: false,
+  contacts: false,
+  onlyAssignedContacts: false,
+  emailAndPhone: false,
+  broadcast: false,
+  ecommerce: false,
+}
+
+describe("contacts route guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("allows assigned-only members to reach contacts and contacts import pages", async () => {
+    mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
+      targetWorkspaceMember: {
+        permissions: {
+          ...basePermissions,
+          onlyAssignedContacts: true,
+        },
+      },
+    })
+
+    await expect(
+      ContactsPage({
+        params: Promise.resolve({ workspaceId: "ws-1" }),
+        searchParams: Promise.resolve({}),
+      }),
+    ).resolves.toBeDefined()
+    await expect(
+      ImportContactsPage({
+        params: Promise.resolve({ workspaceId: "ws-1" }),
+      }),
+    ).resolves.toBeDefined()
+    await expect(
+      ImportContactsHistoriesPage({
+        params: Promise.resolve({ workspaceId: "ws-1" }),
+        searchParams: Promise.resolve({}),
+      }),
+    ).resolves.toBeDefined()
+  })
+
+  test("rejects members without full or assigned-only contact access on contacts routes", async () => {
+    mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
+      targetWorkspaceMember: {
+        permissions: basePermissions,
+      },
+    })
+
+    await expect(
+      ContactsPage({
+        params: Promise.resolve({ workspaceId: "ws-1" }),
+        searchParams: Promise.resolve({}),
+      }),
+    ).rejects.toThrow("not found")
+    await expect(
+      ImportContactsPage({
+        params: Promise.resolve({ workspaceId: "ws-1" }),
+      }),
+    ).rejects.toThrow("not found")
+    await expect(
+      ImportContactsHistoriesPage({
+        params: Promise.resolve({ workspaceId: "ws-1" }),
+        searchParams: Promise.resolve({}),
+      }),
+    ).rejects.toThrow("not found")
+  })
+})

--- a/apps/builder/__tests__/remove-contact-sequence.action.test.ts
+++ b/apps/builder/__tests__/remove-contact-sequence.action.test.ts
@@ -2,8 +2,14 @@
 
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
-const { removeContactSequencesForContactsSpy } = vi.hoisted(() => ({
+const {
+  findManyByIdsSpy,
+  removeContactSequencesForContactsSpy,
+  requireContactPermissionScopeSpy,
+} = vi.hoisted(() => ({
+  findManyByIdsSpy: vi.fn(),
   removeContactSequencesForContactsSpy: vi.fn(),
+  requireContactPermissionScopeSpy: vi.fn(),
 }))
 
 vi.mock("@/lib/safe-action", () => {
@@ -14,10 +20,20 @@ vi.mock("@/lib/safe-action", () => {
   return { workspaceActionClient: chain }
 })
 
+vi.mock("@chatbotx.io/business", () => ({
+  contactService: {
+    findManyByIds: findManyByIdsSpy,
+  },
+}))
+
 vi.mock("@chatbotx.io/business/contact-sequence", () => ({
   contactSequenceService: {
     removeContactSequencesForContacts: removeContactSequencesForContactsSpy,
   },
+}))
+
+vi.mock("../src/features/contacts/permissions", () => ({
+  requireContactPermissionScope: requireContactPermissionScopeSpy,
 }))
 
 const { removeContactSequenceAction } = await import(
@@ -35,7 +51,11 @@ const WORKSPACE_ID = "ws-1"
 describe("removeContactSequenceAction", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    findManyByIdsSpy.mockResolvedValue([{ id: "contact-1" }])
     removeContactSequencesForContactsSpy.mockResolvedValue(undefined)
+    requireContactPermissionScopeSpy.mockResolvedValue({
+      restrictToAssignedUserId: "user-1",
+    })
   })
 
   test("delegates sequence removal to the business service", async () => {
@@ -44,6 +64,11 @@ describe("removeContactSequenceAction", () => {
       parsedInput: { ids: ["contact-1"], sequences: ["sequence-1"] },
     })
 
+    expect(findManyByIdsSpy).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      ids: ["contact-1"],
+      accessScope: { restrictToAssignedUserId: "user-1" },
+    })
     expect(removeContactSequencesForContactsSpy).toHaveBeenCalledWith({
       workspaceId: WORKSPACE_ID,
       contactIds: ["contact-1"],
@@ -54,12 +79,16 @@ describe("removeContactSequenceAction", () => {
 
   test("chunks contact ids before delegating to the business service", async () => {
     const ids = Array.from({ length: 1001 }, (_, index) => `contact-${index}`)
+    findManyByIdsSpy
+      .mockResolvedValueOnce(ids.slice(0, 1000).map((id) => ({ id })))
+      .mockResolvedValueOnce(ids.slice(1000).map((id) => ({ id })))
 
     await callAction({
       bindArgsParsedInputs: [WORKSPACE_ID],
       parsedInput: { ids, sequences: ["sequence-1"] },
     })
 
+    expect(findManyByIdsSpy).toHaveBeenCalledTimes(2)
     expect(removeContactSequencesForContactsSpy).toHaveBeenCalledTimes(2)
     expect(removeContactSequencesForContactsSpy).toHaveBeenNthCalledWith(1, {
       workspaceId: WORKSPACE_ID,
@@ -73,5 +102,16 @@ describe("removeContactSequenceAction", () => {
       sequenceIds: ["sequence-1"],
       reason: "enrollment_removed",
     })
+  })
+
+  test("does not remove enrollments when scoped lookup returns no contacts", async () => {
+    findManyByIdsSpy.mockResolvedValue([])
+
+    await callAction({
+      bindArgsParsedInputs: [WORKSPACE_ID],
+      parsedInput: { ids: ["contact-2"], sequences: ["sequence-1"] },
+    })
+
+    expect(removeContactSequencesForContactsSpy).not.toHaveBeenCalled()
   })
 })

--- a/apps/builder/__tests__/require-workspace-permission.test.ts
+++ b/apps/builder/__tests__/require-workspace-permission.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockGetCurrentUserAndTargetWorkspace, mockNotFound } = vi.hoisted(
+  () => ({
+    mockGetCurrentUserAndTargetWorkspace: vi.fn(),
+    mockNotFound: vi.fn(() => {
+      throw new Error("not found")
+    }),
+  }),
+)
+
+vi.mock("@/lib/auth/utils", () => ({
+  getCurrentUserAndTargetWorkspace: mockGetCurrentUserAndTargetWorkspace,
+}))
+
+vi.mock("next/navigation", () => ({
+  notFound: mockNotFound,
+}))
+
+const { requireContactsAccess, resolveGuardedWorkspaceId } = await import(
+  "../src/lib/auth/require-workspace-permission"
+)
+
+const basePermissions = {
+  superAdmin: false,
+  analytics: false,
+  flows: false,
+  contacts: false,
+  onlyAssignedContacts: false,
+  emailAndPhone: false,
+  broadcast: false,
+  ecommerce: false,
+}
+
+describe("requireContactsAccess", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("allows members with assigned-only contact access", async () => {
+    mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
+      targetWorkspaceMember: {
+        permissions: {
+          ...basePermissions,
+          onlyAssignedContacts: true,
+        },
+      },
+    })
+
+    await expect(requireContactsAccess("ws-1")).resolves.toBeUndefined()
+
+    expect(mockNotFound).not.toHaveBeenCalled()
+  })
+
+  test("rejects members without full or assigned-only contact access", async () => {
+    mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
+      targetWorkspaceMember: {
+        permissions: basePermissions,
+      },
+    })
+
+    await expect(requireContactsAccess("ws-1")).rejects.toThrow("not found")
+
+    expect(mockNotFound).toHaveBeenCalled()
+  })
+})
+
+describe("resolveGuardedWorkspaceId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("returns the workspace id when the requested permission is granted", async () => {
+    mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
+      targetWorkspaceMember: {
+        permissions: {
+          ...basePermissions,
+          broadcast: true,
+        },
+      },
+    })
+
+    await expect(
+      resolveGuardedWorkspaceId(
+        Promise.resolve({ workspaceId: "ws-1" }),
+        "broadcast",
+      ),
+    ).resolves.toBe("ws-1")
+  })
+
+  test("rejects when the requested permission is denied", async () => {
+    mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
+      targetWorkspaceMember: {
+        permissions: basePermissions,
+      },
+    })
+
+    await expect(
+      resolveGuardedWorkspaceId(
+        Promise.resolve({ workspaceId: "ws-1" }),
+        "broadcast",
+      ),
+    ).rejects.toThrow("not found")
+  })
+})

--- a/apps/builder/__tests__/update-contact-sequence.action.test.ts
+++ b/apps/builder/__tests__/update-contact-sequence.action.test.ts
@@ -2,8 +2,13 @@
 
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
-const { findByIdOrFailSpy, updateContactSequencesSpy } = vi.hoisted(() => ({
+const {
+  findByIdOrFailSpy,
+  requireContactPermissionScopeSpy,
+  updateContactSequencesSpy,
+} = vi.hoisted(() => ({
   findByIdOrFailSpy: vi.fn(),
+  requireContactPermissionScopeSpy: vi.fn(),
   updateContactSequencesSpy: vi.fn(),
 }))
 
@@ -27,6 +32,10 @@ vi.mock("@chatbotx.io/business/contact-sequence", () => ({
   },
 }))
 
+vi.mock("../src/features/contacts/permissions", () => ({
+  requireContactPermissionScope: requireContactPermissionScopeSpy,
+}))
+
 vi.mock("../src/features/contact-sequences/schema", () => ({
   updateContactSequenceRequest: {},
 }))
@@ -47,6 +56,9 @@ describe("updateContactSequenceAction", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     findByIdOrFailSpy.mockResolvedValue({ id: "contact-1" })
+    requireContactPermissionScopeSpy.mockResolvedValue({
+      restrictToAssignedUserId: "user-1",
+    })
     updateContactSequencesSpy.mockResolvedValue([
       { id: "enrollment-1", sequence: { id: "sequence-1" } },
     ])
@@ -61,6 +73,7 @@ describe("updateContactSequenceAction", () => {
     expect(findByIdOrFailSpy).toHaveBeenCalledWith({
       workspaceId: WORKSPACE_ID,
       id: "contact-1",
+      accessScope: { restrictToAssignedUserId: "user-1" },
     })
     expect(updateContactSequencesSpy).toHaveBeenCalledWith({
       workspaceId: WORKSPACE_ID,

--- a/apps/builder/__tests__/workspace-members-actions.test.ts
+++ b/apps/builder/__tests__/workspace-members-actions.test.ts
@@ -1,0 +1,377 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+  mockDbDelete,
+  mockDbInsert,
+  mockDbUpdate,
+  mockFindOrFail,
+  mockGetCurrentUserAndTargetWorkspace,
+  mockInsertReturning,
+  mockInsertValues,
+  mockInvalidateCacheByTags,
+  mockIsCommunity,
+  mockQuotaHasReachedLimit,
+  mockUpdateSet,
+  mockWorkspaceFindById,
+} = vi.hoisted(() => {
+  const mockInsertReturning = vi.fn()
+  const mockInsertValues = vi.fn(() => ({ returning: mockInsertReturning }))
+  const mockDbInsert = vi.fn(() => ({ values: mockInsertValues }))
+  const mockUpdateWhere = vi.fn()
+  const mockUpdateSet = vi.fn(() => ({ where: mockUpdateWhere }))
+  const mockDbUpdate = vi.fn(() => ({ set: mockUpdateSet }))
+  const mockDeleteWhere = vi.fn()
+  const mockDbDelete = vi.fn(() => ({ where: mockDeleteWhere }))
+
+  return {
+    mockDbDelete,
+    mockDbInsert,
+    mockDbUpdate,
+    mockDeleteWhere,
+    mockFindOrFail: vi.fn(),
+    mockGetCurrentUserAndTargetWorkspace: vi.fn(),
+    mockInsertReturning,
+    mockInsertValues,
+    mockInvalidateCacheByTags: vi.fn(),
+    mockIsCommunity: vi.fn(),
+    mockQuotaHasReachedLimit: vi.fn(),
+    mockUpdateSet,
+    mockUpdateWhere,
+    mockWorkspaceFindById: vi.fn(),
+  }
+})
+
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, unknown> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.inputSchema = () => chain
+  chain.action = (fn: unknown) => fn
+  return { workspaceActionClient: chain }
+})
+
+vi.mock("@/env", () => ({
+  isCommunity: mockIsCommunity,
+}))
+
+vi.mock("@/lib/auth/utils", () => ({
+  getCurrentUserAndTargetWorkspace: mockGetCurrentUserAndTargetWorkspace,
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  quotaEnforcementService: {
+    hasReachedLimit: mockQuotaHasReachedLimit,
+  },
+  workspaceService: {
+    findById: mockWorkspaceFindById,
+  },
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    delete: mockDbDelete,
+    insert: mockDbInsert,
+    update: mockDbUpdate,
+  },
+  eq: (col: unknown, val: unknown) => ({ eq: [col, val] }),
+  findOrFail: mockFindOrFail,
+}))
+
+vi.mock("@chatbotx.io/redis", () => ({
+  invalidateCacheByTags: mockInvalidateCacheByTags,
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  invitationModel: { _: "invitationModel" },
+  workspaceMemberModel: {
+    id: "workspaceMember.id",
+  },
+}))
+
+vi.mock("@chatbotx.io/utils", () => ({
+  createId: () => "invitation-id",
+  SymbolicSnowflakeIDs: {
+    generate: () => "invite-code",
+  },
+  zodBigintAsString: () => ({
+    describe: () => ({ _: "zodBigintAsString" }),
+  }),
+}))
+
+const { inviteWorkspaceMemberAction } = await import(
+  "../src/features/workspace-members/actions/invite-workspace-member.action"
+)
+const { updateWorkspaceMemberAction } = await import(
+  "../src/features/workspace-members/actions/update-workspace-member.action"
+)
+const { deleteWorkspaceMemberAction } = await import(
+  "../src/features/workspace-members/actions/delete-workspace-member.action"
+)
+const { getSuperAdminPermissions, normalizeContactsPermissions } = await import(
+  "../src/features/workspace-members/helpers"
+)
+
+const WORKSPACE_ID = "ws-1"
+const MEMBER_ID = "member-1"
+const MEMBER_USER_ID = "member-user-1"
+
+const granularPermissions = {
+  superAdmin: false,
+  analytics: true,
+  flows: false,
+  contacts: true,
+  onlyAssignedContacts: true,
+  emailAndPhone: false,
+  broadcast: false,
+  ecommerce: false,
+}
+
+const assignedOnlyPermissions = {
+  ...granularPermissions,
+  contacts: false,
+  onlyAssignedContacts: true,
+}
+
+const fullPermissions = getSuperAdminPermissions()
+const normalizedGranularPermissions =
+  normalizeContactsPermissions(granularPermissions)
+
+const updateInput = {
+  permissions: granularPermissions,
+  notificationTypes: {
+    notifyAdmin: true,
+    newMessageToHuman: false,
+    newOrder: false,
+  },
+  notificationChannels: {
+    messenger: false,
+    email: true,
+    telegram: false,
+    browser: true,
+  },
+}
+
+function actionCtx(permissions = granularPermissions) {
+  return {
+    ctx: { user: { id: "user-1" } },
+    bindArgsParsedInputs: [WORKSPACE_ID],
+    parsedInput: { permissions },
+  }
+}
+
+function updateActionCtx(permissions = granularPermissions) {
+  return {
+    bindArgsParsedInputs: [WORKSPACE_ID, MEMBER_ID],
+    parsedInput: { ...updateInput, permissions },
+  }
+}
+
+function getInsertedValues() {
+  return (
+    mockInsertValues.mock.calls as unknown as [[{ permissions: unknown }]]
+  )[0][0]
+}
+
+function mockCurrentMember(permissions = fullPermissions) {
+  mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
+    user: { id: "user-1" },
+    targetWorkspaceMember: { permissions },
+  })
+}
+
+describe("workspace member permission helpers", () => {
+  test("normalizes mutually exclusive contact access without mutating input", () => {
+    expect(normalizeContactsPermissions(granularPermissions)).toEqual({
+      ...granularPermissions,
+      onlyAssignedContacts: false,
+    })
+    expect(granularPermissions.onlyAssignedContacts).toBe(true)
+    expect(normalizeContactsPermissions(assignedOnlyPermissions)).toEqual(
+      assignedOnlyPermissions,
+    )
+  })
+})
+
+describe("inviteWorkspaceMemberAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockWorkspaceFindById.mockResolvedValue({
+      id: WORKSPACE_ID,
+      ownerId: "owner-1",
+    })
+    mockQuotaHasReachedLimit.mockResolvedValue(false)
+    mockInsertReturning.mockResolvedValue([
+      { id: "invitation-id", code: "invite-code" },
+    ])
+    mockIsCommunity.mockReturnValue(false)
+  })
+
+  test("rejects non-super-admin members before creating invitations", async () => {
+    mockCurrentMember(granularPermissions)
+
+    await expect(
+      (inviteWorkspaceMemberAction as (props: unknown) => Promise<unknown>)(
+        actionCtx(),
+      ),
+    ).rejects.toThrow(
+      "You are not authorized to invite a workspace member. You need to be a super admin to do this.",
+    )
+
+    expect(mockQuotaHasReachedLimit).not.toHaveBeenCalled()
+    expect(mockDbInsert).not.toHaveBeenCalled()
+  })
+
+  test("forces full super-admin permissions for community invitations", async () => {
+    mockCurrentMember()
+    mockIsCommunity.mockReturnValue(true)
+
+    await (inviteWorkspaceMemberAction as (props: unknown) => Promise<unknown>)(
+      actionCtx(),
+    )
+
+    const insertedValues = getInsertedValues()
+    expect(insertedValues.permissions).toEqual(fullPermissions)
+  })
+
+  test("normalizes full contacts permissions outside community edition", async () => {
+    mockCurrentMember()
+
+    await (inviteWorkspaceMemberAction as (props: unknown) => Promise<unknown>)(
+      actionCtx(),
+    )
+
+    const insertedValues = getInsertedValues()
+    expect(insertedValues.permissions).toEqual(normalizedGranularPermissions)
+  })
+
+  test("preserves assigned-only contacts permissions outside community edition", async () => {
+    mockCurrentMember()
+
+    await (inviteWorkspaceMemberAction as (props: unknown) => Promise<unknown>)(
+      actionCtx(assignedOnlyPermissions),
+    )
+
+    const insertedValues = getInsertedValues()
+    expect(insertedValues.permissions).toEqual(assignedOnlyPermissions)
+  })
+})
+
+describe("updateWorkspaceMemberAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFindOrFail.mockResolvedValue({
+      id: MEMBER_ID,
+      userId: MEMBER_USER_ID,
+      workspaceId: WORKSPACE_ID,
+    })
+    mockCurrentMember()
+    mockIsCommunity.mockReturnValue(false)
+  })
+
+  test("forces full super-admin permissions for community updates", async () => {
+    mockIsCommunity.mockReturnValue(true)
+
+    await (updateWorkspaceMemberAction as (props: unknown) => Promise<unknown>)(
+      updateActionCtx(),
+    )
+
+    expect(mockUpdateSet).toHaveBeenCalledWith({
+      ...updateInput,
+      permissions: fullPermissions,
+    })
+  })
+
+  test("normalizes full contacts permissions outside community edition", async () => {
+    await (updateWorkspaceMemberAction as (props: unknown) => Promise<unknown>)(
+      updateActionCtx(),
+    )
+
+    expect(mockUpdateSet).toHaveBeenCalledWith({
+      ...updateInput,
+      permissions: normalizedGranularPermissions,
+    })
+  })
+
+  test("preserves assigned-only contacts permissions outside community edition", async () => {
+    await (updateWorkspaceMemberAction as (props: unknown) => Promise<unknown>)(
+      updateActionCtx(assignedOnlyPermissions),
+    )
+
+    expect(mockUpdateSet).toHaveBeenCalledWith({
+      ...updateInput,
+      permissions: assignedOnlyPermissions,
+    })
+  })
+
+  test("invalidates the member's cached workspace list after updating", async () => {
+    await (updateWorkspaceMemberAction as (props: unknown) => Promise<unknown>)(
+      updateActionCtx(),
+    )
+
+    expect(mockInvalidateCacheByTags).toHaveBeenCalledWith([
+      `users:${MEMBER_USER_ID}:workspace-members`,
+    ])
+  })
+})
+
+function deleteActionCtx() {
+  return {
+    bindArgsParsedInputs: [WORKSPACE_ID, MEMBER_ID],
+  }
+}
+
+describe("deleteWorkspaceMemberAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFindOrFail.mockResolvedValue({
+      id: MEMBER_ID,
+      userId: MEMBER_USER_ID,
+      workspaceId: WORKSPACE_ID,
+      role: "agent",
+    })
+    mockCurrentMember()
+  })
+
+  test("rejects deleting the workspace owner", async () => {
+    mockFindOrFail.mockResolvedValue({
+      id: MEMBER_ID,
+      userId: MEMBER_USER_ID,
+      workspaceId: WORKSPACE_ID,
+      role: "owner",
+    })
+
+    await expect(
+      (deleteWorkspaceMemberAction as (props: unknown) => Promise<unknown>)(
+        deleteActionCtx(),
+      ),
+    ).rejects.toThrow("You cannot delete the owner of the workspace")
+
+    expect(mockDbDelete).not.toHaveBeenCalled()
+  })
+
+  test("rejects non-super-admin members before deleting", async () => {
+    mockCurrentMember(granularPermissions)
+
+    await expect(
+      (deleteWorkspaceMemberAction as (props: unknown) => Promise<unknown>)(
+        deleteActionCtx(),
+      ),
+    ).rejects.toThrow(
+      "You are not authorized to delete this workspace member. You need to be a super admin to do this.",
+    )
+
+    expect(mockDbDelete).not.toHaveBeenCalled()
+  })
+
+  test("invalidates the removed member's cached workspace list", async () => {
+    await (deleteWorkspaceMemberAction as (props: unknown) => Promise<unknown>)(
+      deleteActionCtx(),
+    )
+
+    expect(mockDbDelete).toHaveBeenCalled()
+    expect(mockInvalidateCacheByTags).toHaveBeenCalledWith([
+      `users:${MEMBER_USER_ID}:workspace-members`,
+    ])
+  })
+})

--- a/apps/builder/__tests__/workspace-permission-routes.test.ts
+++ b/apps/builder/__tests__/workspace-permission-routes.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment node
+
+import { describe, expect, test } from "vitest"
+import {
+  hasWorkspacePermission,
+  PERMISSION_NAV,
+  resolveWorkspaceLandingSegment,
+} from "../src/lib/auth/permission-routes"
+
+describe("workspace permission routes", () => {
+  test("maps guarded workspace routes to their permission flags", () => {
+    expect(PERMISSION_NAV).toEqual({
+      dashboard: "analytics",
+      flows: "flows",
+      contacts: "contacts",
+      broadcasts: "broadcast",
+      sequences: "broadcast",
+      products: "ecommerce",
+    })
+  })
+
+  test("allows super admins to access every mapped permission", () => {
+    expect(hasWorkspacePermission({ superAdmin: true }, "flows")).toBe(true)
+    expect(hasWorkspacePermission({ superAdmin: true }, "ecommerce")).toBe(true)
+  })
+
+  test("requires the requested flag when the member is not a super admin", () => {
+    expect(
+      hasWorkspacePermission({ superAdmin: false, flows: true }, "flows"),
+    ).toBe(true)
+    expect(
+      hasWorkspacePermission({ superAdmin: false, flows: true }, "contacts"),
+    ).toBe(false)
+  })
+
+  test("denies missing jsonb permission keys by default", () => {
+    expect(hasWorkspacePermission({}, "broadcast")).toBe(false)
+  })
+})
+
+describe("resolveWorkspaceLandingSegment", () => {
+  test("lands super admins on the dashboard", () => {
+    expect(resolveWorkspaceLandingSegment({ superAdmin: true })).toBe(
+      "dashboard",
+    )
+  })
+
+  test("lands on the dashboard when analytics is granted", () => {
+    expect(
+      resolveWorkspaceLandingSegment({ superAdmin: false, analytics: true }),
+    ).toBe("dashboard")
+  })
+
+  test("skips the dashboard and lands on flows without analytics", () => {
+    expect(
+      resolveWorkspaceLandingSegment({
+        superAdmin: false,
+        analytics: false,
+        flows: true,
+      }),
+    ).toBe("flows")
+  })
+
+  test("lands on the first granted section in nav priority order", () => {
+    expect(
+      resolveWorkspaceLandingSegment({
+        superAdmin: false,
+        analytics: false,
+        flows: false,
+        contacts: true,
+      }),
+    ).toBe("contacts")
+  })
+
+  test("falls back to the ungated inbox when no section is granted", () => {
+    expect(resolveWorkspaceLandingSegment({})).toBe("inbox")
+  })
+})

--- a/apps/builder/src/app/(no-sidebar)/space/[workspaceId]/contacts/import/histories/page.tsx
+++ b/apps/builder/src/app/(no-sidebar)/space/[workspaceId]/contacts/import/histories/page.tsx
@@ -10,6 +10,7 @@ import { Suspense } from "react"
 import { ImportHistoryTable } from "@/features/import/components/import-history-table"
 import { listImports } from "@/features/import/queries/list-imports.queries"
 import { listImportsSearchParamsCache } from "@/features/import/schemas/query"
+import { requireContactsAccess } from "@/lib/auth/require-workspace-permission"
 
 export default async function ImportContactsHistoriesPage(props: {
   params: Promise<{ workspaceId: string }>
@@ -19,6 +20,7 @@ export default async function ImportContactsHistoriesPage(props: {
   if (!workspaceId) {
     return notFound()
   }
+  await requireContactsAccess(workspaceId)
 
   const t = await getTranslations()
   const search = listImportsSearchParamsCache.parse(await props.searchParams)

--- a/apps/builder/src/app/(no-sidebar)/space/[workspaceId]/contacts/import/page.tsx
+++ b/apps/builder/src/app/(no-sidebar)/space/[workspaceId]/contacts/import/page.tsx
@@ -5,6 +5,7 @@ import { CustomFieldStoreProvider } from "@/features/custom-fields/provider/cust
 import { ImportForm } from "@/features/import/components/import-form"
 import { InboxStoreProvider } from "@/features/inboxes/provider/inbox-store-context"
 import { TagStoreProvider } from "@/features/tags/provider/tag-store-context"
+import { requireContactsAccess } from "@/lib/auth/require-workspace-permission"
 
 export default async function ImportContactsPage({
   params,
@@ -15,6 +16,7 @@ export default async function ImportContactsPage({
   if (!workspaceId) {
     return notFound()
   }
+  await requireContactsAccess(workspaceId)
 
   return (
     <InboxStoreProvider autoInitialize={true} workspaceId={workspaceId}>

--- a/apps/builder/src/app/(no-sidebar)/space/[workspaceId]/flows/[id]/analytics/page.tsx
+++ b/apps/builder/src/app/(no-sidebar)/space/[workspaceId]/flows/[id]/analytics/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from "next/navigation"
 import type { FlowVersionResource } from "@/features/flow-versions/schema/resource"
 import { FlowAnalytics } from "@/features/flows/flow-analytics"
 import { withWorkspaceIdAndIdSchema } from "@/features/workspaces/schema/resource"
-import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
+import { requireWorkspacePermission } from "@/lib/auth/require-workspace-permission"
 
 type FlowAnalyticsPageProps = {
   params: Promise<{ workspaceId: string; id: string }>
@@ -18,12 +18,7 @@ export default async function FlowAnalyticsPage({
     return notFound()
   }
 
-  const userAndWorkspace = await getCurrentUserAndTargetWorkspace(
-    data.workspaceId,
-  )
-  if (!userAndWorkspace) {
-    return notFound()
-  }
+  await requireWorkspacePermission(data.workspaceId, "flows")
 
   const flow = await db.query.flowModel.findFirst({
     where: {

--- a/apps/builder/src/app/(no-sidebar)/space/[workspaceId]/flows/[id]/page.tsx
+++ b/apps/builder/src/app/(no-sidebar)/space/[workspaceId]/flows/[id]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation"
 import type { FlowVersionResource } from "@/features/flow-versions/schema/resource"
 import { FlowDetail } from "@/features/flows/flow-detail"
 import { withWorkspaceIdAndIdSchema } from "@/features/workspaces/schema/resource"
-import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
+import { requireWorkspacePermission } from "@/lib/auth/require-workspace-permission"
 
 type FlowPageProps = {
   params: Promise<{ workspaceId: string; id: string }>
@@ -15,12 +15,7 @@ export default async function FlowPage({ params }: FlowPageProps) {
     return notFound()
   }
 
-  const userAndWorkspace = await getCurrentUserAndTargetWorkspace(
-    data.workspaceId,
-  )
-  if (!userAndWorkspace) {
-    return notFound()
-  }
+  await requireWorkspacePermission(data.workspaceId, "flows")
 
   const flow = await db.query.flowModel.findFirst({
     where: {

--- a/apps/builder/src/app/space/[workspaceId]/(e-commerce)/products/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(e-commerce)/products/layout.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react"
+import { resolveGuardedWorkspaceId } from "@/lib/auth/require-workspace-permission"
+
+// This layout and the non-grouped products layout both exist because route groups split URL-equivalent routes.
+
+export default async function ProductsLayout({
+  children,
+  params,
+}: {
+  children: ReactNode
+  params: Promise<{ workspaceId: string }>
+}) {
+  await resolveGuardedWorkspaceId(params, "ecommerce")
+
+  return children
+}

--- a/apps/builder/src/app/space/[workspaceId]/(has-folder)/flows/@folders/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(has-folder)/flows/@folders/page.tsx
@@ -2,6 +2,7 @@ import { getIdFromParams } from "@chatbotx.io/utils"
 import { notFound } from "next/navigation"
 import type { SearchParams } from "nuqs/server"
 import SharedFolderSlot from "@/features/folders/shared-folder-slot"
+import { requireWorkspacePermission } from "@/lib/auth/require-workspace-permission"
 
 export default async function FolderPage(props: {
   params: Promise<{ workspaceId: string }>
@@ -11,6 +12,7 @@ export default async function FolderPage(props: {
   if (!workspaceId) {
     return notFound()
   }
+  await requireWorkspacePermission(workspaceId, "flows")
 
   return (
     <SharedFolderSlot

--- a/apps/builder/src/app/space/[workspaceId]/(has-folder)/flows/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(has-folder)/flows/page.tsx
@@ -6,6 +6,7 @@ import { Suspense } from "react"
 import { FlowsTable } from "@/features/flows/flows-table"
 import { listFlowsRSC } from "@/features/flows/queries"
 import { listFlowsSearchParams } from "@/features/flows/schemas/query"
+import { requireWorkspacePermission } from "@/lib/auth/require-workspace-permission"
 
 export default async function FlowsPage(props: {
   params: Promise<{ workspaceId: string }>
@@ -15,6 +16,7 @@ export default async function FlowsPage(props: {
   if (!workspaceId) {
     return notFound()
   }
+  await requireWorkspacePermission(workspaceId, "flows")
   const searchParams = await props.searchParams
 
   const search = await listFlowsSearchParams.parse(searchParams)

--- a/apps/builder/src/app/space/[workspaceId]/(has-folder)/sequences/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(has-folder)/sequences/layout.tsx
@@ -1,9 +1,10 @@
 import { folderTypes } from "@chatbotx.io/database/partials"
-import { getIdFromParams } from "@chatbotx.io/utils"
-import { notFound } from "next/navigation"
 import { type ReactNode, Suspense } from "react"
 import { FlowStoreProvider } from "@/features/flows/provider/flow-store-context"
 import { FolderStoreProvider } from "@/features/folders/provider/folder-store-context"
+import { resolveGuardedWorkspaceId } from "@/lib/auth/require-workspace-permission"
+
+// This layout and the non-grouped sequences layout both exist because route groups split URL-equivalent routes.
 
 export default async function FolderableLayout({
   children,
@@ -14,10 +15,7 @@ export default async function FolderableLayout({
   folders: ReactNode
   params: Promise<{ workspaceId: string }>
 }) {
-  const workspaceId = getIdFromParams(await params, "workspaceId")
-  if (!workspaceId) {
-    return notFound()
-  }
+  const workspaceId = await resolveGuardedWorkspaceId(params, "broadcast")
 
   return (
     <FolderStoreProvider

--- a/apps/builder/src/app/space/[workspaceId]/(settings)/settings/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(settings)/settings/layout.tsx
@@ -1,11 +1,18 @@
 import type { ReactNode } from "react"
+import { resolveGuardedWorkspaceId } from "@/lib/auth/require-workspace-permission"
 import { SettingsTab } from "./tab"
 
 type LayoutSettingProps = {
   children: ReactNode
+  params: Promise<{ workspaceId: string }>
 }
 
-export default function SettingLayout({ children }: LayoutSettingProps) {
+export default async function SettingLayout({
+  children,
+  params,
+}: LayoutSettingProps) {
+  await resolveGuardedWorkspaceId(params, "superAdmin")
+
   return (
     <>
       <SettingsTab />

--- a/apps/builder/src/app/space/[workspaceId]/broadcasts/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/broadcasts/layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react"
+import { resolveGuardedWorkspaceId } from "@/lib/auth/require-workspace-permission"
+
+export default async function BroadcastsLayout({
+  children,
+  params,
+}: {
+  children: ReactNode
+  params: Promise<{ workspaceId: string }>
+}) {
+  await resolveGuardedWorkspaceId(params, "broadcast")
+
+  return children
+}

--- a/apps/builder/src/app/space/[workspaceId]/contacts/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/contacts/page.tsx
@@ -10,6 +10,7 @@ import { CustomFieldStoreProvider } from "@/features/custom-fields/provider/cust
 import { InboxStoreProvider } from "@/features/inboxes/provider/inbox-store-context"
 import { TagStoreProvider } from "@/features/tags/provider/tag-store-context"
 import { UserStoreProvider } from "@/features/users/provider/user-store-context"
+import { requireContactsAccess } from "@/lib/auth/require-workspace-permission"
 
 export default async function ContactsPage(props: {
   params: Promise<{ workspaceId: string }>
@@ -19,6 +20,7 @@ export default async function ContactsPage(props: {
   if (!workspaceId) {
     return notFound()
   }
+  await requireContactsAccess(workspaceId)
 
   const t = await getTranslations()
   const searchParams = await props.searchParams

--- a/apps/builder/src/app/space/[workspaceId]/dashboard/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { getIdFromParams } from "@chatbotx.io/utils"
 import { notFound } from "next/navigation"
 import { InboxCardList } from "@/features/inboxes/components/inbox-card-list"
 import { listInboxes } from "@/features/inboxes/queries"
+import { requireWorkspacePermission } from "@/lib/auth/require-workspace-permission"
 
 export default async function Dashboard({
   params,
@@ -14,6 +15,7 @@ export default async function Dashboard({
   if (!workspaceId) {
     return notFound()
   }
+  await requireWorkspacePermission(workspaceId, "analytics")
 
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
 

--- a/apps/builder/src/app/space/[workspaceId]/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/layout.tsx
@@ -53,11 +53,10 @@ export default async function WorkspaceLayout({
       cloud ? userQuotaService.getForUser(user.id) : Promise.resolve(null),
       cloud ? quotaEnforcementService.getUsageSummary(user.id) : null,
     ])
-  if (
-    !allWorkspaceMembers.some(
-      (workspaceMember) => workspaceMember.workspace.id === workspaceId,
-    )
-  ) {
+  const targetWorkspaceMember = allWorkspaceMembers.find(
+    (workspaceMember) => workspaceMember.workspace.id === workspaceId,
+  )
+  if (!targetWorkspaceMember) {
     return notFound()
   }
 
@@ -93,11 +92,14 @@ export default async function WorkspaceLayout({
         allWorkspaces={allWorkspaces}
         isPlatformAdmin={platformAdmin}
         isSuperAdmin={isSuperAdmin(user)}
+        permissions={targetWorkspaceMember.permissions}
         quota={quotaSummary}
         workspaceId={workspaceId}
       />
       <SidebarInset>
-        <main className="flex flex-1 flex-col gap-4 p-6">{children}</main>
+        <main className="flex min-w-0 flex-1 flex-col gap-4 p-6">
+          {children}
+        </main>
         <SidebarTrigger className="absolute top-3 -left-2 z-10 border" />
       </SidebarInset>
     </SidebarProvider>

--- a/apps/builder/src/app/space/[workspaceId]/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/page.tsx
@@ -1,4 +1,6 @@
-import { redirect } from "next/navigation"
+import { notFound, redirect } from "next/navigation"
+import { resolveWorkspaceLandingSegment } from "@/lib/auth/permission-routes"
+import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
 
 type WorkspacePageProps = {
   params: Promise<{ workspaceId: string }>
@@ -7,5 +9,16 @@ type WorkspacePageProps = {
 export default async function WorkspacePage(props: WorkspacePageProps) {
   const { workspaceId } = await props.params
 
-  return redirect(`/space/${workspaceId}/dashboard`)
+  // Land on the first section the member can access. Redirecting straight to
+  // /dashboard 404s for members without the `analytics` permission.
+  const userAndWorkspace = await getCurrentUserAndTargetWorkspace(workspaceId)
+  if (!userAndWorkspace) {
+    return notFound()
+  }
+
+  const segment = resolveWorkspaceLandingSegment(
+    userAndWorkspace.targetWorkspaceMember.permissions,
+  )
+
+  return redirect(`/space/${workspaceId}/${segment}`)
 }

--- a/apps/builder/src/app/space/[workspaceId]/products/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/products/layout.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react"
+import { resolveGuardedWorkspaceId } from "@/lib/auth/require-workspace-permission"
+
+// This layout and the grouped products layout both exist because route groups split URL-equivalent routes.
+
+export default async function ProductsLayout({
+  children,
+  params,
+}: {
+  children: ReactNode
+  params: Promise<{ workspaceId: string }>
+}) {
+  await resolveGuardedWorkspaceId(params, "ecommerce")
+
+  return children
+}

--- a/apps/builder/src/app/space/[workspaceId]/sequences/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/sequences/layout.tsx
@@ -1,6 +1,7 @@
-import { getIdFromParams } from "@chatbotx.io/utils"
-import { notFound } from "next/navigation"
 import { FlowStoreProvider } from "@/features/flows/provider/flow-store-context"
+import { resolveGuardedWorkspaceId } from "@/lib/auth/require-workspace-permission"
+
+// This layout and the grouped sequences layout both exist because route groups split URL-equivalent routes.
 
 export default async function SequencesLayout({
   children,
@@ -9,10 +10,7 @@ export default async function SequencesLayout({
   params: Promise<{ workspaceId: string }>
   children: React.ReactNode
 }) {
-  const workspaceId = getIdFromParams(await params, "workspaceId")
-  if (!workspaceId) {
-    return notFound()
-  }
+  const workspaceId = await resolveGuardedWorkspaceId(params, "broadcast")
 
   return (
     <FlowStoreProvider autoInitialize={true} workspaceId={workspaceId}>

--- a/apps/builder/src/components/app-sidebar.tsx
+++ b/apps/builder/src/components/app-sidebar.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { WorkspaceMemberPermissions } from "@chatbotx.io/database/partials"
 import {
   Sidebar,
   SidebarContent,
@@ -12,6 +13,7 @@ import {
   ChartPieIcon,
   ChevronsRight,
   LightbulbIcon,
+  type LucideIcon,
   MessageCircleMoreIcon,
   RadioIcon,
   SlidersHorizontalIcon,
@@ -30,14 +32,28 @@ import { NavMain } from "@/components/nav-main"
 import { NavUsage, type QuotaSummary } from "@/components/nav-usage"
 import { NavUser } from "@/components/nav-user"
 import { WorkspaceSwitcher } from "@/components/workspace-switcher"
+import { canAccessContactsSection } from "@/features/contacts/permissions"
 import type { WorkspaceResource } from "@/features/workspaces/schema/resource"
 import { authClient } from "@/lib/auth/auth-client"
+import {
+  hasWorkspacePermission,
+  PERMISSION_NAV,
+  type WorkspacePermissionKey,
+} from "@/lib/auth/permission-routes"
+
+type SidebarNavItem = {
+  title: string
+  url: string
+  icon: LucideIcon
+  permission?: WorkspacePermissionKey
+}
 
 export function AppSidebar({
   workspaceId,
   allWorkspaces,
   isSuperAdmin,
   isPlatformAdmin,
+  permissions,
   quota,
   ...props
 }: ComponentProps<typeof Sidebar> & {
@@ -45,6 +61,9 @@ export function AppSidebar({
   allWorkspaces: WorkspaceResource[]
   isSuperAdmin?: boolean
   isPlatformAdmin?: boolean
+  // Runtime may be a partial object (the jsonb column defaults to `{}`);
+  // `hasWorkspacePermission` fails closed on any missing flag.
+  permissions: WorkspaceMemberPermissions
   quota: QuotaSummary
 }) {
   const t = useTranslations()
@@ -61,6 +80,7 @@ export function AppSidebar({
         title: t("fields.analytics.label"),
         url: `/space/${workspaceId}/dashboard`,
         icon: ChartPieIcon,
+        permission: PERMISSION_NAV.dashboard,
       },
       {
         title: t("fields.inbox.label"),
@@ -71,11 +91,13 @@ export function AppSidebar({
         title: t("fields.flows.label"),
         url: `/space/${workspaceId}/flows`,
         icon: WorkflowIcon,
+        permission: PERMISSION_NAV.flows,
       },
       {
         title: t("fields.contacts.label"),
         url: `/space/${workspaceId}/contacts`,
         icon: UsersIcon,
+        permission: PERMISSION_NAV.contacts,
       },
       {
         title: t("aiAgent.title"),
@@ -91,11 +113,13 @@ export function AppSidebar({
         title: t("broadcasts.title"),
         url: `/space/${workspaceId}/broadcasts`,
         icon: RadioIcon,
+        permission: PERMISSION_NAV.broadcasts,
       },
       {
         title: t("sequences.title"),
         url: `/space/${workspaceId}/sequences`,
         icon: ChevronsRight,
+        permission: PERMISSION_NAV.sequences,
       },
       {
         title: t("triggers.title"),
@@ -116,9 +140,18 @@ export function AppSidebar({
         title: t("settings.title"),
         url: `/space/${workspaceId}/settings/general`,
         icon: SlidersHorizontalIcon,
+        permission: "superAdmin",
       },
-    ],
+    ] satisfies SidebarNavItem[],
   }
+
+  const navMain = data.navMain.filter(
+    (item) =>
+      !item.permission ||
+      (item.permission === PERMISSION_NAV.contacts
+        ? canAccessContactsSection(permissions)
+        : hasWorkspacePermission(permissions, item.permission)),
+  )
 
   return (
     <Sidebar collapsible="icon" {...props}>
@@ -134,7 +167,7 @@ export function AppSidebar({
         </div>
       </SidebarHeader>
       <SidebarContent>
-        <NavMain items={data.navMain} />
+        <NavMain items={navMain} />
       </SidebarContent>
       <SidebarFooter>
         <NavUsage

--- a/apps/builder/src/components/workspace-switcher.tsx
+++ b/apps/builder/src/components/workspace-switcher.tsx
@@ -94,7 +94,7 @@ export function WorkspaceSwitcher({
                 key={workspace.name}
                 onClick={() => setActiveWorkspace(workspace)}
               >
-                <Link href={`/space/${workspace.id}/dashboard`}>
+                <Link href={`/space/${workspace.id}`}>
                   <Avatar className="rounded-lg border">
                     <AvatarImage
                       alt={workspace.name}

--- a/apps/builder/src/features/contact-notes/actions/create-contact-note.action.ts
+++ b/apps/builder/src/features/contact-notes/actions/create-contact-note.action.ts
@@ -1,10 +1,11 @@
 "use server"
 
-import { contactService } from "@chatbotx.io/business"
+import { type ContactAccessScope, contactService } from "@chatbotx.io/business"
 import { db } from "@chatbotx.io/database/client"
 import { contactNoteModel } from "@chatbotx.io/database/schema"
 import type { UserModel } from "@chatbotx.io/database/types"
 import { createId, zodBigintAsString } from "@chatbotx.io/utils"
+import { requireContactPermissionScope } from "@/features/contacts/permissions"
 import { workspaceActionClient } from "@/lib/safe-action"
 import {
   type AddContactNoteRequest,
@@ -20,20 +21,27 @@ export const createContactNoteAction = workspaceActionClient
       parsedInput,
       ctx: { user },
     } = props
+    const accessScope = await requireContactPermissionScope(workspaceId)
 
     return await createContactNote(
-      { workspaceId, id, userId: (user as UserModel).id },
+      { workspaceId, id, userId: (user as UserModel).id, accessScope },
       parsedInput,
     )
   })
 
 export const createContactNote = async (
-  ctx: { workspaceId: string; id: string; userId: string },
+  ctx: {
+    workspaceId: string
+    id: string
+    userId: string
+    accessScope?: ContactAccessScope
+  },
   parsedInput: AddContactNoteRequest,
 ) => {
   const contact = await contactService.findByIdOrFail({
     workspaceId: ctx.workspaceId,
     id: ctx.id,
+    accessScope: ctx.accessScope,
   })
 
   return await db

--- a/apps/builder/src/features/contact-notes/actions/delete-contact-note.action.ts
+++ b/apps/builder/src/features/contact-notes/actions/delete-contact-note.action.ts
@@ -1,9 +1,10 @@
 "use server"
 
-import { contactService } from "@chatbotx.io/business"
+import { type ContactAccessScope, contactService } from "@chatbotx.io/business"
 import { and, db, eq } from "@chatbotx.io/database/client"
 import { contactNoteModel } from "@chatbotx.io/database/schema"
 import { zodBigintAsString } from "@chatbotx.io/utils"
+import { requireContactPermissionScope } from "@/features/contacts/permissions"
 import { workspaceActionClient } from "@/lib/safe-action"
 import {
   type DeleteContactNoteRequest,
@@ -18,20 +19,23 @@ export const deleteContactNoteAction = workspaceActionClient
       bindArgsParsedInputs: [workspaceId, id],
       parsedInput,
     } = props
+    const accessScope = await requireContactPermissionScope(workspaceId)
 
-    await deleteContactNote({ workspaceId, id }, parsedInput)
+    await deleteContactNote({ workspaceId, id, accessScope }, parsedInput)
   })
 
 export const deleteContactNote = async (
   ctx: {
     workspaceId: string
     id: string
+    accessScope?: ContactAccessScope
   },
   parsedInput: DeleteContactNoteRequest,
 ) => {
   const contact = await contactService.findByIdOrFail({
     workspaceId: ctx.workspaceId,
     id: ctx.id,
+    accessScope: ctx.accessScope,
   })
 
   await db

--- a/apps/builder/src/features/contact-notes/actions/edit-contact-note.action.ts
+++ b/apps/builder/src/features/contact-notes/actions/edit-contact-note.action.ts
@@ -1,9 +1,10 @@
 "use server"
 
-import { contactService } from "@chatbotx.io/business"
+import { type ContactAccessScope, contactService } from "@chatbotx.io/business"
 import { db, eq, findOrFail } from "@chatbotx.io/database/client"
 import { contactNoteModel } from "@chatbotx.io/database/schema"
 import { zodBigintAsString } from "@chatbotx.io/utils"
+import { requireContactPermissionScope } from "@/features/contacts/permissions"
 import { workspaceActionClient } from "@/lib/safe-action"
 import {
   type UpdateContactNoteRequest,
@@ -18,20 +19,23 @@ export const editContactNoteAction = workspaceActionClient
       bindArgsParsedInputs: [workspaceId, id],
       parsedInput,
     } = props
+    const accessScope = await requireContactPermissionScope(workspaceId)
 
-    return await editContactNote({ workspaceId, id }, parsedInput)
+    return await editContactNote({ workspaceId, id, accessScope }, parsedInput)
   })
 
 export const editContactNote = async (
   ctx: {
     workspaceId: string
     id: string
+    accessScope?: ContactAccessScope
   },
   parsedInput: UpdateContactNoteRequest,
 ) => {
   const contact = await contactService.findByIdOrFail({
     workspaceId: ctx.workspaceId,
     id: ctx.id,
+    accessScope: ctx.accessScope,
   })
 
   const foundContactNote = await findOrFail({

--- a/apps/builder/src/features/contact-sequences/actions/update-contact-sequence.action.ts
+++ b/apps/builder/src/features/contact-sequences/actions/update-contact-sequence.action.ts
@@ -3,6 +3,7 @@
 import { contactService } from "@chatbotx.io/business"
 import { contactSequenceService } from "@chatbotx.io/business/contact-sequence"
 import { workspaceIdrequestParams } from "@/features/common/schemas"
+import { requireContactPermissionScope } from "@/features/contacts/permissions"
 import { workspaceActionClient } from "@/lib/safe-action"
 import { updateContactSequenceRequest } from "../schema"
 
@@ -14,10 +15,12 @@ export const updateContactSequenceAction = workspaceActionClient
       bindArgsParsedInputs: [workspaceId],
       parsedInput,
     } = props
+    const accessScope = await requireContactPermissionScope(workspaceId)
 
     const contact = await contactService.findByIdOrFail({
       workspaceId,
       id: parsedInput.contactId,
+      accessScope,
     })
 
     return await contactSequenceService.updateContactSequences({

--- a/apps/builder/src/features/contacts/actions/__tests__/contact-tag-actions.test.ts
+++ b/apps/builder/src/features/contacts/actions/__tests__/contact-tag-actions.test.ts
@@ -114,17 +114,19 @@ vi.mock("@chatbotx.io/database/schema", () => ({
 // ---------------------------------------------------------------------------
 const enqueueAttach = vi.fn(async () => undefined)
 const enqueueDetach = vi.fn(async () => undefined)
+const contactFindManyByIds = vi.fn(async () => state.contactFindMany)
+const contactFindByIdOrFail = vi.fn(() => {
+  if (state.findOrFailError) {
+    return Promise.reject(state.findOrFailError)
+  }
+  return Promise.resolve(state.findOrFailResult ?? {})
+})
 
 vi.mock("@chatbotx.io/business", () => ({
   tagSyncService: { enqueueAttach, enqueueDetach },
-  // update-contact-tag.action.ts resolves the contact via contactService.
   contactService: {
-    findByIdOrFail: vi.fn(() => {
-      if (state.findOrFailError) {
-        return Promise.reject(state.findOrFailError)
-      }
-      return Promise.resolve(state.findOrFailResult ?? {})
-    }),
+    findByIdOrFail: contactFindByIdOrFail,
+    findManyByIds: contactFindManyByIds,
   },
   // safe-action.ts also imports isPlatformAdmin
   isPlatformAdmin: vi.fn(async () => false),
@@ -201,6 +203,7 @@ vi.mock("@/features/workspace-members/queries", () => ({
   getAllWorkspaceMembers: vi.fn(async () => []),
 }))
 vi.mock("@/lib/auth/utils", () => ({
+  getCurrentUserAndTargetWorkspace: vi.fn(),
   getCurrentUserId: vi.fn(async () => "user-1"),
 }))
 vi.mock("@/lib/log", () => ({ logger: { error: vi.fn(), info: vi.fn() } }))
@@ -294,7 +297,7 @@ describe("addContactTags", () => {
     const { db } = await import("@chatbotx.io/database/client")
     expect(db.transaction).toHaveBeenCalledOnce()
     // No contact queries or inserts beyond the tag resolution
-    expect(db.query.contactModel.findMany).not.toHaveBeenCalled()
+    expect(contactFindManyByIds).not.toHaveBeenCalled()
     expect(enqueueAttach).not.toHaveBeenCalled()
   })
 
@@ -390,12 +393,8 @@ describe("addContactTags", () => {
 
     const ids = Array.from({ length: 250 }, (_, i) => `c-${i}`)
     // contactModel.findMany resolves with contacts from current chunk
-    const { db } = await import("@chatbotx.io/database/client")
-    const contactFindMany = db.query.contactModel.findMany as ReturnType<
-      typeof vi.fn
-    >
     // first chunk (200), second chunk (50)
-    contactFindMany
+    contactFindManyByIds
       .mockResolvedValueOnce(ids.slice(0, 200).map((id) => ({ id })))
       .mockResolvedValueOnce(ids.slice(200).map((id) => ({ id })))
 
@@ -406,8 +405,26 @@ describe("addContactTags", () => {
       parsedInput: { ids, tags: ["tag-a"] },
     })
 
-    expect(contactFindMany).toHaveBeenCalledTimes(2)
+    expect(contactFindManyByIds).toHaveBeenCalledTimes(2)
     expect(invalidateCacheByTags).toHaveBeenCalledOnce()
+  })
+
+  test("passes assigned-contact access scope to contact lookup", async () => {
+    const accessScope = { restrictToAssignedUserId: "user-1" }
+    state.txTagFindMany = [{ id: "tag-1" }]
+    state.contactFindMany = [{ id: "c-1" }]
+
+    await addContactTags({
+      workspaceId: "ws-1",
+      parsedInput: { ids: ["c-1"], tags: ["tag-a"] },
+      accessScope,
+    })
+
+    expect(contactFindManyByIds).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      ids: ["c-1"],
+      accessScope,
+    })
   })
 
   // ── partial mix: some pairs new, some existing ───────────────────────────
@@ -506,7 +523,7 @@ describe("removeContactTags", () => {
 
     const { db } = await import("@chatbotx.io/database/client")
     expect(db.query.tagModel.findMany).toHaveBeenCalledOnce()
-    expect(db.query.contactModel.findMany).not.toHaveBeenCalled()
+    expect(contactFindManyByIds).not.toHaveBeenCalled()
     expect(enqueueDetach).not.toHaveBeenCalled()
   })
 
@@ -605,6 +622,24 @@ describe("removeContactTags", () => {
       "workspaces:ws-99#conversations",
       "workspaces:ws-99#tags",
     ])
+  })
+
+  test("passes assigned-contact access scope to contact lookup", async () => {
+    const accessScope = { restrictToAssignedUserId: "user-1" }
+    state.tagFindMany = [{ id: "tag-1" }]
+    state.contactFindMany = [{ id: "c-1" }]
+
+    await removeContactTags({
+      workspaceId: "ws-1",
+      parsedInput: { ids: ["c-1"], tags: ["tag-a"] },
+      accessScope,
+    })
+
+    expect(contactFindManyByIds).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      ids: ["c-1"],
+      accessScope,
+    })
   })
 })
 

--- a/apps/builder/src/features/contacts/actions/add-contact-custom-field.action.ts
+++ b/apps/builder/src/features/contacts/actions/add-contact-custom-field.action.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { contactService } from "@chatbotx.io/business"
+import { type ContactAccessScope, contactService } from "@chatbotx.io/business"
 import { db, eq, findOrFail } from "@chatbotx.io/database/client"
 import {
   contactCustomFieldModel,
@@ -14,6 +14,7 @@ import {
   workspaceIdrequestParams,
 } from "@/features/common/schemas"
 import { workspaceActionClient } from "@/lib/safe-action"
+import { requireContactPermissionScope } from "../permissions"
 import {
   type AddContactCustomFieldRequest,
   addContactCustomFieldRequest,
@@ -27,23 +28,28 @@ export const addContactCustomFieldAction = workspaceActionClient
       bindArgsParsedInputs: [workspaceId],
       parsedInput,
     } = props
+    const accessScope = await requireContactPermissionScope(workspaceId)
 
     await addContactCustomFields({
       bindArgsParsedInputs: [workspaceId],
       parsedInput,
+      accessScope,
     })
   })
 
 export const addContactCustomFields = async ({
   bindArgsParsedInputs: [workspaceId],
   parsedInput,
+  accessScope,
 }: {
   bindArgsParsedInputs: WorkspaceIdRequestParams
   parsedInput: AddContactCustomFieldRequest
+  accessScope?: ContactAccessScope
 }) => {
   const contacts = await contactService.findManyByIds({
     workspaceId,
     ids: parsedInput.ids,
+    accessScope,
   })
   if (contacts.length === 0) {
     return
@@ -127,12 +133,20 @@ export const setContactCustomFieldValue = async ({
   contactId,
   customFieldId,
   value,
+  accessScope,
 }: {
   workspaceId: string
   contactId: string
   customFieldId: string
   value: string
+  accessScope?: ContactAccessScope
 }) => {
+  await contactService.findByIdOrFail({
+    workspaceId,
+    id: contactId,
+    accessScope,
+  })
+
   // Get custom field info for event emission
   const customField = await db.query.customFieldModel.findFirst({
     where: {
@@ -186,11 +200,19 @@ export const setContactCustomFieldValues = async ({
   workspaceId,
   contactId,
   fields,
+  accessScope,
 }: {
   workspaceId: string
   contactId: string
   fields: Array<{ customFieldId: string; value: string }>
+  accessScope?: ContactAccessScope
 }) => {
+  await contactService.findByIdOrFail({
+    workspaceId,
+    id: contactId,
+    accessScope,
+  })
+
   const customFieldIds = fields.map((f) => f.customFieldId)
 
   const customFields = await db.query.customFieldModel.findMany({

--- a/apps/builder/src/features/contacts/actions/add-contact-sequence.action.ts
+++ b/apps/builder/src/features/contacts/actions/add-contact-sequence.action.ts
@@ -9,6 +9,7 @@ import {
 } from "@/features/common/schemas"
 import { calculateNextRunAtBulk } from "@/features/contact-sequences/utils/calculate-next-run-at"
 import { workspaceActionClient } from "@/lib/safe-action"
+import { requireContactPermissionScope } from "../permissions"
 import {
   type AddContactSequenceRequest,
   addContactSequenceRequest,
@@ -84,12 +85,7 @@ export const addContactSequenceAction = workspaceActionClient
         parsedInput.sequences,
         now,
       )
-
-      const existingKeys = await getExistingEnrollments(
-        workspaceId,
-        parsedInput.ids,
-        parsedInput.sequences,
-      )
+      const accessScope = await requireContactPermissionScope(workspaceId)
 
       for (let i = 0; i < parsedInput.ids.length; i += CHUNK_SIZE) {
         const contactIdChunk = parsedInput.ids.slice(i, i + CHUNK_SIZE)
@@ -97,11 +93,18 @@ export const addContactSequenceAction = workspaceActionClient
         const contacts = await contactService.findManyByIds({
           workspaceId,
           ids: contactIdChunk,
+          accessScope,
         })
 
         if (contacts.length === 0) {
           continue
         }
+
+        const existingKeys = await getExistingEnrollments(
+          workspaceId,
+          contacts.map((contact) => contact.id),
+          parsedInput.sequences,
+        )
 
         const records = buildEnrollmentRecords(
           contacts,

--- a/apps/builder/src/features/contacts/actions/add-contact-tag.action.ts
+++ b/apps/builder/src/features/contacts/actions/add-contact-tag.action.ts
@@ -1,6 +1,10 @@
 "use server"
 
-import { contactService, tagSyncService } from "@chatbotx.io/business"
+import {
+  type ContactAccessScope,
+  contactService,
+  tagSyncService,
+} from "@chatbotx.io/business"
 import {
   and,
   db,
@@ -19,6 +23,7 @@ import {
 } from "@/features/common/schemas"
 import { logger } from "@/lib/log"
 import { workspaceActionClient } from "@/lib/safe-action"
+import { requireContactPermissionScope } from "../permissions"
 import {
   type AddContactTagRequest,
   addContactTagRequest,
@@ -37,9 +42,11 @@ export const addContactTagAction = workspaceActionClient
       bindArgsParsedInputs: WorkspaceIdRequestParams
       parsedInput: AddContactTagRequest
     }) => {
+      const accessScope = await requireContactPermissionScope(workspaceId)
       await addContactTags({
         workspaceId,
         parsedInput,
+        accessScope,
       })
     },
   )
@@ -47,9 +54,11 @@ export const addContactTagAction = workspaceActionClient
 export const addContactTags = async ({
   workspaceId,
   parsedInput,
+  accessScope,
 }: {
   workspaceId: string
   parsedInput: AddContactTagRequest
+  accessScope?: ContactAccessScope
 }) => {
   if (parsedInput.ids.length === 0 || parsedInput.tags.length === 0) {
     return
@@ -89,14 +98,10 @@ export const addContactTags = async ({
   // Process selected contacts in chunks — never load all contacts at once.
   for (let i = 0; i < parsedInput.ids.length; i += CONTACT_CHUNK_SIZE) {
     const idChunk = parsedInput.ids.slice(i, i + CONTACT_CHUNK_SIZE)
-    const contacts = await db.query.contactModel.findMany({
-      where: {
-        workspaceId,
-        id: { in: idChunk },
-      },
-      columns: {
-        id: true,
-      },
+    const contacts = await contactService.findManyByIds({
+      workspaceId,
+      ids: idChunk,
+      accessScope,
     })
     if (contacts.length === 0) {
       continue
@@ -151,12 +156,18 @@ export const attachContactTag = async ({
   workspaceId,
   contactId,
   tagId,
+  accessScope,
 }: {
   workspaceId: string
   contactId: string
   tagId: string
+  accessScope?: ContactAccessScope
 }) => {
-  await contactService.findByIdOrFail({ workspaceId, id: contactId })
+  await contactService.findByIdOrFail({
+    workspaceId,
+    id: contactId,
+    accessScope,
+  })
   await findOrFail({
     table: tagModel,
     where: { id: tagId, workspaceId, deletedAt: { isNull: true as const } },
@@ -189,12 +200,18 @@ export const detachContactTag = async ({
   workspaceId,
   contactId,
   tagId,
+  accessScope,
 }: {
   workspaceId: string
   contactId: string
   tagId: string
+  accessScope?: ContactAccessScope
 }) => {
-  await contactService.findByIdOrFail({ workspaceId, id: contactId })
+  await contactService.findByIdOrFail({
+    workspaceId,
+    id: contactId,
+    accessScope,
+  })
   await findOrFail({
     table: tagModel,
     where: { id: tagId, workspaceId, deletedAt: { isNull: true as const } },
@@ -224,12 +241,18 @@ export const attachContactTags = async ({
   workspaceId,
   contactId,
   tagIds,
+  accessScope,
 }: {
   workspaceId: string
   contactId: string
   tagIds: string[]
+  accessScope?: ContactAccessScope
 }) => {
-  await contactService.findByIdOrFail({ workspaceId, id: contactId })
+  await contactService.findByIdOrFail({
+    workspaceId,
+    id: contactId,
+    accessScope,
+  })
 
   const tags = await db.query.tagModel.findMany({
     where: {
@@ -258,12 +281,18 @@ export const detachContactTags = async ({
   workspaceId,
   contactId,
   tagIds,
+  accessScope,
 }: {
   workspaceId: string
   contactId: string
   tagIds: string[]
+  accessScope?: ContactAccessScope
 }) => {
-  await contactService.findByIdOrFail({ workspaceId, id: contactId })
+  await contactService.findByIdOrFail({
+    workspaceId,
+    id: contactId,
+    accessScope,
+  })
 
   await db
     .delete(contactsToTagsModel)

--- a/apps/builder/src/features/contacts/actions/block-contact.action.ts
+++ b/apps/builder/src/features/contacts/actions/block-contact.action.ts
@@ -1,9 +1,10 @@
 "use server"
 
-import { contactService } from "@chatbotx.io/business"
+import { type ContactAccessScope, contactService } from "@chatbotx.io/business"
 import { emit } from "@chatbotx.io/event-bus"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { workspaceActionClient } from "@/lib/safe-action"
+import { requireContactPermissionScope } from "../permissions"
 
 export const blockContactAction = workspaceActionClient
   .bindArgsSchemas([zodBigintAsString(), zodBigintAsString()])
@@ -11,13 +12,15 @@ export const blockContactAction = workspaceActionClient
     const {
       bindArgsParsedInputs: [workspaceId, id],
     } = props
+    const accessScope = await requireContactPermissionScope(workspaceId)
 
-    await blockContact({ workspaceId, id })
+    await blockContact({ workspaceId, id, accessScope })
   })
 
 export const blockContact = async (ctx: {
   workspaceId: string
   id: string
+  accessScope?: ContactAccessScope
 }) => {
   const contact = await contactService.block(ctx)
 

--- a/apps/builder/src/features/contacts/actions/delete-contact-custom-field.action.ts
+++ b/apps/builder/src/features/contacts/actions/delete-contact-custom-field.action.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { contactService } from "@chatbotx.io/business"
+import { type ContactAccessScope, contactService } from "@chatbotx.io/business"
 import { and, db, eq, inArray } from "@chatbotx.io/database/client"
 import { contactCustomFieldModel } from "@chatbotx.io/database/schema"
 import {
@@ -8,6 +8,7 @@ import {
   workspaceIdrequestParams,
 } from "@/features/common/schemas"
 import { workspaceActionClient } from "@/lib/safe-action"
+import { requireContactPermissionScope } from "../permissions"
 import {
   type DeleteContactCustomFieldsRequest,
   deleteContactCustomFieldsRequest,
@@ -24,10 +25,12 @@ export const deleteContactCustomFieldAction = workspaceActionClient
       bindArgsParsedInputs: WorkspaceIdRequestParams
       parsedInput: DeleteContactCustomFieldsRequest
     }) => {
+      const accessScope = await requireContactPermissionScope(workspaceId)
       await deleteContactCustomFields({
         workspaceId,
         contactIds: parsedInput.ids,
         customFieldId: parsedInput.customFieldId,
+        accessScope,
       })
     },
   )
@@ -36,14 +39,17 @@ export const deleteContactCustomFields = async ({
   workspaceId,
   contactIds,
   customFieldId,
+  accessScope,
 }: {
   workspaceId: string
   contactIds: string[]
   customFieldId: string
+  accessScope?: ContactAccessScope
 }) => {
   const contacts = await contactService.findManyByIds({
     workspaceId,
     ids: contactIds,
+    accessScope,
   })
 
   if (contacts.length === 0) {

--- a/apps/builder/src/features/contacts/actions/delete-contact.action.ts
+++ b/apps/builder/src/features/contacts/actions/delete-contact.action.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { contactService } from "@chatbotx.io/business"
+import { type ContactAccessScope, contactService } from "@chatbotx.io/business"
 import { emit } from "@chatbotx.io/event-bus"
 import {
   type BulkUpdateIdsRequest,
@@ -9,10 +9,12 @@ import {
   workspaceIdrequestParams,
 } from "@/features/common/schemas"
 import { workspaceActionClient } from "@/lib/safe-action"
+import { requireContactPermissionScope } from "../permissions"
 
 export const deleteContact = async (ctx: {
   workspaceId: string
   ids: string[]
+  accessScope?: ContactAccessScope
 }) => {
   const contacts = await contactService.delete(ctx)
 
@@ -50,6 +52,7 @@ export const deleteContactAction = workspaceActionClient
       bindArgsParsedInputs: WorkspaceIdRequestParams
       parsedInput: BulkUpdateIdsRequest
     }) => {
-      await deleteContact({ workspaceId, ids: parsedInput.ids })
+      const accessScope = await requireContactPermissionScope(workspaceId)
+      await deleteContact({ workspaceId, ids: parsedInput.ids, accessScope })
     },
   )

--- a/apps/builder/src/features/contacts/actions/export-contacts.action.ts
+++ b/apps/builder/src/features/contacts/actions/export-contacts.action.ts
@@ -1,5 +1,6 @@
 "use server"
 
+import { ChatbotXException } from "@chatbotx.io/business/errors"
 import { db } from "@chatbotx.io/database/client"
 import {
   exportSubTypes,
@@ -10,11 +11,13 @@ import { fileModel } from "@chatbotx.io/database/schema"
 import type { UserModel } from "@chatbotx.io/database/types"
 import { createId } from "@chatbotx.io/utils"
 import { DefaultJobAction, defaultQueue } from "@chatbotx.io/worker-config"
+import { stripContactPIIFields } from "@chatbotx.io/worker-config/contact-pii"
 import {
   type WorkspaceIdRequestParams,
   workspaceIdrequestParams,
 } from "@/features/common/schemas"
 import { workspaceActionClient } from "@/lib/safe-action"
+import { resolveContactPermissionScope } from "../permissions"
 import {
   type ExportContactsRequest,
   type ExportContactsResponse,
@@ -34,7 +37,18 @@ export const exportContactsAction = workspaceActionClient
       bindArgsParsedInputs: WorkspaceIdRequestParams
       parsedInput: ExportContactsRequest
     }): Promise<ExportContactsResponse> => {
-      const { fields } = parsedInput
+      const scope = await resolveContactPermissionScope(workspaceId)
+      if (!scope) {
+        throw new ChatbotXException(
+          "User is not associated with this workspace",
+        )
+      }
+
+      const canExportEmailAndPhone = scope.canViewEmailAndPhone
+      const fields = stripContactPIIFields(
+        parsedInput.fields,
+        canExportEmailAndPhone,
+      )
 
       // The worker resolves the filter and counts records. The action only
       // records the export request and enqueues the job.
@@ -72,8 +86,12 @@ export const exportContactsAction = workspaceActionClient
             requestedUserId: user.id,
             fileId,
             fields,
+            canExportEmailAndPhone,
             outputPath,
             outputFormat: "csv",
+            ...(scope.restrictToAssignedUserId
+              ? { restrictToAssignedUserId: scope.restrictToAssignedUserId }
+              : {}),
             ...(filter ? { filter } : { contactIds: contactIds ?? [] }),
           },
         }),

--- a/apps/builder/src/features/contacts/actions/remove-contact-sequence.action.ts
+++ b/apps/builder/src/features/contacts/actions/remove-contact-sequence.action.ts
@@ -1,11 +1,13 @@
 "use server"
 
+import { contactService } from "@chatbotx.io/business"
 import { contactSequenceService } from "@chatbotx.io/business/contact-sequence"
 import {
   type WorkspaceIdRequestParams,
   workspaceIdrequestParams,
 } from "@/features/common/schemas"
 import { workspaceActionClient } from "@/lib/safe-action"
+import { requireContactPermissionScope } from "../permissions"
 import {
   type RemoveContactSequenceRequest,
   removeContactSequenceRequest,
@@ -24,12 +26,22 @@ export const removeContactSequenceAction = workspaceActionClient
       bindArgsParsedInputs: WorkspaceIdRequestParams
       parsedInput: RemoveContactSequenceRequest
     }) => {
+      const accessScope = await requireContactPermissionScope(workspaceId)
       for (let i = 0; i < parsedInput.ids.length; i += CHUNK_SIZE) {
         const contactIdChunk = parsedInput.ids.slice(i, i + CHUNK_SIZE)
+        const contacts = await contactService.findManyByIds({
+          workspaceId,
+          ids: contactIdChunk,
+          accessScope,
+        })
+
+        if (contacts.length === 0) {
+          continue
+        }
 
         await contactSequenceService.removeContactSequencesForContacts({
           workspaceId,
-          contactIds: contactIdChunk,
+          contactIds: contacts.map((contact) => contact.id),
           sequenceIds: parsedInput.sequences,
           reason: "enrollment_removed",
         })

--- a/apps/builder/src/features/contacts/actions/remove-contact-tag.action.ts
+++ b/apps/builder/src/features/contacts/actions/remove-contact-tag.action.ts
@@ -1,6 +1,10 @@
 "use server"
 
-import { tagSyncService } from "@chatbotx.io/business"
+import {
+  type ContactAccessScope,
+  contactService,
+  tagSyncService,
+} from "@chatbotx.io/business"
 import { and, db, eq, inArray } from "@chatbotx.io/database/client"
 import { contactsToTagsModel } from "@chatbotx.io/database/schema"
 import { emitTagRemoved } from "@chatbotx.io/events"
@@ -11,6 +15,7 @@ import {
 } from "@/features/common/schemas"
 import { logger } from "@/lib/log"
 import { workspaceActionClient } from "@/lib/safe-action"
+import { requireContactPermissionScope } from "../permissions"
 import {
   type RemoveContactTagsRequest,
   removeContactTagsRequest,
@@ -29,9 +34,11 @@ export const removeContactTagAction = workspaceActionClient
       bindArgsParsedInputs: WorkspaceIdRequestParams
       parsedInput: RemoveContactTagsRequest
     }) => {
+      const accessScope = await requireContactPermissionScope(workspaceId)
       await removeContactTags({
         workspaceId,
         parsedInput,
+        accessScope,
       })
     },
   )
@@ -39,9 +46,11 @@ export const removeContactTagAction = workspaceActionClient
 export const removeContactTags = async ({
   workspaceId,
   parsedInput,
+  accessScope,
 }: {
   workspaceId: string
   parsedInput: RemoveContactTagsRequest
+  accessScope?: ContactAccessScope
 }) => {
   if (parsedInput.ids.length === 0 || parsedInput.tags.length === 0) {
     return
@@ -67,14 +76,10 @@ export const removeContactTags = async ({
   // Process selected contacts in chunks — never load all contacts at once.
   for (let i = 0; i < parsedInput.ids.length; i += CONTACT_CHUNK_SIZE) {
     const idChunk = parsedInput.ids.slice(i, i + CONTACT_CHUNK_SIZE)
-    const contacts = await db.query.contactModel.findMany({
-      where: {
-        workspaceId,
-        id: { in: idChunk },
-      },
-      columns: {
-        id: true,
-      },
+    const contacts = await contactService.findManyByIds({
+      workspaceId,
+      ids: idChunk,
+      accessScope,
     })
     if (contacts.length === 0) {
       continue

--- a/apps/builder/src/features/contacts/actions/unblock-contact.action.ts
+++ b/apps/builder/src/features/contacts/actions/unblock-contact.action.ts
@@ -1,8 +1,9 @@
 "use server"
 
-import { contactService } from "@chatbotx.io/business"
+import { type ContactAccessScope, contactService } from "@chatbotx.io/business"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { workspaceActionClient } from "@/lib/safe-action"
+import { requireContactPermissionScope } from "../permissions"
 
 export const unblockContactAction = workspaceActionClient
   .bindArgsSchemas([zodBigintAsString(), zodBigintAsString()])
@@ -10,13 +11,15 @@ export const unblockContactAction = workspaceActionClient
     const {
       bindArgsParsedInputs: [workspaceId, id],
     } = props
+    const accessScope = await requireContactPermissionScope(workspaceId)
 
-    await unblockContact({ workspaceId, id })
+    await unblockContact({ workspaceId, id, accessScope })
   })
 
 export const unblockContact = async (ctx: {
   workspaceId: string
   id: string
+  accessScope?: ContactAccessScope
 }) => {
   await contactService.unblock(ctx)
 }

--- a/apps/builder/src/features/contacts/actions/update-contact-field.action.ts
+++ b/apps/builder/src/features/contacts/actions/update-contact-field.action.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { contactService } from "@chatbotx.io/business"
+import { type ContactAccessScope, contactService } from "@chatbotx.io/business"
 import { db } from "@chatbotx.io/database/client"
 import {
   type FillableContactKey,
@@ -13,6 +13,7 @@ import { listCustomFields } from "@/features/custom-fields/queries"
 import { listCustomFieldsSearchParams } from "@/features/custom-fields/schemas/query"
 import { workspaceActionClient } from "@/lib/safe-action"
 import { maxPerPageString } from "@/lib/shared-request"
+import { requireContactPermissionScope } from "../permissions"
 import {
   type UpdateContactFieldRequest,
   updateContactFieldRequest,
@@ -26,20 +27,23 @@ export const updateContactFieldAction = workspaceActionClient
       bindArgsParsedInputs: [workspaceId, id],
       parsedInput,
     } = props
+    const accessScope = await requireContactPermissionScope(workspaceId)
 
-    await updateContactFields({ workspaceId, id }, parsedInput)
+    await updateContactFields({ workspaceId, id, accessScope }, parsedInput)
   })
 
 export const updateContactFields = async (
   ctx: {
     workspaceId: string
     id: string
+    accessScope?: ContactAccessScope
   },
   parsedInput: UpdateContactFieldRequest,
 ) => {
   await contactService.findByIdOrFail({
     workspaceId: ctx.workspaceId,
     id: ctx.id,
+    accessScope: ctx.accessScope,
   })
 
   const allCustomFields = await listCustomFields({

--- a/apps/builder/src/features/contacts/actions/update-contact-tag.action.ts
+++ b/apps/builder/src/features/contacts/actions/update-contact-tag.action.ts
@@ -1,6 +1,10 @@
 "use server"
 
-import { contactService, tagSyncService } from "@chatbotx.io/business"
+import {
+  type ContactAccessScope,
+  contactService,
+  tagSyncService,
+} from "@chatbotx.io/business"
 import { and, db, eq, isNull, notInArray } from "@chatbotx.io/database/client"
 import { contactsToTagsModel, tagModel } from "@chatbotx.io/database/schema"
 import { emitTagApplied, emitTagRemoved } from "@chatbotx.io/events"
@@ -13,6 +17,7 @@ import {
 import type { TagResource } from "@/features/tags/schema/resource"
 import { logger } from "@/lib/log"
 import { workspaceActionClient } from "@/lib/safe-action"
+import { requireContactPermissionScope } from "../permissions"
 import {
   type UpdateContactTagRequest,
   updateContactTagRequest,
@@ -28,19 +33,25 @@ export const updateContactTagAction = workspaceActionClient
     }: {
       bindArgsParsedInputs: WorkspaceIdRequestParams
       parsedInput: UpdateContactTagRequest
-    }) => await updateContactTags({ workspaceId, parsedInput }),
+    }) => {
+      const accessScope = await requireContactPermissionScope(workspaceId)
+      return await updateContactTags({ workspaceId, parsedInput, accessScope })
+    },
   )
 
 export const updateContactTags = async ({
   workspaceId,
   parsedInput,
+  accessScope,
 }: {
   workspaceId: string
   parsedInput: UpdateContactTagRequest
+  accessScope?: ContactAccessScope
 }): Promise<TagResource[]> => {
   const contact = await contactService.findByIdOrFail({
     workspaceId,
     id: parsedInput.contactId,
+    accessScope,
   })
 
   // Get old tags before update

--- a/apps/builder/src/features/contacts/api/authenticated.ts
+++ b/apps/builder/src/features/contacts/api/authenticated.ts
@@ -8,6 +8,7 @@ import { addContactTags } from "../actions/add-contact-tag.action"
 import { createContact } from "../actions/create-contact.action"
 import { deleteContactCustomFields } from "../actions/delete-contact-custom-field.action"
 import { removeContactTags } from "../actions/remove-contact-tag.action"
+import { requireContactPermissionScope } from "../permissions"
 import { getContact } from "../queries/get-contact.query"
 import { getExportFile } from "../queries/get-export-file.query"
 import { listContactCustomFields } from "../queries/list-contact-fields.query"
@@ -92,7 +93,10 @@ export const contactsAuthenticatedAPI = {
     .input(listContactsRequest)
     .use(workspaceAuthorizedMidddleware, (input) => input.workspaceId)
     .output(z.object({ total: z.number() }))
-    .handler(async ({ input }) => await countContactInboxes(input)),
+    .handler(async ({ input }) => {
+      await requireContactPermissionScope(input.workspaceId)
+      return await countContactInboxes(input)
+    }),
 
   createContactAuthenticatedAPI: authorizedAPI
     .route({
@@ -106,6 +110,7 @@ export const contactsAuthenticatedAPI = {
     .use(workspaceAuthorizedMidddleware, (input) => input.workspaceId)
     .handler(async ({ input }) => {
       const { workspaceId, ...parsedInput } = input
+      await requireContactPermissionScope(workspaceId)
       return await createContact({ workspaceId, parsedInput })
     }),
 
@@ -119,7 +124,10 @@ export const contactsAuthenticatedAPI = {
     .input(getExportFileRequest)
     .output(getExportFileResponse)
     .use(workspaceAuthorizedMidddleware, (input) => input.workspaceId)
-    .handler(async ({ input }) => await getExportFile(input)),
+    .handler(async ({ input }) => {
+      await requireContactPermissionScope(input.workspaceId)
+      return await getExportFile(input)
+    }),
 
   listContactTagsAuthenticatedAPI: authorizedAPI
     .route({
@@ -133,9 +141,11 @@ export const contactsAuthenticatedAPI = {
     .use(workspaceAuthorizedMidddleware, (input) => input.workspaceId)
     .handler(async ({ input }) => {
       const { workspaceId, contactId } = input
+      const accessScope = await requireContactPermissionScope(workspaceId)
       return await listContactTags({
         workspaceId,
         contactId,
+        accessScope,
       })
     }),
 
@@ -150,12 +160,14 @@ export const contactsAuthenticatedAPI = {
     .use(workspaceAuthorizedMidddleware, (input) => input.workspaceId)
     .handler(async ({ input }) => {
       const { workspaceId, tags, ids } = input
+      const accessScope = await requireContactPermissionScope(workspaceId)
       await addContactTags({
         workspaceId,
         parsedInput: {
           ids,
           tags,
         },
+        accessScope,
       })
     }),
 
@@ -170,6 +182,7 @@ export const contactsAuthenticatedAPI = {
     .use(workspaceAuthorizedMidddleware, (input) => input.workspaceId)
     .handler(async ({ input }) => {
       const { workspaceId, contactId, tagId } = input
+      const accessScope = await requireContactPermissionScope(workspaceId)
       // removeContactTags resolves tags by name; this endpoint takes a tag id.
       const tag = await db.query.tagModel.findFirst({
         where: { workspaceId, id: tagId, deletedAt: { isNull: true as const } },
@@ -184,6 +197,7 @@ export const contactsAuthenticatedAPI = {
           ids: [contactId],
           tags: [tag.name],
         },
+        accessScope,
       })
     }),
 
@@ -199,10 +213,12 @@ export const contactsAuthenticatedAPI = {
     .use(workspaceAuthorizedMidddleware, (input) => input.workspaceId)
     .handler(async ({ input }) => {
       const { workspaceId, contactId } = input
+      const accessScope = await requireContactPermissionScope(workspaceId)
 
       return await listContactCustomFields({
         workspaceId,
         contactId,
+        accessScope,
       })
     }),
 
@@ -217,11 +233,13 @@ export const contactsAuthenticatedAPI = {
     .use(workspaceAuthorizedMidddleware, (input) => input.workspaceId)
     .handler(async ({ input }) => {
       const { workspaceId, contactId } = input
+      const accessScope = await requireContactPermissionScope(workspaceId)
       return await setContactCustomFieldValue({
         workspaceId,
         contactId,
         customFieldId: input.customFieldId,
         value: input.value,
+        accessScope,
       })
     }),
 
@@ -236,10 +254,12 @@ export const contactsAuthenticatedAPI = {
     .use(workspaceAuthorizedMidddleware, (input) => input.workspaceId)
     .handler(async ({ input }) => {
       const { workspaceId, contactId, customFieldId } = input
+      const accessScope = await requireContactPermissionScope(workspaceId)
       return await deleteContactCustomFields({
         workspaceId,
         contactIds: [contactId],
         customFieldId,
+        accessScope,
       })
     }),
 }

--- a/apps/builder/src/features/contacts/permissions.ts
+++ b/apps/builder/src/features/contacts/permissions.ts
@@ -1,3 +1,4 @@
+import { ChatbotXException } from "@chatbotx.io/business/errors"
 import type { WorkspaceMemberPermissions } from "@chatbotx.io/database/partials"
 import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
 import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
@@ -45,6 +46,32 @@ export async function resolveContactPermissionScope(
 
   const { user, targetWorkspaceMember } = userAndWorkspace
   const permissions = targetWorkspaceMember.permissions
+  if (!canAccessContactsSection(permissions)) {
+    return null
+  }
+
+  return {
+    canViewEmailAndPhone: canViewContactEmailAndPhone(permissions),
+    restrictToAssignedUserId: getAssignedContactsUserId({
+      permissions,
+      userId: user.id,
+    }),
+  }
+}
+
+export async function requireContactPermissionScope(
+  workspaceId: string,
+): Promise<ContactPermissionScope> {
+  const userAndWorkspace = await getCurrentUserAndTargetWorkspace(workspaceId)
+  if (!userAndWorkspace) {
+    throw new ChatbotXException("User is not associated with this workspace")
+  }
+
+  const { user, targetWorkspaceMember } = userAndWorkspace
+  const permissions = targetWorkspaceMember.permissions
+  if (!canAccessContactsSection(permissions)) {
+    throw new ChatbotXException("User is not authorized to access contacts")
+  }
 
   return {
     canViewEmailAndPhone: canViewContactEmailAndPhone(permissions),

--- a/apps/builder/src/features/contacts/permissions.ts
+++ b/apps/builder/src/features/contacts/permissions.ts
@@ -1,0 +1,66 @@
+import type { WorkspaceMemberPermissions } from "@chatbotx.io/database/partials"
+import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
+import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
+
+type Permissions = WorkspaceMemberPermissions | Record<string, unknown>
+
+export { stripContactPIIFields } from "@chatbotx.io/worker-config/contact-pii"
+
+export type ContactPermissionScope = {
+  canViewEmailAndPhone: boolean
+  restrictToAssignedUserId?: string
+}
+
+export function canViewContactEmailAndPhone(permissions: Permissions): boolean {
+  return hasWorkspacePermission(permissions, "emailAndPhone")
+}
+
+export function canAccessContactsSection(permissions: Permissions): boolean {
+  return (
+    hasWorkspacePermission(permissions, "contacts") ||
+    hasWorkspacePermission(permissions, "onlyAssignedContacts")
+  )
+}
+
+export function getAssignedContactsUserId(input: {
+  permissions: Permissions
+  userId: string
+}): string | undefined {
+  if (hasWorkspacePermission(input.permissions, "superAdmin")) {
+    return
+  }
+
+  return hasWorkspacePermission(input.permissions, "onlyAssignedContacts")
+    ? input.userId
+    : undefined
+}
+
+export async function resolveContactPermissionScope(
+  workspaceId: string,
+): Promise<ContactPermissionScope | null> {
+  const userAndWorkspace = await getCurrentUserAndTargetWorkspace(workspaceId)
+  if (!userAndWorkspace) {
+    return null
+  }
+
+  const { user, targetWorkspaceMember } = userAndWorkspace
+  const permissions = targetWorkspaceMember.permissions
+
+  return {
+    canViewEmailAndPhone: canViewContactEmailAndPhone(permissions),
+    restrictToAssignedUserId: getAssignedContactsUserId({
+      permissions,
+      userId: user.id,
+    }),
+  }
+}
+
+export function maskContactEmailAndPhone<
+  TContact extends { email: string | null; phoneNumber: string | null },
+>(contact: TContact): TContact {
+  return {
+    ...contact,
+    email: null,
+    phoneNumber: null,
+  }
+}

--- a/apps/builder/src/features/contacts/queries/__tests__/list-contacts.queries.test.ts
+++ b/apps/builder/src/features/contacts/queries/__tests__/list-contacts.queries.test.ts
@@ -2,23 +2,28 @@
 import { describe, expect, test, vi } from "vitest"
 
 vi.mock("@chatbotx.io/database/client", () => ({
+  countWithRelationsFilter: vi.fn(),
   db: { query: { contactModel: { findMany: vi.fn() } }, $count: vi.fn() },
-  relationsFilterToSQL: vi.fn(),
 }))
 vi.mock("@chatbotx.io/database/queries", () => ({
-  applyContactFilter: vi.fn(),
+  applyContactFilter: (criteria: unknown) => ({
+    conversation: { status: "open" },
+    __filter: criteria,
+  }),
 }))
 vi.mock("@chatbotx.io/database/schema", () => ({
   contactModel: { createdAt: "createdAt", fullName: "fullName" },
 }))
 vi.mock("@/lib/auth/utils", () => ({
-  assertCurrentUserCanAccessChatbot: vi.fn(),
+  getCurrentUserAndTargetWorkspace: vi.fn(),
 }))
 vi.mock("@/lib/log", () => ({
   logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }))
 
-const { resolveOrderBy } = await import("../list-contacts.queries")
+const { generateWhere, resolveOrderBy } = await import(
+  "../list-contacts.queries"
+)
 
 const baseInput = { workspaceId: "1" }
 
@@ -40,5 +45,46 @@ describe("resolveOrderBy", () => {
         sort: [{ id: "fullName", desc: false }],
       }),
     ).toEqual({ fullName: "asc" })
+  })
+})
+
+describe("generateWhere", () => {
+  test("adds the assigned-user conversation filter", () => {
+    const where = generateWhere(baseInput, {
+      canViewEmailAndPhone: true,
+      restrictToAssignedUserId: "user-1",
+    })
+
+    expect(where.conversation).toEqual({ assignedUserId: "user-1" })
+  })
+
+  test("drops email and phone keyword clauses when PII is denied", () => {
+    const where = generateWhere(
+      { ...baseInput, keyword: "Alice" },
+      { canViewEmailAndPhone: false },
+    )
+
+    expect(where.OR).toEqual([
+      { firstName: { ilike: "%alice%" } },
+      { lastName: { ilike: "%alice%" } },
+    ])
+  })
+
+  test("preserves existing conversation filters when adding assigned-user scope", () => {
+    const where = generateWhere(
+      {
+        ...baseInput,
+        contactFilter: { operator: "and", conditions: [] },
+      },
+      {
+        canViewEmailAndPhone: true,
+        restrictToAssignedUserId: "user-1",
+      },
+    )
+
+    expect(where.conversation).toEqual({
+      status: "open",
+      assignedUserId: "user-1",
+    })
   })
 })

--- a/apps/builder/src/features/contacts/queries/get-contact.query.ts
+++ b/apps/builder/src/features/contacts/queries/get-contact.query.ts
@@ -1,11 +1,20 @@
 import { notFoundException } from "@chatbotx.io/business/errors"
 import { db } from "@chatbotx.io/database/client"
 import type { CustomFieldType } from "@chatbotx.io/database/partials"
+import {
+  maskContactEmailAndPhone,
+  resolveContactPermissionScope,
+} from "../permissions"
 import type { GetContactRequest, GetContactResponse } from "../schemas/query"
 
 export async function getContact(
   input: GetContactRequest,
 ): Promise<GetContactResponse> {
+  const scope = await resolveContactPermissionScope(input.workspaceId)
+  if (!scope) {
+    throw notFoundException("Contact not found")
+  }
+
   const contact = await db.query.contactModel.findFirst({
     where: {
       id: input.contactId,
@@ -24,6 +33,7 @@ export async function getContact(
           sequence: true,
         },
       },
+      conversation: true,
     },
   })
 
@@ -31,10 +41,24 @@ export async function getContact(
     throw notFoundException("Contact not found")
   }
 
-  const { contactCustomFields, ...contactFields } = contact
+  if (
+    scope.restrictToAssignedUserId &&
+    contact.conversation?.assignedUserId !== scope.restrictToAssignedUserId
+  ) {
+    throw notFoundException("Contact not found")
+  }
+
+  const {
+    contactCustomFields,
+    conversation: _conversation,
+    ...contactFields
+  } = contact
+  const visibleContactFields = scope.canViewEmailAndPhone
+    ? contactFields
+    : maskContactEmailAndPhone(contactFields)
 
   return {
-    ...contactFields,
+    ...visibleContactFields,
     customFields: contactCustomFields.map((ccf) => ({
       ...ccf.customField,
       type: ccf.customField.type as CustomFieldType,

--- a/apps/builder/src/features/contacts/queries/list-contact-fields.query.ts
+++ b/apps/builder/src/features/contacts/queries/list-contact-fields.query.ts
@@ -1,3 +1,4 @@
+import { type ContactAccessScope, contactService } from "@chatbotx.io/business"
 import { notFoundException } from "@chatbotx.io/business/errors"
 import { db } from "@chatbotx.io/database/client"
 import type { CustomFieldType } from "@chatbotx.io/database/partials"
@@ -8,8 +9,16 @@ import type {
 } from "../schemas/contact-custom-field"
 
 export async function listContactCustomFields(
-  input: ListContactCustomFieldsRequest,
+  input: ListContactCustomFieldsRequest & { accessScope?: ContactAccessScope },
 ): Promise<ListPublicContactCustomFieldsResponse> {
+  if (input.accessScope) {
+    await contactService.findByIdOrFail({
+      workspaceId: input.workspaceId,
+      id: input.contactId,
+      accessScope: input.accessScope,
+    })
+  }
+
   const data = await db.query.contactCustomFieldModel.findMany({
     where: {
       contactId: input.contactId,

--- a/apps/builder/src/features/contacts/queries/list-contact-tags.query.ts
+++ b/apps/builder/src/features/contacts/queries/list-contact-tags.query.ts
@@ -1,3 +1,4 @@
+import { type ContactAccessScope, contactService } from "@chatbotx.io/business"
 import { db } from "@chatbotx.io/database/client"
 import type {
   ListContactTagsRequest,
@@ -5,8 +6,16 @@ import type {
 } from "../schemas/contact-tag"
 
 export async function listContactTags(
-  input: ListContactTagsRequest,
+  input: ListContactTagsRequest & { accessScope?: ContactAccessScope },
 ): Promise<ListContactTagsResponse> {
+  if (input.accessScope) {
+    await contactService.findByIdOrFail({
+      workspaceId: input.workspaceId,
+      id: input.contactId,
+      accessScope: input.accessScope,
+    })
+  }
+
   const data = await db.query.tagModel.findMany({
     where: {
       workspaceId: input.workspaceId,

--- a/apps/builder/src/features/contacts/queries/list-contacts.queries.ts
+++ b/apps/builder/src/features/contacts/queries/list-contacts.queries.ts
@@ -1,12 +1,17 @@
-import { db, relationsFilterToSQL } from "@chatbotx.io/database/client"
+import { ChatbotXException } from "@chatbotx.io/business/errors"
+import { countWithRelationsFilter, db } from "@chatbotx.io/database/client"
 import { applyContactFilter } from "@chatbotx.io/database/queries"
 import { contactModel } from "@chatbotx.io/database/schema"
 import {
   getPaginationWithDefaults,
   parseOrderByAsObject,
 } from "@chatbotx.io/database/utils"
-import { assertCurrentUserCanAccessChatbot } from "@/lib/auth/utils"
 import { logger } from "@/lib/log"
+import {
+  type ContactPermissionScope,
+  maskContactEmailAndPhone,
+  resolveContactPermissionScope,
+} from "../permissions"
 import type {
   ListContactsRequest,
   ListContactsResponse,
@@ -28,20 +33,24 @@ export function resolveOrderBy(input: ListContactsRequest) {
 export async function listContacts(
   input: ListContactsRequest,
 ): Promise<ListContactsResponse> {
-  await assertCurrentUserCanAccessChatbot(input.workspaceId)
-  return queryContacts(input)
+  const scope = await requireContactPermissionScope(input.workspaceId)
+  return queryContacts(input, scope)
 }
 
 export function listContactsForAPI(
   input: ListContactsRequest,
 ): Promise<ListContactsResponse> {
-  return queryContacts(input)
+  // Workspace-token surface: not scoped to a workspace member. Callers must opt
+  // out of member scoping explicitly so it can never be dropped by accident.
+  return queryContacts(input, "unscoped")
 }
 
 async function queryContacts(
   input: ListContactsRequest,
+  scopeInput: ContactPermissionScope | "unscoped",
 ): Promise<ListContactsResponse> {
-  const where = generateWhere(input)
+  const scope = scopeInput === "unscoped" ? undefined : scopeInput
+  const where = generateWhere(input, scope)
 
   const pagination = getPaginationWithDefaults(input)
   const orderBy = resolveOrderBy(input)
@@ -67,21 +76,29 @@ async function queryContacts(
         },
       },
     }),
-    // biome-ignore lint/suspicious/noExplicitAny: relationsFilterToSQL requires typed Drizzle filter
-    db.$count(contactModel, relationsFilterToSQL(contactModel, where as any)),
+    countWithRelationsFilter({
+      table: contactModel,
+      tsName: "contactModel",
+      where,
+    }),
   ])
 
   const pageCount = Math.ceil(totalRows / pagination.limit)
+  // Unscoped (token) callers see PII; scoped members only when permitted.
+  const visibleData =
+    scope && !scope.canViewEmailAndPhone
+      ? data.map(maskContactEmailAndPhone)
+      : data
 
-  return { data, pageCount }
+  return { data: visibleData, pageCount }
 }
 
 export async function listContactsRSC(
   input: ListContactsRequest & { workspaceId: string },
 ): Promise<ListContactsResponse> {
-  await assertCurrentUserCanAccessChatbot(input.workspaceId)
+  const scope = await requireContactPermissionScope(input.workspaceId)
 
-  const where = generateWhere(input)
+  const where = generateWhere(input, scope)
 
   const pagination = getPaginationWithDefaults(input)
   const orderBy = resolveOrderBy(input)
@@ -106,31 +123,39 @@ export async function listContactsRSC(
         },
       },
     }),
-    // biome-ignore lint/suspicious/noExplicitAny: relationsFilterToSQL requires typed Drizzle filter
-    db.$count(contactModel, relationsFilterToSQL(contactModel, where as any)),
+    countWithRelationsFilter({
+      table: contactModel,
+      tsName: "contactModel",
+      where,
+    }),
   ])
 
   const pageCount = Math.ceil(totalRows / pagination.limit)
+  const visibleData = scope.canViewEmailAndPhone
+    ? data
+    : data.map(maskContactEmailAndPhone)
 
-  return { data, pageCount }
+  return { data: visibleData, pageCount }
 }
 
 export async function countContacts(
   input: ListContactsRequest,
 ): Promise<{ total: number }> {
-  await assertCurrentUserCanAccessChatbot(input.workspaceId)
+  const scope = await requireContactPermissionScope(input.workspaceId)
 
-  if (!input.keyword) {
+  if (
+    !(input.keyword || input.contactFilter || scope.restrictToAssignedUserId)
+  ) {
     return getTotalContactsFromStats(input.workspaceId)
   }
 
-  const where = generateWhere(input)
+  const where = generateWhere(input, scope)
 
-  const total = await db.$count(
-    contactModel,
-    // biome-ignore lint/suspicious/noExplicitAny: relationsFilterToSQL requires typed Drizzle filter
-    relationsFilterToSQL(contactModel, where as any),
-  )
+  const total = await countWithRelationsFilter({
+    table: contactModel,
+    tsName: "contactModel",
+    where,
+  })
   return { total }
 }
 
@@ -157,7 +182,21 @@ async function getTotalContactsFromStats(
   }
 }
 
-const generateWhere = (input: ListContactsRequest) => {
+async function requireContactPermissionScope(
+  workspaceId: string,
+): Promise<ContactPermissionScope> {
+  const scope = await resolveContactPermissionScope(workspaceId)
+  if (!scope) {
+    throw new ChatbotXException("User is not associated with this workspace")
+  }
+
+  return scope
+}
+
+export const generateWhere = (
+  input: ListContactsRequest,
+  scope?: ContactPermissionScope,
+) => {
   const keyword = input.keyword?.toLowerCase()
   const where: Record<string, unknown> = {
     workspaceId: input.workspaceId,
@@ -166,8 +205,12 @@ const generateWhere = (input: ListContactsRequest) => {
           OR: [
             { firstName: { ilike: `%${keyword}%` } },
             { lastName: { ilike: `%${keyword}%` } },
-            { email: { ilike: `%${keyword}%` } },
-            { phoneNumber: { ilike: `%${keyword}%` } },
+            ...(scope?.canViewEmailAndPhone === false
+              ? []
+              : [
+                  { email: { ilike: `%${keyword}%` } },
+                  { phoneNumber: { ilike: `%${keyword}%` } },
+                ]),
           ],
         }
       : {}),
@@ -175,6 +218,20 @@ const generateWhere = (input: ListContactsRequest) => {
 
   if (input.contactFilter) {
     Object.assign(where, applyContactFilter(input.contactFilter))
+  }
+
+  if (scope?.restrictToAssignedUserId) {
+    const conversation =
+      typeof where.conversation === "object" &&
+      where.conversation !== null &&
+      !Array.isArray(where.conversation)
+        ? where.conversation
+        : {}
+
+    where.conversation = {
+      ...conversation,
+      assignedUserId: scope.restrictToAssignedUserId,
+    }
   }
 
   return where

--- a/apps/builder/src/features/integration-instagram/libs/oauth.ts
+++ b/apps/builder/src/features/integration-instagram/libs/oauth.ts
@@ -14,7 +14,7 @@ export async function generateInstagramRedirectUri(
   const redirectUrl = buildBrokerCallbackUrl("/integrations/instagram/callback")
   const baseUrl = await getOriginUrlFromHeader()
   const referer = workspaceId
-    ? new URL(`/space/${workspaceId}/dashboard`, baseUrl).toString()
+    ? new URL(`/space/${workspaceId}`, baseUrl).toString()
     : baseUrl
 
   return generateAuthUrl({

--- a/apps/builder/src/features/integration-messenger/libs/oauth.ts
+++ b/apps/builder/src/features/integration-messenger/libs/oauth.ts
@@ -14,7 +14,7 @@ export async function generateMessengerRedirectUri(
   const redirectUrl = buildBrokerCallbackUrl("/integrations/messenger/callback")
   const baseUrl = await getOriginUrlFromHeader()
   const referer = workspaceId
-    ? new URL(`/space/${workspaceId}/dashboard`, baseUrl).toString()
+    ? new URL(`/space/${workspaceId}`, baseUrl).toString()
     : baseUrl
 
   return generateAuthUrl({

--- a/apps/builder/src/features/integration-tiktok/libs/tiktok.ts
+++ b/apps/builder/src/features/integration-tiktok/libs/tiktok.ts
@@ -14,7 +14,7 @@ export async function generateTiktokRedirectUri(
   const redirectUrl = buildBrokerCallbackUrl("/integrations/tiktok/callback")
   const baseUrl = await getOriginUrlFromHeader()
   const referer = workspaceId
-    ? new URL(`/space/${workspaceId}/dashboard`, baseUrl).toString()
+    ? new URL(`/space/${workspaceId}`, baseUrl).toString()
     : baseUrl
 
   return generateAuthUrl({

--- a/apps/builder/src/features/integration-whatsapp/actions/connect.action.ts
+++ b/apps/builder/src/features/integration-whatsapp/actions/connect.action.ts
@@ -326,7 +326,7 @@ function buildResult(params: {
 
   return {
     type: "redirect",
-    redirectUrl: `/space/${workspaceId}/dashboard`,
+    redirectUrl: `/space/${workspaceId}`,
     integrationId,
     workspaceId,
     isCoexist,

--- a/apps/builder/src/features/integration-zalo/libs/zalo.ts
+++ b/apps/builder/src/features/integration-zalo/libs/zalo.ts
@@ -15,7 +15,7 @@ export async function generateZaloRedirectUri(
   // `referer` (the callback relays back to it), matching the other integrations.
   const redirectUrl = buildBrokerCallbackUrl("/integrations/zalo/callback")
   const referer = workspaceId
-    ? new URL(`/space/${workspaceId}/dashboard`, baseUrl).toString()
+    ? new URL(`/space/${workspaceId}`, baseUrl).toString()
     : baseUrl
 
   return generateAuthUrl({

--- a/apps/builder/src/features/invitations/actions/accept-invitation.ts
+++ b/apps/builder/src/features/invitations/actions/accept-invitation.ts
@@ -10,8 +10,11 @@ import {
   invitationModel,
   workspaceMemberModel,
 } from "@chatbotx.io/database/schema"
+import { invalidateCacheByTags } from "@chatbotx.io/redis"
 import { createId } from "@chatbotx.io/utils"
 import { z } from "zod"
+import { isCommunity } from "@/env"
+import { getSuperAdminPermissions } from "@/features/workspace-members/helpers"
 import { authActionClient } from "@/lib/safe-action"
 
 export const acceptInvitationAction = authActionClient
@@ -64,12 +67,19 @@ export const acceptInvitationAction = authActionClient
       }
     }
 
+    // Defense in depth: even though invite-time normalization is the source of
+    // truth, re-force full super-admin permissions for community here so a row
+    // written by any other path can't grant a restricted community member.
+    const permissions = isCommunity()
+      ? getSuperAdminPermissions()
+      : invitation.permissions
+
     await db.insert(workspaceMemberModel).values({
       id: createId(),
       workspaceId: invitation.workspaceId,
       userId: ctx.user.id,
       role: "agent",
-      permissions: invitation.permissions,
+      permissions,
       notificationTypes: {
         notifyAdmin: true,
         newMessageToHuman: true,
@@ -82,4 +92,8 @@ export const acceptInvitationAction = authActionClient
         browser: true,
       },
     })
+
+    // The new membership must show up in the invitee's cached workspace list
+    // right away; bust the tag so the workspace becomes reachable immediately.
+    await invalidateCacheByTags([`users:${ctx.user.id}:workspace-members`])
   })

--- a/apps/builder/src/features/workspace-members/actions/delete-workspace-member.action.ts
+++ b/apps/builder/src/features/workspace-members/actions/delete-workspace-member.action.ts
@@ -3,7 +3,9 @@
 import { ChatbotXException } from "@chatbotx.io/business/errors"
 import { db, eq, findOrFail } from "@chatbotx.io/database/client"
 import { workspaceMemberModel } from "@chatbotx.io/database/schema"
+import { invalidateCacheByTags } from "@chatbotx.io/redis"
 import { zodBigintAsString } from "@chatbotx.io/utils"
+import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
 import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
 import { workspaceActionClient } from "@/lib/safe-action"
 
@@ -36,11 +38,17 @@ export const deleteWorkspaceMemberAction = workspaceActionClient
 
     const permissions =
       currentUserAndTargetChatbot.targetWorkspaceMember.permissions
-    if (!permissions.superAdmin) {
+    if (!hasWorkspacePermission(permissions, "superAdmin")) {
       throw new ChatbotXException(
         "You are not authorized to delete this workspace member. You need to be a super admin to do this.",
       )
     }
 
     await db.delete(workspaceMemberModel).where(eq(workspaceMemberModel.id, id))
+
+    // The removed member's cached `listByUserId` result still lists this
+    // workspace; bust it so their access is revoked immediately.
+    await invalidateCacheByTags([
+      `users:${workspaceMember.userId}:workspace-members`,
+    ])
   })

--- a/apps/builder/src/features/workspace-members/actions/invite-workspace-member.action.ts
+++ b/apps/builder/src/features/workspace-members/actions/invite-workspace-member.action.ts
@@ -9,8 +9,15 @@ import { db } from "@chatbotx.io/database/client"
 import { invitationModel } from "@chatbotx.io/database/schema"
 import { createId, SymbolicSnowflakeIDs } from "@chatbotx.io/utils"
 import { addDays } from "date-fns"
+import { isCommunity } from "@/env"
 import { workspaceIdrequestParams } from "@/features/common/schemas"
+import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
+import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
 import { workspaceActionClient } from "@/lib/safe-action"
+import {
+  getSuperAdminPermissions,
+  normalizeContactsPermissions,
+} from "../helpers"
 import { inviteWorkspaceMemberRequest } from "../schema/mutation"
 
 export const inviteWorkspaceMemberAction = workspaceActionClient
@@ -21,6 +28,22 @@ export const inviteWorkspaceMemberAction = workspaceActionClient
     // is accepted (accept-invitation.ts), so block issuing a new invitation
     // once the workspace owner is already at the limit (own or reseller pool).
     const workspace = await workspaceService.findById({ id: workspaceId })
+    const currentUserAndTargetChatbot =
+      await getCurrentUserAndTargetWorkspace(workspaceId)
+    if (!currentUserAndTargetChatbot) {
+      throw new ChatbotXException(
+        "You are not authorized to invite a workspace member",
+      )
+    }
+
+    const currentPermissions =
+      currentUserAndTargetChatbot.targetWorkspaceMember.permissions
+    if (!hasWorkspacePermission(currentPermissions, "superAdmin")) {
+      throw new ChatbotXException(
+        "You are not authorized to invite a workspace member. You need to be a super admin to do this.",
+      )
+    }
+
     const atLimit = await quotaEnforcementService.hasReachedLimit({
       userId: workspace.ownerId,
       metric: "teamMembers",
@@ -36,7 +59,9 @@ export const inviteWorkspaceMemberAction = workspaceActionClient
       .values({
         id: createId(),
         code: SymbolicSnowflakeIDs.generate(),
-        permissions: parsedInput.permissions,
+        permissions: isCommunity()
+          ? getSuperAdminPermissions()
+          : normalizeContactsPermissions(parsedInput.permissions),
         expiresAt: addDays(new Date(), 1),
         workspaceId,
         invitedBy: ctx.user.id,

--- a/apps/builder/src/features/workspace-members/actions/update-workspace-member.action.ts
+++ b/apps/builder/src/features/workspace-members/actions/update-workspace-member.action.ts
@@ -3,9 +3,16 @@
 import { ChatbotXException } from "@chatbotx.io/business/errors"
 import { db, eq, findOrFail } from "@chatbotx.io/database/client"
 import { workspaceMemberModel } from "@chatbotx.io/database/schema"
+import { invalidateCacheByTags } from "@chatbotx.io/redis"
+import { isCommunity } from "@/env"
 import { workspaceIdAndIdRequestParams } from "@/features/common/schemas"
+import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
 import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
 import { workspaceActionClient } from "@/lib/safe-action"
+import {
+  getSuperAdminPermissions,
+  normalizeContactsPermissions,
+} from "../helpers"
 import { updateWorkspaceMemberRequest } from "../schema/mutation"
 
 export const updateWorkspaceMemberAction = workspaceActionClient
@@ -28,14 +35,30 @@ export const updateWorkspaceMemberAction = workspaceActionClient
 
     const permissions =
       currentUserAndTargetChatbot.targetWorkspaceMember.permissions
-    if (!permissions.superAdmin) {
+    if (!hasWorkspacePermission(permissions, "superAdmin")) {
       throw new ChatbotXException(
         "You are not authorized to update this workspace member. You need to be a super admin to do this.",
       )
     }
 
+    const updateInput = isCommunity()
+      ? {
+          ...parsedInput,
+          permissions: getSuperAdminPermissions(),
+        }
+      : {
+          ...parsedInput,
+          permissions: normalizeContactsPermissions(parsedInput.permissions),
+        }
+
     await db
       .update(workspaceMemberModel)
-      .set(parsedInput)
+      .set(updateInput)
       .where(eq(workspaceMemberModel.id, workspaceMember.id))
+
+    // The member's permissions/nav are served from the cached
+    // `listByUserId` result; bust it so the change takes effect immediately.
+    await invalidateCacheByTags([
+      `users:${workspaceMember.userId}:workspace-members`,
+    ])
   })

--- a/apps/builder/src/features/workspace-members/components/invite-workspace-member.tsx
+++ b/apps/builder/src/features/workspace-members/components/invite-workspace-member.tsx
@@ -22,14 +22,15 @@ import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hoo
 import { CopyIcon, CrownIcon, Loader2Icon, PlusIcon } from "lucide-react"
 import Link from "next/link"
 import { useTranslations } from "next-intl"
-import { useEffect, useState } from "react"
-import { useWatch } from "react-hook-form"
+import { useState } from "react"
 import { toast } from "sonner"
 import { useCopyToClipboard } from "usehooks-ts"
 import { UpgradePlanButton } from "@/enterprise/features/billing/upgrade-plan-dialog"
 import { isCloud, isCommunity } from "@/env"
 import { useWorkspaceId } from "@/hooks/routing"
 import { inviteWorkspaceMemberAction } from "../actions/invite-workspace-member.action"
+import { getSuperAdminPermissions } from "../helpers"
+import { useWorkspaceMemberPermissionsCoupling } from "../hooks/use-permissions-coupling"
 import { inviteWorkspaceMemberRequest } from "../schema/mutation"
 export function InviteWorkspaceMemberDialog({
   atLimit = false,
@@ -173,37 +174,14 @@ export function AddWorkspaceMemberForm({
         formProps: {
           mode: "onChange",
           defaultValues: {
-            permissions: {
-              superAdmin: true,
-              analytics: false,
-              flows: false,
-              contacts: false,
-              onlyAssignedContacts: false,
-              emailAndPhone: false,
-              broadcast: false,
-              ecommerce: false,
-            },
+            permissions: getSuperAdminPermissions(),
           },
         },
       },
     )
 
-  const { setValue } = form
-  const isSuperAdmin = useWatch({
-    control: form.control,
-    name: "permissions.superAdmin",
-  })
-  useEffect(() => {
-    if (isSuperAdmin) {
-      setValue("permissions.analytics", true)
-      setValue("permissions.flows", true)
-      setValue("permissions.contacts", true)
-      setValue("permissions.onlyAssignedContacts", true)
-      setValue("permissions.emailAndPhone", true)
-      setValue("permissions.broadcast", true)
-      setValue("permissions.ecommerce", true)
-    }
-  }, [isSuperAdmin, setValue])
+  const { isSuperAdmin, contactsEnabled } =
+    useWorkspaceMemberPermissionsCoupling(form)
 
   return (
     <Form {...form}>
@@ -237,12 +215,14 @@ export function AddWorkspaceMemberForm({
                 name="permissions.contacts"
                 required
               />
-              <SwitchField
-                formItemClassName="flex flex-row-reverse items-center justify-end gap-2"
-                label={t("fields.permissions.onlyAssignedContacts")}
-                name="permissions.onlyAssignedContacts"
-                required
-              />
+              {!contactsEnabled && (
+                <SwitchField
+                  formItemClassName="flex flex-row-reverse items-center justify-end gap-2"
+                  label={t("fields.permissions.onlyAssignedContacts")}
+                  name="permissions.onlyAssignedContacts"
+                  required
+                />
+              )}
               <SwitchField
                 formItemClassName="flex flex-row-reverse items-center justify-end gap-2"
                 label={t("fields.permissions.emailAndPhone")}

--- a/apps/builder/src/features/workspace-members/components/update-workspace-member.tsx
+++ b/apps/builder/src/features/workspace-members/components/update-workspace-member.tsx
@@ -19,10 +19,11 @@ import { Loader2Icon } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { useEffect } from "react"
-import { useWatch } from "react-hook-form"
 import { toast } from "sonner"
 import { isCommunity } from "@/env"
 import { updateWorkspaceMemberAction } from "../actions/update-workspace-member.action"
+import { getSuperAdminPermissions } from "../helpers"
+import { useWorkspaceMemberPermissionsCoupling } from "../hooks/use-permissions-coupling"
 import { updateWorkspaceMemberRequest } from "../schema/mutation"
 import type { WorkspaceMemberResource } from "../schema/resource"
 
@@ -113,16 +114,7 @@ export function UpdateWorkspaceMemberForm({
         formProps: {
           mode: "onChange",
           defaultValues: {
-            permissions: {
-              superAdmin: true,
-              analytics: true,
-              flows: true,
-              contacts: true,
-              onlyAssignedContacts: true,
-              emailAndPhone: true,
-              broadcast: true,
-              ecommerce: true,
-            },
+            permissions: getSuperAdminPermissions(),
             notificationTypes: {
               notifyAdmin: false,
               newMessageToHuman: false,
@@ -139,23 +131,9 @@ export function UpdateWorkspaceMemberForm({
       },
     )
 
-  const { setValue, reset } = form
-  const isSuperAdmin = useWatch({
-    control: form.control,
-    name: "permissions.superAdmin",
-  })
-
-  useEffect(() => {
-    if (isSuperAdmin) {
-      setValue("permissions.analytics", true)
-      setValue("permissions.flows", true)
-      setValue("permissions.contacts", true)
-      setValue("permissions.onlyAssignedContacts", true)
-      setValue("permissions.emailAndPhone", true)
-      setValue("permissions.broadcast", true)
-      setValue("permissions.ecommerce", true)
-    }
-  }, [isSuperAdmin, setValue])
+  const { reset } = form
+  const { isSuperAdmin, contactsEnabled } =
+    useWorkspaceMemberPermissionsCoupling(form)
 
   useEffect(() => {
     if (workspaceMember) {
@@ -203,12 +181,14 @@ export function UpdateWorkspaceMemberForm({
                   name="permissions.contacts"
                   required
                 />
-                <SwitchField
-                  formItemClassName="flex flex-row-reverse items-center justify-end gap-2"
-                  label={t("fields.permissions.onlyAssignedContacts")}
-                  name="permissions.onlyAssignedContacts"
-                  required
-                />
+                {!contactsEnabled && (
+                  <SwitchField
+                    formItemClassName="flex flex-row-reverse items-center justify-end gap-2"
+                    label={t("fields.permissions.onlyAssignedContacts")}
+                    name="permissions.onlyAssignedContacts"
+                    required
+                  />
+                )}
                 <SwitchField
                   formItemClassName="flex flex-row-reverse items-center justify-end gap-2"
                   label={t("fields.permissions.emailAndPhone")}

--- a/apps/builder/src/features/workspace-members/helpers.ts
+++ b/apps/builder/src/features/workspace-members/helpers.ts
@@ -1,4 +1,31 @@
-import type { WorkspaceMemberNotificationTypes } from "@chatbotx.io/database/partials"
+import type {
+  WorkspaceMemberNotificationTypes,
+  WorkspaceMemberPermissions,
+} from "@chatbotx.io/database/partials"
+
+export function getSuperAdminPermissions(): WorkspaceMemberPermissions {
+  return {
+    superAdmin: true,
+    analytics: true,
+    flows: true,
+    contacts: true,
+    onlyAssignedContacts: true,
+    emailAndPhone: true,
+    broadcast: true,
+    ecommerce: true,
+  }
+}
+
+export function normalizeContactsPermissions(
+  permissions: WorkspaceMemberPermissions,
+): WorkspaceMemberPermissions {
+  return {
+    ...permissions,
+    onlyAssignedContacts: permissions.contacts
+      ? false
+      : permissions.onlyAssignedContacts,
+  }
+}
 
 export function isEnableAtLeastOneNotification(
   notificationTypes: Partial<WorkspaceMemberNotificationTypes>,

--- a/apps/builder/src/features/workspace-members/hooks/use-permissions-coupling.ts
+++ b/apps/builder/src/features/workspace-members/hooks/use-permissions-coupling.ts
@@ -1,0 +1,50 @@
+"use client"
+
+import { useEffect } from "react"
+import { type UseFormReturn, useWatch } from "react-hook-form"
+import type {
+  InviteWorkspaceMemberRequest,
+  UpdateWorkspaceMemberRequest,
+} from "../schema/mutation"
+
+type CouplingResult = {
+  isSuperAdmin: boolean
+  contactsEnabled: boolean
+}
+
+export function useWorkspaceMemberPermissionsCoupling(
+  form:
+    | UseFormReturn<InviteWorkspaceMemberRequest>
+    | UseFormReturn<UpdateWorkspaceMemberRequest>,
+): CouplingResult {
+  const permissionForm = form as UseFormReturn<InviteWorkspaceMemberRequest>
+  const { setValue } = permissionForm
+  const isSuperAdmin = useWatch({
+    control: permissionForm.control,
+    name: "permissions.superAdmin",
+  })
+  const contactsEnabled = useWatch({
+    control: permissionForm.control,
+    name: "permissions.contacts",
+  })
+
+  useEffect(() => {
+    if (isSuperAdmin) {
+      setValue("permissions.analytics", true)
+      setValue("permissions.flows", true)
+      setValue("permissions.contacts", true)
+      setValue("permissions.onlyAssignedContacts", true)
+      setValue("permissions.emailAndPhone", true)
+      setValue("permissions.broadcast", true)
+      setValue("permissions.ecommerce", true)
+    }
+  }, [isSuperAdmin, setValue])
+
+  useEffect(() => {
+    if (contactsEnabled && !isSuperAdmin) {
+      setValue("permissions.onlyAssignedContacts", false)
+    }
+  }, [contactsEnabled, isSuperAdmin, setValue])
+
+  return { isSuperAdmin, contactsEnabled }
+}

--- a/apps/builder/src/features/workspace-members/workspace-members-table.tsx
+++ b/apps/builder/src/features/workspace-members/workspace-members-table.tsx
@@ -37,6 +37,13 @@ type WorkspaceMembersTableProps = {
   teamMembersAtLimit?: boolean
 }
 
+const renderPermissionCell = (enabled: boolean) =>
+  enabled ? (
+    <CheckCircle2Icon className="size-5 text-primary" />
+  ) : (
+    <XCircleIcon className="size-5" />
+  )
+
 export function WorkspaceMembersTable({
   promises,
   teamMembersAtLimit = false,
@@ -55,7 +62,10 @@ export function WorkspaceMembersTable({
       {
         id: "name",
         header: ({ column }) => (
-          <DataTableColumnHeader column={column} title="Name" />
+          <DataTableColumnHeader
+            column={column}
+            title={t("fields.name.label")}
+          />
         ),
         cell: ({ row }) => (
           <div className="flex items-center gap-2">
@@ -84,71 +94,100 @@ export function WorkspaceMembersTable({
         enableHiding: false,
       },
       {
-        id: "enableContacts",
+        id: "superAdmin",
         header: ({ column }) => (
-          <DataTableColumnHeader column={column} title="Contacts" />
+          <DataTableColumnHeader
+            column={column}
+            title={t("fields.permissions.superAdmin")}
+          />
         ),
         cell: ({ row }) =>
-          row.original.permissions.contacts ? (
-            <CheckCircle2Icon className="size-5 text-primary" />
-          ) : (
-            <XCircleIcon className="size-5" />
-          ),
+          renderPermissionCell(row.original.permissions.superAdmin),
         enableHiding: false,
       },
       {
-        id: "enableAnalytics",
+        id: "analytics",
         header: ({ column }) => (
-          <DataTableColumnHeader column={column} title="Analytics" />
+          <DataTableColumnHeader
+            column={column}
+            title={t("fields.permissions.analytics")}
+          />
         ),
         cell: ({ row }) =>
-          row.original.permissions.analytics ? (
-            <CheckCircle2Icon className="size-5 text-primary" />
-          ) : (
-            <XCircleIcon className="size-5" />
-          ),
-        enableHiding: false,
-      },
-      {
-        id: "enableFlows",
-        header: ({ column }) => (
-          <DataTableColumnHeader column={column} title="Flows" />
-        ),
-        cell: ({ row }) =>
-          row.original.permissions.flows ? (
-            <CheckCircle2Icon className="size-5 text-primary" />
-          ) : (
-            <XCircleIcon className="size-5" />
-          ),
+          renderPermissionCell(row.original.permissions.analytics),
         enableHiding: false,
       },
       {
         id: "flows",
-        className: "justify-center",
         header: ({ column }) => (
-          <DataTableColumnHeader column={column} title="Flows" />
+          <DataTableColumnHeader
+            column={column}
+            title={t("fields.permissions.flows")}
+          />
         ),
-        cell: ({ row }) =>
-          row.original.permissions.flows ? (
-            <CheckCircle2Icon className="size-5 text-primary" />
-          ) : (
-            <XCircleIcon className="size-5" />
-          ),
+        cell: ({ row }) => renderPermissionCell(row.original.permissions.flows),
         enableHiding: false,
       },
-      // {
-      //   id: "notificationTypes",
-      //   header: ({ column }) => (
-      //     <DataTableColumnHeader column={column} title="Notifications" />
-      //   ),
-      //   cell: ({ row }) =>
-      //     isEnableAtLeastOneNotification(row.original.notificationTypes) ? (
-      //       <CheckCircle2Icon className="size-5 text-green-500" />
-      //     ) : (
-      //       <XCircleIcon className="size-5" />
-      //     ),
-      //   enableHiding: false,
-      // },
+      {
+        id: "contacts",
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={t("fields.permissions.contacts")}
+          />
+        ),
+        cell: ({ row }) =>
+          renderPermissionCell(row.original.permissions.contacts),
+        enableHiding: false,
+      },
+      {
+        id: "onlyAssignedContacts",
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={t("fields.permissions.onlyAssignedContacts")}
+          />
+        ),
+        cell: ({ row }) =>
+          renderPermissionCell(row.original.permissions.onlyAssignedContacts),
+        enableHiding: false,
+      },
+      {
+        id: "emailAndPhone",
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={t("fields.permissions.emailAndPhone")}
+          />
+        ),
+        cell: ({ row }) =>
+          renderPermissionCell(row.original.permissions.emailAndPhone),
+        enableHiding: false,
+      },
+      {
+        id: "broadcast",
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={t("fields.permissions.broadcast")}
+          />
+        ),
+        cell: ({ row }) =>
+          renderPermissionCell(row.original.permissions.broadcast),
+        enableHiding: false,
+      },
+      {
+        id: "ecommerce",
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={t("fields.permissions.ecommerce")}
+          />
+        ),
+        cell: ({ row }) =>
+          renderPermissionCell(row.original.permissions.ecommerce),
+        enableHiding: false,
+      },
       {
         id: "actions",
         cell: ({ row }) => (
@@ -156,7 +195,7 @@ export function WorkspaceMembersTable({
             <DropdownMenuTrigger asChild>
               <Button size="icon" variant="ghost">
                 <MoreHorizontalIcon className="h-4 w-4" />
-                <span className="sr-only">Open menu</span>
+                <span className="sr-only">{t("actions.openMenu")}</span>
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
@@ -195,7 +234,7 @@ export function WorkspaceMembersTable({
 
   return (
     <>
-      <DataTable table={table}>
+      <DataTable scrollable table={table}>
         <DataTableToolbar table={table}>
           <InviteWorkspaceMemberDialog atLimit={teamMembersAtLimit} />
         </DataTableToolbar>

--- a/apps/builder/src/features/workspaces/components/workspaces-list.tsx
+++ b/apps/builder/src/features/workspaces/components/workspaces-list.tsx
@@ -108,7 +108,7 @@ type WorkspaceCardProps = {
 const WorkspaceCard = ({ workspace, ownerLabel }: WorkspaceCardProps) => {
   const firstLetter = workspace.name?.[0]?.toUpperCase() ?? ""
   const name = workspace.name ?? ""
-  const href = `/space/${workspace.id}/dashboard`
+  const href = `/space/${workspace.id}`
 
   return (
     <Card className={cn(CARD_STYLES, "relative")}>

--- a/apps/builder/src/lib/auth/permission-routes.ts
+++ b/apps/builder/src/lib/auth/permission-routes.ts
@@ -1,0 +1,54 @@
+import type { WorkspaceMemberPermissions } from "@chatbotx.io/database/partials"
+
+export const PERMISSION_NAV = {
+  dashboard: "analytics",
+  flows: "flows",
+  contacts: "contacts",
+  broadcasts: "broadcast",
+  sequences: "broadcast",
+  products: "ecommerce",
+} as const satisfies Record<string, keyof WorkspaceMemberPermissions>
+
+export type WorkspacePermissionKey = keyof WorkspaceMemberPermissions
+
+// The `permissions` jsonb column defaults to `{}`, so at runtime any flag can be
+// absent even though the type claims every key is present. The `Record` union is
+// intentional: it accepts a possibly-partial object, and the strict `=== true`
+// checks fail closed on missing/undefined keys.
+export function hasWorkspacePermission(
+  permissions: WorkspaceMemberPermissions | Record<string, unknown>,
+  key: WorkspacePermissionKey,
+): boolean {
+  return permissions.superAdmin === true || permissions[key] === true
+}
+
+// Ordered candidates for the workspace landing route. Each entry maps a path
+// segment (relative to `/space/:workspaceId`) to an optional permission gate.
+// A `null` gate means the page is always reachable, so the last always-open
+// entry guarantees resolution never falls through to a 404. Order reflects the
+// sidebar nav priority: prefer analytics/flows-style landing spots, then fall
+// back to the ungated inbox.
+const WORKSPACE_LANDING_ROUTES = [
+  ...Object.entries(PERMISSION_NAV).map(([segment, permission]) => ({
+    segment,
+    permission,
+  })),
+  { segment: "inbox", permission: null },
+] as const satisfies ReadonlyArray<{
+  segment: string
+  permission: WorkspacePermissionKey | null
+}>
+
+// Resolve the first section the member can access. Used by the workspace root
+// page so users without `analytics` don't get redirected into a 404 dashboard.
+export function resolveWorkspaceLandingSegment(
+  permissions: WorkspaceMemberPermissions | Record<string, unknown>,
+): string {
+  const target = WORKSPACE_LANDING_ROUTES.find(
+    (route) =>
+      route.permission === null ||
+      hasWorkspacePermission(permissions, route.permission),
+  )
+  // `inbox` is always ungated, so `find` always resolves; fall back defensively.
+  return target?.segment ?? "inbox"
+}

--- a/apps/builder/src/lib/auth/require-workspace-permission.ts
+++ b/apps/builder/src/lib/auth/require-workspace-permission.ts
@@ -1,0 +1,54 @@
+"use server"
+
+import { getIdFromParams } from "@chatbotx.io/utils"
+import { notFound } from "next/navigation"
+import { canAccessContactsSection } from "@/features/contacts/permissions"
+import {
+  hasWorkspacePermission,
+  type WorkspacePermissionKey,
+} from "@/lib/auth/permission-routes"
+import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
+
+export async function requireWorkspacePermission(
+  workspaceId: string,
+  key: WorkspacePermissionKey,
+): Promise<void> {
+  const userAndWorkspace = await getCurrentUserAndTargetWorkspace(workspaceId)
+  const canAccess = userAndWorkspace
+    ? hasWorkspacePermission(
+        userAndWorkspace.targetWorkspaceMember.permissions,
+        key,
+      )
+    : false
+
+  if (!canAccess) {
+    notFound()
+  }
+}
+
+export async function requireContactsAccess(
+  workspaceId: string,
+): Promise<void> {
+  const userAndWorkspace = await getCurrentUserAndTargetWorkspace(workspaceId)
+  const canAccess = userAndWorkspace
+    ? canAccessContactsSection(
+        userAndWorkspace.targetWorkspaceMember.permissions,
+      )
+    : false
+
+  if (!canAccess) {
+    notFound()
+  }
+}
+
+export async function resolveGuardedWorkspaceId(
+  params: Promise<{ workspaceId: string }>,
+  key: WorkspacePermissionKey,
+): Promise<string> {
+  const workspaceId = getIdFromParams(await params, "workspaceId")
+  if (!workspaceId) {
+    notFound()
+  }
+  await requireWorkspacePermission(workspaceId, key)
+  return workspaceId
+}

--- a/apps/builder/src/lib/auth/utils.ts
+++ b/apps/builder/src/lib/auth/utils.ts
@@ -8,6 +8,7 @@ import type {
   WorkspaceModel,
 } from "@chatbotx.io/database/types"
 import { headers } from "next/headers"
+import { cache } from "react"
 import { getTenantSettings } from "@/features/tenant/utils"
 import { auth } from "./auth"
 
@@ -49,47 +50,54 @@ export const assertCurrentUserCanAccessChatbot = async (
   }
 }
 
-export const getCurrentUserAndAllLinkedWorkspaces = async (): Promise<{
-  user: SessionUser
-  allWorkspaces: WorkspaceModel[]
-  allWorkspaceMembers: (WorkspaceMemberModel & { workspace: WorkspaceModel })[]
-} | null> => {
-  const user = await getCurrentUser()
-  if (!user) {
-    return null
-  }
+const getCachedCurrentUserAndAllLinkedWorkspaces = cache(
+  async (): Promise<{
+    user: SessionUser
+    allWorkspaces: WorkspaceModel[]
+    allWorkspaceMembers: (WorkspaceMemberModel & {
+      workspace: WorkspaceModel
+    })[]
+  } | null> => {
+    const user = await getCurrentUser()
+    if (!user) {
+      return null
+    }
 
-  const [workspaceMembers, { storageUrl }] = await Promise.all([
-    db.query.workspaceMemberModel.findMany({
-      where: {
-        userId: user.id,
+    const [workspaceMembers, { storageUrl }] = await Promise.all([
+      db.query.workspaceMemberModel.findMany({
+        where: {
+          userId: user.id,
+        },
+        with: {
+          workspace: true,
+        },
+      }),
+      getTenantSettings(),
+    ])
+
+    const resolveLogoUrl = (logo: string | null) =>
+      logo ? new URL(logo, storageUrl).toString() : null
+
+    const membersWithResolvedLogos = workspaceMembers.map((member) => ({
+      ...member,
+      workspace: {
+        ...member.workspace,
+        logo: resolveLogoUrl(member.workspace.logo),
       },
-      with: {
-        workspace: true,
-      },
-    }),
-    getTenantSettings(),
-  ])
+    }))
 
-  const resolveLogoUrl = (logo: string | null) =>
-    logo ? new URL(logo, storageUrl).toString() : null
+    return {
+      user,
+      allWorkspaces: membersWithResolvedLogos.map(
+        (workspaceMember) => workspaceMember.workspace,
+      ),
+      allWorkspaceMembers: membersWithResolvedLogos,
+    }
+  },
+)
 
-  const membersWithResolvedLogos = workspaceMembers.map((member) => ({
-    ...member,
-    workspace: {
-      ...member.workspace,
-      logo: resolveLogoUrl(member.workspace.logo),
-    },
-  }))
-
-  return {
-    user,
-    allWorkspaces: membersWithResolvedLogos.map(
-      (workspaceMember) => workspaceMember.workspace,
-    ),
-    allWorkspaceMembers: membersWithResolvedLogos,
-  }
-}
+export const getCurrentUserAndAllLinkedWorkspaces = async () =>
+  getCachedCurrentUserAndAllLinkedWorkspaces()
 
 export const getCurrentUserAndTargetWorkspace = async (
   workspaceId: string,

--- a/apps/worker/__tests__/export-contacts-handler.test.ts
+++ b/apps/worker/__tests__/export-contacts-handler.test.ts
@@ -86,6 +86,7 @@ const buildData = (overrides: Partial<ExportData> = {}): ExportData =>
     workspaceId: "ws-1",
     fileId: "file-1",
     fields: ["sys:fullName", "sys:email"],
+    canExportEmailAndPhone: true,
     outputPath: "exports/ws-1/contacts.csv",
     outputFormat: "csv",
     contactIds: ["1", "2"],

--- a/apps/worker/__tests__/export-contacts-where.test.ts
+++ b/apps/worker/__tests__/export-contacts-where.test.ts
@@ -49,6 +49,9 @@ vi.mock("@chatbotx.io/filesystem", () => ({
 const { buildBaseWhere } = await import(
   "../src/default/handlers/export-contacts"
 )
+const { stripContactPIIFields } = await import(
+  "@chatbotx.io/worker-config/contact-pii"
+)
 
 // ── Type helpers ──────────────────────────────────────────────────────────────
 
@@ -62,6 +65,8 @@ const buildData = (
     workspaceId: "ws-1",
     fileId: "file-1",
     fields: ["sys:email"],
+    // The real producer always sets this; PII export fails closed when omitted.
+    canExportEmailAndPhone: true,
     outputPath: "exports/ws-1/contacts.csv",
     outputFormat: "csv",
     contactIds: ["c-1", "c-2"],
@@ -103,6 +108,20 @@ describe("buildBaseWhere", () => {
       // Assert
       expect(where).not.toHaveProperty("OR")
     })
+
+    test("where includes assigned-user relation scope when provided", () => {
+      // Arrange
+      const data = buildData({
+        filter: undefined,
+        restrictToAssignedUserId: "user-1",
+      })
+
+      // Act
+      const where = buildBaseWhere(data)
+
+      // Assert
+      expect(where.conversation).toEqual({ assignedUserId: "user-1" })
+    })
   })
 
   describe("filter with keyword only", () => {
@@ -136,6 +155,40 @@ describe("buildBaseWhere", () => {
       expect(or[1]).toEqual({ lastName: { ilike: "%hello%" } })
       expect(or[2]).toEqual({ email: { ilike: "%hello%" } })
       expect(or[3]).toEqual({ phoneNumber: { ilike: "%hello%" } })
+    })
+
+    test("OR array omits email and phoneNumber when PII export is denied", () => {
+      // Arrange
+      const data = buildData({
+        filter: { keyword: "hello" },
+        canExportEmailAndPhone: false,
+      })
+
+      // Act
+      const where = buildBaseWhere(data)
+
+      // Assert
+      expect(where.OR).toEqual([
+        { firstName: { ilike: "%hello%" } },
+        { lastName: { ilike: "%hello%" } },
+      ])
+    })
+
+    test("OR array omits email and phoneNumber when PII flag is omitted (fails closed)", () => {
+      // Arrange
+      const data = buildData({
+        filter: { keyword: "hello" },
+        canExportEmailAndPhone: undefined,
+      })
+
+      // Act
+      const where = buildBaseWhere(data)
+
+      // Assert
+      expect(where.OR).toEqual([
+        { firstName: { ilike: "%hello%" } },
+        { lastName: { ilike: "%hello%" } },
+      ])
     })
 
     test("where does not contain an id key when filter is present", () => {
@@ -202,6 +255,27 @@ describe("buildBaseWhere", () => {
 
       // Assert
       expect(where).not.toHaveProperty("OR")
+    })
+
+    test("assigned-user scope merges with contact filter conversation clauses", () => {
+      // Arrange
+      const criteria = { operator: "and" as const, conditions: [] }
+      applyContactFilterSpy.mockReturnValueOnce({
+        conversation: { botEnabled: false },
+      })
+      const data = buildData({
+        filter: { contactFilter: criteria },
+        restrictToAssignedUserId: "user-1",
+      })
+
+      // Act
+      const where = buildBaseWhere(data)
+
+      // Assert
+      expect(where.conversation).toEqual({
+        botEnabled: false,
+        assignedUserId: "user-1",
+      })
     })
   })
 
@@ -301,5 +375,22 @@ describe("buildBaseWhere", () => {
       expect(where).not.toHaveProperty("id")
       expect(applyContactFilterSpy).not.toHaveBeenCalled()
     })
+  })
+})
+
+describe("stripContactPIIFields", () => {
+  test("removes email and phoneNumber fields when PII export is denied", () => {
+    expect(
+      stripContactPIIFields(
+        ["sys:firstName", "sys:email", "sys:phoneNumber", "tag:t1"],
+        false,
+      ),
+    ).toEqual(["sys:firstName", "tag:t1"])
+  })
+
+  test("preserves fields when PII export is allowed", () => {
+    expect(
+      stripContactPIIFields(["sys:email", "sys:phoneNumber"], true),
+    ).toEqual(["sys:email", "sys:phoneNumber"])
   })
 })

--- a/apps/worker/src/default/handlers/export-contacts.ts
+++ b/apps/worker/src/default/handlers/export-contacts.ts
@@ -12,6 +12,7 @@ import {
   type JobExportContacts,
   loopableItemsCount,
 } from "@chatbotx.io/worker-config"
+import { stripContactPIIFields } from "@chatbotx.io/worker-config/contact-pii"
 
 type ExportData = JobExportContacts["data"]
 
@@ -117,6 +118,7 @@ export const buildBaseWhere = (data: ExportData): Record<string, unknown> => {
 
   if (!data.filter) {
     where.id = { in: data.contactIds }
+    addAssignedContactScope(where, data.restrictToAssignedUserId)
     return where
   }
 
@@ -125,8 +127,9 @@ export const buildBaseWhere = (data: ExportData): Record<string, unknown> => {
     where.OR = [
       { firstName: { ilike: keyword } },
       { lastName: { ilike: keyword } },
-      { email: { ilike: keyword } },
-      { phoneNumber: { ilike: keyword } },
+      ...(data.canExportEmailAndPhone === true
+        ? [{ email: { ilike: keyword } }, { phoneNumber: { ilike: keyword } }]
+        : []),
     ]
   }
 
@@ -134,7 +137,30 @@ export const buildBaseWhere = (data: ExportData): Record<string, unknown> => {
     Object.assign(where, applyContactFilter(data.filter.contactFilter))
   }
 
+  addAssignedContactScope(where, data.restrictToAssignedUserId)
+
   return where
+}
+
+const addAssignedContactScope = (
+  where: Record<string, unknown>,
+  restrictToAssignedUserId?: string,
+) => {
+  if (!restrictToAssignedUserId) {
+    return
+  }
+
+  const conversation =
+    typeof where.conversation === "object" &&
+    where.conversation !== null &&
+    !Array.isArray(where.conversation)
+      ? where.conversation
+      : {}
+
+  where.conversation = {
+    ...conversation,
+    assignedUserId: restrictToAssignedUserId,
+  }
 }
 
 // ── Selected-field resolution ─────────────────────────────────────────────────
@@ -283,7 +309,10 @@ export const loopableExportContacts = async (data: ExportData) => {
     return
   }
 
-  const selectedFields = await buildSelectedFields(fields, workspaceId)
+  const selectedFields = await buildSelectedFields(
+    stripContactPIIFields(fields, data.canExportEmailAndPhone === true),
+    workspaceId,
+  )
   const baseWhere = buildBaseWhere(data)
 
   const { stream, done } = createUpload(outputPath, {

--- a/docs/developer/workspace-permission-guards.md
+++ b/docs/developer/workspace-permission-guards.md
@@ -1,0 +1,155 @@
+# Workspace permission guards and contact PII scoping
+
+This document is for developers adding or changing workspace member permission
+checks in the builder app. Workspace permissions are security boundaries, so
+server guards and data scoping must be kept in sync with any UI visibility
+changes.
+
+## Permission model
+
+Workspace member permissions are stored in the `WorkspaceMember.permissions`
+jsonb field and typed by `WorkspaceMemberPermissions` in
+`packages/database/src/partials/workspace.ts`.
+
+| Permission | Meaning |
+| --- | --- |
+| `superAdmin` | Full workspace access. Bypasses every permission gate. |
+| `analytics` | Analytics and dashboard access. |
+| `flows` | Flow builder access. |
+| `contacts` | Full contacts section access. |
+| `onlyAssignedContacts` | Contacts section access limited to contacts assigned to the current user. |
+| `emailAndPhone` | Permission to view and export contact email and phone fields. |
+| `broadcast` | Broadcast and sequence access. |
+| `ecommerce` | Product and ecommerce access. |
+
+Always use `hasWorkspacePermission()` from
+`apps/builder/src/lib/auth/permission-routes.ts` instead of reading flags
+directly. It grants every permission to `superAdmin` and fails closed when a
+jsonb key is missing or `undefined`.
+
+## Route and navigation guards
+
+Server-side route guards are the source of truth. Sidebar filtering only hides
+links and is not an authorization boundary.
+
+Use these helpers from
+`apps/builder/src/lib/auth/require-workspace-permission.ts`:
+
+```ts
+await resolveGuardedWorkspaceId(params, "broadcast")
+await requireWorkspacePermission(workspaceId, "flows")
+await requireContactsAccess(workspaceId)
+```
+
+- Use `resolveGuardedWorkspaceId(params, key)` in layouts and pages that receive
+  `params: Promise<{ workspaceId: string }>` and need the resolved workspace id.
+- Use `requireWorkspacePermission(workspaceId, key)` when the workspace id is
+  already resolved.
+- Use `requireContactsAccess(workspaceId)` for contacts pages. Contacts access is
+  compound: `contacts || onlyAssignedContacts`.
+- New guarded top-level sections should be added to `PERMISSION_NAV` in
+  `apps/builder/src/lib/auth/permission-routes.ts` and to the sidebar filter in
+  `apps/builder/src/components/app-sidebar.tsx`.
+- Guard URL-equivalent route groups independently. For example, if both
+  `products` and `(e-commerce)/products` can render product pages, both layouts
+  need the ecommerce guard.
+
+Existing examples:
+
+- `apps/builder/src/app/space/[workspaceId]/dashboard/page.tsx` gates analytics
+  with `requireWorkspacePermission(workspaceId, "analytics")`.
+- `apps/builder/src/app/space/[workspaceId]/broadcasts/layout.tsx` gates
+  broadcasts with `resolveGuardedWorkspaceId(params, "broadcast")`.
+- `apps/builder/src/app/space/[workspaceId]/contacts/page.tsx` gates contacts
+  with `requireContactsAccess(workspaceId)`.
+
+## Contact data scoping
+
+Contacts have two extra permission dimensions:
+
+- `onlyAssignedContacts` restricts the member to contacts whose conversation is
+  assigned to the current user.
+- `emailAndPhone` controls whether contact email and phone fields can be read,
+  searched, or exported.
+
+Before returning or mutating contact data, resolve a contact permission scope
+from `apps/builder/src/features/contacts/permissions.ts`:
+
+```ts
+const scope = await resolveContactPermissionScope(workspaceId)
+const accessScope = await requireContactPermissionScope(workspaceId)
+```
+
+- Use `resolveContactPermissionScope()` when the caller can return a not-found or
+  empty result for unauthorized access.
+- Use `requireContactPermissionScope()` in mutations and authenticated APIs that
+  should raise a domain error when the member cannot access contacts.
+- Thread `scope.restrictToAssignedUserId` into database filters through
+  `conversation.assignedUserId`.
+- If `scope.canViewEmailAndPhone` is false, return `email: null` and
+  `phoneNumber: null` using `maskContactEmailAndPhone()`.
+- If `scope.canViewEmailAndPhone` is false, do not include `email` or
+  `phoneNumber` keyword search clauses. A member without PII access should not be
+  able to infer hidden values through search results.
+
+Existing examples:
+
+- `apps/builder/src/features/contacts/queries/list-contacts.queries.ts` applies
+  assigned-contact scoping and removes PII keyword clauses.
+- `apps/builder/src/features/contacts/queries/get-contact.query.ts` verifies the
+  assigned user before returning a single contact and masks email and phone when
+  needed.
+- Contact server actions and authenticated contact APIs call
+  `requireContactPermissionScope()` before mutating contact-owned data.
+
+## Contact exports
+
+CSV export crosses the builder-worker boundary, so the job payload must carry
+the already-resolved permission scope explicitly.
+
+- `apps/builder/src/features/contacts/actions/export-contacts.action.ts`
+  resolves the contact permission scope before enqueueing the export job.
+- `canExportEmailAndPhone` is required in
+  `packages/worker-config/src/queues/default/index.ts`. Do not make it optional
+  or default it to true.
+- Pass `restrictToAssignedUserId` when the member has assigned-only contact
+  access.
+- Strip PII fields in the builder before enqueueing and again in the worker with
+  `stripContactPIIFields()` from `@chatbotx.io/worker-config/contact-pii`.
+- The worker's export filter in
+  `apps/worker/src/default/handlers/export-contacts.ts` must mirror the builder
+  contact list filter: workspace id, optional keyword and contact filter,
+  assigned-user scope, and no email or phone keyword clauses when PII export is
+  denied.
+
+Treat an omitted or non-true `canExportEmailAndPhone` value as denied. This keeps
+old or malformed jobs from failing open.
+
+## Workspace-token APIs
+
+Workspace-token APIs authenticate by workspace token, not by the current
+workspace member. Do not assume member-scoped contact permissions apply there.
+When adding a workspace-token surface that returns contacts or contact-derived
+data, make the intended scope explicit in the API contract and tests.
+
+## Change checklist
+
+When adding or changing a guarded workspace feature:
+
+1. Add the server-side route/page/layout guard.
+2. Update `PERMISSION_NAV` and sidebar filtering if the feature appears in main
+   navigation.
+3. For contact data, resolve and thread `ContactPermissionScope` through every
+   query, mutation, API, and worker job that can read or write contacts.
+4. Mask or remove contact email and phone everywhere `emailAndPhone` is denied,
+   including search filters and export fields.
+5. Add or update tests for fail-closed behavior, `superAdmin` bypass,
+   assigned-only scoping, and PII masking.
+
+Useful tests:
+
+- `apps/builder/__tests__/workspace-permission-routes.test.ts`
+- `apps/builder/__tests__/require-workspace-permission.test.ts`
+- `apps/builder/__tests__/contacts-route-guards.test.ts`
+- `apps/builder/__tests__/contacts-permissions.test.ts`
+- `apps/worker/__tests__/export-contacts-where.test.ts`

--- a/packages/business/__tests__/contact-service.test.ts
+++ b/packages/business/__tests__/contact-service.test.ts
@@ -96,3 +96,82 @@ describe("contactService.unblockIfBlocked", () => {
     expect(unblock).not.toHaveBeenCalled()
   })
 })
+
+describe("contactService assigned-contact access scope", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test("adds assigned conversation scope when finding one contact", async () => {
+    const findFirst = vi.fn().mockResolvedValue(contact({ id: "contact-1" }))
+    const tx = {
+      query: {
+        contactModel: {
+          findFirst,
+        },
+      },
+    }
+
+    await contactService.findById({
+      workspaceId: "ws-1",
+      id: "contact-1",
+      accessScope: { restrictToAssignedUserId: "user-1" },
+      tx: tx as never,
+    })
+
+    expect(findFirst).toHaveBeenCalledWith({
+      where: {
+        id: "contact-1",
+        workspaceId: "ws-1",
+        conversation: { assignedUserId: "user-1" },
+      },
+    })
+  })
+
+  test("adds assigned conversation scope when finding many contacts", async () => {
+    const findMany = vi.fn().mockResolvedValue([{ id: "contact-1" }])
+    const tx = {
+      query: {
+        contactModel: {
+          findMany,
+        },
+      },
+    }
+
+    await contactService.findManyByIds({
+      workspaceId: "ws-1",
+      ids: ["contact-1", "contact-2"],
+      accessScope: { restrictToAssignedUserId: "user-1" },
+      tx: tx as never,
+    })
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: {
+        workspaceId: "ws-1",
+        id: { in: ["contact-1", "contact-2"] },
+        conversation: { assignedUserId: "user-1" },
+      },
+      columns: { id: true },
+    })
+  })
+
+  test("throws not found when scoped contact lookup has no assigned match", async () => {
+    const findFirst = vi.fn().mockResolvedValue(undefined)
+    const tx = {
+      query: {
+        contactModel: {
+          findFirst,
+        },
+      },
+    }
+
+    await expect(
+      contactService.findByIdOrFail({
+        workspaceId: "ws-1",
+        id: "contact-2",
+        accessScope: { restrictToAssignedUserId: "user-1" },
+        tx: tx as never,
+      }),
+    ).rejects.toThrow("Contact not found")
+  })
+})

--- a/packages/business/src/contact/service.ts
+++ b/packages/business/src/contact/service.ts
@@ -67,6 +67,10 @@ export function isRichSystemContactField(
 
 type ContactWithInboxes = ContactModel & { contactInboxes: ContactInboxModel[] }
 
+export type ContactAccessScope = {
+  restrictToAssignedUserId?: string
+}
+
 class ContactService extends BaseService {
   // ─── Legacy generic find (preserved for backward compat) ────────────────
   async findBy(props: {
@@ -90,14 +94,15 @@ class ContactService extends BaseService {
   async findById(props: {
     workspaceId: string
     id: string
+    accessScope?: ContactAccessScope
     tx?: DatabaseClient
   }): Promise<ContactModel | undefined> {
-    const { workspaceId, id, tx = db } = props
+    const { workspaceId, id, accessScope, tx = db } = props
     // return await withCache(
     //   `contacts:${workspaceId}:${id}`,
     //   async () =>
     return await tx.query.contactModel.findFirst({
-      where: { id, workspaceId },
+      where: withContactAccessScope({ id, workspaceId }, accessScope),
     })
     // {
     //   dynamicTags: (result) =>
@@ -111,6 +116,7 @@ class ContactService extends BaseService {
   async findByIdOrFail(props: {
     workspaceId: string
     id: string
+    accessScope?: ContactAccessScope
     tx?: DatabaseClient
   }): Promise<ContactModel> {
     const contact = await this.findById(props)
@@ -124,11 +130,15 @@ class ContactService extends BaseService {
   async findManyByIds(props: {
     workspaceId: string
     ids: string[]
+    accessScope?: ContactAccessScope
     tx?: DatabaseClient
   }): Promise<{ id: string }[]> {
-    const { workspaceId, ids, tx = db } = props
+    const { workspaceId, ids, accessScope, tx = db } = props
     return await tx.query.contactModel.findMany({
-      where: { workspaceId, id: { in: ids } },
+      where: withContactAccessScope(
+        { workspaceId, id: { in: ids } },
+        accessScope,
+      ),
       columns: { id: true },
     })
   }
@@ -159,11 +169,16 @@ class ContactService extends BaseService {
   }
 
   async update(
-    ctx: { workspaceId: string; id: string },
+    ctx: { workspaceId: string; id: string; accessScope?: ContactAccessScope },
     data: ContactWriteData,
     tx: DatabaseClient = db,
   ): Promise<ContactModel> {
-    await this.findByIdOrFail({ workspaceId: ctx.workspaceId, id: ctx.id, tx })
+    await this.findByIdOrFail({
+      workspaceId: ctx.workspaceId,
+      id: ctx.id,
+      accessScope: ctx.accessScope,
+      tx,
+    })
     const [updated] = await tx
       .update(contactModel)
       .set(data)
@@ -173,13 +188,18 @@ class ContactService extends BaseService {
     return updated
   }
 
-  async block(ctx: { workspaceId: string; id: string }): Promise<ContactModel> {
+  async block(ctx: {
+    workspaceId: string
+    id: string
+    accessScope?: ContactAccessScope
+  }): Promise<ContactModel> {
     return await this.update(ctx, { blockedAt: new Date() })
   }
 
   async unblock(ctx: {
     workspaceId: string
     id: string
+    accessScope?: ContactAccessScope
   }): Promise<ContactModel> {
     return await this.update(ctx, { blockedAt: null })
   }
@@ -227,10 +247,14 @@ class ContactService extends BaseService {
   async delete(props: {
     workspaceId: string
     ids: string[]
+    accessScope?: ContactAccessScope
   }): Promise<ContactWithInboxes[]> {
-    const { workspaceId, ids } = props
+    const { workspaceId, ids, accessScope } = props
     const contacts = await db.query.contactModel.findMany({
-      where: { workspaceId, id: { in: ids } },
+      where: withContactAccessScope(
+        { workspaceId, id: { in: ids } },
+        accessScope,
+      ),
       with: { contactInboxes: true },
     })
 
@@ -492,6 +516,30 @@ function richSystemFieldToContactData(
     }
     default:
       return {}
+  }
+}
+
+function withContactAccessScope<TWhere extends Record<string, unknown>>(
+  where: TWhere,
+  accessScope?: ContactAccessScope,
+) {
+  if (!accessScope?.restrictToAssignedUserId) {
+    return where
+  }
+
+  const conversation =
+    typeof where.conversation === "object" &&
+    where.conversation !== null &&
+    !Array.isArray(where.conversation)
+      ? where.conversation
+      : {}
+
+  return {
+    ...where,
+    conversation: {
+      ...conversation,
+      assignedUserId: accessScope.restrictToAssignedUserId,
+    },
   }
 }
 

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -43,6 +43,39 @@ export type Transaction = Parameters<
 export type { PgTable } from "drizzle-orm/pg-core"
 export type DatabaseClient = typeof db | Transaction
 
+export const countWithRelationsFilter = <TTable extends PgTable>(props: {
+  client?: DatabaseClient
+  table: TTable
+  tsName: string
+  where: Record<string, unknown> | undefined
+}): Promise<number> => {
+  const { client = db, table, tsName, where } = props
+
+  if (!where || Object.keys(where).length === 0) {
+    return client.$count(table)
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: reaching drizzle beta relation internals in one place
+  const anyDb = client as any
+  const rootDb = db as typeof anyDb
+  const relationInternals = anyDb._?.relations ?? rootDb._.relations
+  const tableRelations = relationInternals[tsName]?.relations
+
+  if (!tableRelations) {
+    throw new Error(`Relation config not found for table: ${tsName}`)
+  }
+
+  const filter = relationsFilterToSQL(
+    table,
+    where as RelationsFilterArg,
+    tableRelations,
+    relationInternals,
+    anyDb.dialect?.casing ?? rootDb.dialect.casing,
+  )
+
+  return client.$count(table, filter)
+}
+
 export const findOrFail = async <TTable extends PgTable>(props: {
   client?: DatabaseClient
   table: TTable

--- a/packages/ui/src/components/data-table/data-table.tsx
+++ b/packages/ui/src/components/data-table/data-table.tsx
@@ -20,12 +20,14 @@ interface DataTableProps<TData> extends React.ComponentProps<"div"> {
   labels?: DataTablePaginationLabels & {
     noResults?: string
   }
+  scrollable?: boolean
 }
 
 export function DataTable<TData>({
   table,
   actionBar,
   labels,
+  scrollable = false,
   children,
   className,
   ...props
@@ -36,7 +38,12 @@ export function DataTable<TData>({
       {...props}
     >
       {children}
-      <div className="overflow-hidden rounded-md border">
+      <div
+        className={cn(
+          "rounded-md border",
+          scrollable ? "overflow-x-auto" : "overflow-hidden",
+        )}
+      >
         <Table>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (

--- a/packages/ui/src/components/ui/sidebar.tsx
+++ b/packages/ui/src/components/ui/sidebar.tsx
@@ -318,7 +318,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "bg-background relative flex w-full flex-1 flex-col",
+        "bg-background relative flex w-full min-w-0 flex-1 flex-col",
         "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className,
       )}

--- a/packages/worker-config/package.json
+++ b/packages/worker-config/package.json
@@ -23,6 +23,7 @@
   },
   "exports": {
     ".": "./src/index.ts",
+    "./contact-pii": "./src/lib/contact-pii.ts",
     "./keys": "./src/keys.ts",
     "./message-queue/factory": "./src/message-queue/factory.ts"
   },

--- a/packages/worker-config/src/lib/contact-pii.ts
+++ b/packages/worker-config/src/lib/contact-pii.ts
@@ -1,0 +1,12 @@
+const contactPIIExportFields = new Set(["sys:email", "sys:phoneNumber"])
+
+export function stripContactPIIFields(
+  fields: string[],
+  canViewPII: boolean,
+): string[] {
+  if (canViewPII) {
+    return [...fields]
+  }
+
+  return fields.filter((field) => !contactPIIExportFields.has(field))
+}

--- a/packages/worker-config/src/queues/default/index.ts
+++ b/packages/worker-config/src/queues/default/index.ts
@@ -37,6 +37,10 @@ export type JobExportContacts = {
     workspaceId: string
     fileId: string
     fields: string[]
+    // Required so the export always states PII visibility explicitly and can
+    // never fail open: an omitted flag must not silently re-enable PII export.
+    canExportEmailAndPhone: boolean
+    restrictToAssignedUserId?: string
     outputPath: string
     outputFormat: "csv"
   } & (


### PR DESCRIPTION
## Summary
- Members can now only reach the space sections their workspace permissions allow; the workspace root lands each member on their first accessible section instead of dead-ending on a 404 dashboard.
- Contacts data is scoped per member: email/phone are masked without `emailAndPhone`, listings/detail are restricted to assigned contacts when applicable, and PII export columns are dropped for members who can't view them.
- The workspace-token contacts API remains explicitly unscoped so member-scoping can never be dropped by accident.

## Changes
- **Auth guards** — `lib/auth/require-workspace-permission.ts` and `lib/auth/permission-routes.ts` (permission → nav mapping, `hasWorkspacePermission`, landing-segment resolver). Applied across space layouts/pages: flows, contacts, broadcasts, sequences, products, dashboard, and the workspace root `page.tsx`.
- **Contacts scoping** — `features/contacts/permissions.ts` (scope resolution, email/phone masking, assigned-contacts restriction); `list-contacts.queries.ts` and `get-contact.query.ts` now resolve and apply scope; `countWithRelationsFilter` added to the database client.
- **Export PII redaction** — `packages/worker-config/src/lib/contact-pii.ts` `stripContactPIIFields`, wired into the export action and worker handler.
- **Workspace members** — permission coupling hook + reworked members table, invite/update/delete actions and components.
- **Tests** — permission routes, route guards, contacts permission scoping, contacts export `where`, and workspace-members actions.

## Test plan
- [ ] pnpm lint
- [ ] pnpm --filter builder check-types
- [ ] pnpm --filter worker check-types
- [ ] pnpm --filter builder test (permission/contacts/members suites)
- [ ] Manual: member without `analytics` lands on an accessible section (no 404) and cannot open gated routes
- [ ] Manual: member without `emailAndPhone` sees masked email/phone in list + detail and export omits those columns
- [ ] Manual: `onlyAssignedContacts` member sees only assigned contacts