### PR TITLE
chore(builder): replace hardcoded UI strings with translations

### DIFF
--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -89,6 +89,13 @@
     "flowVersions": "Flow Versions",
     "revertToPublished": "Revert to Published",
     "search": "Search",
+    "pleaseSelect": "Please select",
+    "noRecordFound": "No record found.",
+    "typeMessage": "Type a message",
+    "enterText": "Enter text",
+    "enterFieldAndPressEnter": "Enter {field} and press Enter",
+    "addAnother": "Add another...",
+    "messagePlaceholder": "Message...",
     "signOut": "Sign Out",
     "backToSignIn": "Back to sign in",
     "connectFeature": "Connect {feature}",
@@ -701,6 +708,12 @@
     "file": {
       "label": "File"
     },
+    "link": {
+      "label": "Link"
+    },
+    "message": {
+      "label": "Message"
+    },
     "filter": {
       "label": "Filter"
     },
@@ -911,6 +924,9 @@
       "label": "Name",
       "placeholder": "Enter name",
       "searchPlaceholder": "Search name..."
+    },
+    "selectUsers": {
+      "label": "Select users"
     },
     "node": {
       "label": "Node"
@@ -1344,6 +1360,9 @@
     "spreadsheet": {
       "label": "Spreadsheet"
     },
+    "worksheet": {
+      "label": "Worksheet"
+    },
     "source": {
       "label": "Source",
       "placeholder": "Select a source"
@@ -1713,7 +1732,11 @@
     "fields": {
       "selectTemplatePlaceholder": "Choose a WhatsApp template",
       "selectMessengerTemplatePlaceholder": "Choose a Messenger template",
-      "preview": "Preview"
+      "preview": "Preview",
+      "typingSecondsLabel": "Typing for (seconds)",
+      "lookupColumnsLabel": "Lookup Columns:",
+      "filterModeAnd": "AND",
+      "filterModeOr": "OR"
     },
     "operators": {
       "append": "Append to the end",
@@ -1747,7 +1770,8 @@
       "maxLabel": "Max",
       "unitLabel": "Unit",
       "specific": "Specific",
-      "dynamic": "Dynamic"
+      "dynamic": "Dynamic",
+      "selectTimePlaceholder": "Select a time"
     }
   },
   "folders": {
@@ -2467,7 +2491,8 @@
         "latitude": "Latitude",
         "longitude": "Longitude",
         "locationName": "Location name (optional)",
-        "locationAddress": "Address (optional)"
+        "locationAddress": "Address (optional)",
+        "enterFormatUrl": "Enter {format} URL"
       }
     },
     "sampleBodyCardContent": {
@@ -2481,6 +2506,9 @@
     },
     "showFooter": {
       "label": "Show footer"
+    },
+    "showHeader": {
+      "label": "Show header"
     },
     "tabs": {
       "accountHealths": "Account Health",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -89,6 +89,13 @@
     "flowVersions": "Phiên bản luồng",
     "revertToPublished": "Khôi phục về phiên bản đã xuất bản",
     "search": "Tìm kiếm",
+    "pleaseSelect": "Vui lòng chọn",
+    "noRecordFound": "Không tìm thấy dữ liệu.",
+    "typeMessage": "Nhập tin nhắn",
+    "enterText": "Nhập văn bản",
+    "enterFieldAndPressEnter": "Nhập {field} và nhấn Enter",
+    "addAnother": "Thêm mục khác...",
+    "messagePlaceholder": "Tin nhắn...",
     "signOut": "Đăng xuất",
     "backToSignIn": "Quay lại đăng nhập",
     "connectFeature": "Kết nối {feature}",
@@ -448,7 +455,7 @@
       "label": "Pipeline"
     },
     "sequences": {
-      "label": "Chuỗi"
+      "label": "Chăm sóc"
     },
     "entryPointLink": {
       "label": "Liên kết điểm vào"
@@ -709,6 +716,12 @@
     "file": {
       "label": "Tệp"
     },
+    "link": {
+      "label": "Liên kết"
+    },
+    "message": {
+      "label": "Tin nhắn"
+    },
     "filter": {
       "label": "Lọc"
     },
@@ -900,6 +913,9 @@
       "label": "Tên",
       "placeholder": "Nhập tên",
       "searchPlaceholder": "Tìm kiếm tên..."
+    },
+    "selectUsers": {
+      "label": "Chọn người dùng"
     },
     "node": {
       "label": "Nút"
@@ -1324,6 +1340,9 @@
     "spreadsheet": {
       "label": "Bảng tính"
     },
+    "worksheet": {
+      "label": "Trang tính"
+    },
     "source": {
       "label": "Nguồn",
       "placeholder": "Chọn nguồn"
@@ -1721,7 +1740,11 @@
     "fields": {
       "selectTemplatePlaceholder": "Chọn mẫu WhatsApp",
       "selectMessengerTemplatePlaceholder": "Chọn mẫu Messenger",
-      "preview": "Xem trước"
+      "preview": "Xem trước",
+      "typingSecondsLabel": "Thời gian nhập (giây)",
+      "lookupColumnsLabel": "Cột tra cứu:",
+      "filterModeAnd": "VÀ",
+      "filterModeOr": "HOẶC"
     },
     "operators": {
       "append": "Thêm vào cuối",
@@ -1755,7 +1778,8 @@
       "maxLabel": "Tối đa",
       "unitLabel": "Đơn vị",
       "specific": "Cụ thể",
-      "dynamic": "Tùy chỉnh"
+      "dynamic": "Tùy chỉnh",
+      "selectTimePlaceholder": "Chọn thời gian"
     }
   },
   "folders": {
@@ -2473,7 +2497,8 @@
         "latitude": "Vĩ độ",
         "longitude": "Kinh độ",
         "locationName": "Tên vị trí (tùy chọn)",
-        "locationAddress": "Địa chỉ (tùy chọn)"
+        "locationAddress": "Địa chỉ (tùy chọn)",
+        "enterFormatUrl": "Nhập URL {format}"
       }
     },
     "sampleBodyCardContent": {
@@ -2487,6 +2512,9 @@
     },
     "showFooter": {
       "label": "Hiển thị chân trang"
+    },
+    "showHeader": {
+      "label": "Hiển thị đầu trang"
     },
     "tabs": {
       "accountHealths": "Tình trạng tài khoản",
@@ -2823,7 +2851,7 @@
     "saturday": "Thứ Bảy",
     "sunday": "Chủ Nhật",
     "afterText": "Sau",
-    "title": "Sequences"
+    "title": "Chăm sóc"
   },
   "tools": {
     "title": "Công cụ"

--- a/apps/builder/src/components/node-header.tsx
+++ b/apps/builder/src/components/node-header.tsx
@@ -8,6 +8,7 @@ import { cn } from "@chatbotx.io/ui/lib/utils"
 import { Slot } from "@radix-ui/react-slot"
 import { useNodeId, useReactFlow } from "@xyflow/react"
 import { EllipsisVertical, Trash } from "lucide-react"
+import { useTranslations } from "next-intl"
 import { type HTMLAttributes, type ReactNode, useCallback } from "react"
 
 /* NODE HEADER -------------------------------------------------------------- */
@@ -189,6 +190,7 @@ NodeHeaderMenuAction.displayName = "NodeHeaderMenuAction"
 /* NODE HEADER DELETE ACTION --------------------------------------- */
 
 export const NodeHeaderDeleteAction = () => {
+  const t = useTranslations()
   const id = useNodeId()
   const { setNodes } = useReactFlow()
 
@@ -197,7 +199,11 @@ export const NodeHeaderDeleteAction = () => {
   }, [id, setNodes])
 
   return (
-    <NodeHeaderAction label="Delete node" onClick={handleClick} variant="ghost">
+    <NodeHeaderAction
+      label={t("actions.delete")}
+      onClick={handleClick}
+      variant="ghost"
+    >
       <Trash />
     </NodeHeaderAction>
   )

--- a/apps/builder/src/enterprise/features/inbox-teams/add-inbox-team-member-dialog.tsx
+++ b/apps/builder/src/enterprise/features/inbox-teams/add-inbox-team-member-dialog.tsx
@@ -91,7 +91,7 @@ export function AddInboxTeamMemberDialog({
               onSubmit={handleSubmitWithAction}
             >
               <MultiSelectField
-                label="Select users"
+                label={t("fields.selectUsers.label")}
                 name="userIds"
                 options={userOptions}
               />

--- a/apps/builder/src/enterprise/features/inbox-teams/create-inbox-team-dialog.tsx
+++ b/apps/builder/src/enterprise/features/inbox-teams/create-inbox-team-dialog.tsx
@@ -98,10 +98,10 @@ export function CreateInboxTeamDialog({
               className="flex-1 space-y-4"
               onSubmit={handleSubmitWithAction}
             >
-              <InputField label="Name" name="name" required />
+              <InputField label={t("fields.name.label")} name="name" required />
 
               <MultiSelectField
-                label="Select users"
+                label={t("fields.selectUsers.label")}
                 name="userIds"
                 options={userOptions}
               />

--- a/apps/builder/src/enterprise/features/inbox-teams/rename-inbox-team-dialog.tsx
+++ b/apps/builder/src/enterprise/features/inbox-teams/rename-inbox-team-dialog.tsx
@@ -97,7 +97,7 @@ export function RenameInboxTeamDialog({
               className="flex-1 space-y-4"
               onSubmit={handleSubmitWithAction}
             >
-              <InputField label="Name" name="name" required />
+              <InputField label={t("fields.name.label")} name="name" required />
 
               <DialogFooter className="sm:justify-start">
                 <DialogClose asChild>

--- a/apps/builder/src/features/ai-functions/ai-functions-columns.tsx
+++ b/apps/builder/src/features/ai-functions/ai-functions-columns.tsx
@@ -38,7 +38,7 @@ export const getAIFunctionsColumns = (
     id: "select",
     header: ({ table: innerTable }) => (
       <Checkbox
-        aria-label="Select all"
+        aria-label={t("actions.selectAll")}
         checked={
           innerTable.getIsAllPageRowsSelected() ||
           (innerTable.getIsSomePageRowsSelected() && "indeterminate")
@@ -50,7 +50,7 @@ export const getAIFunctionsColumns = (
     ),
     cell: ({ row }) => (
       <Checkbox
-        aria-label="Select row"
+        aria-label={t("actions.selectRow")}
         checked={row.getIsSelected()}
         onCheckedChange={(value) => row.toggleSelected(Boolean(value))}
       />

--- a/apps/builder/src/features/ai-functions/ai-functions-create.tsx
+++ b/apps/builder/src/features/ai-functions/ai-functions-create.tsx
@@ -184,7 +184,10 @@ export function AIFunctionsCreate({
                     placeholder="Attribute"
                   />
                   <MoveRightIcon className="size-10" />
-                  <CustomFieldField name={`dataCollect.${index}.to`} />
+                  <CustomFieldField
+                    name={`dataCollect.${index}.to`}
+                    placeholder={t("actions.pleaseSelect")}
+                  />
                   <Button
                     onClick={() => remove(index)}
                     type="button"

--- a/apps/builder/src/features/ai-triggers/create.tsx
+++ b/apps/builder/src/features/ai-triggers/create.tsx
@@ -140,6 +140,7 @@ export function CreateAITriggerDialog({
                       <ComboboxField
                         name={`questions.${i}.customFieldId`}
                         options={customFieldSelectOptions}
+                        placeholder={t("actions.pleaseSelect")}
                       />
                     </div>
 
@@ -168,6 +169,7 @@ export function CreateAITriggerDialog({
                 label={t("fields.flowId.label")}
                 name="flowId"
                 options={flowOptions}
+                placeholder={t("actions.pleaseSelect")}
               />
 
               <TextareaField

--- a/apps/builder/src/features/ai-triggers/table-columns.tsx
+++ b/apps/builder/src/features/ai-triggers/table-columns.tsx
@@ -20,15 +20,18 @@ import type { DataTableRowAction } from "@chatbotx.io/ui/types/data-table"
 import type { ColumnDef } from "@tanstack/react-table"
 import { format } from "date-fns"
 import { EllipsisVerticalIcon } from "lucide-react"
+import type { useTranslations } from "next-intl"
 import type { Dispatch, SetStateAction } from "react"
 
 type GetColumnsProps = {
+  t: ReturnType<typeof useTranslations>
   setRowAction: Dispatch<
     SetStateAction<DataTableRowAction<AITriggerModel> | null>
   >
 }
 
 export function getAITriggersColumns({
+  t,
   setRowAction,
 }: GetColumnsProps): ColumnDef<AITriggerModel>[] {
   return [
@@ -36,7 +39,7 @@ export function getAITriggersColumns({
       id: "select",
       header: ({ table }) => (
         <Checkbox
-          aria-label="Select all"
+          aria-label={t("actions.selectAll")}
           checked={
             table.getIsAllPageRowsSelected() ||
             (table.getIsSomePageRowsSelected() && "indeterminate")
@@ -49,7 +52,7 @@ export function getAITriggersColumns({
       ),
       cell: ({ row }) => (
         <Checkbox
-          aria-label="Select row"
+          aria-label={t("actions.selectRow")}
           checked={row.getIsSelected()}
           className="translate-y-0.5"
           onCheckedChange={(value) => row.toggleSelected(Boolean(value))}

--- a/apps/builder/src/features/ai-triggers/table.tsx
+++ b/apps/builder/src/features/ai-triggers/table.tsx
@@ -6,6 +6,7 @@ import { DataTableToolbar } from "@chatbotx.io/ui/components/data-table/data-tab
 import { useDataTable } from "@chatbotx.io/ui/hooks/use-data-table"
 import type { DataTableRowAction } from "@chatbotx.io/ui/types/data-table"
 import { useRouter } from "next/navigation"
+import { useTranslations } from "next-intl"
 import { useAction } from "next-safe-action/hooks"
 import { use, useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
@@ -25,11 +26,12 @@ export function AITriggersTable({
   workspaceId,
 }: AITriggersTableProps) {
   const [{ data, pageCount }] = use(promises)
+  const t = useTranslations()
   const router = useRouter()
   const [rowAction, setRowAction] =
     useState<DataTableRowAction<AITriggerModel> | null>(null)
 
-  const columns = useMemo(() => getAITriggersColumns({ setRowAction }), [])
+  const columns = useMemo(() => getAITriggersColumns({ setRowAction, t }), [t])
 
   const { execute } = useAction(
     duplicateAITriggerAction.bind(

--- a/apps/builder/src/features/automated-response/automated-response-table.tsx
+++ b/apps/builder/src/features/automated-response/automated-response-table.tsx
@@ -69,7 +69,7 @@ export function AutomatedResponsesTable({
         size: 32,
         header: ({ table: innerTable }) => (
           <Checkbox
-            aria-label="Select all"
+            aria-label={t("actions.selectAll")}
             checked={
               innerTable.getIsAllPageRowsSelected() ||
               (innerTable.getIsSomePageRowsSelected() && "indeterminate")
@@ -81,7 +81,7 @@ export function AutomatedResponsesTable({
         ),
         cell: ({ row }) => (
           <Checkbox
-            aria-label="Select row"
+            aria-label={t("actions.selectRow")}
             checked={row.getIsSelected()}
             onCheckedChange={(value) => row.toggleSelected(Boolean(value))}
           />

--- a/apps/builder/src/features/automated-response/create-automated-response-form.tsx
+++ b/apps/builder/src/features/automated-response/create-automated-response-form.tsx
@@ -178,6 +178,7 @@ export function CreateAutomatedResponseForm(
             label={t("fields.flowId.label")}
             name="flowId"
             options={flowOptions}
+            placeholder={t("actions.pleaseSelect")}
             required
           />
         )}

--- a/apps/builder/src/features/automated-response/edit-automated-response-form.tsx
+++ b/apps/builder/src/features/automated-response/edit-automated-response-form.tsx
@@ -182,6 +182,7 @@ export default function EditAutomatedResponseForm(
             label={t("fields.flowId.label")}
             name="flowId"
             options={flowOptions}
+            placeholder={t("actions.pleaseSelect")}
             required
           />
         )}

--- a/apps/builder/src/features/bot-fields/bot-field-table.tsx
+++ b/apps/builder/src/features/bot-fields/bot-field-table.tsx
@@ -69,7 +69,7 @@ export function BotFieldsTable({
         id: "select",
         header: ({ table: innerTable }) => (
           <Checkbox
-            aria-label="Select all"
+            aria-label={t("actions.selectAll")}
             checked={
               innerTable.getIsAllPageRowsSelected() ||
               (innerTable.getIsSomePageRowsSelected() && "indeterminate")
@@ -81,7 +81,7 @@ export function BotFieldsTable({
         ),
         cell: ({ row }) => (
           <Checkbox
-            aria-label="Select row"
+            aria-label={t("actions.selectRow")}
             checked={row.getIsSelected()}
             onCheckedChange={(value) => row.toggleSelected(Boolean(value))}
           />

--- a/apps/builder/src/features/broadcasts/components/messenger-broadcast-flow-buttons.tsx
+++ b/apps/builder/src/features/broadcasts/components/messenger-broadcast-flow-buttons.tsx
@@ -89,6 +89,7 @@ function FlowSelectDialog({
               label={t("fields.flowId.label")}
               name="flowId"
               options={flowOptions}
+              placeholder={t("actions.pleaseSelect")}
               required={true}
             />
           </div>

--- a/apps/builder/src/features/broadcasts/create-broadcast-form.tsx
+++ b/apps/builder/src/features/broadcasts/create-broadcast-form.tsx
@@ -704,6 +704,7 @@ function CreateBroadcastChooseFlow(props: CreateBroadcastChooseFlowProps) {
                   label: integration.name,
                   value: integration.id,
                 }))}
+                placeholder={t("actions.pleaseSelect")}
                 required={true}
               />
 
@@ -717,6 +718,7 @@ function CreateBroadcastChooseFlow(props: CreateBroadcastChooseFlowProps) {
                       label: `${template.name} (${template.language})`,
                       value: template.id,
                     }))}
+                    placeholder={t("actions.pleaseSelect")}
                     required={true}
                   />
 
@@ -756,6 +758,7 @@ function CreateBroadcastChooseFlow(props: CreateBroadcastChooseFlowProps) {
                 label={t("fields.messengerChannel.label")}
                 name="integrationMessengerId"
                 options={messengerIntegrationOptions}
+                placeholder={t("actions.pleaseSelect")}
                 required={true}
               />
 
@@ -769,6 +772,7 @@ function CreateBroadcastChooseFlow(props: CreateBroadcastChooseFlowProps) {
                       label: `${template.name} (${template.language})`,
                       value: template.id,
                     }))}
+                    placeholder={t("actions.pleaseSelect")}
                     required={true}
                   />
 
@@ -820,6 +824,7 @@ function CreateBroadcastChooseFlow(props: CreateBroadcastChooseFlowProps) {
                 label: flow.name,
                 value: flow.id,
               }))}
+              placeholder={t("actions.pleaseSelect")}
               required={true}
             />
           )}

--- a/apps/builder/src/features/conditions/custom-field-value-changed.tsx
+++ b/apps/builder/src/features/conditions/custom-field-value-changed.tsx
@@ -82,7 +82,7 @@ export const CustomFieldValueChanged = ({
             value={currentOperator}
           >
             <SelectTrigger>
-              <SelectValue placeholder="Select operator" />
+              <SelectValue placeholder={t("actions.pleaseSelect")} />
             </SelectTrigger>
             <SelectContent>
               {operatorOptions.map((option) => (
@@ -195,11 +195,15 @@ export const CustomFieldValueChanged = ({
                     value={field.value?.text || ""}
                   >
                     <SelectTrigger>
-                      <SelectValue placeholder="Select value" />
+                      <SelectValue placeholder={t("actions.pleaseSelect")} />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="true">True</SelectItem>
-                      <SelectItem value="false">False</SelectItem>
+                      <SelectItem value="true">
+                        {t("fields.boolean.true")}
+                      </SelectItem>
+                      <SelectItem value="false">
+                        {t("fields.boolean.false")}
+                      </SelectItem>
                     </SelectContent>
                   </Select>
                 )}

--- a/apps/builder/src/features/contacts/components/add-contact-tag-dialog.tsx
+++ b/apps/builder/src/features/contacts/components/add-contact-tag-dialog.tsx
@@ -92,8 +92,12 @@ export default function AddContactTagDialog({
             onSubmit={handleSubmitWithAction}
           >
             <TagsInputField
+              addAnotherPlaceholder={t("actions.addAnother")}
               label={t("fields.tag.label")}
               name="tags"
+              placeholder={t("actions.enterFieldAndPressEnter", {
+                field: t("fields.tag.label").toLowerCase(),
+              })}
               suggestions={tagOptions}
             />
 

--- a/apps/builder/src/features/contacts/components/contact-filter-condition-form.tsx
+++ b/apps/builder/src/features/contacts/components/contact-filter-condition-form.tsx
@@ -237,6 +237,7 @@ export const ContactFilterConditionForm = ({
                 className="overflow-hidden truncate"
                 name="field"
                 options={fieldOptions}
+                placeholder={t("actions.pleaseSelect")}
                 triggerValueChange={triggerFieldChange}
               />
               <SelectField

--- a/apps/builder/src/features/contacts/components/delete-contact-custom-field.tsx
+++ b/apps/builder/src/features/contacts/components/delete-contact-custom-field.tsx
@@ -88,6 +88,7 @@ export default function ClearContactCustomFieldDialog({
               label={t("fields.customField.label")}
               name="customFieldId"
               options={customFieldSelectOptions}
+              placeholder={t("actions.pleaseSelect")}
               required
             />
 

--- a/apps/builder/src/features/contacts/components/remove-contact-tag-dialog.tsx
+++ b/apps/builder/src/features/contacts/components/remove-contact-tag-dialog.tsx
@@ -90,8 +90,12 @@ export default function RemoveContactTagDialog({
             onSubmit={handleSubmitWithAction}
           >
             <TagsInputField
+              addAnotherPlaceholder={t("actions.addAnother")}
               label={t("fields.tag.label")}
               name="tags"
+              placeholder={t("actions.enterFieldAndPressEnter", {
+                field: t("fields.tag.label").toLowerCase(),
+              })}
               suggestions={tagOptions}
             />
 

--- a/apps/builder/src/features/contacts/components/update-contact-tag-field.tsx
+++ b/apps/builder/src/features/contacts/components/update-contact-tag-field.tsx
@@ -4,6 +4,7 @@ import { Form } from "@chatbotx.io/ui/components/ui/form"
 import { TagsInputField } from "@chatbotx.io/ui/components/ui/muhammada86/tags-input-field"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hooks"
+import { useTranslations } from "next-intl"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import { useTagOptions } from "@/features/tags/provider/tag-hook"
@@ -23,6 +24,7 @@ export default function UpdateContactTagField({
   tags: TagResource[]
   onSuccess: (updatedTags: TagResource[]) => void
 }) {
+  const t = useTranslations()
   const [currentTagsName, setCurrentTagsName] = useState<string[]>(
     tags.map((tag) => tag.name) ?? [],
   )
@@ -64,12 +66,14 @@ export default function UpdateContactTagField({
     <Form {...form}>
       <form className="flex flex-1 flex-col gap-2">
         <TagsInputField
+          addAnotherPlaceholder={t("actions.addAnother")}
           label=""
           name="tags"
           onSelect={(value: string[]) => {
             setCurrentTagsName(value)
             handleSubmitWithAction()
           }}
+          placeholder={t("actions.enterText")}
           suggestions={tagOptions}
         />
       </form>

--- a/apps/builder/src/features/contacts/contact-detail.tsx
+++ b/apps/builder/src/features/contacts/contact-detail.tsx
@@ -93,28 +93,28 @@ export const ContactDetail = ({
           {
             key: "email",
             icon: AtSignIcon,
-            label: "Email",
+            label: t("fields.email.label"),
             value: conversation.contact.email,
             type: "shortText",
           },
           {
             key: "firstName",
             icon: TextIcon,
-            label: "First Name",
+            label: t("fields.firstName.label"),
             value: conversation.contact.firstName,
             type: "shortText",
           },
           {
             key: "lastName",
             icon: TextIcon,
-            label: "Last Name",
+            label: t("fields.lastName.label"),
             value: conversation.contact.lastName,
             type: "shortText",
           },
           {
             key: "phoneNumber",
             icon: PhoneIcon,
-            label: "Phone Number",
+            label: t("fields.phoneNumber.label"),
             value: conversation.contact.phoneNumber,
             type: "shortText",
           },
@@ -148,6 +148,7 @@ export const ContactDetail = ({
     initializedCustomFields,
     contact,
     customFieldMap,
+    t,
   ])
 
   return contact ? (

--- a/apps/builder/src/features/contacts/contacts-table.tsx
+++ b/apps/builder/src/features/contacts/contacts-table.tsx
@@ -85,7 +85,7 @@ export function ContactsTable({
         id: "select",
         header: ({ table: innerTable }) => (
           <Checkbox
-            aria-label="Select all"
+            aria-label={t("actions.selectAll")}
             checked={
               innerTable.getIsAllPageRowsSelected() ||
               (innerTable.getIsSomePageRowsSelected() && "indeterminate")
@@ -97,7 +97,7 @@ export function ContactsTable({
         ),
         cell: ({ row }) => (
           <Checkbox
-            aria-label="Select row"
+            aria-label={t("actions.selectRow")}
             checked={row.getIsSelected()}
             onCheckedChange={(value) => row.toggleSelected(Boolean(value))}
           />

--- a/apps/builder/src/features/contacts/edit-contact-field.tsx
+++ b/apps/builder/src/features/contacts/edit-contact-field.tsx
@@ -149,6 +149,7 @@ export function EditContactField(props: EditContactField) {
               <Button
                 onClick={() => onOpenChange(false)}
                 size="sm"
+                type="button"
                 variant="ghost"
               >
                 {t("actions.cancel")}

--- a/apps/builder/src/features/conversations/components/assign-conversation-dialog.tsx
+++ b/apps/builder/src/features/conversations/components/assign-conversation-dialog.tsx
@@ -112,6 +112,7 @@ export default function AssignConversationDialog({
               label={t("fields.assignedId.label")}
               name="assignedId"
               options={contactAssigneeOptions}
+              placeholder={t("actions.pleaseSelect")}
               required
             />
 

--- a/apps/builder/src/features/conversations/conversation-filter.tsx
+++ b/apps/builder/src/features/conversations/conversation-filter.tsx
@@ -94,6 +94,7 @@ export function ConversationFilter() {
             label={t("fields.assignedId.label")}
             name="assignedId"
             options={contactAssigneeOptions}
+            placeholder={t("actions.pleaseSelect")}
             required
           />
 

--- a/apps/builder/src/features/custom-fields/contact-custom-field-manage.tsx
+++ b/apps/builder/src/features/custom-fields/contact-custom-field-manage.tsx
@@ -78,9 +78,9 @@ export function ContactCustomFieldManage({
         </div>
 
         <Command className="rounded-lg border">
-          <CommandInput className="h-9" placeholder="Search..." />
+          <CommandInput className="h-9" placeholder={t("actions.search")} />
           <CommandList>
-            <CommandEmpty>No record found.</CommandEmpty>
+            <CommandEmpty>{t("actions.noRecordFound")}</CommandEmpty>
             {options.map((option) => (
               <CommandItem
                 key={option.value}

--- a/apps/builder/src/features/custom-fields/custom-field-select.tsx
+++ b/apps/builder/src/features/custom-fields/custom-field-select.tsx
@@ -29,9 +29,10 @@ type CustomFieldSelectProps = {
 }
 
 export const CustomFieldSelect = (props: CustomFieldSelectProps) => {
+  const t = useTranslations()
   const {
     name,
-    label = "Select Custom Field",
+    label = t("fields.customField.label"),
     required,
     allowCreate,
     customFieldTypes,
@@ -41,7 +42,6 @@ export const CustomFieldSelect = (props: CustomFieldSelectProps) => {
     portal,
   } = props
 
-  const t = useTranslations()
   const workspaceId = useWorkspaceId()
   const customFieldSelectOptions = useCustomFieldSelectOptions({
     customFieldTypes,
@@ -91,7 +91,7 @@ export const CustomFieldSelect = (props: CustomFieldSelectProps) => {
       <ComboboxField
         name={name}
         options={customFieldSelectOptions}
-        placeholder={placeholder || "Please select"}
+        placeholder={placeholder || t("actions.pleaseSelect")}
         portal={portal}
         triggerValueChange={onValueChange}
       />

--- a/apps/builder/src/features/custom-fields/custom-field-table.tsx
+++ b/apps/builder/src/features/custom-fields/custom-field-table.tsx
@@ -77,7 +77,7 @@ export function CustomFieldsTable({
         id: "select",
         header: ({ table: innerTable }) => (
           <Checkbox
-            aria-label="Select all"
+            aria-label={t("actions.selectAll")}
             checked={
               innerTable.getIsAllPageRowsSelected() ||
               (innerTable.getIsSomePageRowsSelected() && "indeterminate")
@@ -89,7 +89,7 @@ export function CustomFieldsTable({
         ),
         cell: ({ row }) => (
           <Checkbox
-            aria-label="Select row"
+            aria-label={t("actions.selectRow")}
             checked={row.getIsSelected()}
             onCheckedChange={(value) => row.toggleSelected(Boolean(value))}
           />

--- a/apps/builder/src/features/email-topics/email-topics-table-columns.tsx
+++ b/apps/builder/src/features/email-topics/email-topics-table-columns.tsx
@@ -44,7 +44,7 @@ export function getEmailTopicColumns({
       id: "select",
       header: ({ table }) => (
         <Checkbox
-          aria-label="Select all"
+          aria-label={t("actions.selectAll")}
           checked={
             table.getIsAllPageRowsSelected() ||
             (table.getIsSomePageRowsSelected() && "indeterminate")
@@ -57,7 +57,7 @@ export function getEmailTopicColumns({
       ),
       cell: ({ row }) => (
         <Checkbox
-          aria-label="Select row"
+          aria-label={t("actions.selectRow")}
           checked={row.getIsSelected()}
           className="translate-y-0.5"
           onCheckedChange={(value) => row.toggleSelected(Boolean(value))}

--- a/apps/builder/src/features/error-logs/error-logs-table-columns.tsx
+++ b/apps/builder/src/features/error-logs/error-logs-table-columns.tsx
@@ -39,7 +39,7 @@ export function getColumns({
       id: "select",
       header: ({ table }) => (
         <Checkbox
-          aria-label="Select all"
+          aria-label={t("actions.selectAll")}
           checked={
             table.getIsAllPageRowsSelected() ||
             (table.getIsSomePageRowsSelected() && "indeterminate")
@@ -52,7 +52,7 @@ export function getColumns({
       ),
       cell: ({ row }) => (
         <Checkbox
-          aria-label="Select row"
+          aria-label={t("actions.selectRow")}
           checked={row.getIsSelected()}
           className="translate-y-0.5"
           onCheckedChange={(value) => row.toggleSelected(Boolean(value))}

--- a/apps/builder/src/features/fb-comments/components/bulk-move-folder-dialog.tsx
+++ b/apps/builder/src/features/fb-comments/components/bulk-move-folder-dialog.tsx
@@ -115,6 +115,7 @@ export function BulkMoveFolderDialog({
               label={t("fields.folder.label")}
               name="newFolderId"
               options={folderOptions}
+              placeholder={t("actions.pleaseSelect")}
               required
             />
 

--- a/apps/builder/src/features/fb-comments/components/fb-comment-form.tsx
+++ b/apps/builder/src/features/fb-comments/components/fb-comment-form.tsx
@@ -259,6 +259,7 @@ export function FbCommentForm({
                 label={t("fields.flow.label")}
                 name="privateReply.value"
                 options={flowOptions}
+                placeholder={t("actions.pleaseSelect")}
                 required
               />
             )}
@@ -267,6 +268,7 @@ export function FbCommentForm({
                 label={t("fields.aiAgent.label")}
                 name="privateReply.value"
                 options={aiAgentOptions}
+                placeholder={t("actions.pleaseSelect")}
                 required
               />
             )}
@@ -299,6 +301,7 @@ export function FbCommentForm({
                 label={t("fields.flow.label")}
                 name="publicReply.value"
                 options={flowOptions}
+                placeholder={t("actions.pleaseSelect")}
                 required
               />
             )}
@@ -307,6 +310,7 @@ export function FbCommentForm({
                 label={t("fields.aiAgent.label")}
                 name="publicReply.value"
                 options={aiAgentOptions}
+                placeholder={t("actions.pleaseSelect")}
                 required
               />
             )}

--- a/apps/builder/src/features/fb-comments/fb-comments-table.tsx
+++ b/apps/builder/src/features/fb-comments/fb-comments-table.tsx
@@ -91,7 +91,7 @@ export function FbCommentsTable({
         id: "select",
         header: ({ table: dataTable }) => (
           <Checkbox
-            aria-label="Select all"
+            aria-label={t("actions.selectAll")}
             checked={
               dataTable.getIsAllPageRowsSelected() ||
               (dataTable.getIsSomePageRowsSelected() && "indeterminate")
@@ -104,7 +104,7 @@ export function FbCommentsTable({
         ),
         cell: ({ row }) => (
           <Checkbox
-            aria-label="Select row"
+            aria-label={t("actions.selectRow")}
             checked={row.getIsSelected()}
             className="translate-y-0.5 cursor-pointer"
             onCheckedChange={(value) => row.toggleSelected(Boolean(value))}

--- a/apps/builder/src/features/flows/flows-table-columns.tsx
+++ b/apps/builder/src/features/flows/flows-table-columns.tsx
@@ -47,7 +47,7 @@ export function getFlowColumns({
       id: "select",
       header: ({ table }) => (
         <Checkbox
-          aria-label="Select all"
+          aria-label={t("actions.selectAll")}
           checked={
             table.getIsAllPageRowsSelected() ||
             (table.getIsSomePageRowsSelected() && "indeterminate")
@@ -60,7 +60,7 @@ export function getFlowColumns({
       ),
       cell: ({ row }) => (
         <Checkbox
-          aria-label="Select row"
+          aria-label={t("actions.selectRow")}
           checked={row.getIsSelected()}
           className="translate-y-0.5"
           onCheckedChange={(value) => row.toggleSelected(Boolean(value))}

--- a/apps/builder/src/features/flows/react-flow/nodes/node-name-editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/nodes/node-name-editor.tsx
@@ -58,7 +58,7 @@ export function NodeNameEditor({ activeNode }: { activeNode: FlowNode }) {
             className="flex w-full flex-col gap-6"
             onSubmit={form.handleSubmit(onSubmit)}
           >
-            <InputField label="Name" name="name" required />
+            <InputField label={t("fields.name.label")} name="name" required />
 
             <DialogFooter>
               <Button

--- a/apps/builder/src/features/flows/react-flow/steps/add-contact-tag/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/add-contact-tag/editor.tsx
@@ -19,8 +19,12 @@ const AddContactTagStepEditor = ({
   return (
     <BaseStepEditor icon={TagIcon} title={t("flows.actions.addContactTag")}>
       <TagsInputField
+        addAnotherPlaceholder={t("actions.addAnother")}
         label={t("fields.tag.label")}
         name={`${parentName}.tags`}
+        placeholder={t("actions.enterFieldAndPressEnter", {
+          field: t("fields.tag.label").toLowerCase(),
+        })}
         suggestions={tagOptions}
       />
     </BaseStepEditor>

--- a/apps/builder/src/features/flows/react-flow/steps/ai-analyze-image/components/ai-model-select.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/ai-analyze-image/components/ai-model-select.tsx
@@ -35,6 +35,7 @@ export const AIModelSelect = (props: AIModelSelectProps) => {
     <ComboboxField
       label={t("fields.model.label")}
       options={options}
+      placeholder={t("actions.pleaseSelect")}
       {...rest}
     />
   )

--- a/apps/builder/src/features/flows/react-flow/steps/ai-extract-data/components/dialog.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/ai-extract-data/components/dialog.tsx
@@ -111,7 +111,7 @@ export const AIExtractDataDialog = ({
 
               {inputType === "text" ? (
                 <TiptapEditorField
-                  label="Input Text"
+                  label={t("fields.inputText.label")}
                   name="inputFieldId"
                   required
                 />
@@ -119,7 +119,11 @@ export const AIExtractDataDialog = ({
                 <CustomFieldSelect
                   allowCreate={true}
                   includeReserved={false}
-                  label={inputType === "image" ? "Image" : "File"}
+                  label={
+                    inputType === "image"
+                      ? t("fields.image.label")
+                      : t("fields.file.label")
+                  }
                   name="inputFieldId"
                   required
                 />

--- a/apps/builder/src/features/flows/react-flow/steps/ai-generate-image/components/ai-model-select.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/ai-generate-image/components/ai-model-select.tsx
@@ -33,6 +33,7 @@ export const AIModelSelect = (props: AIModelSelectProps) => {
     <ComboboxField
       label={t("fields.model.label")}
       options={options}
+      placeholder={t("actions.pleaseSelect")}
       {...rest}
     />
   )

--- a/apps/builder/src/features/flows/react-flow/steps/ai-generate-text/components/ai-model-select.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/ai-generate-text/components/ai-model-select.tsx
@@ -39,6 +39,7 @@ export const AIModelSelect = (props: AIModelSelectProps) => {
     <ComboboxField
       label={t("fields.model.label")}
       options={options}
+      placeholder={t("actions.pleaseSelect")}
       {...rest}
     />
   )

--- a/apps/builder/src/features/flows/react-flow/steps/assign-conversation/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/assign-conversation/editor.tsx
@@ -25,6 +25,7 @@ const AssignConversationStepEditor = (
         label={t("fields.agent.label")}
         name={`${props.parentName}.assignedId`}
         options={contactAssigneeOptions}
+        placeholder={t("actions.pleaseSelect")}
       />
     </BaseStepEditor>
   )

--- a/apps/builder/src/features/flows/react-flow/steps/get-user-data/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/get-user-data/editor.tsx
@@ -102,6 +102,7 @@ const GetUserDataStepForm = ({
         <CustomFieldField
           label={t("fields.outputCustomField.label")}
           name="outputFieldId"
+          placeholder={t("actions.pleaseSelect")}
           required
         />
 
@@ -173,7 +174,7 @@ const GetUserDataStepEditor = ({ parentName }: { parentName: string }) => {
     <BaseStepEditor icon={KeyboardIcon} title={t("flows.actions.getUserData")}>
       <div className="flex flex-col gap-3">
         <TiptapEditorField
-          label="Message"
+          label={t("fields.messages.label")}
           name={`${parentName}.message`}
           required
         />

--- a/apps/builder/src/features/flows/react-flow/steps/mailchimp-add-member/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/mailchimp-add-member/editor.tsx
@@ -204,6 +204,7 @@ const MailchimpDialog = ({ parentName }: { parentName: string }) => {
               label={t("mailchimp.fields.audience")}
               name="listId"
               options={audienceOptions}
+              placeholder={t("actions.pleaseSelect")}
               required
               triggerValueChange={onChangeAudience}
             />

--- a/apps/builder/src/features/flows/react-flow/steps/open-website/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/open-website/editor.tsx
@@ -14,7 +14,7 @@ const OpenWebsiteStepEditor = ({ parentName }: OpenWebsiteStepEditorProps) => {
 
   return (
     <BaseStepEditor icon={LinkIcon} title={t("flows.actions.openWebsite")}>
-      <InputField label="Link" name={`${parentName}.url`} />
+      <InputField label={t("fields.link.label")} name={`${parentName}.url`} />
     </BaseStepEditor>
   )
 }

--- a/apps/builder/src/features/flows/react-flow/steps/remove-contact-tag/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/remove-contact-tag/editor.tsx
@@ -21,8 +21,12 @@ const RemoveContactTagStepEditor = (props: RemoveContactTagStepEditorProps) => {
       title={t("flows.actions.removeContactTag")}
     >
       <TagsInputField
+        addAnotherPlaceholder={t("actions.addAnother")}
         label={t("fields.tag.label")}
         name={`${parentName}.tags`}
+        placeholder={t("actions.enterFieldAndPressEnter", {
+          field: t("fields.tag.label").toLowerCase(),
+        })}
         suggestions={tagOptions}
       />
     </BaseStepEditor>

--- a/apps/builder/src/features/flows/react-flow/steps/send-messenger-template-message/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-messenger-template-message/editor.tsx
@@ -198,6 +198,7 @@ function SendMessengerTemplateMessageStepEditor(
         <ComboboxField
           name={`${parentName}.template.inboxId`}
           options={messengerInboxOptions}
+          placeholder={t("actions.pleaseSelect")}
           required={true}
         />
 

--- a/apps/builder/src/features/flows/react-flow/steps/send-wa-template-message/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-wa-template-message/editor.tsx
@@ -133,6 +133,7 @@ function SendWaTemplateMessageStepEditor(
         <ComboboxField
           name={`${parentName}.template.inboxId`}
           options={whatsappInboxOptions}
+          placeholder={t("actions.pleaseSelect")}
           required={true}
         />
 

--- a/apps/builder/src/features/flows/react-flow/steps/spreadsheet/components/spreadsheet-column-filter.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/spreadsheet/components/spreadsheet-column-filter.tsx
@@ -5,6 +5,7 @@ import { InputField } from "@chatbotx.io/ui/components/form/input-field"
 import { SelectField } from "@chatbotx.io/ui/components/form/select-field"
 import { Button } from "@chatbotx.io/ui/components/ui/button"
 import { TrashIcon } from "lucide-react"
+import { useTranslations } from "next-intl"
 import { useFieldArray, useFormContext } from "react-hook-form"
 import { SpreadsheetOperatorSelect } from "../spreadsheet-operator-select"
 import { WorksheetColumnSelect } from "../worksheet-column-select"
@@ -20,6 +21,7 @@ export const SpreadsheetColumnFilter = ({
 }: {
   parentName?: string
 }) => {
+  const t = useTranslations()
   const { control } = useFormContext()
   const getFieldName = (field: string) => {
     if (!parentName) {
@@ -42,13 +44,15 @@ export const SpreadsheetColumnFilter = ({
   return (
     <div className="flex flex-col gap-2">
       <div className="mb-2 flex items-center justify-between gap-2">
-        <span className="flex-1 text-nowrap">Lookup Columns:</span>
+        <span className="flex-1 text-nowrap">
+          {t("flows.fields.lookupColumnsLabel")}
+        </span>
         <SelectField
           defaultValue={FilterMode.AND}
           name={getFieldName("lookup.mode")}
           options={[
-            { label: "AND", value: FilterMode.AND },
-            { label: "OR", value: FilterMode.OR },
+            { label: t("flows.fields.filterModeAnd"), value: FilterMode.AND },
+            { label: t("flows.fields.filterModeOr"), value: FilterMode.OR },
           ]}
         />
       </div>
@@ -67,7 +71,7 @@ export const SpreadsheetColumnFilter = ({
           />
           <InputField
             name={getFieldName(`lookup.conditions.${idx}.value`)}
-            placeholder="Value"
+            placeholder={t("fields.value.label")}
           />
           <Button onClick={() => remove(idx)} type="button" variant="ghost">
             <TrashIcon size={20} />
@@ -80,7 +84,7 @@ export const SpreadsheetColumnFilter = ({
         type="button"
         variant="secondary"
       >
-        + Filter
+        + {t("actions.filter")}
       </Button>
     </div>
   )

--- a/apps/builder/src/features/flows/react-flow/steps/spreadsheet/spreadsheet-operator-select.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/spreadsheet/spreadsheet-operator-select.tsx
@@ -2,6 +2,7 @@
 
 import { Operator } from "@chatbotx.io/flow-config"
 import { SelectField } from "@chatbotx.io/ui/components/form/select-field"
+import { useTranslations } from "next-intl"
 import { useMemo } from "react"
 
 type ISpreadsheetOperatorSelectProps = {
@@ -13,20 +14,25 @@ export const SpreadsheetOperatorSelect = ({
   name,
   label = "",
 }: ISpreadsheetOperatorSelectProps) => {
+  const t = useTranslations()
+
   const operators = useMemo(
     () => [
-      { label: "Is", value: Operator.IS },
-      { label: "Is Not", value: Operator.IS_NOT },
-      { label: "Greater than or Equal to", value: Operator.GTE },
-      { label: "Less than or Equal to", value: Operator.LTE },
-      { label: "Greater than", value: Operator.GT },
-      { label: "Less than", value: Operator.LT },
-      { label: "Contains", value: Operator.CONTAINS },
-      { label: "Not Contains", value: Operator.NOT_CONTAINS },
-      { label: "Starts With", value: Operator.STARTS_WITH },
-      { label: "Ends With", value: Operator.ENDS_WITH },
+      { label: t("fields.operator.is"), value: Operator.IS },
+      { label: t("fields.operator.isNot"), value: Operator.IS_NOT },
+      { label: t("fields.operator.gte"), value: Operator.GTE },
+      { label: t("fields.operator.lte"), value: Operator.LTE },
+      { label: t("fields.operator.gt"), value: Operator.GT },
+      { label: t("fields.operator.lt"), value: Operator.LT },
+      { label: t("fields.operator.contains"), value: Operator.CONTAINS },
+      {
+        label: t("fields.operator.notContains"),
+        value: Operator.NOT_CONTAINS,
+      },
+      { label: t("fields.operator.startsWith"), value: Operator.STARTS_WITH },
+      { label: t("fields.operator.endsWith"), value: Operator.ENDS_WITH },
     ],
-    [],
+    [t],
   )
 
   return (
@@ -34,7 +40,7 @@ export const SpreadsheetOperatorSelect = ({
       label={label}
       name={name}
       options={operators}
-      placeholder="Please select"
+      placeholder={t("actions.pleaseSelect")}
     />
   )
 }

--- a/apps/builder/src/features/flows/react-flow/steps/spreadsheet/worksheet-column-select.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/spreadsheet/worksheet-column-select.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { SelectField } from "@chatbotx.io/ui/components/form/select-field"
+import { useTranslations } from "next-intl"
 import { useFormContext, useWatch } from "react-hook-form"
 import { useWorkspaceId } from "@/hooks/routing"
 import { callAPI } from "@/lib/swr"
@@ -16,6 +17,7 @@ export const WorksheetColumnSelect = ({
   name,
   label = "",
 }: IWorksheetColumnSelectProps) => {
+  const t = useTranslations()
   const workspaceId = useWorkspaceId()
   const getFieldName = (field: string) => {
     if (!parentName) {
@@ -46,7 +48,7 @@ export const WorksheetColumnSelect = ({
       label={label}
       name={getFieldName(name)}
       options={headers}
-      placeholder="Please select"
+      placeholder={t("actions.pleaseSelect")}
     />
   )
 }

--- a/apps/builder/src/features/flows/react-flow/steps/spreadsheet/worksheet-select.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/spreadsheet/worksheet-select.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { SelectField } from "@chatbotx.io/ui/components/form/select-field"
+import { useTranslations } from "next-intl"
 import { useWorkspaceId } from "@/hooks/routing"
 import { callAPI } from "@/lib/swr"
 
@@ -14,9 +15,10 @@ type WorksheetSelectProps = {
 export const WorksheetSelect = ({
   name,
   spreadsheetId,
-  label = "Worksheet",
+  label,
   required = true,
 }: WorksheetSelectProps) => {
+  const t = useTranslations()
   const workspaceId = useWorkspaceId()
 
   const url = `/api/workspaces/${workspaceId}/worksheets?spreadsheetId=${spreadsheetId}`
@@ -36,10 +38,10 @@ export const WorksheetSelect = ({
 
   return (
     <SelectField
-      label={label}
+      label={label ?? t("fields.worksheet.label")}
       name={name}
       options={worksheetOptions}
-      placeholder="Please select"
+      placeholder={t("actions.pleaseSelect")}
       required={required}
     />
   )

--- a/apps/builder/src/features/flows/react-flow/steps/start-another-node/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/start-another-node/editor.tsx
@@ -33,6 +33,7 @@ const StartAnotherNodeStepEditor = (props: StartAnotherNodeStepEditorProps) => {
             label: node.data.name as string,
             value: node.id,
           }))}
+          placeholder={t("actions.pleaseSelect")}
           required={true}
         />
       </div>

--- a/apps/builder/src/features/flows/react-flow/steps/start-external-flow/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/start-external-flow/editor.tsx
@@ -25,6 +25,7 @@ const SendExternalFlowStepEditor = ({ parentName }: { parentName: string }) => {
         disableValues={activeFlowId ? [activeFlowId] : undefined}
         name={name}
         options={flowOptions}
+        placeholder={t("actions.pleaseSelect")}
         required={true}
       />
     </BaseStepEditor>

--- a/apps/builder/src/features/flows/react-flow/steps/start-external-node/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/start-external-node/editor.tsx
@@ -55,6 +55,7 @@ const StartExternalNodeStepEditor = (
           label={t("fields.flow.label")}
           name={flowIdField}
           options={flowOptions}
+          placeholder={t("actions.pleaseSelect")}
           required={true}
         />
 
@@ -62,6 +63,7 @@ const StartExternalNodeStepEditor = (
           label={t("fields.node.label")}
           name={nodeIdField}
           options={nodeOptions}
+          placeholder={t("actions.pleaseSelect")}
           required={true}
         />
       </div>

--- a/apps/builder/src/features/flows/react-flow/steps/typing/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/typing/editor.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { InputNumberField } from "@chatbotx.io/ui/components/form/input-number-field"
+import { useTranslations } from "next-intl"
 
 type TypingStepEditorProps = {
   parentName: string
@@ -8,11 +9,12 @@ type TypingStepEditorProps = {
 
 export default function TypingStepEditor(props: TypingStepEditorProps) {
   const { parentName } = props
+  const t = useTranslations()
 
   return (
     <div className="flex flex-col gap-3">
       <InputNumberField
-        label="Typing for (seconds)"
+        label={t("flows.fields.typingSecondsLabel")}
         max={60}
         min={1}
         name={`${parentName}.seconds`}

--- a/apps/builder/src/features/flows/react-flow/steps/wait/components/time-select.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/wait/components/time-select.tsx
@@ -1,4 +1,5 @@
 import { SelectField } from "@chatbotx.io/ui/components/form/select-field"
+import { useTranslations } from "next-intl"
 
 type TimeSelectProps = {
   name: string
@@ -6,6 +7,7 @@ type TimeSelectProps = {
 
 const TimeSelect = (props: TimeSelectProps) => {
   const { name } = props
+  const t = useTranslations()
 
   const times: { value: string; label: string }[] = []
   for (let hour = 0; hour < 24; hour++) {
@@ -16,7 +18,13 @@ const TimeSelect = (props: TimeSelectProps) => {
     })
   }
 
-  return <SelectField name={name} options={times} placeholder="Select a time" />
+  return (
+    <SelectField
+      name={name}
+      options={times}
+      placeholder={t("flows.wait.selectTimePlaceholder")}
+    />
+  )
 }
 
 export default TimeSelect

--- a/apps/builder/src/features/flows/react-flow/steps/whatsapp-flow/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/whatsapp-flow/editor.tsx
@@ -75,6 +75,7 @@ const WhatsappFlowStepEditor = ({
         <ComboboxField
           name={`${parentName}.inboxId`}
           options={whatsappInboxOptions}
+          placeholder={t("actions.pleaseSelect")}
           required={true}
         />
 

--- a/apps/builder/src/features/folders/change-folder.tsx
+++ b/apps/builder/src/features/folders/change-folder.tsx
@@ -142,6 +142,7 @@ export function ChangeFolderForm(props: ChangeFolderFormProps) {
           label={t("fields.folder.label")}
           name="newFolderId"
           options={folderOptions}
+          placeholder={t("actions.pleaseSelect")}
           required
         />
 

--- a/apps/builder/src/features/folders/delete-folder-dialog.tsx
+++ b/apps/builder/src/features/folders/delete-folder-dialog.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
 } from "@chatbotx.io/ui/components/ui/dialog"
 import { Loader2Icon } from "lucide-react"
+import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { useAction } from "next-safe-action/hooks"
 import { toast } from "sonner"
@@ -28,6 +29,7 @@ export function DeleteFolderDialog({
   folder: FolderResource | null
 }) {
   const t = useTranslations()
+  const router = useRouter()
 
   const { execute, isPending } = useAction(
     deleteFolderAction.bind(null, workspaceId),
@@ -39,6 +41,7 @@ export function DeleteFolderDialog({
           }),
         )
         onOpenChange(false)
+        router.refresh()
       },
       onError: ({ error }) => {
         if (error.serverError) {

--- a/apps/builder/src/features/folders/edit-folder-dialog.tsx
+++ b/apps/builder/src/features/folders/edit-folder-dialog.tsx
@@ -13,6 +13,7 @@ import { Form } from "@chatbotx.io/ui/components/ui/form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hooks"
 import { Loader2Icon } from "lucide-react"
+import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { useEffect } from "react"
 import { toast } from "sonner"
@@ -32,6 +33,7 @@ export function EditFolderDialog({
   folder: FolderResource | null
 }) {
   const t = useTranslations()
+  const router = useRouter()
 
   const { form, handleSubmitWithAction, resetFormAndAction } =
     useHookFormAction(
@@ -47,6 +49,7 @@ export function EditFolderDialog({
             )
             resetFormAndAction()
             onOpenChange(false)
+            router.refresh()
           },
           onError: ({ error }) => {
             if (error.serverError) {

--- a/apps/builder/src/features/integration-instagram/components/update-instagram-form.tsx
+++ b/apps/builder/src/features/integration-instagram/components/update-instagram-form.tsx
@@ -111,6 +111,7 @@ export function UpdateInstagramForm({
           label={t("fields.welcomeFlowId.label")}
           name="welcomeFlowId"
           options={flowOptions}
+          placeholder={t("actions.pleaseSelect")}
         />
 
         <Card>

--- a/apps/builder/src/features/integration-messenger/update-messenger-form.tsx
+++ b/apps/builder/src/features/integration-messenger/update-messenger-form.tsx
@@ -163,6 +163,7 @@ export function UpdateMessengerForm({
           label={t("fields.welcomeFlowId.label")}
           name="welcomeFlowId"
           options={flowOptions}
+          placeholder={t("actions.pleaseSelect")}
         />
 
         <Card>

--- a/apps/builder/src/features/integration-webchat/components/create-webchat-form.tsx
+++ b/apps/builder/src/features/integration-webchat/components/create-webchat-form.tsx
@@ -128,6 +128,7 @@ export function CreateWebchatForm({ workspaceId }: { workspaceId: string }) {
           label={t("fields.welcomeFlowId.label")}
           name="welcomeFlowId"
           options={flowOptions}
+          placeholder={t("actions.pleaseSelect")}
         />
 
         <Separator />

--- a/apps/builder/src/features/integration-webchat/components/persistent-menu-field.tsx
+++ b/apps/builder/src/features/integration-webchat/components/persistent-menu-field.tsx
@@ -72,6 +72,7 @@ const PersistentMenuItem = memo(
             label={t("fields.flowId.label")}
             name={`persistentMenus.${index}.flowId`}
             options={flowOptions}
+            placeholder={t("actions.pleaseSelect")}
             required
           />
         )}

--- a/apps/builder/src/features/integration-webchat/components/update-webchat-form.tsx
+++ b/apps/builder/src/features/integration-webchat/components/update-webchat-form.tsx
@@ -147,6 +147,7 @@ export function UpdateWebchatForm({
           label={t("fields.welcomeFlowId.label")}
           name="welcomeFlowId"
           options={flowOptions}
+          placeholder={t("actions.pleaseSelect")}
         />
 
         <Separator />

--- a/apps/builder/src/features/integration-webchat/components/webchat-widget.tsx
+++ b/apps/builder/src/features/integration-webchat/components/webchat-widget.tsx
@@ -5,6 +5,7 @@ import { Button } from "@chatbotx.io/ui/components/ui/button"
 import { Card } from "@chatbotx.io/ui/components/ui/card"
 import { Input } from "@chatbotx.io/ui/components/ui/input"
 import { MessageCircleIcon, SendIcon, XIcon } from "lucide-react"
+import { useTranslations } from "next-intl"
 import { useEffect, useState } from "react"
 import {
   GuestSessionStoreProvider,
@@ -21,6 +22,7 @@ type WebchatWidgetProps = {
 }
 
 const WebchatWidgetContent = () => {
+  const t = useTranslations()
   const { initGuestSession, guestConversationId, config } =
     useGuestSessionStore((state) => state)
   const [message, setMessage] = useState("")
@@ -102,7 +104,7 @@ const WebchatWidgetContent = () => {
                 disabled={false}
                 onChange={(e) => setMessage(e.target.value)}
                 onKeyPress={handleKeyPress}
-                placeholder="Type your message..."
+                placeholder={t("actions.typeMessage")}
                 value={message}
               />
               <Button

--- a/apps/builder/src/features/integration-whatsapp/message-templates/components/category-select.tsx
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/components/category-select.tsx
@@ -40,15 +40,15 @@ export function WhatsappMessageTemplateCategorySelect({
     () =>
       [
         {
-          label: "Marketing",
+          label: t("whatsapp.category.marketing.label"),
           value: whatsappTemplateCategories.enum.MARKETING,
         },
         {
-          label: "Utility",
+          label: t("whatsapp.category.utility.label"),
           value: whatsappTemplateCategories.enum.UTILITY,
         },
       ].filter((option) => allowOptions.includes(option.value)),
-    [allowOptions],
+    [allowOptions, t],
   )
 
   return (
@@ -57,7 +57,7 @@ export function WhatsappMessageTemplateCategorySelect({
         label={label}
         name={name}
         options={options}
-        placeholder="Please select"
+        placeholder={t("actions.pleaseSelect")}
         required={required}
       />
       {category === whatsappTemplateCategories.enum.MARKETING && (

--- a/apps/builder/src/features/integration-whatsapp/message-templates/components/language-select.tsx
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/components/language-select.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { SelectField } from "@chatbotx.io/ui/components/form/select-field"
+import { useTranslations } from "next-intl"
 import { languageOptions } from "../type"
 
 export function WhatsappMessageTemplateLanguageSelect({
@@ -12,12 +13,14 @@ export function WhatsappMessageTemplateLanguageSelect({
   label: string
   required?: boolean
 }) {
+  const t = useTranslations()
+
   return (
     <SelectField
       label={label}
       name={name}
       options={languageOptions}
-      placeholder="Please select"
+      placeholder={t("actions.pleaseSelect")}
       required={required}
     />
   )

--- a/apps/builder/src/features/integration-whatsapp/message-templates/components/template-params-form.tsx
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/components/template-params-form.tsx
@@ -134,11 +134,20 @@ function CarouselParamField({
           {t("whatsapp.messageTemplate.params.carouselCard", {
             index: (param.cardIndex ?? 0) + 1,
           })}{" "}
-          - {param.format === "image" ? "Image" : "Video"} URL
+          -{" "}
+          {param.format === "image"
+            ? t("whatsapp.messageTemplate.image.label")
+            : t("whatsapp.messageTemplate.video.label")}{" "}
+          {t("fields.url.label")}
         </Label>
         <TiptapEditorField
           name={`${fieldName}.header[0].${param.format}.link`}
-          placeholder={`Enter ${param.format} URL`}
+          placeholder={t("whatsapp.messageTemplate.params.enterFormatUrl", {
+            format:
+              param.format === "image"
+                ? t("whatsapp.messageTemplate.image.label")
+                : t("whatsapp.messageTemplate.video.label"),
+          })}
           showEmojiPicker={false}
         />
       </div>
@@ -229,6 +238,7 @@ export function TemplateParamsForm({
   components,
   parentName,
 }: TemplateParamsFormProps) {
+  const t = useTranslations()
   const { setValue } = useFormContext()
   const parameters = useMemo(
     () => extractParameterInfos(components),
@@ -295,7 +305,12 @@ export function TemplateParamsForm({
             <div className="space-y-1" key={key}>
               <TiptapEditorField
                 name={`${fieldName}.${param.format}.link`}
-                placeholder={`Enter ${param.format} URL`}
+                placeholder={t(
+                  "whatsapp.messageTemplate.params.enterFormatUrl",
+                  {
+                    format: t(`whatsapp.messageTemplate.${param.format}.label`),
+                  },
+                )}
                 showEmojiPicker={false}
               />
             </div>

--- a/apps/builder/src/features/integration-whatsapp/message-templates/templates/carousel-image/partial.tsx
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/templates/carousel-image/partial.tsx
@@ -10,22 +10,26 @@ const VariableInput = memo(
   ({
     parentName,
     index,
-    placeholder = "Type a message",
+    placeholder,
   }: {
     parentName: string
     index: number
     placeholder?: string
-  }) => (
-    <div className="mt-2 flex w-full gap-2">
-      <Button variant="secondary">{`{{${index + 1}}}`}</Button>
-      <div className="flex-1">
-        <InputField
-          name={`${parentName}.variables.${index}`}
-          placeholder={placeholder}
-        />
+  }) => {
+    const t = useTranslations()
+
+    return (
+      <div className="mt-2 flex w-full gap-2">
+        <Button variant="secondary">{`{{${index + 1}}}`}</Button>
+        <div className="flex-1">
+          <InputField
+            name={`${parentName}.variables.${index}`}
+            placeholder={placeholder ?? t("actions.typeMessage")}
+          />
+        </div>
       </div>
-    </div>
-  ),
+    )
+  },
 )
 
 const CardVariables = memo(

--- a/apps/builder/src/features/integration-whatsapp/message-templates/templates/carousel-video/partial.tsx
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/templates/carousel-video/partial.tsx
@@ -10,22 +10,26 @@ const VariableInput = memo(
   ({
     parentName,
     index,
-    placeholder = "Type a message",
+    placeholder,
   }: {
     parentName: string
     index: number
     placeholder?: string
-  }) => (
-    <div className="mt-2 flex w-full gap-2">
-      <Button variant="secondary">{`{{${index + 1}}}`}</Button>
-      <div className="flex-1">
-        <InputField
-          name={`${parentName}.variables.${index}`}
-          placeholder={placeholder}
-        />
+  }) => {
+    const t = useTranslations()
+
+    return (
+      <div className="mt-2 flex w-full gap-2">
+        <Button variant="secondary">{`{{${index + 1}}}`}</Button>
+        <div className="flex-1">
+          <InputField
+            name={`${parentName}.variables.${index}`}
+            placeholder={placeholder ?? t("actions.typeMessage")}
+          />
+        </div>
       </div>
-    </div>
-  ),
+    )
+  },
 )
 
 const CardVariables = memo(

--- a/apps/builder/src/features/integration-whatsapp/message-templates/templates/catalog/partial.tsx
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/templates/catalog/partial.tsx
@@ -8,17 +8,21 @@ import { memo, useCallback } from "react"
 import { useFormContext, useWatch } from "react-hook-form"
 
 const VariableInput = memo(
-  ({ parentName, index }: { parentName: string; index: number }) => (
-    <div className="mt-2 flex w-full gap-2">
-      <Button variant="secondary">{`{{${index + 1}}}`}</Button>
-      <div className="flex-1">
-        <InputField
-          name={`${parentName}.body.variables.${index}`}
-          placeholder="Type a message"
-        />
+  ({ parentName, index }: { parentName: string; index: number }) => {
+    const t = useTranslations()
+
+    return (
+      <div className="mt-2 flex w-full gap-2">
+        <Button variant="secondary">{`{{${index + 1}}}`}</Button>
+        <div className="flex-1">
+          <InputField
+            name={`${parentName}.body.variables.${index}`}
+            placeholder={t("actions.typeMessage")}
+          />
+        </div>
       </div>
-    </div>
-  ),
+    )
+  },
 )
 
 const TemplateCatalogPartialComponent = (props: { parentName?: string }) => {

--- a/apps/builder/src/features/integration-whatsapp/message-templates/templates/components/body.tsx
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/templates/components/body.tsx
@@ -83,7 +83,7 @@ const TemplateBodyComponent = ({ parentName }: { parentName: string }) => {
             autoFocus
             maxLength={1024}
             onChange={(e) => onChangeValue(e.target.value)}
-            placeholder="Enter text"
+            placeholder={t("actions.enterText")}
             value={localBody}
           />
           <Button onClick={addParam} variant="link">

--- a/apps/builder/src/features/integration-whatsapp/message-templates/templates/components/footer.tsx
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/templates/components/footer.tsx
@@ -50,7 +50,7 @@ const TemplateFooterComponent = ({ parentName }: { parentName: string }) => {
             autoFocus
             maxLength={60}
             onChange={handleTextChange}
-            placeholder="Enter text"
+            placeholder={t("actions.enterText")}
             value={localFooter}
           />
         </div>

--- a/apps/builder/src/features/integration-whatsapp/message-templates/templates/components/header.tsx
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/templates/components/header.tsx
@@ -75,7 +75,7 @@ const TemplateHeaderComponent = ({ parentName }: { parentName: string }) => {
             autoFocus
             maxLength={1024}
             onChange={(e) => onChangeValue(e.target.value)}
-            placeholder="Enter text"
+            placeholder={t("actions.enterText")}
             value={localHeader}
           />
           <Button

--- a/apps/builder/src/features/integration-whatsapp/message-templates/templates/document/partial.tsx
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/templates/document/partial.tsx
@@ -8,17 +8,21 @@ import { memo, useCallback } from "react"
 import { useFormContext, useWatch } from "react-hook-form"
 
 const VariableInput = memo(
-  ({ index, parentName }: { index: number; parentName: string }) => (
-    <div className="mt-2 flex w-full gap-2">
-      <Button variant="secondary">{`{{${index + 1}}}`}</Button>
-      <div className="flex-1">
-        <InputField
-          name={`${parentName}.body.variables.${index}`}
-          placeholder="Type a message"
-        />
+  ({ index, parentName }: { index: number; parentName: string }) => {
+    const t = useTranslations()
+
+    return (
+      <div className="mt-2 flex w-full gap-2">
+        <Button variant="secondary">{`{{${index + 1}}}`}</Button>
+        <div className="flex-1">
+          <InputField
+            name={`${parentName}.body.variables.${index}`}
+            placeholder={t("actions.typeMessage")}
+          />
+        </div>
       </div>
-    </div>
-  ),
+    )
+  },
 )
 
 const TemplateDocumentPartialComponent = (props: { parentName?: string }) => {
@@ -48,7 +52,7 @@ const TemplateDocumentPartialComponent = (props: { parentName?: string }) => {
           name={`${parentName}.showFooter`}
           options={[
             {
-              label: "Show footer",
+              label: t("whatsapp.showFooter.label"),
               value: "showFooter",
             },
           ]}

--- a/apps/builder/src/features/integration-whatsapp/message-templates/templates/image/partial.tsx
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/templates/image/partial.tsx
@@ -8,17 +8,21 @@ import { memo, useCallback } from "react"
 import { useFormContext, useWatch } from "react-hook-form"
 
 const VariableInput = memo(
-  ({ index, parentName }: { index: number; parentName: string }) => (
-    <div className="mt-2 flex w-full gap-2">
-      <Button variant="secondary">{`{{${index + 1}}}`}</Button>
-      <div className="flex-1">
-        <InputField
-          name={`${parentName}.body.variables.${index}`}
-          placeholder="Type a message"
-        />
+  ({ index, parentName }: { index: number; parentName: string }) => {
+    const t = useTranslations()
+
+    return (
+      <div className="mt-2 flex w-full gap-2">
+        <Button variant="secondary">{`{{${index + 1}}}`}</Button>
+        <div className="flex-1">
+          <InputField
+            name={`${parentName}.body.variables.${index}`}
+            placeholder={t("actions.typeMessage")}
+          />
+        </div>
       </div>
-    </div>
-  ),
+    )
+  },
 )
 
 const TemplateImagePartialComponent = (props: { parentName?: string }) => {
@@ -49,7 +53,7 @@ const TemplateImagePartialComponent = (props: { parentName?: string }) => {
           name={`${parentName}.showFooter`}
           options={[
             {
-              label: "Show footer",
+              label: t("whatsapp.showFooter.label"),
               value: "showFooter",
             },
           ]}

--- a/apps/builder/src/features/integration-whatsapp/message-templates/templates/product/partial.tsx
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/templates/product/partial.tsx
@@ -16,18 +16,22 @@ const VariableInput = memo(
     index: number
     parentName: string
     type: "header" | "body"
-  }) => (
-    <div className="mt-2 flex w-full gap-2">
-      <Button variant="secondary">{`{{${index + 1}}}`}</Button>
-      <div className="flex-1">
-        <InputField
-          label={type === "body" ? "" : undefined}
-          name={`${parentName}.${type}.variables.${index}`}
-          placeholder="Type a message"
-        />
+  }) => {
+    const t = useTranslations()
+
+    return (
+      <div className="mt-2 flex w-full gap-2">
+        <Button variant="secondary">{`{{${index + 1}}}`}</Button>
+        <div className="flex-1">
+          <InputField
+            label={type === "body" ? "" : undefined}
+            name={`${parentName}.${type}.variables.${index}`}
+            placeholder={t("actions.typeMessage")}
+          />
+        </div>
       </div>
-    </div>
-  ),
+    )
+  },
 )
 
 const TemplateProductPartialComponent = (props: { parentName?: string }) => {
@@ -62,7 +66,7 @@ const TemplateProductPartialComponent = (props: { parentName?: string }) => {
           name={`${parentName}.showFooter`}
           options={[
             {
-              label: "Show footer",
+              label: t("whatsapp.showFooter.label"),
               value: "showFooter",
             },
           ]}

--- a/apps/builder/src/features/integration-whatsapp/message-templates/templates/text/partial.tsx
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/templates/text/partial.tsx
@@ -16,17 +16,21 @@ const VariableInput = memo(
     parentName: string
     index: number
     type: "header" | "body"
-  }) => (
-    <div className="mt-2 flex w-full gap-2">
-      <Button variant="secondary">{`{{${index + 1}}}`}</Button>
-      <div className="flex-1">
-        <InputField
-          name={`${parentName}.${type}.variables.${index}`}
-          placeholder="Type a message"
-        />
+  }) => {
+    const t = useTranslations()
+
+    return (
+      <div className="mt-2 flex w-full gap-2">
+        <Button variant="secondary">{`{{${index + 1}}}`}</Button>
+        <div className="flex-1">
+          <InputField
+            name={`${parentName}.${type}.variables.${index}`}
+            placeholder={t("actions.typeMessage")}
+          />
+        </div>
       </div>
-    </div>
-  ),
+    )
+  },
 )
 
 type TemplateTextPartialComponentProps = {
@@ -84,7 +88,7 @@ const TemplateTextPartialComponent = (
           name={`${parentName}.hideHeader`}
           options={[
             {
-              label: "Show header",
+              label: t("whatsapp.showHeader.label"),
               value: "hideHeader",
             },
           ]}
@@ -95,7 +99,7 @@ const TemplateTextPartialComponent = (
           name={`${parentName}.showFooter`}
           options={[
             {
-              label: "Show footer",
+              label: t("whatsapp.showFooter.label"),
               value: "showFooter",
             },
           ]}

--- a/apps/builder/src/features/integration-whatsapp/message-templates/templates/video/partial.tsx
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/templates/video/partial.tsx
@@ -8,17 +8,21 @@ import { memo, useCallback } from "react"
 import { useFormContext, useWatch } from "react-hook-form"
 
 const VariableInput = memo(
-  ({ index, parentName }: { index: number; parentName: string }) => (
-    <div className="mt-2 flex w-full gap-2">
-      <Button variant="secondary">{`{{${index + 1}}}`}</Button>
-      <div className="flex-1">
-        <InputField
-          name={`${parentName}.body.variables.${index}`}
-          placeholder="Type a message"
-        />
+  ({ index, parentName }: { index: number; parentName: string }) => {
+    const t = useTranslations()
+
+    return (
+      <div className="mt-2 flex w-full gap-2">
+        <Button variant="secondary">{`{{${index + 1}}}`}</Button>
+        <div className="flex-1">
+          <InputField
+            name={`${parentName}.body.variables.${index}`}
+            placeholder={t("actions.typeMessage")}
+          />
+        </div>
       </div>
-    </div>
-  ),
+    )
+  },
 )
 
 const TemplateVideoPartialComponent = (props: { parentName?: string }) => {
@@ -49,7 +53,7 @@ const TemplateVideoPartialComponent = (props: { parentName?: string }) => {
           name={`${parentName}.showFooter`}
           options={[
             {
-              label: "Show footer",
+              label: t("whatsapp.showFooter.label"),
               value: "showFooter",
             },
           ]}

--- a/apps/builder/src/features/messages/components/message-input.tsx
+++ b/apps/builder/src/features/messages/components/message-input.tsx
@@ -59,7 +59,7 @@ const CHANNEL_WINDOW_SECONDS: Record<ChannelType, number> = {
   smtp: 0,
   telegram: 0,
   instagram: 24 * 60 * 60,
-  tiktok: 0,
+  tiktok: 24 * 60 * 60,
 }
 
 const MESSENGER_HUMAN_AGENT_WINDOW_SECONDS = 7 * 24 * 60 * 60
@@ -353,8 +353,8 @@ export const MessageInput = () => {
     )
   }, [isMetaDm, lastIncomingTs, clockTick])
 
-  const isWhatsappWindowClosed = useMemo(
-    () => channel === "whatsapp" && isWindowExpired,
+  const isDirectChannelWindowClosed = useMemo(
+    () => (channel === "whatsapp" || channel === "tiktok") && isWindowExpired,
     [channel, isWindowExpired],
   )
 
@@ -417,7 +417,7 @@ export const MessageInput = () => {
     )
   }
 
-  if (isWhatsappWindowClosed) {
+  if (isDirectChannelWindowClosed) {
     return (
       <div className="m-3 rounded-xl border pt-2">
         <div className="flex flex-col items-center justify-center gap-3 px-4 py-6 text-center">
@@ -468,10 +468,10 @@ export const MessageInput = () => {
                   onSelect={setContent}
                 >
                   <Textarea
-                    aria-label="Type your message"
+                    aria-label={t("actions.typeMessage")}
                     autoComplete="off"
                     className="h-16 resize-none border-0 px-1.5 py-1 shadow-none focus:ring-0 focus-visible:ring-0 dark:bg-neutral-900"
-                    placeholder="Message..."
+                    placeholder={t("actions.messagePlaceholder")}
                     {...field}
                     onKeyDown={onKeyDown}
                     ref={textareaRef}

--- a/apps/builder/src/features/products/components/product-more-options-section.tsx
+++ b/apps/builder/src/features/products/components/product-more-options-section.tsx
@@ -144,6 +144,7 @@ export function ProductMoreOptionsSection() {
         </CardHeader>
         <CardContent className="space-y-2">
           <TagsInputField<ProductFormRequest>
+            addAnotherPlaceholder={tActions("addAnother")}
             className="[&>label]:hidden"
             name="tags"
             placeholder={t("sections.tags")}

--- a/apps/builder/src/features/products/components/product-variants-section.tsx
+++ b/apps/builder/src/features/products/components/product-variants-section.tsx
@@ -134,6 +134,7 @@ export function ProductVariantsSection() {
                 />
 
                 <TagsInputField
+                  addAnotherPlaceholder={tActions("addAnother")}
                   className="[&>label+div]:mt-0 [&>label]:hidden"
                   name={`variantOptions.${index}.values`}
                   placeholder={t("fields.optionValue.label")}

--- a/apps/builder/src/features/products/products-table-columns.tsx
+++ b/apps/builder/src/features/products/products-table-columns.tsx
@@ -63,7 +63,7 @@ export function getProductColumns({
       id: "select",
       header: ({ table }) => (
         <Checkbox
-          aria-label="Select all"
+          aria-label={t("actions.selectAll")}
           checked={
             table.getIsAllPageRowsSelected() ||
             (table.getIsSomePageRowsSelected() && "indeterminate")
@@ -76,7 +76,7 @@ export function getProductColumns({
       ),
       cell: ({ row }) => (
         <Checkbox
-          aria-label="Select row"
+          aria-label={t("actions.selectRow")}
           checked={row.getIsSelected()}
           className="translate-y-0.5"
           onCheckedChange={(value) => row.toggleSelected(Boolean(value))}

--- a/apps/builder/src/features/qr-codes/create-qr-code-form.tsx
+++ b/apps/builder/src/features/qr-codes/create-qr-code-form.tsx
@@ -63,6 +63,7 @@ export function CreateQrCodeForm({ workspaceId }: { workspaceId: string }) {
           label={t("fields.botResponse.label")}
           name="flowId"
           options={flowOptions}
+          placeholder={t("actions.pleaseSelect")}
           required
         />
 

--- a/apps/builder/src/features/qr-codes/update-qr-code-form.tsx
+++ b/apps/builder/src/features/qr-codes/update-qr-code-form.tsx
@@ -100,6 +100,7 @@ export function UpdateQrCodeForm({
                 label={t("fields.botResponse.label")}
                 name="flowId"
                 options={flowOptions}
+                placeholder={t("actions.pleaseSelect")}
                 required
               />
 

--- a/apps/builder/src/features/reflinks/create-reflink.tsx
+++ b/apps/builder/src/features/reflinks/create-reflink.tsx
@@ -117,6 +117,7 @@ export function CreateReflinkForm({
           label={t("fields.botResponse.label")}
           name="flowId"
           options={flowOptions}
+          placeholder={t("actions.pleaseSelect")}
           required
         />
 

--- a/apps/builder/src/features/reflinks/reflinks-table.tsx
+++ b/apps/builder/src/features/reflinks/reflinks-table.tsx
@@ -60,7 +60,7 @@ export function ReflinksTable({ workspaceId, promises }: ReflinksTableProps) {
         id: "select",
         header: ({ table: tableData }) => (
           <Checkbox
-            aria-label="Select all"
+            aria-label={t("actions.selectAll")}
             checked={
               tableData.getIsAllPageRowsSelected() ||
               (tableData.getIsSomePageRowsSelected() && "indeterminate")
@@ -73,7 +73,7 @@ export function ReflinksTable({ workspaceId, promises }: ReflinksTableProps) {
         ),
         cell: ({ row }) => (
           <Checkbox
-            aria-label="Select row"
+            aria-label={t("actions.selectRow")}
             checked={row.getIsSelected()}
             className="translate-y-0.5"
             onCheckedChange={(value) => row.toggleSelected(Boolean(value))}

--- a/apps/builder/src/features/reflinks/update-reflink.tsx
+++ b/apps/builder/src/features/reflinks/update-reflink.tsx
@@ -126,6 +126,7 @@ export function UpdateReflinkForm(props: {
           label={t("fields.flow.label")}
           name="flowId"
           options={flowOptions}
+          placeholder={t("actions.pleaseSelect")}
           required
         />
 

--- a/apps/builder/src/features/sequences/bulk-move-folder-dialog.tsx
+++ b/apps/builder/src/features/sequences/bulk-move-folder-dialog.tsx
@@ -117,6 +117,7 @@ export function BulkMoveFolderDialog({
               label={t("fields.folder.label")}
               name="newFolderId"
               options={folderOptions}
+              placeholder={t("actions.pleaseSelect")}
               required
             />
 

--- a/apps/builder/src/features/sequences/sequence-editor.tsx
+++ b/apps/builder/src/features/sequences/sequence-editor.tsx
@@ -109,11 +109,21 @@ export function SequenceEditor({ sequence, workspaceId }: SequenceEditorProps) {
                         <div className="min-w-[320px] flex-1" />
                         <div className="w-[280px]" />
                         <div className="ml-2 flex w-[400px] items-center justify-between gap-4 text-xs">
-                          <span className="w-12 text-center">Sent</span>
-                          <span className="w-12 text-center">Delivered</span>
-                          <span className="w-12 text-center">Seen</span>
-                          <span className="w-12 text-center">Clicked</span>
-                          <span className="w-12 text-center">Failed</span>
+                          <span className="w-12 text-center">
+                            {t("sequences.stats.sent")}
+                          </span>
+                          <span className="w-12 text-center">
+                            {t("sequences.stats.delivered")}
+                          </span>
+                          <span className="w-12 text-center">
+                            {t("sequences.stats.seen")}
+                          </span>
+                          <span className="w-12 text-center">
+                            {t("sequences.stats.clicked")}
+                          </span>
+                          <span className="w-12 text-center">
+                            {t("sequences.stats.failed")}
+                          </span>
                         </div>
                         <div className="w-[68px]" />
                       </div>

--- a/apps/builder/src/features/sequences/sequences-table.tsx
+++ b/apps/builder/src/features/sequences/sequences-table.tsx
@@ -80,7 +80,7 @@ export function SequencesTable({ workspaceId, promises }: SequencesTableProps) {
         id: "select",
         header: ({ table: dataTable }) => (
           <Checkbox
-            aria-label="Select all"
+            aria-label={t("actions.selectAll")}
             checked={
               dataTable.getIsAllPageRowsSelected() ||
               (dataTable.getIsSomePageRowsSelected() && "indeterminate")
@@ -93,7 +93,7 @@ export function SequencesTable({ workspaceId, promises }: SequencesTableProps) {
         ),
         cell: ({ row }) => (
           <Checkbox
-            aria-label="Select row"
+            aria-label={t("actions.selectRow")}
             checked={row.getIsSelected()}
             className="translate-y-0.5 cursor-pointer"
             onCheckedChange={(value) => row.toggleSelected(Boolean(value))}

--- a/apps/builder/src/features/tags/tags-table-columns.tsx
+++ b/apps/builder/src/features/tags/tags-table-columns.tsx
@@ -48,7 +48,7 @@ export function getTagColumns({
       id: "select",
       header: ({ table }) => (
         <Checkbox
-          aria-label="Select all"
+          aria-label={t("actions.selectAll")}
           checked={
             table.getIsAllPageRowsSelected() ||
             (table.getIsSomePageRowsSelected() && "indeterminate")
@@ -61,7 +61,7 @@ export function getTagColumns({
       ),
       cell: ({ row }) => (
         <Checkbox
-          aria-label="Select row"
+          aria-label={t("actions.selectRow")}
           checked={row.getIsSelected()}
           className="translate-y-0.5"
           onCheckedChange={(value) => row.toggleSelected(Boolean(value))}

--- a/apps/builder/src/features/triggers/components/actions/editor.tsx
+++ b/apps/builder/src/features/triggers/components/actions/editor.tsx
@@ -47,6 +47,7 @@ export const ActionEditor = ({
         <ComboboxField
           name={`${parentName}.flowId`}
           options={flowOptions}
+          placeholder={t("actions.pleaseSelect")}
           required={true}
         />
       )

--- a/apps/builder/src/features/triggers/triggers-table-columns.tsx
+++ b/apps/builder/src/features/triggers/triggers-table-columns.tsx
@@ -49,7 +49,7 @@ export function getColumns({
       id: "select",
       header: ({ table }) => (
         <Checkbox
-          aria-label="Select all"
+          aria-label={t("actions.selectAll")}
           checked={
             table.getIsAllPageRowsSelected() ||
             (table.getIsSomePageRowsSelected() && "indeterminate")
@@ -62,7 +62,7 @@ export function getColumns({
       ),
       cell: ({ row }) => (
         <Checkbox
-          aria-label="Select row"
+          aria-label={t("actions.selectRow")}
           checked={row.getIsSelected()}
           className="translate-y-0.5"
           onCheckedChange={(value) => row.toggleSelected(Boolean(value))}

--- a/apps/builder/src/features/webhooks/webhooks-table-columns.tsx
+++ b/apps/builder/src/features/webhooks/webhooks-table-columns.tsx
@@ -49,7 +49,7 @@ export function getColumns({
       id: "select",
       header: ({ table }) => (
         <Checkbox
-          aria-label="Select all"
+          aria-label={t("actions.selectAll")}
           checked={
             table.getIsAllPageRowsSelected() ||
             (table.getIsSomePageRowsSelected() && "indeterminate")
@@ -62,7 +62,7 @@ export function getColumns({
       ),
       cell: ({ row }) => (
         <Checkbox
-          aria-label="Select row"
+          aria-label={t("actions.selectRow")}
           checked={row.getIsSelected()}
           className="translate-y-0.5"
           onCheckedChange={(value) => row.toggleSelected(Boolean(value))}

--- a/apps/builder/src/features/workspaces/update-workspace-advanced-form.tsx
+++ b/apps/builder/src/features/workspaces/update-workspace-advanced-form.tsx
@@ -76,14 +76,22 @@ export function UpdateWorkspaceAdvancedForm({
               description={t("fields.defaultReply.description")}
               label={t("fields.defaultReply.label")}
             >
-              <ComboboxField name="defaultReply" options={flowOptions} />
+              <ComboboxField
+                name="defaultReply"
+                options={flowOptions}
+                placeholder={t("actions.pleaseSelect")}
+              />
             </SettingRow>
 
             <SettingRow
               description={t("fields.targetCountry.description")}
               label={t("fields.targetCountry.label")}
             >
-              <ComboboxField name="targetCountry" options={allCountryOptions} />
+              <ComboboxField
+                name="targetCountry"
+                options={allCountryOptions}
+                placeholder={t("actions.pleaseSelect")}
+              />
             </SettingRow>
 
             <SettingRow
@@ -96,6 +104,7 @@ export function UpdateWorkspaceAdvancedForm({
                   { value: "en", label: t("fields.language.english") },
                   { value: "vi", label: t("fields.language.vietnamese") },
                 ]}
+                placeholder={t("actions.pleaseSelect")}
               />
             </SettingRow>
 
@@ -103,7 +112,11 @@ export function UpdateWorkspaceAdvancedForm({
               description={t("fields.timezone.description")}
               label={t("fields.timezone.label")}
             >
-              <ComboboxField name="timezone" options={allTimezoneOptions} />
+              <ComboboxField
+                name="timezone"
+                options={allTimezoneOptions}
+                placeholder={t("actions.pleaseSelect")}
+              />
             </SettingRow>
 
             <SettingRow

--- a/packages/ui/src/components/form/combobox-field.tsx
+++ b/packages/ui/src/components/form/combobox-field.tsx
@@ -57,6 +57,8 @@ export type ComboboxFieldProps<T extends FieldValues> = {
   label?: string
   required?: boolean
   placeholder?: string
+  searchPlaceholder?: string
+  emptyText?: string
   description?: string
   descriptionType?: "inline" | "tooltip"
   options: SelectOption[]
@@ -73,6 +75,8 @@ export function ComboboxField<T extends FieldValues>({
   label,
   required,
   placeholder,
+  searchPlaceholder,
+  emptyText,
   description,
   descriptionType = "inline",
   options,
@@ -136,9 +140,12 @@ export function ComboboxField<T extends FieldValues>({
               side={side}
             >
               <Command>
-                <CommandInput className="h-9" placeholder="Search..." />
+                <CommandInput
+                  className="h-9"
+                  placeholder={searchPlaceholder ?? "Search..."}
+                />
                 <CommandList>
-                  <CommandEmpty>No record found.</CommandEmpty>
+                  <CommandEmpty>{emptyText ?? "No record found."}</CommandEmpty>
                   {options.map((option) =>
                     option.children ? (
                       <CommandGroup heading={option.label} key={option.value}>

--- a/packages/ui/src/components/ui/muhammada86/tags-input-field.tsx
+++ b/packages/ui/src/components/ui/muhammada86/tags-input-field.tsx
@@ -10,6 +10,11 @@ import {
 } from "@chatbotx.io/ui/components/ui/form";
 import { Input } from "@chatbotx.io/ui/components/ui/input";
 import { Badge } from "@chatbotx.io/ui/components/ui/badge";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "@chatbotx.io/ui/components/ui/popover";
 import { cn } from "@chatbotx.io/ui/lib/utils";
 import {
   type ReactNode,
@@ -29,6 +34,7 @@ interface TagsInputFieldProps<TFieldValues extends FieldValues> {
   description?: string;
   label?: string;
   placeholder?: string;
+  addAnotherPlaceholder?: string;
   disabled?: boolean;
   className?: string;
   maxTags?: number;
@@ -49,6 +55,7 @@ const TagsInputFieldBase = <TFieldValues extends FieldValues>({
   description,
   label,
   placeholder,
+  addAnotherPlaceholder,
   disabled = false,
   className,
   maxTags,
@@ -192,6 +199,16 @@ const TagsInputFieldBase = <TFieldValues extends FieldValues>({
             </FormLabel>}
 
             <FormControl>
+              <Popover
+                open={showSuggestions && visibleSuggestions.length > 0}
+                onOpenChange={(open) => {
+                  if (!open) {
+                    setShowSuggestions(false);
+                    setShowAllSuggestions(false);
+                  }
+                }}
+              >
+              <PopoverAnchor asChild>
               <div ref={containerRef} className="relative mb-0">
                 <div
                   className={cn(
@@ -263,7 +280,7 @@ const TagsInputFieldBase = <TFieldValues extends FieldValues>({
                             `Enter ${label?.toLowerCase()} and press Enter`
                           : maxTags && tags.length >= maxTags
                           ? `Maximum ${maxTags} tags reached`
-                          : "Add another..."
+                          : addAnotherPlaceholder ?? "Add another..."
                       }
                       className={styles.input}
                       disabled={
@@ -299,60 +316,50 @@ const TagsInputFieldBase = <TFieldValues extends FieldValues>({
                     </button>
                   )}
                 </div>
-
-                {/* Suggestions Dropdown */}
-                <AnimatePresence>
-                  {showSuggestions && visibleSuggestions.length > 0 && (
-                    <motion.div
-                      initial={{ opacity: 0, y: -10 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      exit={{ opacity: 0, y: -10 }}
-                      transition={{ duration: 0.2 }}
-                      className={cn(
-                        "absolute z-50 w-full mt-1 rounded-md max-h-60 overflow-auto",
-                        styles.suggestions
-                      )}
-                    >
-                      {visibleSuggestions.map((suggestion) => {
-                        const isSelected =
-                          !allowDuplicates && tags.includes(suggestion);
-
-                        return (
-                          <button
-                            key={suggestion}
-                            type="button"
-                            onClick={() =>
-                              addTag(suggestion, tags, field.onChange)
-                            }
-                            className={cn(
-                              "w-full px-3 py-2 text-left hover:bg-muted transition-colors text-sm disabled:cursor-not-allowed disabled:text-muted-foreground disabled:opacity-50 disabled:hover:bg-transparent",
-                              isSelected &&
-                                "cursor-not-allowed text-muted-foreground hover:bg-transparent"
-                            )}
-                            disabled={isSelected}
-                          >
-                            <div className="flex items-center gap-2">
-                              <span
-                                className={cn(
-                                  "text-muted-foreground",
-                                  isSelected && "text-muted-foreground"
-                                )}
-                              >
-                                {startIcon ? (
-                                  startIcon
-                                ) : (
-                                  <Tag className="w-3 h-3" />
-                                )}
-                              </span>
-                              <span>{suggestion}</span>
-                            </div>
-                          </button>
-                        );
-                      })}
-                    </motion.div>
-                  )}
-                </AnimatePresence>
               </div>
+              </PopoverAnchor>
+
+              <PopoverContent
+                align="start"
+                className={cn(
+                  "w-(--radix-popover-trigger-width) max-h-60 overflow-auto rounded-md p-0",
+                  styles.suggestions
+                )}
+                onOpenAutoFocus={(e) => e.preventDefault()}
+                onCloseAutoFocus={(e) => e.preventDefault()}
+              >
+                {visibleSuggestions.map((suggestion) => {
+                  const isSelected =
+                    !allowDuplicates && tags.includes(suggestion);
+
+                  return (
+                    <button
+                      key={suggestion}
+                      type="button"
+                      onClick={() => addTag(suggestion, tags, field.onChange)}
+                      className={cn(
+                        "w-full px-3 py-2 text-left hover:bg-muted transition-colors text-sm disabled:cursor-not-allowed disabled:text-muted-foreground disabled:opacity-50 disabled:hover:bg-transparent",
+                        isSelected &&
+                          "cursor-not-allowed text-muted-foreground hover:bg-transparent"
+                      )}
+                      disabled={isSelected}
+                    >
+                      <div className="flex items-center gap-2">
+                        <span
+                          className={cn(
+                            "text-muted-foreground",
+                            isSelected && "text-muted-foreground"
+                          )}
+                        >
+                          {startIcon ? startIcon : <Tag className="w-3 h-3" />}
+                        </span>
+                        <span>{suggestion}</span>
+                      </div>
+                    </button>
+                  );
+                })}
+              </PopoverContent>
+              </Popover>
             </FormControl>
 
             {description && <FormDescription>{description}</FormDescription>}


### PR DESCRIPTION
## Summary
- Replace hardcoded English UI strings (aria-labels, placeholders, empty-state text, table action labels, etc.) with `useTranslations()` calls across the builder app and the shared `packages/ui` package.
- Add the corresponding translation keys to `en.json` and `vi.json` so both locales stay in sync.

## Changes
- 102 files across `apps/builder/src/**` and `packages/ui/src/**` — hardcoded strings routed through i18n
- `apps/builder/messages/en.json`, `apps/builder/messages/vi.json` — new/updated translation keys (e.g. `actions.selectAll`, `actions.selectRow`, `actions.pleaseSelect`, `actions.delete`, `sequences.stats.*`)
- `packages/ui/src/components/form/combobox-field.tsx` — adds optional `searchPlaceholder` / `emptyText` props so consumers can localize the combobox's built-in "Search..." / "No record found." text
- `packages/ui/src/components/ui/muhammada86/tags-input-field.tsx` — same localization pass for the tags input

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [ ] Manual UI check: verify no hardcoded English labels remain in switched-to-Vietnamese locale
