### PR TITLE
fix(messenger): handle failed attachment downloads and dedupe duplicate urls

### DIFF
--- a/integrations/instagram/__tests__/incoming-attachment.test.ts
+++ b/integrations/instagram/__tests__/incoming-attachment.test.ts
@@ -1,0 +1,137 @@
+import { HttpResponse, http, server } from "@chatbotx.io/vitest-config/msw"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import { receiveMessage } from "../src/handlers/message/incomming-message"
+
+const AUTH = {
+  clientId: "app-123",
+  tokens: { accessToken: "page-token" },
+  metadata: {
+    igId: "ig-123",
+    igName: "Test IG",
+    pageId: "page-123",
+    version: "v23.0",
+  },
+} as never
+
+function buildCtx() {
+  return {
+    storagePrefix: "workspace-1",
+    uploader: { putObject: vi.fn(async () => undefined) },
+    auth: AUTH,
+  } as never
+}
+
+function buildWebhookPayload(attachmentUrl: string) {
+  return buildWebhookPayloadWithAttachmentUrls([attachmentUrl])
+}
+
+function buildWebhookPayloadWithAttachmentUrls(attachmentUrls: string[]) {
+  return {
+    object: "instagram",
+    entry: [
+      {
+        id: "ig-123",
+        time: 1_700_000_000,
+        messaging: [
+          {
+            sender: { id: "user-1" },
+            recipient: { id: "ig-123" },
+            timestamp: 1_700_000_000,
+            message: {
+              mid: "mid-1",
+              attachments: attachmentUrls.map((url) => ({
+                type: "image",
+                payload: { url },
+              })),
+            },
+          },
+        ],
+      },
+    ],
+  } as never
+}
+
+describe("instagram incoming sticker/image attachments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("drops the message's attachment instead of producing a malformed entry when the CDN download fails", async () => {
+    server.use(
+      http.get("https://sticker.cdn.test/broken.png", () =>
+        HttpResponse.text("forbidden", { status: 403 }),
+      ),
+    )
+
+    const result = await receiveMessage({
+      ctx: buildCtx(),
+      data: {
+        integrationType: "instagram",
+        integrationIdentifier: "ig-123",
+        payload: buildWebhookPayload("https://sticker.cdn.test/broken.png"),
+      },
+    } as never)
+
+    expect(result?.message?.attachments).toEqual([])
+  })
+
+  test("keeps the sticker as an image attachment even when its dimensions can't be parsed", async () => {
+    server.use(
+      http.get(
+        "https://sticker.cdn.test/sticker.webp",
+        () =>
+          new HttpResponse(new Uint8Array([1, 2, 3, 4]), {
+            headers: { "content-type": "image/webp" },
+            status: 200,
+          }),
+      ),
+    )
+
+    const result = await receiveMessage({
+      ctx: buildCtx(),
+      data: {
+        integrationType: "instagram",
+        integrationIdentifier: "ig-123",
+        payload: buildWebhookPayload("https://sticker.cdn.test/sticker.webp"),
+      },
+    } as never)
+
+    const [attachment] = result?.message?.attachments ?? []
+    expect(attachment).toEqual(
+      expect.objectContaining({
+        fileType: "image",
+        mimeType: "image/webp",
+      }),
+    )
+    expect(attachment).not.toHaveProperty("width")
+    expect(attachment).not.toHaveProperty("height")
+  })
+
+  test("dedupes attachments sharing the same url instead of storing the sticker twice", async () => {
+    let downloadCount = 0
+    server.use(
+      http.get("https://sticker.cdn.test/duplicate.png", () => {
+        downloadCount++
+        return new HttpResponse(new Uint8Array([1, 2, 3, 4]), {
+          headers: { "content-type": "image/png" },
+          status: 200,
+        })
+      }),
+    )
+
+    const result = await receiveMessage({
+      ctx: buildCtx(),
+      data: {
+        integrationType: "instagram",
+        integrationIdentifier: "ig-123",
+        payload: buildWebhookPayloadWithAttachmentUrls([
+          "https://sticker.cdn.test/duplicate.png",
+          "https://sticker.cdn.test/duplicate.png",
+        ]),
+      },
+    } as never)
+
+    expect(result?.message?.attachments).toHaveLength(1)
+    expect(downloadCount).toBe(1)
+  })
+})

--- a/integrations/instagram/src/apis/page.ts
+++ b/integrations/instagram/src/apis/page.ts
@@ -9,6 +9,7 @@ import imageSize from "image-size"
 import { DEFAULT_API_VERSION } from "../constants"
 import { rescue } from "../exception"
 import { instagramBusinessClient } from "../lib/http-client"
+import { logger } from "../lib/logger"
 import type {
   InstagramAttachment,
   InstagramAuthValue,
@@ -137,36 +138,44 @@ export const getMessageAttachmentEntity = async ({
       "User-Agent": "node",
     },
   })
-  if (response.ok && response.body) {
-    const originPath = `${ctx.storagePrefix}/${createId()}`
-    const bytes = await response.arrayBuffer()
-    const mimeType = response.headers.get("content-type") ?? "image/png"
-    const fileType = guessFileTypeFromMimeType(mimeType)
+  if (!(response.ok && response.body)) {
+    throw new Error(
+      `Failed to download attachment (status ${response.status} ${response.statusText}): ${attachment.payload.url}`,
+    )
+  }
 
-    await ctx.uploader?.putObject(originPath, Buffer.from(bytes), {
-      ACL: "public-read",
-      ContentType: mimeType,
-    })
+  const originPath = `${ctx.storagePrefix}/${createId()}`
+  const bytes = await response.arrayBuffer()
+  const mimeType = response.headers.get("content-type") ?? "image/png"
+  const fileType = guessFileTypeFromMimeType(mimeType)
 
-    const imageProperties: {
-      width?: number
-      height?: number
-    } = {}
-    if (mimeType.startsWith("image/")) {
+  await ctx.uploader?.putObject(originPath, Buffer.from(bytes), {
+    ACL: "public-read",
+    ContentType: mimeType,
+  })
+
+  const imageProperties: {
+    width?: number
+    height?: number
+  } = {}
+  if (mimeType.startsWith("image/")) {
+    try {
       const arrayBytes = new Uint8Array(bytes)
       const dimensions = imageSize(arrayBytes)
       imageProperties.width = dimensions.width
       imageProperties.height = dimensions.height
+    } catch (error) {
+      logger.warn(error, "Failed to read attachment image dimensions")
     }
+  }
 
-    return {
-      sourceId: createId(),
-      originPath,
-      fileType,
-      mimeType,
-      size: Number.parseInt(response.headers.get("content-length") ?? "0", 10),
-      ...imageProperties,
-    }
+  return {
+    sourceId: createId(),
+    originPath,
+    fileType,
+    mimeType,
+    size: Number.parseInt(response.headers.get("content-length") ?? "0", 10),
+    ...imageProperties,
   }
 }
 

--- a/integrations/instagram/src/handlers/message/incomming-message.ts
+++ b/integrations/instagram/src/handlers/message/incomming-message.ts
@@ -27,20 +27,31 @@ const getMessageAttachments = async (
   }
 
   try {
-    const attachmentPromises = message.attachments
-      .filter((attachment) => attachment.payload.url)
-      .map((attachment) =>
-        getMessageAttachmentEntity({ ctx, attachment }).catch((error) => {
-          logger.error("Error processing attachment", error)
-          return null
-        }),
-      )
+    // Instagram/Messenger can send the same sticker/attachment twice in one
+    // message's attachments array (same payload.url repeated) — dedupe
+    // before downloading, otherwise it gets uploaded and stored twice.
+    const seenUrls = new Set<string>()
+    const uniqueAttachments = message.attachments.filter((attachment) => {
+      const url = attachment.payload.url
+      if (!url || seenUrls.has(url)) {
+        return false
+      }
+      seenUrls.add(url)
+      return true
+    })
+
+    const attachmentPromises = uniqueAttachments.map((attachment) =>
+      getMessageAttachmentEntity({ ctx, attachment }).catch((error) => {
+        logger.error("Error processing attachment", error)
+        return null
+      }),
+    )
 
     const attachmentResults = await Promise.allSettled(attachmentPromises)
     return attachmentResults
       .filter(
         (result): result is PromiseFulfilledResult<IncomingAttachment> =>
-          result.status === "fulfilled" && result.value !== null,
+          result.status === "fulfilled" && result.value != null,
       )
       .map((result) => result.value)
   } catch (error) {

--- a/integrations/messenger/__tests__/incoming-attachment.test.ts
+++ b/integrations/messenger/__tests__/incoming-attachment.test.ts
@@ -1,0 +1,140 @@
+import { HttpResponse, http, server } from "@chatbotx.io/vitest-config/msw"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import { receiveMessage } from "../src/handlers/message/incomming-message"
+import type { MessengerWebhookEvent } from "../src/schema"
+
+const AUTH = {
+  clientId: "app-123",
+  tokens: { accessToken: "page-token" },
+  metadata: {
+    pageId: "page-123",
+    version: "v23.0",
+  },
+} as never
+
+function buildCtx() {
+  return {
+    storagePrefix: "workspace-1",
+    uploader: { putObject: vi.fn(async () => undefined) },
+    auth: AUTH,
+  } as never
+}
+
+function buildWebhookPayload(
+  attachmentUrl: string,
+): { object: "page" } & Pick<MessengerWebhookEvent, "entry"> {
+  return buildWebhookPayloadWithAttachmentUrls([attachmentUrl])
+}
+
+function buildWebhookPayloadWithAttachmentUrls(
+  attachmentUrls: string[],
+): { object: "page" } & Pick<MessengerWebhookEvent, "entry"> {
+  return {
+    object: "page",
+    entry: [
+      {
+        id: "page-123",
+        time: 1_700_000_000,
+        messaging: [
+          {
+            sender: { id: "user-1" },
+            recipient: { id: "page-123" },
+            timestamp: 1_700_000_000,
+            message: {
+              mid: "mid-1",
+              attachments: attachmentUrls.map((url) => ({
+                type: "image",
+                payload: { url },
+              })),
+            },
+          },
+        ],
+      },
+    ],
+  } as never
+}
+
+describe("messenger incoming sticker/image attachments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("drops the message's attachment instead of producing a malformed entry when the CDN download fails", async () => {
+    server.use(
+      http.get("https://sticker.cdn.test/broken.png", () =>
+        HttpResponse.text("forbidden", { status: 403 }),
+      ),
+    )
+
+    const result = await receiveMessage({
+      ctx: buildCtx(),
+      data: {
+        integrationType: "messenger",
+        integrationIdentifier: "page-123",
+        payload: buildWebhookPayload("https://sticker.cdn.test/broken.png"),
+      },
+    } as never)
+
+    expect(result?.message?.attachments).toEqual([])
+  })
+
+  test("keeps the sticker as an image attachment even when its dimensions can't be parsed", async () => {
+    server.use(
+      http.get(
+        "https://sticker.cdn.test/sticker.webp",
+        () =>
+          new HttpResponse(new Uint8Array([1, 2, 3, 4]), {
+            headers: { "content-type": "image/webp" },
+            status: 200,
+          }),
+      ),
+    )
+
+    const result = await receiveMessage({
+      ctx: buildCtx(),
+      data: {
+        integrationType: "messenger",
+        integrationIdentifier: "page-123",
+        payload: buildWebhookPayload("https://sticker.cdn.test/sticker.webp"),
+      },
+    } as never)
+
+    const [attachment] = result?.message?.attachments ?? []
+    expect(attachment).toEqual(
+      expect.objectContaining({
+        fileType: "image",
+        mimeType: "image/webp",
+      }),
+    )
+    expect(attachment).not.toHaveProperty("width")
+    expect(attachment).not.toHaveProperty("height")
+  })
+
+  test("dedupes attachments sharing the same url instead of storing the sticker twice", async () => {
+    let downloadCount = 0
+    server.use(
+      http.get("https://sticker.cdn.test/duplicate.png", () => {
+        downloadCount++
+        return new HttpResponse(new Uint8Array([1, 2, 3, 4]), {
+          headers: { "content-type": "image/png" },
+          status: 200,
+        })
+      }),
+    )
+
+    const result = await receiveMessage({
+      ctx: buildCtx(),
+      data: {
+        integrationType: "messenger",
+        integrationIdentifier: "page-123",
+        payload: buildWebhookPayloadWithAttachmentUrls([
+          "https://sticker.cdn.test/duplicate.png",
+          "https://sticker.cdn.test/duplicate.png",
+        ]),
+      },
+    } as never)
+
+    expect(result?.message?.attachments).toHaveLength(1)
+    expect(downloadCount).toBe(1)
+  })
+})

--- a/integrations/messenger/src/apis/attachment.ts
+++ b/integrations/messenger/src/apis/attachment.ts
@@ -9,6 +9,7 @@ import fetch from "cross-fetch"
 import imageSize from "image-size"
 import { rescue } from "../exception"
 import { facebookAttachmentClient } from "../lib/http-client"
+import { logger } from "../lib/logger"
 import type {
   FacebookMessageAttachment,
   FacebookSendMessageResponse,
@@ -59,36 +60,44 @@ export const getMessageAttachmentEntity = async ({
       "User-Agent": "node",
     },
   })
-  if (response.ok && response.body) {
-    const originPath = `${ctx.storagePrefix}/${createId()}`
-    const bytes = await response.arrayBuffer()
-    const mimeType = response.headers.get("content-type") ?? "image/png"
-    const fileType = guessFileTypeFromMimeType(mimeType)
+  if (!(response.ok && response.body)) {
+    throw new Error(
+      `Failed to download attachment (status ${response.status} ${response.statusText}): ${attachment.payload.url}`,
+    )
+  }
 
-    await ctx.uploader?.putObject(originPath, Buffer.from(bytes), {
-      ACL: "public-read",
-      ContentType: mimeType,
-    })
+  const originPath = `${ctx.storagePrefix}/${createId()}`
+  const bytes = await response.arrayBuffer()
+  const mimeType = response.headers.get("content-type") ?? "image/png"
+  const fileType = guessFileTypeFromMimeType(mimeType)
 
-    const imageProperties: {
-      width?: number
-      height?: number
-    } = {}
-    if (mimeType.startsWith("image/")) {
-      // Retrieve width / height
+  await ctx.uploader?.putObject(originPath, Buffer.from(bytes), {
+    ACL: "public-read",
+    ContentType: mimeType,
+  })
+
+  const imageProperties: {
+    width?: number
+    height?: number
+  } = {}
+  if (mimeType.startsWith("image/")) {
+    // Retrieve width / height
+    try {
       const arrayBytes = new Uint8Array(bytes)
       const dimensions = imageSize(arrayBytes)
       imageProperties.width = dimensions.width
       imageProperties.height = dimensions.height
+    } catch (error) {
+      logger.warn(error, "Failed to read attachment image dimensions")
     }
+  }
 
-    return {
-      sourceId: createId(),
-      originPath,
-      fileType,
-      mimeType,
-      size: Number.parseInt(response.headers.get("content-length") ?? "0", 10),
-      ...imageProperties,
-    }
+  return {
+    sourceId: createId(),
+    originPath,
+    fileType,
+    mimeType,
+    size: Number.parseInt(response.headers.get("content-length") ?? "0", 10),
+    ...imageProperties,
   }
 }

--- a/integrations/messenger/src/handlers/message/incomming-message.ts
+++ b/integrations/messenger/src/handlers/message/incomming-message.ts
@@ -27,20 +27,31 @@ const getMessageAttachments = async (
   }
 
   try {
-    const attachmentPromises = message.attachments
-      .filter((attachment) => attachment.payload.url)
-      .map((attachment) =>
-        getMessageAttachmentEntity({ ctx, attachment }).catch((error) => {
-          logger.error("Error processing attachment", error)
-          return null
-        }),
-      )
+    // Facebook can send the same sticker/attachment twice in one message's
+    // attachments array (same payload.url repeated) — dedupe before
+    // downloading, otherwise it gets uploaded and stored as two attachments.
+    const seenUrls = new Set<string>()
+    const uniqueAttachments = message.attachments.filter((attachment) => {
+      const url = attachment.payload.url
+      if (!url || seenUrls.has(url)) {
+        return false
+      }
+      seenUrls.add(url)
+      return true
+    })
+
+    const attachmentPromises = uniqueAttachments.map((attachment) =>
+      getMessageAttachmentEntity({ ctx, attachment }).catch((error) => {
+        logger.error("Error processing attachment", error)
+        return null
+      }),
+    )
 
     const attachmentResults = await Promise.allSettled(attachmentPromises)
     return attachmentResults
       .filter(
         (result): result is PromiseFulfilledResult<IncomingAttachment> =>
-          result.status === "fulfilled" && result.value !== null,
+          result.status === "fulfilled" && result.value != null,
       )
       .map((result) => result.value)
   } catch (error) {


### PR DESCRIPTION
## Summary
- Dedupe Instagram/Messenger message attachments by `payload.url` before downloading — a sticker sent twice in one message's attachments array was previously downloaded and stored as two duplicate objects.
- A failed CDN download now throws instead of silently returning nothing, so the caller drops the malformed attachment cleanly rather than producing an incomplete entry.
- A failed image-dimension read (`imageSize`) is now caught and logged instead of crashing the whole attachment handler.

## Changes
- `integrations/instagram/src/apis/page.ts`, `integrations/messenger/src/apis/attachment.ts` — throw on failed download, catch/log dimension-read errors
- `integrations/instagram/src/handlers/message/incomming-message.ts`, `integrations/messenger/src/handlers/message/incomming-message.ts` — dedupe attachments by url before fetching
- `integrations/instagram/__tests__/incoming-attachment.test.ts`, `integrations/messenger/__tests__/incoming-attachment.test.ts` — new tests covering dedup, failed download, and unparseable dimensions

## Test plan
- [x] `pnpm --filter @chatbotx.io/integration-messenger test`
- [x] `pnpm --filter @chatbotx.io/integration-instagram test`
- [x] `pnpm --filter @chatbotx.io/integration-messenger check-types`, `pnpm --filter @chatbotx.io/integration-instagram check-types`
