### PR TITLE
perf(contact-filter): skip subquery when no filter conditions are set

### DIFF
--- a/packages/database/src/queries/contact-filter.ts
+++ b/packages/database/src/queries/contact-filter.ts
@@ -171,6 +171,10 @@ export const buildContactInboxContactFilterSQL = ({
   workspaceId: string
   contactFilter: ContactFilterCriteriaInput
 }): SQL => {
+  if (contactFilter.conditions.length === 0) {
+    return sql`TRUE`
+  }
+
   const contactWhere = buildContactWhere({
     workspaceId,
     contactFilter,


### PR DESCRIPTION
## Summary
- Returns `TRUE` directly instead of building an unnecessary subquery when a contact filter has no conditions to check

## Test plan
- [x] `pnpm --filter builder check-types` / full `check-types` via pre-commit hook (49/49 packages passed)
- [x] `pnpm ultracite fix` (biome) — no issues