### PR TITLE
fix(inbox): prevent long inbox labels from pushing buttons out of view

### DIFF
--- a/apps/builder/src/features/broadcasts/create-broadcast-form.tsx
+++ b/apps/builder/src/features/broadcasts/create-broadcast-form.tsx
@@ -279,7 +279,7 @@ function CreateBroadcastChooseChannel() {
       <CardContent className="flex flex-col gap-4">
         {configs.map((config) => (
           <div className="flex w-full items-center gap-2" key={config.value}>
-            <div className="flex-1">
+            <div className="min-w-0 flex-1">
               <InboxIcon channel={config.value} />
             </div>
             <Button
@@ -690,7 +690,7 @@ function CreateBroadcastChooseFlow(props: CreateBroadcastChooseFlowProps) {
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-6">
       <Card>
         <CardContent className="flex px-3">
-          <div className="flex flex-1 flex-col gap-2">
+          <div className="flex min-w-0 flex-1 flex-col gap-2">
             <InboxIcon channel={props.channel} label={subactionInfo.name} />
             {subactionInfo.description && (
               <span className="text-gray-500 text-sm">

--- a/apps/builder/src/features/inboxes/components/get-inbox-url.tsx
+++ b/apps/builder/src/features/inboxes/components/get-inbox-url.tsx
@@ -81,7 +81,7 @@ function GetInboxUrlItem({
       className="flex w-full items-center gap-3 border-t py-4 first:border-t-0"
       key={inbox.id}
     >
-      <div className="flex-1">
+      <div className="min-w-0 flex-1">
         <InboxIcon
           channel={inbox.channel as ChannelType}
           iconClassName="size-6"

--- a/apps/builder/src/features/inboxes/components/inbox-icon.tsx
+++ b/apps/builder/src/features/inboxes/components/inbox-icon.tsx
@@ -33,10 +33,10 @@ const ICON_SIZE_CLASSES: Record<IconSize, string> = {
 }
 
 const LABEL_SIZE_CLASSES: Record<IconSize, string> = {
-  small: "text-xs truncate",
-  medium: "text-sm truncate",
-  large: "text-base truncate",
-  xlarge: "text-base truncate",
+  small: "text-xs truncate min-w-0",
+  medium: "text-sm truncate min-w-0",
+  large: "text-base truncate min-w-0",
+  xlarge: "text-base truncate min-w-0",
 }
 
 type InboxIconConfig = {
@@ -128,7 +128,7 @@ export const InboxIcon = memo(
     } = config
 
     return (
-      <div className={cn("flex items-center gap-2", wrapperClassName)}>
+      <div className={cn("flex min-w-0 items-center gap-2", wrapperClassName)}>
         <Icon
           className={cn(
             ICON_SIZE_CLASSES[size],
@@ -138,7 +138,9 @@ export const InboxIcon = memo(
           {...(fill !== undefined && { fill })}
         />
         {showLabel && (
-          <span className={cn(LABEL_SIZE_CLASSES[size], labelClassName)}>
+          <span
+            className={cn("flex-1", LABEL_SIZE_CLASSES[size], labelClassName)}
+          >
             {label ?? defaultLabel}
           </span>
         )}

--- a/apps/builder/src/features/inboxes/components/inbox-select-card.tsx
+++ b/apps/builder/src/features/inboxes/components/inbox-select-card.tsx
@@ -57,7 +57,7 @@ function InboxSelectCard({ configuredChannels }: InboxSelectCardProps) {
         <ul aria-label="Available inbox types" className="flex flex-col gap-4">
           {inboxOptions.map((channel) => (
             <li className="flex items-center gap-2" key={channel}>
-              <div className="flex-1">
+              <div className="min-w-0 flex-1">
                 <InboxIcon channel={channel} size="large" />
               </div>
               <Button

--- a/apps/builder/src/features/inboxes/components/landing-inbox-list.tsx
+++ b/apps/builder/src/features/inboxes/components/landing-inbox-list.tsx
@@ -45,7 +45,7 @@ function QrLandingInboxItem({
 
   return (
     <div className="flex w-full items-center gap-3 border-t py-4 first:border-t-0">
-      <div className="flex-1">
+      <div className="min-w-0 flex-1">
         <InboxIcon
           channel={inbox.channel as ChannelType}
           label={inbox.name}

--- a/apps/builder/src/features/messages/components/message-input.tsx
+++ b/apps/builder/src/features/messages/components/message-input.tsx
@@ -486,7 +486,7 @@ export const MessageInput = () => {
             </div>
           )}
           <div className="flex w-full items-center pl-2.5">
-            <div className="flex-1">
+            <div className="min-w-0 flex-1">
               <InboxIcon
                 channel={
                   (conversation?.contactInboxes[0]?.channel ??


### PR DESCRIPTION
## Summary
- `InboxIcon`'s label `<span>` and its `flex-1` wrapper `<div>`s were missing `min-w-0`, so as flex items they defaulted to `min-width: auto` and refused to shrink below their text content's width.
- With a long inbox/channel name, the label overflowed its container instead of truncating, pushing the adjacent action button (Continue / Copy / Remove) outside the card.
- Added `min-w-0` to the `InboxIcon` wrapper div and label span, and to every `flex-1` container that wraps `InboxIcon` next to a sibling button, so the label truncates correctly under long names.

## Changes
- `apps/builder/src/features/inboxes/components/inbox-icon.tsx` — `min-w-0` on the icon/label wrapper, `flex-1 min-w-0` on the label span
- `apps/builder/src/features/inboxes/components/landing-inbox-list.tsx`
- `apps/builder/src/features/inboxes/components/get-inbox-url.tsx`
- `apps/builder/src/features/inboxes/components/inbox-select-card.tsx`
- `apps/builder/src/features/messages/components/message-input.tsx`
- `apps/builder/src/features/broadcasts/create-broadcast-form.tsx`

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [ ] Manually verify: create/view an inbox with a very long name in the QR landing page, get-inbox-url dialog, inbox select card, message input, and broadcast create-flow — confirm the label truncates with an ellipsis and the button stays visible
