### PR TITLE
fix(workspace): invalidate member caches on workspace rename

### DIFF
--- a/apps/builder/src/features/workspace-members/actions/delete-workspace-member.action.ts
+++ b/apps/builder/src/features/workspace-members/actions/delete-workspace-member.action.ts
@@ -1,5 +1,6 @@
 "use server"
 
+import { workspaceMemberCacheTag } from "@chatbotx.io/business"
 import { ChatbotXException } from "@chatbotx.io/business/errors"
 import { db, eq, findOrFail } from "@chatbotx.io/database/client"
 import { workspaceMemberModel } from "@chatbotx.io/database/schema"
@@ -49,6 +50,6 @@ export const deleteWorkspaceMemberAction = workspaceActionClient
     // The removed member's cached `listByUserId` result still lists this
     // workspace; bust it so their access is revoked immediately.
     await invalidateCacheByTags([
-      `users:${workspaceMember.userId}:workspace-members`,
+      workspaceMemberCacheTag(workspaceMember.userId),
     ])
   })

--- a/apps/builder/src/features/workspace-members/actions/update-workspace-member.action.ts
+++ b/apps/builder/src/features/workspace-members/actions/update-workspace-member.action.ts
@@ -1,5 +1,6 @@
 "use server"
 
+import { workspaceMemberCacheTag } from "@chatbotx.io/business"
 import { ChatbotXException } from "@chatbotx.io/business/errors"
 import { db, eq, findOrFail } from "@chatbotx.io/database/client"
 import { workspaceMemberModel } from "@chatbotx.io/database/schema"
@@ -59,6 +60,6 @@ export const updateWorkspaceMemberAction = workspaceActionClient
     // The member's permissions/nav are served from the cached
     // `listByUserId` result; bust it so the change takes effect immediately.
     await invalidateCacheByTags([
-      `users:${workspaceMember.userId}:workspace-members`,
+      workspaceMemberCacheTag(workspaceMember.userId),
     ])
   })

--- a/apps/builder/src/features/workspaces/update-workspace-basic-form.tsx
+++ b/apps/builder/src/features/workspaces/update-workspace-basic-form.tsx
@@ -8,6 +8,7 @@ import { Input } from "@chatbotx.io/ui/components/ui/input"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hooks"
 import { CopyIcon, Loader2Icon } from "lucide-react"
+import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { toast } from "sonner"
 import { useCopyToClipboard } from "usehooks-ts"
@@ -23,6 +24,7 @@ export function UpdateWorkspaceBasicForm({
   workspace: WorkspaceResource
 }) {
   const t = useTranslations()
+  const router = useRouter()
 
   const session = authClient.useSession()
 
@@ -44,6 +46,7 @@ export function UpdateWorkspaceBasicForm({
               feature: t("fields.workspace.label"),
             }),
           )
+          router.refresh()
         },
         onError: ({ error }) => {
           if (error.serverError) {

--- a/packages/business/__tests__/workspace.service.test.ts
+++ b/packages/business/__tests__/workspace.service.test.ts
@@ -6,9 +6,23 @@ const returningWorkspace = vi.fn(async () => [
 const valuesWorkspace = vi.fn(() => ({ returning: returningWorkspace }))
 const insert = vi.fn(() => ({ values: valuesWorkspace }))
 
+const returningUpdatedWorkspace = vi.fn(async () => [
+  { id: "ws-1", name: "New Name" },
+])
+const whereUpdate = vi.fn(() => ({ returning: returningUpdatedWorkspace }))
+const setUpdate = vi.fn(() => ({ where: whereUpdate }))
+const update = vi.fn(() => ({ set: setUpdate }))
+
 const findFirstUser = vi.fn(async () => ({ tenantId: "1" }))
-const db = { insert, query: { userModel: { findFirst: findFirstUser } } }
-vi.mock("@chatbotx.io/database/client", () => ({ db }))
+const db = {
+  insert,
+  update,
+  query: { userModel: { findFirst: findFirstUser } },
+}
+vi.mock("@chatbotx.io/database/client", () => ({
+  db,
+  eq: vi.fn((field: unknown, value: unknown) => ({ field, value })),
+}))
 vi.mock("@chatbotx.io/database/schema", () => ({
   workspaceModel: {},
   ROOT_TENANT_ID: "1",
@@ -19,8 +33,9 @@ vi.mock("../src/enterprise/tenant/service", () => ({ tenantService }))
 vi.mock("@chatbotx.io/database/partials", () => ({
   workspaceMemberRoles: { enum: { owner: "owner" } },
 }))
+const invalidateCacheByTags = vi.fn(async () => undefined)
 vi.mock("@chatbotx.io/redis", () => ({
-  invalidateCacheByTags: vi.fn(async () => undefined),
+  invalidateCacheByTags,
   withCache: vi.fn(async (_key: string, fn: () => unknown) => fn()),
 }))
 vi.mock("@chatbotx.io/utils", () => ({ createId: () => "usage-1" }))
@@ -37,8 +52,13 @@ vi.mock("../src/quota-enforcement/service", () => ({ quotaEnforcementService }))
 
 const workspaceMemberService = {
   create: vi.fn(async () => undefined),
+  listUserIdsByWorkspaceId: vi.fn(async () => [] as string[]),
 }
-vi.mock("../src/workspace-member/service", () => ({ workspaceMemberService }))
+vi.mock("../src/workspace-member/service", () => ({
+  workspaceMemberService,
+  workspaceMemberCacheTag: (userId: string) =>
+    `users:${userId}:workspace-members`,
+}))
 
 const macRepository = {
   ensureWorkspaceMac: vi.fn(async () => new Map<string, string>()),
@@ -72,11 +92,20 @@ beforeEach(() => {
   quotaEnforcementService.tryConsume.mockReset().mockResolvedValue({ ok: true })
   userQuotaService.getForUser.mockReset().mockResolvedValue(null)
   workspaceMemberService.create.mockClear()
+  workspaceMemberService.listUserIdsByWorkspaceId
+    .mockReset()
+    .mockResolvedValue([])
   macRepository.ensureWorkspaceMac
     .mockReset()
     .mockResolvedValue(new Map<string, string>())
   anchoredPeriod.mockClear()
   logger.error.mockClear()
+  returningUpdatedWorkspace
+    .mockReset()
+    .mockResolvedValue([{ id: "ws-1", name: "New Name" }])
+  setUpdate.mockClear()
+  update.mockClear()
+  invalidateCacheByTags.mockClear()
 })
 
 describe("WorkspaceService.create — MAC pre-provisioning", () => {
@@ -157,5 +186,37 @@ describe("WorkspaceService.create — happy path", () => {
     const memberArg = workspaceMemberService.create.mock.calls[0][0]
     expect(memberArg.data.workspaceId).toBe("ws-1")
     expect(memberArg.data.role).toBe("owner")
+  })
+})
+
+describe("WorkspaceService.update — member cache invalidation", () => {
+  test("invalidates the workspace tag and every member's workspace-members tag", async () => {
+    workspaceMemberService.listUserIdsByWorkspaceId.mockResolvedValue([
+      "user-1",
+      "user-2",
+    ])
+
+    const result = await workspaceService.update({
+      id: "ws-1",
+      data: { name: "New Name" },
+    })
+
+    expect(result).toEqual({ id: "ws-1", name: "New Name" })
+    expect(
+      workspaceMemberService.listUserIdsByWorkspaceId,
+    ).toHaveBeenCalledWith({ tx: db, workspaceId: "ws-1" })
+    expect(invalidateCacheByTags).toHaveBeenCalledWith([
+      "workspaces:ws-1",
+      "users:user-1:workspace-members",
+      "users:user-2:workspace-members",
+    ])
+  })
+
+  test("invalidates only the workspace tag when the workspace has no members", async () => {
+    workspaceMemberService.listUserIdsByWorkspaceId.mockResolvedValue([])
+
+    await workspaceService.update({ id: "ws-1", data: { name: "New Name" } })
+
+    expect(invalidateCacheByTags).toHaveBeenCalledWith(["workspaces:ws-1"])
   })
 })

--- a/packages/business/src/workspace-member/service.ts
+++ b/packages/business/src/workspace-member/service.ts
@@ -13,6 +13,9 @@ type WorkspaceMemberWithWorkspace = WorkspaceMemberModel & {
   workspace: WorkspaceModel
 }
 
+export const workspaceMemberCacheTag = (userId: string) =>
+  `users:${userId}:workspace-members`
+
 export class WorkspaceMemberService extends BaseService {
   async create(props: {
     tx?: DatabaseClient
@@ -47,12 +50,12 @@ export class WorkspaceMemberService extends BaseService {
     tx?: DatabaseClient
     userId: string
   }): Promise<WorkspaceMemberWithWorkspace[]> {
-    const key = `users:${props.userId}:workspace-members`
+    const key = workspaceMemberCacheTag(props.userId)
     return await withCache(
       key,
       async () => await this.listByUserIdUncached(props),
       {
-        tags: [`users:${props.userId}:workspace-members`],
+        tags: [workspaceMemberCacheTag(props.userId)],
       },
     )
   }
@@ -120,6 +123,19 @@ export class WorkspaceMemberService extends BaseService {
       )
       .limit(1)
     return !!row
+  }
+
+  async listUserIdsByWorkspaceId(props: {
+    tx?: DatabaseClient
+    workspaceId: string
+  }): Promise<string[]> {
+    const { tx = db, workspaceId } = props
+    const rows = await tx
+      .select({ userId: workspaceMemberModel.userId })
+      .from(workspaceMemberModel)
+      .where(eq(workspaceMemberModel.workspaceId, workspaceId))
+
+    return rows.map((row) => row.userId)
   }
 
   async listByWorkspaceId(props: {

--- a/packages/business/src/workspace/service.ts
+++ b/packages/business/src/workspace/service.ts
@@ -10,7 +10,10 @@ import { ChatbotXException, notFoundException } from "../errors"
 import { logger } from "../logger"
 import { quotaEnforcementService } from "../quota-enforcement/service"
 import { userQuotaService } from "../user-quota/service"
-import { workspaceMemberService } from "../workspace-member/service"
+import {
+  workspaceMemberCacheTag,
+  workspaceMemberService,
+} from "../workspace-member/service"
 
 type WorkspaceWhere = Partial<{ id: string; ownerId: string; token: string }>
 
@@ -66,7 +69,15 @@ class WorkspaceService extends BaseService {
       .set(data)
       .where(eq(workspaceModel.id, id))
       .returning()
-    await this.invalidateCacheTags([`workspaces:${id}`])
+
+    const memberUserIds = await workspaceMemberService.listUserIdsByWorkspaceId(
+      { tx, workspaceId: id },
+    )
+    await this.invalidateCacheTags([
+      `workspaces:${id}`,
+      ...memberUserIds.map((userId) => workspaceMemberCacheTag(userId)),
+    ])
+
     return updated
   }
 
@@ -146,7 +157,7 @@ class WorkspaceService extends BaseService {
       tx,
     })
 
-    this.invalidateCacheTags([`users:${props.createdBy}:workspace-members`])
+    await this.invalidateCacheTags([workspaceMemberCacheTag(props.createdBy)])
 
     return newWorkspace
   }

--- a/packages/redis/src/cache-utils.ts
+++ b/packages/redis/src/cache-utils.ts
@@ -58,8 +58,10 @@ export const invalidateCacheByTags = async (tags: string[]) => {
   if (tags.length === 0) {
     return
   }
-  for (const tag of tags) {
-    const keys = await distributedStore.smembers(`tags:${tag}`)
-    await distributedStore.delete([...keys, `tags:${tag}`])
-  }
+  await Promise.all(
+    tags.map(async (tag) => {
+      const keys = await distributedStore.smembers(`tags:${tag}`)
+      await distributedStore.delete([...keys, `tags:${tag}`])
+    }),
+  )
 }


### PR DESCRIPTION
## Summary
- Workspace rename/basic-info updates only invalidated the `workspaces:{id}` cache tag, leaving each member's cached `workspace-members` list stale until natural expiry
- Also invalidate `users:{userId}:workspace-members` for every member of the workspace on update
- Refresh the router client-side after a successful basic-info update so the change reflects immediately in the UI

## Changes
- `packages/business/src/workspace/service.ts` — fetch workspace members and invalidate their `workspace-members` cache tag alongside the existing `workspaces:{id}` tag
- `apps/builder/src/features/workspaces/update-workspace-basic-form.tsx` — call `router.refresh()` on successful update

## Test plan
- [x] pnpm lint (via pre-commit hook)
- [x] pnpm check-types (via pre-commit hook, all packages)
- [ ] manual verification: rename a workspace and confirm members' sidebar/workspace list reflects the new name without a hard refresh
