### PR TITLE
fix(forms): localize empty-state text for all ComboboxField usages

### DIFF
--- a/apps/builder/src/features/ai-functions/ai-functions-create.tsx
+++ b/apps/builder/src/features/ai-functions/ai-functions-create.tsx
@@ -185,6 +185,7 @@ export function AIFunctionsCreate({
                   />
                   <MoveRightIcon className="size-10" />
                   <CustomFieldField
+                    emptyText={t("actions.noRecordFound")}
                     name={`dataCollect.${index}.to`}
                     placeholder={t("actions.pleaseSelect")}
                   />
@@ -212,6 +213,7 @@ export function AIFunctionsCreate({
               placeholder={t("fields.outputMessage.placeholder")}
             />
             <ComboboxField
+              emptyText={t("actions.noRecordFound")}
               label={t("fields.triggerFlowId.label")}
               name="triggerFlowId"
               options={flowOptions}

--- a/apps/builder/src/features/ai-triggers/create.tsx
+++ b/apps/builder/src/features/ai-triggers/create.tsx
@@ -138,6 +138,7 @@ export function CreateAITriggerDialog({
 
                     <div className="basis-5/12">
                       <ComboboxField
+                        emptyText={t("actions.noRecordFound")}
                         name={`questions.${i}.customFieldId`}
                         options={customFieldSelectOptions}
                         placeholder={t("actions.pleaseSelect")}
@@ -166,6 +167,7 @@ export function CreateAITriggerDialog({
               </div>
 
               <ComboboxField
+                emptyText={t("actions.noRecordFound")}
                 label={t("fields.flowId.label")}
                 name="flowId"
                 options={flowOptions}

--- a/apps/builder/src/features/automated-response/create-automated-response-form.tsx
+++ b/apps/builder/src/features/automated-response/create-automated-response-form.tsx
@@ -175,6 +175,7 @@ export function CreateAutomatedResponseForm(
 
         {responseMode === responseModes.enum.flowId && (
           <ComboboxField
+            emptyText={t("actions.noRecordFound")}
             label={t("fields.flowId.label")}
             name="flowId"
             options={flowOptions}

--- a/apps/builder/src/features/automated-response/edit-automated-response-form.tsx
+++ b/apps/builder/src/features/automated-response/edit-automated-response-form.tsx
@@ -179,6 +179,7 @@ export default function EditAutomatedResponseForm(
 
         {responseMode === responseModes.enum.flowId && (
           <ComboboxField
+            emptyText={t("actions.noRecordFound")}
             label={t("fields.flowId.label")}
             name="flowId"
             options={flowOptions}

--- a/apps/builder/src/features/broadcasts/components/messenger-broadcast-flow-buttons.tsx
+++ b/apps/builder/src/features/broadcasts/components/messenger-broadcast-flow-buttons.tsx
@@ -86,6 +86,7 @@ function FlowSelectDialog({
         <FormProvider {...dialogForm}>
           <div className="py-2">
             <ComboboxField
+              emptyText={t("actions.noRecordFound")}
               label={t("fields.flowId.label")}
               name="flowId"
               options={flowOptions}

--- a/apps/builder/src/features/broadcasts/create-broadcast-form.tsx
+++ b/apps/builder/src/features/broadcasts/create-broadcast-form.tsx
@@ -719,6 +719,7 @@ function CreateBroadcastChooseFlow(props: CreateBroadcastChooseFlowProps) {
             broadcastSubactions.enum.whatsappTemplateMessage && (
             <>
               <ComboboxField
+                emptyText={t("actions.noRecordFound")}
                 key="integrationWhatsappId"
                 label={t("fields.whatsappChannel.label")}
                 name="integrationWhatsappId"
@@ -733,6 +734,7 @@ function CreateBroadcastChooseFlow(props: CreateBroadcastChooseFlowProps) {
               {watchedTemplateType === broadcastFlowTypes.enum.template && (
                 <>
                   <ComboboxField
+                    emptyText={t("actions.noRecordFound")}
                     key="templateId"
                     label={t("fields.templateId.label")}
                     name="templateId"
@@ -776,6 +778,7 @@ function CreateBroadcastChooseFlow(props: CreateBroadcastChooseFlowProps) {
             broadcastSubactions.enum.messengerTemplateMessage && (
             <>
               <ComboboxField
+                emptyText={t("actions.noRecordFound")}
                 key="integrationMessengerId"
                 label={t("fields.messengerChannel.label")}
                 name="integrationMessengerId"
@@ -787,6 +790,7 @@ function CreateBroadcastChooseFlow(props: CreateBroadcastChooseFlowProps) {
               {watchedTemplateType === broadcastFlowTypes.enum.template && (
                 <>
                   <ComboboxField
+                    emptyText={t("actions.noRecordFound")}
                     key="messengerTemplateId"
                     label={t("fields.messengerTemplateId.label")}
                     name="templateId"
@@ -839,6 +843,7 @@ function CreateBroadcastChooseFlow(props: CreateBroadcastChooseFlowProps) {
           {(!watchedTemplateType ||
             watchedTemplateType !== broadcastFlowTypes.enum.template) && (
             <ComboboxField
+              emptyText={t("actions.noRecordFound")}
               key="flowId"
               label={t("fields.flowId.label")}
               name="flowId"

--- a/apps/builder/src/features/contact-filter/components/contact-filter-condition-form.tsx
+++ b/apps/builder/src/features/contact-filter/components/contact-filter-condition-form.tsx
@@ -473,6 +473,7 @@ export const ContactFilterConditionForm = ({
             <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
               <ComboboxField
                 className="overflow-hidden truncate"
+                emptyText={t("actions.noRecordFound")}
                 name="field"
                 options={fieldOptions}
                 placeholder={t("actions.pleaseSelect")}

--- a/apps/builder/src/features/contacts/components/delete-contact-custom-field.tsx
+++ b/apps/builder/src/features/contacts/components/delete-contact-custom-field.tsx
@@ -85,6 +85,7 @@ export default function ClearContactCustomFieldDialog({
             onSubmit={handleSubmitWithAction}
           >
             <ComboboxField
+              emptyText={t("actions.noRecordFound")}
               label={t("fields.customField.label")}
               name="customFieldId"
               options={customFieldSelectOptions}

--- a/apps/builder/src/features/conversations/components/assign-conversation-dialog.tsx
+++ b/apps/builder/src/features/conversations/components/assign-conversation-dialog.tsx
@@ -109,6 +109,7 @@ export default function AssignConversationDialog({
             onSubmit={handleSubmitWithAction}
           >
             <ComboboxField
+              emptyText={t("actions.noRecordFound")}
               label={t("fields.assignedId.label")}
               name="assignedId"
               options={contactAssigneeOptions}

--- a/apps/builder/src/features/conversations/conversation-filter.tsx
+++ b/apps/builder/src/features/conversations/conversation-filter.tsx
@@ -104,6 +104,7 @@ export function ConversationFilter() {
           />
 
           <ComboboxField
+            emptyText={t("actions.noRecordFound")}
             label={t("fields.assignedId.label")}
             name="assignedId"
             options={contactAssigneeOptions}

--- a/apps/builder/src/features/custom-fields/custom-field-select.tsx
+++ b/apps/builder/src/features/custom-fields/custom-field-select.tsx
@@ -89,6 +89,7 @@ export const CustomFieldSelect = (props: CustomFieldSelectProps) => {
         </div>
       )}
       <ComboboxField
+        emptyText={t("actions.noRecordFound")}
         name={name}
         options={customFieldSelectOptions}
         placeholder={placeholder || t("actions.pleaseSelect")}

--- a/apps/builder/src/features/fb-comments/components/bulk-move-folder-dialog.tsx
+++ b/apps/builder/src/features/fb-comments/components/bulk-move-folder-dialog.tsx
@@ -112,6 +112,7 @@ export function BulkMoveFolderDialog({
             onSubmit={form.handleSubmit(handleBulkMove)}
           >
             <ComboboxField
+              emptyText={t("actions.noRecordFound")}
               label={t("fields.folder.label")}
               name="newFolderId"
               options={folderOptions}

--- a/apps/builder/src/features/fb-comments/components/fb-comment-form.tsx
+++ b/apps/builder/src/features/fb-comments/components/fb-comment-form.tsx
@@ -256,6 +256,7 @@ export function FbCommentForm({
             )}
             {privateReplyType === "flow" && (
               <ComboboxField
+                emptyText={t("actions.noRecordFound")}
                 label={t("fields.flow.label")}
                 name="privateReply.value"
                 options={flowOptions}
@@ -265,6 +266,7 @@ export function FbCommentForm({
             )}
             {privateReplyType === "AIAgent" && (
               <ComboboxField
+                emptyText={t("actions.noRecordFound")}
                 label={t("fields.aiAgent.label")}
                 name="privateReply.value"
                 options={aiAgentOptions}
@@ -298,6 +300,7 @@ export function FbCommentForm({
             )}
             {publicReplyType === "flow" && (
               <ComboboxField
+                emptyText={t("actions.noRecordFound")}
                 label={t("fields.flow.label")}
                 name="publicReply.value"
                 options={flowOptions}
@@ -307,6 +310,7 @@ export function FbCommentForm({
             )}
             {publicReplyType === "AIAgent" && (
               <ComboboxField
+                emptyText={t("actions.noRecordFound")}
                 label={t("fields.aiAgent.label")}
                 name="publicReply.value"
                 options={aiAgentOptions}

--- a/apps/builder/src/features/flows/components/select-flow-dialog.tsx
+++ b/apps/builder/src/features/flows/components/select-flow-dialog.tsx
@@ -158,6 +158,7 @@ export function SelectFlowDialog({
 
                 <TabsContent value="flows">
                   <ComboboxField
+                    emptyText={t("actions.noRecordFound")}
                     label={t("fields.flows.label")}
                     name="flowId"
                     options={flowOptions}
@@ -169,6 +170,7 @@ export function SelectFlowDialog({
 
                 <TabsContent value="steps">
                   <ComboboxField
+                    emptyText={t("actions.noRecordFound")}
                     label={t("fields.steps.label")}
                     name="nodeId"
                     options={nodesSelectOptions}

--- a/apps/builder/src/features/flows/react-flow/steps/active-campaign-sync-contact/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/active-campaign-sync-contact/editor.tsx
@@ -239,6 +239,7 @@ const ActiveCampaignDialog = ({ parentName }: { parentName: string }) => {
                 )}
                 {!(automationsLoading || automationsError) && (
                   <ComboboxField
+                    emptyText={t("actions.noRecordFound")}
                     label={t("activeCampaign.fields.automation")}
                     name="automationId"
                     options={automationOptions}
@@ -337,6 +338,7 @@ const ActiveCampaignDialog = ({ parentName }: { parentName: string }) => {
                       />
                       <ArrowRightIcon className="size-4 text-muted-foreground" />
                       <ComboboxField
+                        emptyText={t("actions.noRecordFound")}
                         label=""
                         name={`fieldValues.${index}.activeCampaignFieldId`}
                         options={customFieldOptions}

--- a/apps/builder/src/features/flows/react-flow/steps/ai-analyze-image/components/ai-model-select.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/ai-analyze-image/components/ai-model-select.tsx
@@ -33,6 +33,7 @@ export const AIModelSelect = (props: AIModelSelectProps) => {
 
   return (
     <ComboboxField
+      emptyText={t("actions.noRecordFound")}
       label={t("fields.model.label")}
       options={options}
       placeholder={t("actions.pleaseSelect")}

--- a/apps/builder/src/features/flows/react-flow/steps/ai-generate-image/components/ai-model-select.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/ai-generate-image/components/ai-model-select.tsx
@@ -31,6 +31,7 @@ export const AIModelSelect = (props: AIModelSelectProps) => {
 
   return (
     <ComboboxField
+      emptyText={t("actions.noRecordFound")}
       label={t("fields.model.label")}
       options={options}
       placeholder={t("actions.pleaseSelect")}

--- a/apps/builder/src/features/flows/react-flow/steps/ai-generate-text/components/ai-model-select.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/ai-generate-text/components/ai-model-select.tsx
@@ -37,6 +37,7 @@ export const AIModelSelect = (props: AIModelSelectProps) => {
 
   return (
     <ComboboxField
+      emptyText={t("actions.noRecordFound")}
       label={t("fields.model.label")}
       options={options}
       placeholder={t("actions.pleaseSelect")}

--- a/apps/builder/src/features/flows/react-flow/steps/assign-conversation/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/assign-conversation/editor.tsx
@@ -22,6 +22,7 @@ const AssignConversationStepEditor = (
       title={t("flows.actions.assignConversation")}
     >
       <ComboboxField
+        emptyText={t("actions.noRecordFound")}
         label={t("fields.agent.label")}
         name={`${props.parentName}.assignedId`}
         options={contactAssigneeOptions}

--- a/apps/builder/src/features/flows/react-flow/steps/drip-subscribe-subscriber/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/drip-subscribe-subscriber/editor.tsx
@@ -160,6 +160,7 @@ const DripDialog = ({ parentName }: { parentName: string }) => {
             onSubmit={form.handleSubmit(submit)}
           >
             <ComboboxField
+              emptyText={t("actions.noRecordFound")}
               label={t("drip.fields.account")}
               name="accountId"
               options={accountOptions}
@@ -256,6 +257,7 @@ const DripDialog = ({ parentName }: { parentName: string }) => {
                       />
                       <ArrowRightIcon className="size-4 text-muted-foreground" />
                       <ComboboxField
+                        emptyText={t("actions.noRecordFound")}
                         label=""
                         name={`mergeFields.${index}.dripField`}
                         options={customFieldOptions}

--- a/apps/builder/src/features/flows/react-flow/steps/get-response-add-contact/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/get-response-add-contact/editor.tsx
@@ -153,6 +153,7 @@ const GetResponseDialog = ({ parentName }: { parentName: string }) => {
             )}
             {!(campaignsLoading || campaignsError) && (
               <ComboboxField
+                emptyText={t("actions.noRecordFound")}
                 label={t("getResponse.fields.list")}
                 name="campaignId"
                 options={campaignOptions}

--- a/apps/builder/src/features/flows/react-flow/steps/get-user-data/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/get-user-data/editor.tsx
@@ -100,6 +100,7 @@ const GetUserDataStepForm = ({
         />
 
         <CustomFieldField
+          emptyText={t("actions.noRecordFound")}
           label={t("fields.outputCustomField.label")}
           name="outputFieldId"
           placeholder={t("actions.pleaseSelect")}

--- a/apps/builder/src/features/flows/react-flow/steps/mailchimp-add-member/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/mailchimp-add-member/editor.tsx
@@ -201,6 +201,7 @@ const MailchimpDialog = ({ parentName }: { parentName: string }) => {
             onSubmit={form.handleSubmit(submit)}
           >
             <ComboboxField
+              emptyText={t("actions.noRecordFound")}
               label={t("mailchimp.fields.audience")}
               name="listId"
               options={audienceOptions}

--- a/apps/builder/src/features/flows/react-flow/steps/moosend-create-contact/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/moosend-create-contact/editor.tsx
@@ -101,6 +101,7 @@ const MoosendDialog = ({ parentName }: { parentName: string }) => {
             onSubmit={form.handleSubmit(submit)}
           >
             <ComboboxField
+              emptyText={t("actions.noRecordFound")}
               label={t("moosend.fields.list")}
               name="listId"
               options={listOptions}

--- a/apps/builder/src/features/flows/react-flow/steps/send-messenger-template-message/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-messenger-template-message/editor.tsx
@@ -196,6 +196,7 @@ function SendMessengerTemplateMessageStepEditor(
     <BaseStepEditor>
       <div className="space-y-3">
         <ComboboxField
+          emptyText={t("actions.noRecordFound")}
           name={`${parentName}.template.inboxId`}
           options={messengerInboxOptions}
           placeholder={t("actions.pleaseSelect")}

--- a/apps/builder/src/features/flows/react-flow/steps/send-wa-template-message/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-wa-template-message/editor.tsx
@@ -131,6 +131,7 @@ function SendWaTemplateMessageStepEditor(
     <BaseStepEditor>
       <div className="space-y-3">
         <ComboboxField
+          emptyText={t("actions.noRecordFound")}
           name={`${parentName}.template.inboxId`}
           options={whatsappInboxOptions}
           placeholder={t("actions.pleaseSelect")}

--- a/apps/builder/src/features/flows/react-flow/steps/sendgrid-add-contact/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/sendgrid-add-contact/editor.tsx
@@ -147,6 +147,7 @@ const SendGridDialog = ({ parentName }: { parentName: string }) => {
             onSubmit={form.handleSubmit(submit)}
           >
             <ComboboxField
+              emptyText={t("actions.noRecordFound")}
               label={t("sendGrid.fields.list")}
               name="listId"
               options={listOptions}
@@ -197,6 +198,7 @@ const SendGridDialog = ({ parentName }: { parentName: string }) => {
                   />
                   <ArrowRightIcon className="size-4 text-muted-foreground" />
                   <ComboboxField
+                    emptyText={t("actions.noRecordFound")}
                     label=""
                     name={`mergeFields.${index}.sendGridField`}
                     options={customFieldOptions}

--- a/apps/builder/src/features/flows/react-flow/steps/start-another-node/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/start-another-node/editor.tsx
@@ -28,6 +28,7 @@ const StartAnotherNodeStepEditor = (props: StartAnotherNodeStepEditorProps) => {
       <div className="flex flex-col gap-4">
         <ComboboxField
           disableValues={currentNodeId ? [currentNodeId] : undefined}
+          emptyText={t("actions.noRecordFound")}
           name={`${parentName}.nodeId`}
           options={nodes.map((node) => ({
             label: node.data.name as string,

--- a/apps/builder/src/features/flows/react-flow/steps/start-external-flow/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/start-external-flow/editor.tsx
@@ -23,6 +23,7 @@ const SendExternalFlowStepEditor = ({ parentName }: { parentName: string }) => {
     >
       <ComboboxField
         disableValues={activeFlowId ? [activeFlowId] : undefined}
+        emptyText={t("actions.noRecordFound")}
         name={name}
         options={flowOptions}
         placeholder={t("actions.pleaseSelect")}

--- a/apps/builder/src/features/flows/react-flow/steps/start-external-node/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/start-external-node/editor.tsx
@@ -52,6 +52,7 @@ const StartExternalNodeStepEditor = (
       <div className="flex flex-col gap-4">
         <ComboboxField
           disableValues={activeFlowId ? [activeFlowId] : undefined}
+          emptyText={t("actions.noRecordFound")}
           label={t("fields.flow.label")}
           name={flowIdField}
           options={flowOptions}
@@ -60,6 +61,7 @@ const StartExternalNodeStepEditor = (
         />
 
         <ComboboxField
+          emptyText={t("actions.noRecordFound")}
           label={t("fields.node.label")}
           name={nodeIdField}
           options={nodeOptions}

--- a/apps/builder/src/features/flows/react-flow/steps/whatsapp-flow/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/whatsapp-flow/editor.tsx
@@ -73,6 +73,7 @@ const WhatsappFlowStepEditor = ({
     <div className="items-center justify-center overflow-hidden rounded-lg">
       <div className="space-y-3 bg-slate-100 px-4 py-2 dark:bg-neutral-900">
         <ComboboxField
+          emptyText={t("actions.noRecordFound")}
           name={`${parentName}.inboxId`}
           options={whatsappInboxOptions}
           placeholder={t("actions.pleaseSelect")}

--- a/apps/builder/src/features/folders/change-folder.tsx
+++ b/apps/builder/src/features/folders/change-folder.tsx
@@ -139,6 +139,7 @@ export function ChangeFolderForm(props: ChangeFolderFormProps) {
     <Form {...form}>
       <form className="space-y-6" onSubmit={handleSubmitWithAction}>
         <ComboboxField
+          emptyText={t("actions.noRecordFound")}
           label={t("fields.folder.label")}
           name="newFolderId"
           options={folderOptions}

--- a/apps/builder/src/features/integration-instagram/components/update-instagram-form.tsx
+++ b/apps/builder/src/features/integration-instagram/components/update-instagram-form.tsx
@@ -108,6 +108,7 @@ export function UpdateInstagramForm({
       <form className="space-y-6" onSubmit={handleSubmitWithAction}>
         <ComboboxField
           description={t("fields.welcomeFlowId.description")}
+          emptyText={t("actions.noRecordFound")}
           label={t("fields.welcomeFlowId.label")}
           name="welcomeFlowId"
           options={flowOptions}

--- a/apps/builder/src/features/integration-messenger/update-messenger-form.tsx
+++ b/apps/builder/src/features/integration-messenger/update-messenger-form.tsx
@@ -160,6 +160,7 @@ export function UpdateMessengerForm({
       <form className="space-y-6" onSubmit={handleSubmitWithAction}>
         <ComboboxField
           description={t("fields.welcomeFlowId.description")}
+          emptyText={t("actions.noRecordFound")}
           label={t("fields.welcomeFlowId.label")}
           name="welcomeFlowId"
           options={flowOptions}

--- a/apps/builder/src/features/integration-webchat/components/create-webchat-form.tsx
+++ b/apps/builder/src/features/integration-webchat/components/create-webchat-form.tsx
@@ -125,6 +125,7 @@ export function CreateWebchatForm({ workspaceId }: { workspaceId: string }) {
 
         <ComboboxField
           description={t("fields.welcomeFlowId.description")}
+          emptyText={t("actions.noRecordFound")}
           label={t("fields.welcomeFlowId.label")}
           name="welcomeFlowId"
           options={flowOptions}

--- a/apps/builder/src/features/integration-webchat/components/persistent-menu-field.tsx
+++ b/apps/builder/src/features/integration-webchat/components/persistent-menu-field.tsx
@@ -69,6 +69,7 @@ const PersistentMenuItem = memo(
 
         {menuType === webchatPersistentMenuType.enum.flow && (
           <ComboboxField
+            emptyText={t("actions.noRecordFound")}
             label={t("fields.flowId.label")}
             name={`persistentMenus.${index}.flowId`}
             options={flowOptions}

--- a/apps/builder/src/features/integration-webchat/components/update-webchat-form.tsx
+++ b/apps/builder/src/features/integration-webchat/components/update-webchat-form.tsx
@@ -144,6 +144,7 @@ export function UpdateWebchatForm({
         <InputField label="Name" name="name" required />
         <ComboboxField
           description={t("fields.welcomeFlowId.description")}
+          emptyText={t("actions.noRecordFound")}
           label={t("fields.welcomeFlowId.label")}
           name="welcomeFlowId"
           options={flowOptions}

--- a/apps/builder/src/features/qr-codes/create-qr-code-form.tsx
+++ b/apps/builder/src/features/qr-codes/create-qr-code-form.tsx
@@ -60,6 +60,7 @@ export function CreateQrCodeForm({ workspaceId }: { workspaceId: string }) {
         <InputField label={t("fields.name.label")} name="name" required />
 
         <ComboboxField
+          emptyText={t("actions.noRecordFound")}
           label={t("fields.botResponse.label")}
           name="flowId"
           options={flowOptions}

--- a/apps/builder/src/features/qr-codes/update-qr-code-form.tsx
+++ b/apps/builder/src/features/qr-codes/update-qr-code-form.tsx
@@ -97,6 +97,7 @@ export function UpdateQrCodeForm({
               <InputField label={t("fields.name.label")} name="name" required />
 
               <ComboboxField
+                emptyText={t("actions.noRecordFound")}
                 label={t("fields.botResponse.label")}
                 name="flowId"
                 options={flowOptions}

--- a/apps/builder/src/features/reflinks/create-reflink.tsx
+++ b/apps/builder/src/features/reflinks/create-reflink.tsx
@@ -114,6 +114,7 @@ export function CreateReflinkForm({
         />
 
         <ComboboxField
+          emptyText={t("actions.noRecordFound")}
           label={t("fields.botResponse.label")}
           name="flowId"
           options={flowOptions}

--- a/apps/builder/src/features/reflinks/update-reflink.tsx
+++ b/apps/builder/src/features/reflinks/update-reflink.tsx
@@ -123,6 +123,7 @@ export function UpdateReflinkForm(props: {
         <InputField label={t("fields.name.label")} name="name" required />
 
         <ComboboxField
+          emptyText={t("actions.noRecordFound")}
           label={t("fields.flow.label")}
           name="flowId"
           options={flowOptions}

--- a/apps/builder/src/features/sequences/bulk-move-folder-dialog.tsx
+++ b/apps/builder/src/features/sequences/bulk-move-folder-dialog.tsx
@@ -114,6 +114,7 @@ export function BulkMoveFolderDialog({
             onSubmit={form.handleSubmit(handleBulkMove)}
           >
             <ComboboxField
+              emptyText={t("actions.noRecordFound")}
               label={t("fields.folder.label")}
               name="newFolderId"
               options={folderOptions}

--- a/apps/builder/src/features/sequences/components/flow-selector.tsx
+++ b/apps/builder/src/features/sequences/components/flow-selector.tsx
@@ -45,6 +45,7 @@ export function FlowSelectorSimple({
     <Form {...form}>
       <ComboboxField
         className={cn("flex-1", showError && "border-destructive")}
+        emptyText={t("actions.noRecordFound")}
         name="flowId"
         options={flowOptions}
         placeholder={t("sequences.selectFlow")}

--- a/apps/builder/src/features/triggers/components/actions/editor.tsx
+++ b/apps/builder/src/features/triggers/components/actions/editor.tsx
@@ -45,6 +45,7 @@ export const ActionEditor = ({
     case triggerActions.enum.startAnotherFlow:
       return (
         <ComboboxField
+          emptyText={t("actions.noRecordFound")}
           name={`${parentName}.flowId`}
           options={flowOptions}
           placeholder={t("actions.pleaseSelect")}

--- a/apps/builder/src/features/workspaces/update-workspace-advanced-form.tsx
+++ b/apps/builder/src/features/workspaces/update-workspace-advanced-form.tsx
@@ -77,6 +77,7 @@ export function UpdateWorkspaceAdvancedForm({
               label={t("fields.defaultReply.label")}
             >
               <ComboboxField
+                emptyText={t("actions.noRecordFound")}
                 name="defaultReply"
                 options={flowOptions}
                 placeholder={t("actions.pleaseSelect")}
@@ -88,6 +89,7 @@ export function UpdateWorkspaceAdvancedForm({
               label={t("fields.targetCountry.label")}
             >
               <ComboboxField
+                emptyText={t("actions.noRecordFound")}
                 name="targetCountry"
                 options={allCountryOptions}
                 placeholder={t("actions.pleaseSelect")}
@@ -113,6 +115,7 @@ export function UpdateWorkspaceAdvancedForm({
               label={t("fields.timezone.label")}
             >
               <ComboboxField
+                emptyText={t("actions.noRecordFound")}
                 name="timezone"
                 options={allTimezoneOptions}
                 placeholder={t("actions.pleaseSelect")}


### PR DESCRIPTION
## Summary
- `ComboboxField` falls back to the hardcoded English string "No record found." when the caller doesn't pass `emptyText`, breaking i18n for the combobox empty state.
- Added `emptyText={t("actions.noRecordFound")}` to every `ComboboxField` usage across the builder app that was missing it (~55 occurrences across 45 files), using the existing `actions.noRecordFound` translation key already present in `en.json` and `vi.json`.
- For the `CustomFieldField` wrapper (which spreads props into `ComboboxField`), fixed the two call sites instead of hardcoding the wrapper.

## Changes
- `apps/builder/src/features/**` — ~45 files across broadcasts, flows/react-flow steps, integrations (webchat/messenger/instagram), automated-response, contact-filter, conversations, custom-fields, fb-comments, qr-codes, reflinks, sequences, triggers, workspaces

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [ ] manual verification (open a combobox with no options in both `en` and `vi` locales and confirm the empty state text is translated)
