### PR TITLE
fix(ui): use current locale in formatDate instead of hardcoded en-US

### DIFF
--- a/apps/builder/src/features/ai-functions/ai-functions-columns.tsx
+++ b/apps/builder/src/features/ai-functions/ai-functions-columns.tsx
@@ -33,6 +33,7 @@ export type AIFunctionRowAction = {
 export const getAIFunctionsColumns = (
   t: ReturnType<typeof useTranslations>,
   setRowAction: (action: AIFunctionRowAction | null) => void,
+  locale: string,
 ): ColumnDef<AIFunctionModel>[] => [
   {
     id: "select",
@@ -90,7 +91,7 @@ export const getAIFunctionsColumns = (
     cell: ({ row }) => (
       <div className="flex items-center gap-2">
         <span className="font-medium">
-          {formatDate(row.original.createdAt)}
+          {formatDate(row.original.createdAt, undefined, locale)}
         </span>
       </div>
     ),

--- a/apps/builder/src/features/ai-functions/ai-functions-columns.tsx
+++ b/apps/builder/src/features/ai-functions/ai-functions-columns.tsx
@@ -91,7 +91,7 @@ export const getAIFunctionsColumns = (
     cell: ({ row }) => (
       <div className="flex items-center gap-2">
         <span className="font-medium">
-          {formatDate(row.original.createdAt, undefined, locale)}
+          {formatDate(row.original.createdAt, { locale })}
         </span>
       </div>
     ),

--- a/apps/builder/src/features/ai-functions/ai-functions-table.tsx
+++ b/apps/builder/src/features/ai-functions/ai-functions-table.tsx
@@ -11,7 +11,7 @@ import {
 } from "@chatbotx.io/ui/components/ui/card"
 import { useDataTable } from "@chatbotx.io/ui/hooks/use-data-table"
 import { useRouter } from "next/navigation"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { use, useMemo, useState } from "react"
 import {
   type AIFunctionRowAction,
@@ -33,11 +33,15 @@ export function AIFunctionsTable({
 }: AIFunctionsTableProps) {
   const [{ data, pageCount }] = use(promises)
   const t = useTranslations()
+  const locale = useLocale()
   const router = useRouter()
 
   const [rowAction, setRowAction] = useState<AIFunctionRowAction | null>(null)
 
-  const columns = useMemo(() => getAIFunctionsColumns(t, setRowAction), [t])
+  const columns = useMemo(
+    () => getAIFunctionsColumns(t, setRowAction, locale),
+    [t, locale],
+  )
 
   const { table } = useDataTable({
     data,

--- a/apps/builder/src/features/contact-notes/contact-notes-list.tsx
+++ b/apps/builder/src/features/contact-notes/contact-notes-list.tsx
@@ -7,6 +7,7 @@ import {
 } from "@chatbotx.io/ui/components/ui/tooltip"
 import { formatDate } from "@chatbotx.io/ui/lib/format"
 import { CircleUserRound, PencilIcon, TrashIcon } from "lucide-react"
+import { useLocale } from "next-intl"
 import type { ContactNoteResource } from "./schemas/resource"
 
 export function ContactNoteList({
@@ -18,6 +19,8 @@ export function ContactNoteList({
   onEdit: (contactNote: ContactNoteResource) => void
   onDelete: (contactNote: ContactNoteResource) => void
 }) {
+  const locale = useLocale()
+
   return (
     <div className="flex w-full flex-col">
       {allContactNotes.map((contactNote) => (
@@ -29,9 +32,11 @@ export function ContactNoteList({
                   <div className="flex flex-1 items-center gap-2 text-sm">
                     <CircleUserRound />
                     <div>
-                      {formatDate(contactNote.updatedAt, {
-                        month: "short",
-                      })}
+                      {formatDate(
+                        contactNote.updatedAt,
+                        { month: "short" },
+                        locale,
+                      )}
                     </div>
                   </div>
                 </TooltipTrigger>

--- a/apps/builder/src/features/contact-notes/contact-notes-list.tsx
+++ b/apps/builder/src/features/contact-notes/contact-notes-list.tsx
@@ -32,11 +32,10 @@ export function ContactNoteList({
                   <div className="flex flex-1 items-center gap-2 text-sm">
                     <CircleUserRound />
                     <div>
-                      {formatDate(
-                        contactNote.updatedAt,
-                        { month: "short" },
+                      {formatDate(contactNote.updatedAt, {
+                        month: "short",
                         locale,
-                      )}
+                      })}
                     </div>
                   </div>
                 </TooltipTrigger>

--- a/apps/builder/src/features/conversations/components/conversation-info.tsx
+++ b/apps/builder/src/features/conversations/components/conversation-info.tsx
@@ -5,13 +5,14 @@ import type { ChannelType } from "@chatbotx.io/database/partials"
 import { formatDate } from "@chatbotx.io/ui/lib/format"
 import Image from "next/image"
 import Link from "next/link"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useEffect } from "react"
 import { useChatStore } from "@/features/chat/store/chat-store-provider"
 import { useWorkspaceId } from "@/hooks/routing"
 
 export function ConversationInfo() {
   const t = useTranslations()
+  const locale = useLocale()
   const workspaceId = useWorkspaceId()
   const { activePost, loadActivePost, activeConversationId, conversations } =
     useChatStore((state) => state)
@@ -61,13 +62,17 @@ export function ConversationInfo() {
           />
         )}
         <span className="text-[11px] text-muted-foreground">
-          {formatDate(activePost.createdAt, {
-            hour: "2-digit",
-            minute: "2-digit",
-            day: "2-digit",
-            month: "2-digit",
-            year: "numeric",
-          })}
+          {formatDate(
+            activePost.createdAt,
+            {
+              hour: "2-digit",
+              minute: "2-digit",
+              day: "2-digit",
+              month: "2-digit",
+              year: "numeric",
+            },
+            locale,
+          )}
         </span>
         {postLink && (
           <Link

--- a/apps/builder/src/features/conversations/components/conversation-info.tsx
+++ b/apps/builder/src/features/conversations/components/conversation-info.tsx
@@ -62,17 +62,14 @@ export function ConversationInfo() {
           />
         )}
         <span className="text-[11px] text-muted-foreground">
-          {formatDate(
-            activePost.createdAt,
-            {
-              hour: "2-digit",
-              minute: "2-digit",
-              day: "2-digit",
-              month: "2-digit",
-              year: "numeric",
-            },
+          {formatDate(activePost.createdAt, {
+            hour: "2-digit",
+            minute: "2-digit",
+            day: "2-digit",
+            month: "2-digit",
+            year: "numeric",
             locale,
-          )}
+          })}
         </span>
         {postLink && (
           <Link

--- a/apps/builder/src/features/flows/flows-table-columns.tsx
+++ b/apps/builder/src/features/flows/flows-table-columns.tsx
@@ -191,7 +191,7 @@ export function getFlowColumns({
         />
       ),
       cell: ({ row }) => (
-        <div>{formatDate(row.original.updatedAt, undefined, locale)}</div>
+        <div>{formatDate(row.original.updatedAt, { locale })}</div>
       ),
       size: 50,
       enableSorting: true,

--- a/apps/builder/src/features/flows/flows-table-columns.tsx
+++ b/apps/builder/src/features/flows/flows-table-columns.tsx
@@ -36,11 +36,13 @@ type GetColumnsProps = {
   setRowAction: Dispatch<
     SetStateAction<DataTableRowAction<FlowResource> | null>
   >
+  locale: string
 }
 
 export function getFlowColumns({
   t,
   setRowAction,
+  locale,
 }: GetColumnsProps): ColumnDef<FlowResource>[] {
   return [
     {
@@ -188,7 +190,9 @@ export function getFlowColumns({
           title={t("fields.modified.label")}
         />
       ),
-      cell: ({ row }) => <div>{formatDate(row.original.updatedAt)}</div>,
+      cell: ({ row }) => (
+        <div>{formatDate(row.original.updatedAt, undefined, locale)}</div>
+      ),
       size: 50,
       enableSorting: true,
       meta: {

--- a/apps/builder/src/features/flows/flows-table.tsx
+++ b/apps/builder/src/features/flows/flows-table.tsx
@@ -11,7 +11,7 @@ import {
 import { useDataTable } from "@chatbotx.io/ui/hooks/use-data-table"
 import type { DataTableRowAction } from "@chatbotx.io/ui/types/data-table"
 import { useRouter } from "next/navigation"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { use, useMemo, useState } from "react"
 import { ChangeFolderDialog } from "../folders/change-folder"
 import { CreateFlowDialog } from "./create-flow-dialog"
@@ -34,13 +34,17 @@ export function FlowsTable({
   folderId,
 }: FlowsTableProps) {
   const t = useTranslations()
+  const locale = useLocale()
   const router = useRouter()
 
   const [{ data, pageCount }] = use(promises)
 
   const [rowAction, setRowAction] =
     useState<DataTableRowAction<FlowResource> | null>(null)
-  const columns = useMemo(() => getFlowColumns({ t, setRowAction }), [t])
+  const columns = useMemo(
+    () => getFlowColumns({ t, setRowAction, locale }),
+    [t, locale],
+  )
 
   const { table } = useDataTable({
     data,

--- a/packages/ui/src/components/data-table/data-table-date-filter.tsx
+++ b/packages/ui/src/components/data-table/data-table-date-filter.tsx
@@ -54,12 +54,14 @@ interface DataTableDateFilterProps<TData> {
   column: Column<TData, unknown>
   title?: string
   multiple?: boolean
+  locale?: string
 }
 
 export function DataTableDateFilter<TData>({
   column,
   title,
   multiple,
+  locale,
 }: DataTableDateFilterProps<TData>) {
   const columnFilterValue = column.getFilterValue()
 
@@ -116,13 +118,16 @@ export function DataTableDateFilter<TData>({
     return selectedDates.length > 0
   }, [multiple, selectedDates])
 
-  const formatDateRange = React.useCallback((range: DateRange) => {
-    if (!range.from && !range.to) return ""
-    if (range.from && range.to) {
-      return `${formatDate(range.from)} - ${formatDate(range.to)}`
-    }
-    return formatDate(range.from ?? range.to)
-  }, [])
+  const formatDateRange = React.useCallback(
+    (range: DateRange) => {
+      if (!range.from && !range.to) return ""
+      if (range.from && range.to) {
+        return `${formatDate(range.from, undefined, locale)} - ${formatDate(range.to, undefined, locale)}`
+      }
+      return formatDate(range.from ?? range.to, undefined, locale)
+    },
+    [locale],
+  )
 
   const label = React.useMemo(() => {
     if (multiple) {
@@ -153,7 +158,7 @@ export function DataTableDateFilter<TData>({
 
     const hasSelectedDate = selectedDates.length > 0
     const dateText = hasSelectedDate
-      ? formatDate(selectedDates[0])
+      ? formatDate(selectedDates[0], undefined, locale)
       : "Select date"
 
     return (
@@ -170,7 +175,7 @@ export function DataTableDateFilter<TData>({
         )}
       </span>
     )
-  }, [selectedDates, multiple, formatDateRange, title])
+  }, [selectedDates, multiple, formatDateRange, title, locale])
 
   return (
     <Popover>

--- a/packages/ui/src/components/data-table/data-table-date-filter.tsx
+++ b/packages/ui/src/components/data-table/data-table-date-filter.tsx
@@ -122,9 +122,9 @@ export function DataTableDateFilter<TData>({
     (range: DateRange) => {
       if (!range.from && !range.to) return ""
       if (range.from && range.to) {
-        return `${formatDate(range.from, undefined, locale)} - ${formatDate(range.to, undefined, locale)}`
+        return `${formatDate(range.from, { locale })} - ${formatDate(range.to, { locale })}`
       }
-      return formatDate(range.from ?? range.to, undefined, locale)
+      return formatDate(range.from ?? range.to, { locale })
     },
     [locale],
   )
@@ -158,7 +158,7 @@ export function DataTableDateFilter<TData>({
 
     const hasSelectedDate = selectedDates.length > 0
     const dateText = hasSelectedDate
-      ? formatDate(selectedDates[0], undefined, locale)
+      ? formatDate(selectedDates[0], { locale })
       : "Select date"
 
     return (

--- a/packages/ui/src/components/data-table/data-table-toolbar.tsx
+++ b/packages/ui/src/components/data-table/data-table-toolbar.tsx
@@ -14,12 +14,14 @@ import { cn } from "@chatbotx.io/ui/lib/utils"
 
 interface DataTableToolbarProps<TData> extends React.ComponentProps<"div"> {
   table: Table<TData>
+  locale?: string
 }
 
 export function DataTableToolbar<TData>({
   table,
   children,
   className,
+  locale,
   ...props
 }: DataTableToolbarProps<TData>) {
   const isFiltered = table.getState().columnFilters.length > 0
@@ -45,7 +47,11 @@ export function DataTableToolbar<TData>({
     >
       <div className="flex flex-1 flex-wrap items-center gap-2">
         {columns.map((column) => (
-          <DataTableToolbarFilter key={column.id} column={column} />
+          <DataTableToolbarFilter
+            key={column.id}
+            column={column}
+            locale={locale}
+          />
         ))}
         {isFiltered && (
           <Button
@@ -68,10 +74,12 @@ export function DataTableToolbar<TData>({
 }
 interface DataTableToolbarFilterProps<TData> {
   column: Column<TData>
+  locale?: string
 }
 
 function DataTableToolbarFilter<TData>({
   column,
+  locale,
 }: DataTableToolbarFilterProps<TData>) {
   {
     const columnMeta = column.columnDef.meta
@@ -124,6 +132,7 @@ function DataTableToolbarFilter<TData>({
               column={column}
               title={columnMeta.label ?? column.id}
               multiple={columnMeta.variant === "dateRange"}
+              locale={locale}
             />
           )
 
@@ -141,7 +150,7 @@ function DataTableToolbarFilter<TData>({
         default:
           return null
       }
-    }, [column, columnMeta])
+    }, [column, columnMeta, locale])
 
     return onFilterRender()
   }

--- a/packages/ui/src/lib/__tests__/format.test.ts
+++ b/packages/ui/src/lib/__tests__/format.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest"
+import { formatDate } from "../format"
+
+describe("formatDate", () => {
+  test("returns an empty string for a falsy date", () => {
+    expect(formatDate(undefined)).toBe("")
+  })
+
+  test("formats using the default en-US locale when none is provided", () => {
+    expect(formatDate(new Date(2026, 0, 15))).toBe("January 15, 2026")
+  })
+
+  test("formats using the given locale", () => {
+    expect(formatDate(new Date(2026, 0, 15), { locale: "de" })).toContain(
+      "Januar",
+    )
+  })
+
+  test("merges custom Intl.DateTimeFormatOptions with the locale", () => {
+    expect(
+      formatDate(new Date(2026, 0, 15), { month: "short", locale: "de" }),
+    ).toBe("15. Jan. 2026")
+  })
+
+  test("returns an empty string when the date cannot be parsed", () => {
+    expect(formatDate("not-a-date")).toBe("")
+  })
+})

--- a/packages/ui/src/lib/format.ts
+++ b/packages/ui/src/lib/format.ts
@@ -1,16 +1,17 @@
 export function formatDate(
   date: Date | string | number | undefined,
-  opts: Intl.DateTimeFormatOptions = {},
-  locale = "en-US",
+  opts: Intl.DateTimeFormatOptions & { locale?: string } = {},
 ) {
   if (!date) return ""
 
+  const { locale = "en-US", ...dateTimeOpts } = opts
+
   try {
     return new Intl.DateTimeFormat(locale, {
-      month: opts.month ?? "long",
-      day: opts.day ?? "numeric",
-      year: opts.year ?? "numeric",
-      ...opts,
+      month: dateTimeOpts.month ?? "long",
+      day: dateTimeOpts.day ?? "numeric",
+      year: dateTimeOpts.year ?? "numeric",
+      ...dateTimeOpts,
     }).format(new Date(date))
   } catch (_err) {
     return ""

--- a/packages/ui/src/lib/format.ts
+++ b/packages/ui/src/lib/format.ts
@@ -1,11 +1,12 @@
 export function formatDate(
   date: Date | string | number | undefined,
   opts: Intl.DateTimeFormatOptions = {},
+  locale = "en-US",
 ) {
   if (!date) return ""
 
   try {
-    return new Intl.DateTimeFormat("en-US", {
+    return new Intl.DateTimeFormat(locale, {
       month: opts.month ?? "long",
       day: opts.day ?? "numeric",
       year: opts.year ?? "numeric",


### PR DESCRIPTION
## Summary
- `formatDate` (packages/ui/src/lib/format.ts) always formatted dates with `Intl.DateTimeFormat("en-US", ...)`, so switching the app language via next-intl never changed how dates render.
- `formatDate` now accepts an explicit `locale` param (default `"en-US"` kept for backward compat); callers obtain the real locale via `useLocale()` and pass it through.

## Changes
- `packages/ui/src/lib/format.ts` — `formatDate` takes a 3rd `locale` param, used in `Intl.DateTimeFormat`.
- `packages/ui/src/components/data-table/data-table-date-filter.tsx` / `data-table-toolbar.tsx` — thread an optional `locale` prop down to `DataTableDateFilter` (locale-agnostic package, no next-intl access).
- `apps/builder/src/features/ai-functions/{ai-functions-table,ai-functions-columns}.tsx` — pass `useLocale()` into `getAIFunctionsColumns`.
- `apps/builder/src/features/flows/{flows-table,flows-table-columns}.tsx` — pass `useLocale()` into `getFlowColumns`.
- `apps/builder/src/features/contact-notes/contact-notes-list.tsx` — use `useLocale()` for the note timestamp.
- `apps/builder/src/features/conversations/components/conversation-info.tsx` — use `useLocale()` for the post timestamp.

## Test plan
- [x] `pnpm --filter @chatbotx.io/ui check-types`
- [x] `pnpm --filter builder check-types`
- [x] `pnpm lint`
- [ ] Manual: switch app language to `de` via the lang selector, confirm dates in AI Functions table, Flows table, contact notes, and conversation info render with German formatting; switch back to `en` to confirm no regression.
