### PR TITLE
feat(flows): add undo/redo history to the flow editor

### DIFF
--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -23,6 +23,8 @@
     "back": "Back",
     "blockContact": "Block Contact",
     "unblockContact": "Unblock Contact",
+    "undo": "Undo",
+    "redo": "Redo",
     "cancel": "Cancel",
     "clear": "Clear",
     "clearCustomField": "Clear Custom Field",

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -2156,7 +2156,9 @@
     "publishVersionSuccess": "A new version has been published",
     "flowConfigIncomplete": "Some configurations are incomplete",
     "duplicateNodeError": "Could not duplicate the block. Please try again.",
-    "deleteNodeError": "Could not delete the block. Please try again."
+    "deleteNodeError": "Could not delete the block. Please try again.",
+    "redoHistoryCleared": "Redo history cleared",
+    "historyDepth": "({count})"
   },
   "instagram": {
     "description": "This integration lets you create Instagram bots.",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -2164,7 +2164,9 @@
     "publishVersionSuccess": "Đã xuất bản phiên bản mới",
     "flowConfigIncomplete": "Một số cấu hình chưa hoàn chỉnh",
     "duplicateNodeError": "Không thể nhân bản khối. Vui lòng thử lại.",
-    "deleteNodeError": "Không thể xoá khối. Vui lòng thử lại."
+    "deleteNodeError": "Không thể xoá khối. Vui lòng thử lại.",
+    "redoHistoryCleared": "Đã xoá lịch sử làm lại",
+    "historyDepth": "({count})"
   },
   "instagram": {
     "description": "Tích hợp này cho phép bạn tạo bot Instagram.",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -24,6 +24,8 @@
     "back": "Quay lại",
     "blockContact": "Chặn liên hệ",
     "unblockContact": "Bỏ chặn liên hệ",
+    "undo": "Hoàn tác",
+    "redo": "Làm lại",
     "cancel": "Hủy",
     "clearCustomField": "Xóa trường tùy chỉnh",
     "collapse": "Thu gọn",

--- a/apps/builder/src/features/flows/react-flow/__tests__/flow-edit-toolbar-keyboard.test.ts
+++ b/apps/builder/src/features/flows/react-flow/__tests__/flow-edit-toolbar-keyboard.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest"
+import {
+  isEditableTarget,
+  isRedoShortcut,
+  isUndoShortcut,
+} from "../flow-edit-toolbar-keyboard"
+
+describe("flow-edit-toolbar keyboard helpers", () => {
+  test("recognizes editable targets", () => {
+    expect(isEditableTarget(document.createElement("input"))).toBe(true)
+    expect(isEditableTarget(document.createElement("textarea"))).toBe(true)
+
+    const div = document.createElement("div")
+    Object.defineProperty(div, "isContentEditable", { value: true })
+    expect(isEditableTarget(div)).toBe(true)
+
+    expect(isEditableTarget(document.createElement("button"))).toBe(false)
+    expect(isEditableTarget(null)).toBe(false)
+  })
+
+  test("recognizes undo and redo shortcuts", () => {
+    expect(
+      isUndoShortcut(new KeyboardEvent("keydown", { ctrlKey: true, key: "z" })),
+    ).toBe(true)
+    expect(
+      isRedoShortcut(new KeyboardEvent("keydown", { metaKey: true, key: "y" })),
+    ).toBe(true)
+    expect(
+      isRedoShortcut(
+        new KeyboardEvent("keydown", {
+          ctrlKey: true,
+          key: "Z",
+          shiftKey: true,
+        }),
+      ),
+    ).toBe(true)
+  })
+})

--- a/apps/builder/src/features/flows/react-flow/__tests__/react-flow-wrapper.test.ts
+++ b/apps/builder/src/features/flows/react-flow/__tests__/react-flow-wrapper.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest"
+import { hasMeaningfulNodeChange } from "../react-flow-node-change"
+
+describe("hasMeaningfulNodeChange", () => {
+  test("ignores measurement and programmatic position changes", () => {
+    const changes = [
+      { type: "dimensions", id: "node-1" },
+      { type: "position", id: "node-2" },
+    ] as any[]
+
+    expect(hasMeaningfulNodeChange(changes)).toBe(false)
+  })
+
+  test("treats add and remove as meaningful changes", () => {
+    expect(
+      hasMeaningfulNodeChange([{ type: "add", item: { id: "node-1" } } as any]),
+    ).toBe(true)
+    expect(
+      hasMeaningfulNodeChange([{ type: "remove", id: "node-1" } as any]),
+    ).toBe(true)
+  })
+})

--- a/apps/builder/src/features/flows/react-flow/flow-edit-toolbar-keyboard.ts
+++ b/apps/builder/src/features/flows/react-flow/flow-edit-toolbar-keyboard.ts
@@ -1,0 +1,26 @@
+const isMacModifierKey = (event: KeyboardEvent) =>
+  event.metaKey || event.ctrlKey
+
+export const isEditableTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+
+  return Boolean(
+    target.tagName === "INPUT" ||
+      target.tagName === "TEXTAREA" ||
+      target.isContentEditable,
+  )
+}
+
+export const isUndoShortcut = (event: KeyboardEvent): boolean =>
+  isMacModifierKey(event) &&
+  !event.altKey &&
+  !event.shiftKey &&
+  event.key.toLowerCase() === "z"
+
+export const isRedoShortcut = (event: KeyboardEvent): boolean =>
+  isMacModifierKey(event) &&
+  !event.altKey &&
+  (event.key.toLowerCase() === "y" ||
+    (event.shiftKey && event.key.toLowerCase() === "z"))

--- a/apps/builder/src/features/flows/react-flow/flow-edit-toolbar.tsx
+++ b/apps/builder/src/features/flows/react-flow/flow-edit-toolbar.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import type { FlowModel } from "@chatbotx.io/database/types"
+import { Badge } from "@chatbotx.io/ui/components/ui/badge"
 import { Button } from "@chatbotx.io/ui/components/ui/button"
 import {
   DropdownMenu,
@@ -32,7 +33,7 @@ import {
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { useAction } from "next-safe-action/hooks"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
 import { GetInboxUrlDialog } from "@/features/inboxes/components/get-inbox-url"
 import { publishFlowAction } from "../actions/publish-flow-action"
@@ -45,19 +46,12 @@ import AnalyticsFlow from "./components/analytics-flow"
 import { DuplicateFlowDialog } from "./components/duplicate-flow"
 import { FlowVersionsDialog } from "./components/flow-versions-dialog"
 import { RenameFlowDialog } from "./components/rename-flow"
+import {
+  isEditableTarget,
+  isRedoShortcut,
+  isUndoShortcut,
+} from "./flow-edit-toolbar-keyboard"
 import { useFlowHistory } from "./stores/use-flow-history"
-
-const isEditableTarget = (target: EventTarget | null): boolean => {
-  if (!(target instanceof HTMLElement)) {
-    return false
-  }
-
-  return (
-    target.tagName === "INPUT" ||
-    target.tagName === "TEXTAREA" ||
-    target.isContentEditable
-  )
-}
 
 export function FlowEditToolbar({
   workspaceId,
@@ -68,6 +62,7 @@ export function FlowEditToolbar({
 }) {
   const t = useTranslations()
   const router = useRouter()
+  const lastBranchClearedCountRef = useRef(0)
 
   const [isValidating, setIsValidating] = useState<boolean>(false)
   const [action, setAction] = useState<
@@ -85,7 +80,23 @@ export function FlowEditToolbar({
 
   // NOTES: DO NOT use useNodes & useEdges, it makes component re-render when node or edge is changed
   const { getNodes, getEdges, setNodes, setEdges } = useReactFlow()
-  const { canUndo, canRedo, undo, redo, reset } = useFlowHistory()
+  const {
+    branchClearedCount,
+    canUndo,
+    canRedo,
+    futureCount,
+    pastCount,
+    undo,
+    redo,
+    reset,
+  } = useFlowHistory()
+
+  useEffect(() => {
+    if (branchClearedCount > lastBranchClearedCountRef.current) {
+      toast.info(t("messages.redoHistoryCleared"))
+    }
+    lastBranchClearedCountRef.current = branchClearedCount
+  }, [branchClearedCount, t])
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -93,17 +104,15 @@ export function FlowEditToolbar({
         return
       }
 
-      const isModifierPressed = event.metaKey || event.ctrlKey
-      if (!isModifierPressed || event.key.toLowerCase() !== "z") {
+      if (isUndoShortcut(event)) {
+        event.preventDefault()
+        undo()
         return
       }
 
-      if (event.shiftKey) {
+      if (isRedoShortcut(event)) {
         event.preventDefault()
         redo()
-      } else {
-        event.preventDefault()
-        undo()
       }
     }
 
@@ -147,33 +156,57 @@ export function FlowEditToolbar({
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
-            className="px-1.5"
+            aria-label={t("actions.undo")}
+            className="relative px-1.5"
             disabled={!canUndo}
             onClick={undo}
             size="sm"
             variant="ghost"
           >
             <RotateCcwIcon />
+            {pastCount > 0 && (
+              <Badge
+                className="absolute -top-1 -right-1 min-h-5 min-w-5 rounded-full px-1 text-[10px]"
+                variant="secondary"
+              >
+                {pastCount}
+              </Badge>
+            )}
           </Button>
         </TooltipTrigger>
         <TooltipContent>
-          <p>{t("actions.undo")}</p>
+          <p>
+            {t("actions.undo")}{" "}
+            {t("messages.historyDepth", { count: pastCount })}
+          </p>
         </TooltipContent>
       </Tooltip>
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
-            className="px-1.5"
+            aria-label={t("actions.redo")}
+            className="relative px-1.5"
             disabled={!canRedo}
             onClick={redo}
             size="sm"
             variant="ghost"
           >
             <RotateCwIcon />
+            {futureCount > 0 && (
+              <Badge
+                className="absolute -top-1 -right-1 min-h-5 min-w-5 rounded-full px-1 text-[10px]"
+                variant="secondary"
+              >
+                {futureCount}
+              </Badge>
+            )}
           </Button>
         </TooltipTrigger>
         <TooltipContent>
-          <p>{t("actions.redo")}</p>
+          <p>
+            {t("actions.redo")}{" "}
+            {t("messages.historyDepth", { count: futureCount })}
+          </p>
         </TooltipContent>
       </Tooltip>
       <Button

--- a/apps/builder/src/features/flows/react-flow/flow-edit-toolbar.tsx
+++ b/apps/builder/src/features/flows/react-flow/flow-edit-toolbar.tsx
@@ -10,6 +10,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@chatbotx.io/ui/components/ui/dropdown-menu"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@chatbotx.io/ui/components/ui/tooltip"
 import { type Edge, MarkerType, type Node, useReactFlow } from "@xyflow/react"
 import {
   ChartNoAxesCombinedIcon,
@@ -27,7 +32,7 @@ import {
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { useAction } from "next-safe-action/hooks"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import { GetInboxUrlDialog } from "@/features/inboxes/components/get-inbox-url"
 import { publishFlowAction } from "../actions/publish-flow-action"
@@ -40,6 +45,19 @@ import AnalyticsFlow from "./components/analytics-flow"
 import { DuplicateFlowDialog } from "./components/duplicate-flow"
 import { FlowVersionsDialog } from "./components/flow-versions-dialog"
 import { RenameFlowDialog } from "./components/rename-flow"
+import { useFlowHistory } from "./stores/use-flow-history"
+
+const isEditableTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+
+  return (
+    target.tagName === "INPUT" ||
+    target.tagName === "TEXTAREA" ||
+    target.isContentEditable
+  )
+}
 
 export function FlowEditToolbar({
   workspaceId,
@@ -67,6 +85,31 @@ export function FlowEditToolbar({
 
   // NOTES: DO NOT use useNodes & useEdges, it makes component re-render when node or edge is changed
   const { getNodes, getEdges, setNodes, setEdges } = useReactFlow()
+  const { canUndo, canRedo, undo, redo, reset } = useFlowHistory()
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (isEditableTarget(event.target)) {
+        return
+      }
+
+      const isModifierPressed = event.metaKey || event.ctrlKey
+      if (!isModifierPressed || event.key.toLowerCase() !== "z") {
+        return
+      }
+
+      if (event.shiftKey) {
+        event.preventDefault()
+        redo()
+      } else {
+        event.preventDefault()
+        undo()
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [undo, redo])
 
   const { execute: executePublish, isPending: isPendingPublish } = useAction(
     publishFlowAction.bind(null, workspaceId, flow.id),
@@ -101,12 +144,38 @@ export function FlowEditToolbar({
 
   return (
     <div className="flex gap-2">
-      <Button className="px-1.5" size="sm" variant="ghost">
-        <RotateCcwIcon />
-      </Button>
-      <Button className="px-1.5" size="sm" variant="ghost">
-        <RotateCwIcon />
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            className="px-1.5"
+            disabled={!canUndo}
+            onClick={undo}
+            size="sm"
+            variant="ghost"
+          >
+            <RotateCcwIcon />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>{t("actions.undo")}</p>
+        </TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            className="px-1.5"
+            disabled={!canRedo}
+            onClick={redo}
+            size="sm"
+            variant="ghost"
+          >
+            <RotateCwIcon />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>{t("actions.redo")}</p>
+        </TooltipContent>
+      </Tooltip>
       <Button
         className="ml-5"
         disabled={isValidating || isPendingPublish}
@@ -224,6 +293,7 @@ export function FlowEditToolbar({
               markerEnd: { type: MarkerType.ArrowClosed },
             })),
           )
+          reset()
         }}
         open={action === "flowVersions"}
         workspaceId={workspaceId}

--- a/apps/builder/src/features/flows/react-flow/frame.tsx
+++ b/apps/builder/src/features/flows/react-flow/frame.tsx
@@ -42,7 +42,7 @@ export function ReactFlowFrame({ flow, flowVersion }: ReactFlowFrameProps) {
   )
 
   return (
-    <FlowHistoryStoreProvider>
+    <FlowHistoryStoreProvider key={flowVersion.id}>
       <FrameHeader flow={flow} />
 
       <ReactFlowWrapper

--- a/apps/builder/src/features/flows/react-flow/frame.tsx
+++ b/apps/builder/src/features/flows/react-flow/frame.tsx
@@ -1,12 +1,14 @@
 "use client"
 
 import "@xyflow/react/dist/style.css"
+import { useCallback, useState } from "react"
 import type { FlowVersionResource } from "@/features/flow-versions/schema/resource"
 import type { FlowResource } from "../schemas/resource"
 import { ButtonEditorDialog } from "./button-editor-dialog"
 import { FrameHeader } from "./frame-header"
 import { NodeDetailSheet } from "./nodes/node-detail-sheet"
 import { ReactFlowWrapper } from "./react-flow-wrapper"
+import { FlowHistoryStoreProvider } from "./stores/flow-history-store-provider"
 import { useStepStore } from "./stores/step-store-provider"
 
 type ReactFlowFrameProps = {
@@ -19,22 +21,42 @@ export function ReactFlowFrame({ flow, flowVersion }: ReactFlowFrameProps) {
   const setOpenNodeDetailSheet = useStepStore(
     (state) => state.setOpenNodeDetailSheet,
   )
+  const [flushAutosave, setFlushAutosave] = useState<(() => void) | null>(null)
+
+  const handleAutosaveFlushChange = useCallback(
+    (flush: (() => void) | null) => {
+      setFlushAutosave(() => flush)
+    },
+    [],
+  )
+
+  const handleNodeDetailSheetOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        flushAutosave?.()
+      }
+
+      setOpenNodeDetailSheet(open)
+    },
+    [flushAutosave, setOpenNodeDetailSheet],
+  )
 
   return (
-    <>
+    <FlowHistoryStoreProvider>
       <FrameHeader flow={flow} />
 
       <ReactFlowWrapper
         flowVersion={flowVersion}
+        onAutosaveFlushChange={handleAutosaveFlushChange}
         setOpenNodeDetailSheet={setOpenNodeDetailSheet}
       />
 
       <NodeDetailSheet
-        onOpenChange={setOpenNodeDetailSheet}
+        onOpenChange={handleNodeDetailSheetOpenChange}
         open={openNodeDetailSheet}
       />
 
       <ButtonEditorDialog />
-    </>
+    </FlowHistoryStoreProvider>
   )
 }

--- a/apps/builder/src/features/flows/react-flow/nodes/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/nodes/editor.tsx
@@ -20,20 +20,22 @@ import {
   SortableItem,
   SortableItemHandle,
 } from "@chatbotx.io/ui/components/ui/sortable"
+import { createDebouncedFn } from "@chatbotx.io/ui/hooks/create-debounced-fn"
+import { useCallbackRef } from "@chatbotx.io/ui/hooks/use-callback-ref"
 import { cn } from "@chatbotx.io/ui/lib/utils"
 import { createId } from "@chatbotx.io/utils"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useReactFlow } from "@xyflow/react"
 import { CopyIcon, MoveVerticalIcon, PlusIcon, XIcon } from "lucide-react"
 import { useTranslations } from "next-intl"
-import { memo, useCallback, useEffect, useMemo, useState } from "react"
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
+  type Control,
   useFieldArray,
   useForm,
   useFormContext,
   useWatch,
 } from "react-hook-form"
-import { funnel } from "remeda"
 import { useInboxStore } from "@/features/inboxes/provider/inbox-store-context"
 import RecursiveDropdownMenu from "../components/recursive-dropdown-menu"
 import { allSteps, DynamicStepEditor } from "../steps"
@@ -41,6 +43,7 @@ import { ButtonStepEditor } from "../steps/button/editor"
 import { ErrorAlert } from "../steps/error-alert"
 import { useFlowTemplate } from "../stores/flow-template-store-provider"
 import { useStepStore } from "../stores/step-store-provider"
+import { useFlowHistory } from "../stores/use-flow-history"
 import { useWhatsappFlow } from "../stores/whatsapp-flow-store-provider"
 import { allNodesConfig } from "./node-config"
 import type { MenuItem } from "./types"
@@ -72,6 +75,23 @@ type NodeEditorProps = {
   nodeId: string
   nodeType: NodeType
   nodeDetails: FlowNode["data"]["details"]
+}
+
+const replaceIds = (data: unknown): unknown => {
+  if (Array.isArray(data)) {
+    return data.map(replaceIds)
+  }
+
+  if (data && typeof data === "object") {
+    const nextData: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(data)) {
+      nextData[key] = key === "id" ? createId() : replaceIds(value)
+    }
+
+    return nextData
+  }
+
+  return data
 }
 
 const NodeEditorQuickReplies = () => {
@@ -190,6 +210,25 @@ const NodeEditorMenu = memo(
   },
 )
 
+const FlowValueSync = memo(
+  ({
+    control,
+    pushToFlow,
+  }: {
+    // biome-ignore lint/suspicious/noExplicitAny: form value shape is dynamic per node
+    control: Control<any>
+    pushToFlow: (values: FlowNode["data"]["details"]) => void
+  }) => {
+    const values = useWatch({ control })
+
+    useEffect(() => {
+      pushToFlow(values as FlowNode["data"]["details"])
+    }, [pushToFlow, values])
+
+    return null
+  },
+)
+
 export const NodeEditor = memo((props: NodeEditorProps) => {
   const { nodeId, nodeType, nodeDetails } = props
 
@@ -197,10 +236,11 @@ export const NodeEditor = memo((props: NodeEditorProps) => {
   const nodeConfig = nodeType ? allNodesConfig[nodeType]?.(t) : null
   const validator = nodeConfig?.validator.shape.data.shape.details
 
-  const { getNodes, updateNodeData } = useReactFlow()
+  const { getNode, updateNodeData } = useReactFlow()
   const { updatedButtonData, onChangeButtonData } = useStepStore(
     (state) => state,
   )
+  const { takeSnapshot } = useFlowHistory()
 
   // biome-ignore lint/suspicious/noExplicitAny: wip - complex node data types
   const form = useForm<any>({
@@ -224,38 +264,55 @@ export const NodeEditor = memo((props: NodeEditorProps) => {
     name: "steps",
   })
 
-  const allValues = useWatch({ control })
-  const debounceUpdateNodeData = useMemo(
+  const editSnapshotTakenRef = useRef(false)
+  const pushNodeDetailsToFlow = useCallbackRef(
+    (values: FlowNode["data"]["details"]) => {
+      const currentNode = getNode(nodeId)
+
+      if (currentNode) {
+        updateNodeData(nodeId, {
+          ...currentNode.data,
+          details: values,
+        })
+      }
+    },
+  )
+  const releaseEditSnapshot = useMemo(
     () =>
-      funnel(
-        () => {
-          if (nodeId) {
-            const currentNode = getNodes().find((node) => node.id === nodeId)
-            if (currentNode) {
-              updateNodeData(nodeId, {
-                ...currentNode.data,
-                details: allValues,
-              })
-            }
-          }
-        },
-        { minQuietPeriodMs: 500 },
-      ),
-    [updateNodeData, nodeId, getNodes, allValues],
+      createDebouncedFn(() => {
+        editSnapshotTakenRef.current = false
+      }, 500),
+    [],
+  )
+
+  const pushToFlow = useMemo(
+    () => createDebouncedFn(pushNodeDetailsToFlow, 700),
+    [pushNodeDetailsToFlow],
   )
 
   useEffect(() => {
-    debounceUpdateNodeData.call()
-  }, [debounceUpdateNodeData])
+    const subscription = form.watch((_values, { type } = {}) => {
+      if (type && !editSnapshotTakenRef.current) {
+        takeSnapshot()
+        editSnapshotTakenRef.current = true
+      }
 
-  // useEffect(() => {
-  // if (nodeId && targetNode) {
-  //   updateNodeData(nodeId, {
-  //     ...targetNode.data,
-  //     details: debouncedValue,
-  //   })
-  // }
-  // }, [debouncedValue, nodeId, targetNode, updateNodeData])
+      if (type) {
+        releaseEditSnapshot()
+      }
+    })
+
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [form, releaseEditSnapshot, takeSnapshot])
+
+  useEffect(
+    () => () => {
+      pushToFlow.flush()
+    },
+    [pushToFlow],
+  )
 
   useEffect(() => {
     if (updatedButtonData) {
@@ -279,7 +336,6 @@ export const NodeEditor = memo((props: NodeEditorProps) => {
 
       // reset updatedButtonData
       onChangeButtonData(null)
-      //   setOpenNodeDetailSheet(false)
     }
   }, [updatedButtonData, getValues, onChangeButtonData, setValue])
 
@@ -295,38 +351,23 @@ export const NodeEditor = memo((props: NodeEditorProps) => {
     [appendStep],
   )
 
-  // biome-ignore lint/suspicious/noExplicitAny: wip
-  const replaceIds = (data: any): any => {
-    if (typeof data === "object" && data !== null) {
-      if (Array.isArray(data)) {
-        return data.map((item) => replaceIds(item))
+  const onCopyStep = useCallback(
+    (index: number) => {
+      // biome-ignore lint/suspicious/noExplicitAny: wip - dynamic field path
+      const values = getValues(`steps.${index}` as any)
+      if (values) {
+        insertStep(index + 1, replaceIds(values))
       }
+    },
+    [getValues, insertStep],
+  )
 
-      // biome-ignore lint/suspicious/noExplicitAny: wip
-      const newData: any = {}
-      for (const key in data) {
-        if (key === "id") {
-          newData[key] = createId()
-        } else {
-          newData[key] = replaceIds(data[key])
-        }
-      }
-      return newData
-    }
-    return data
-  }
-
-  const onCopyStep = (index: number) => {
-    // biome-ignore lint/suspicious/noExplicitAny: wip - dynamic field path
-    const values = getValues(`steps.${index}` as any)
-    if (values) {
-      insertStep(index + 1, replaceIds(values))
-    }
-  }
-
-  const onRemoveStep = (index: number) => {
-    removeStep(index)
-  }
+  const onRemoveStep = useCallback(
+    (index: number) => {
+      removeStep(index)
+    },
+    [removeStep],
+  )
 
   return (
     <Form {...form}>
@@ -447,6 +488,8 @@ export const NodeEditor = memo((props: NodeEditorProps) => {
       )}
 
       <NodeEditorMenu nodeType={nodeType} onClick={onAddStep} />
+
+      <FlowValueSync control={control} pushToFlow={pushToFlow} />
 
       <TriggerFormInitially form={form} />
     </Form>

--- a/apps/builder/src/features/flows/react-flow/nodes/node-detail-sheet.tsx
+++ b/apps/builder/src/features/flows/react-flow/nodes/node-detail-sheet.tsx
@@ -7,8 +7,8 @@ import {
   SheetDescription,
   SheetTitle,
 } from "@chatbotx.io/ui/components/ui/sheet"
-import { type ReactFlowState, useStore } from "@xyflow/react"
-import { memo } from "react"
+import { type ReactFlowState, useReactFlow, useStore } from "@xyflow/react"
+import { memo, useEffect, useMemo, useRef, useState } from "react"
 import { NodeEditor } from "./editor"
 import { NodeNameEditor } from "./node-name-editor"
 
@@ -21,32 +21,54 @@ type NodeDetailSheetProps = {
 const selectSelectedNode = (state: ReactFlowState): FlowNode | null =>
   (state.nodes.find((node) => node.selected) as FlowNode) || null
 
-// Custom equality function that compares node ID and data reference
-// This prevents re-renders from position/dragging changes but allows data updates
+// Keep the sheet mounted against the selected node ID so the editor does not
+// re-render from its own form writes while typing.
 const equalityFn = (a: FlowNode | null, b: FlowNode | null): boolean => {
   if (a === b) {
     return true
   }
-  if (!a) {
-    return false
-  }
-  if (!b) {
-    return false
-  }
-
-  // Compare ID and data reference (data reference changes when updateNodeData is called)
-  return a.id === b.id && a.data === b.data
+  return a?.id === b?.id
 }
 
 export function NodeDetailSheet({ open, onOpenChange }: NodeDetailSheetProps) {
   // Use store selector with custom equality function
   const activeNode = useStore(selectSelectedNode, equalityFn)
+  const { getNode } = useReactFlow()
 
-  return open && activeNode ? (
+  // Bump the editor key only on the discrete open transition so reopening a
+  // node re-seeds from the latest flow data without disturbing typing.
+  const prevOpenRef = useRef(false)
+  const [openToken, setOpenToken] = useState(0)
+  const isOpening = open && !prevOpenRef.current
+  const renderToken = openToken + (isOpening ? 1 : 0)
+
+  useEffect(() => {
+    if (isOpening) {
+      setOpenToken((token) => token + 1)
+    }
+    prevOpenRef.current = open
+  }, [isOpening, open])
+
+  const activeNodeId = activeNode?.id
+  // Read the latest node data at open time instead of trusting the stale
+  // id-only store snapshot.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: getNode is stable; re-read only on open/node changes
+  const freshDetails = useMemo(
+    () =>
+      activeNodeId
+        ? ((getNode(activeNodeId) as FlowNode | null)?.data.details ??
+          activeNode?.data.details)
+        : undefined,
+    [activeNodeId, renderToken],
+  )
+
+  return open && activeNode && freshDetails !== undefined ? (
     <NodeDetailSheetContent
       activeNode={activeNode}
+      freshDetails={freshDetails}
       onOpenChange={onOpenChange}
       open={open}
+      openToken={renderToken}
     />
   ) : null
 }
@@ -54,11 +76,15 @@ export function NodeDetailSheet({ open, onOpenChange }: NodeDetailSheetProps) {
 export const NodeDetailSheetContent = memo(
   ({
     activeNode,
+    freshDetails,
     open,
+    openToken,
     onOpenChange,
   }: {
     activeNode: FlowNode
+    freshDetails: FlowNode["data"]["details"]
     open: boolean
+    openToken: number
     onOpenChange: (open: boolean) => void
   }) => (
     <Sheet onOpenChange={onOpenChange} open={open}>
@@ -69,7 +95,8 @@ export const NodeDetailSheetContent = memo(
         <SheetDescription />
         <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-5">
           <NodeEditor
-            nodeDetails={activeNode.data.details}
+            key={`${activeNode.id}:${openToken}`}
+            nodeDetails={freshDetails}
             nodeId={activeNode.id}
             nodeType={activeNode.type as NodeType}
           />

--- a/apps/builder/src/features/flows/react-flow/react-flow-node-change.ts
+++ b/apps/builder/src/features/flows/react-flow/react-flow-node-change.ts
@@ -1,0 +1,5 @@
+import type { FlowNode } from "@chatbotx.io/flow-config"
+import type { NodeChange } from "@xyflow/react"
+
+export const hasMeaningfulNodeChange = (changes: NodeChange<FlowNode>[]) =>
+  changes.some((change) => change.type === "add" || change.type === "remove")

--- a/apps/builder/src/features/flows/react-flow/react-flow-wrapper.tsx
+++ b/apps/builder/src/features/flows/react-flow/react-flow-wrapper.tsx
@@ -188,6 +188,9 @@ export function ReactFlowWrapper({
   const [isFlowMutating, setIsFlowMutating] = useState(false)
   const isMutatingRef = useRef(false)
   const snapshotSessionRef = useRef(false)
+  // Capture deliberately reads React Flow's internal store here. The restore
+  // path writes through the controlled props so undo/redo stays out of
+  // onNodesChange/onEdgesChange.
   const { takeSnapshot } = useFlowHistory()
   const historyStore = useFlowHistoryStoreApi()
 

--- a/apps/builder/src/features/flows/react-flow/react-flow-wrapper.tsx
+++ b/apps/builder/src/features/flows/react-flow/react-flow-wrapper.tsx
@@ -18,6 +18,7 @@ import {
   type FinalConnectionState,
   MarkerType,
   type Node,
+  type NodeChange,
   Panel,
   ReactFlow,
   useEdgesState,
@@ -57,6 +58,9 @@ import { createId } from "@chatbotx.io/utils"
 import type { ButtonProps } from "react-day-picker"
 import type { FlowVersionResource } from "@/features/flow-versions/schema/resource"
 import ButtonEdge from "./edges/button-edge"
+import { hasMeaningfulNodeChange } from "./react-flow-node-change"
+import { useFlowHistoryStoreApi } from "./stores/flow-history-store-provider"
+import { useFlowHistory } from "./stores/use-flow-history"
 
 const viewerNodeTypes = {
   [nodeTypeSchema.enum.sendMessage]: NodeViewer,
@@ -73,13 +77,52 @@ const edgeTypes = {
   buttonedge: ButtonEdge,
 }
 
+const normalizeNodeForSave = (node: FlowNode) => {
+  const {
+    selected: _selected,
+    dragging: _dragging,
+    width: _width,
+    height: _height,
+    data,
+    ...rest
+  } = node as FlowNode & {
+    dragging?: boolean
+    height?: number
+    width?: number
+  }
+  const { forceToolbarVisible: _forceToolbarVisible, ...restData } = {
+    ...((data ?? {}) as Record<string, unknown>),
+  }
+
+  return {
+    ...rest,
+    data: restData as FlowNode["data"],
+  }
+}
+
+const normalizeEdgeForSave = (edge: Edge) => ({
+  id: edge.id,
+  source: edge.source,
+  sourceHandle: edge.sourceHandle,
+  target: edge.target,
+  targetHandle: edge.targetHandle,
+})
+
+const serializeFlow = (nodes: FlowNode[], edges: Edge[]) =>
+  JSON.stringify({
+    nodes: nodes.map(normalizeNodeForSave),
+    edges: edges.map(normalizeEdgeForSave),
+  })
+
 type ReactFlowFrameProps = {
   flowVersion: FlowVersionResource
   setOpenNodeDetailSheet: (open: boolean) => void
+  onAutosaveFlushChange: (flushAutosave: (() => void) | null) => void
 }
 
 export function ReactFlowWrapper({
   flowVersion,
+  onAutosaveFlushChange,
   setOpenNodeDetailSheet,
 }: ReactFlowFrameProps) {
   const reactFlow = useReactFlow()
@@ -94,7 +137,7 @@ export function ReactFlowWrapper({
     screenToFlowPosition,
   } = reactFlow
 
-  const [nodes, _setNodes, onNodesChange] = useNodesState(
+  const [nodes, setNodes, onNodesChange] = useNodesState(
     flowVersion.nodes as unknown as FlowNode[],
   )
   const [edges, setEdges, onEdgesChange] = useEdgesState(
@@ -104,8 +147,13 @@ export function ReactFlowWrapper({
       markerEnd: {
         type: MarkerType.ArrowClosed,
       },
-      // data: edge.data,
     })),
+  )
+  const lastSavedSerializedRef = useRef(
+    serializeFlow(
+      flowVersion.nodes as unknown as FlowNode[],
+      flowVersion.edges as unknown as Edge[],
+    ),
   )
 
   const { execute: savingDraft, executeAsync: savingDraftAsync } =
@@ -132,12 +180,99 @@ export function ReactFlowWrapper({
     (changedNodes: any[], changedEdges: any[]) => {
       savingDraft({ nodes: changedNodes, edges: changedEdges })
     },
-    1000,
+    1500,
+    4000,
   )
 
   const t = useTranslations()
   const [isFlowMutating, setIsFlowMutating] = useState(false)
   const isMutatingRef = useRef(false)
+  const snapshotSessionRef = useRef(false)
+  const { takeSnapshot } = useFlowHistory()
+  const historyStore = useFlowHistoryStoreApi()
+
+  // Register the local state setters as the history store's restore handlers so
+  // undo/redo write through the controlled nodes/edges props. React Flow's
+  // StoreUpdater syncs those props into its internal store WITHOUT firing
+  // onNodesChange/onEdgesChange, so restoring never re-enters the snapshot path.
+  useEffect(() => {
+    const restoreNodes = (restoredNodes: Node[]) =>
+      setNodes(restoredNodes as unknown as FlowNode[])
+
+    const restoreEdges = (restoredEdges: Edge[]) =>
+      setEdges(
+        restoredEdges.map((edge) => ({
+          ...edge,
+          type: "buttonedge",
+          markerEnd: { type: MarkerType.ArrowClosed },
+        })),
+      )
+
+    historyStore
+      .getState()
+      .setRestoreHandlers({ setNodes: restoreNodes, setEdges: restoreEdges })
+
+    return () => historyStore.getState().setRestoreHandlers(null)
+  }, [historyStore, setNodes, setEdges])
+
+  const releaseSnapshotSession = useDebouncedCallback(() => {
+    snapshotSessionRef.current = false
+  }, 500)
+
+  const takeCoalescedSnapshot = useCallback(() => {
+    if (!snapshotSessionRef.current) {
+      takeSnapshot()
+      snapshotSessionRef.current = true
+    }
+    releaseSnapshotSession()
+  }, [takeSnapshot, releaseSnapshotSession])
+
+  // Snapshot first, then mutate React Flow's live node data. updateNodeData
+  // writes directly into the internal store, so callers must preserve the
+  // pre-mutation state before passing data in.
+  const updateNodeDataWithHistory = useCallback(
+    (nodeId: string, data: FlowNode["data"]) => {
+      takeCoalescedSnapshot()
+      updateNodeData(nodeId, data)
+    },
+    [takeCoalescedSnapshot, updateNodeData],
+  )
+
+  const hasMeaningfulEdgeChange = useCallback(
+    (changes: Parameters<typeof onEdgesChange>[0]) =>
+      changes.some(
+        (change) => change.type === "add" || change.type === "remove",
+      ),
+    [],
+  )
+
+  const handleNodesChange = useCallback(
+    (changes: NodeChange<FlowNode>[]) => {
+      if (hasMeaningfulNodeChange(changes)) {
+        takeCoalescedSnapshot()
+      }
+      onNodesChange(changes)
+    },
+    [onNodesChange, takeCoalescedSnapshot],
+  )
+
+  const handleEdgesChange = useCallback(
+    (changes: Parameters<typeof onEdgesChange>[0]) => {
+      if (hasMeaningfulEdgeChange(changes)) {
+        takeCoalescedSnapshot()
+      }
+      onEdgesChange(changes)
+    },
+    [hasMeaningfulEdgeChange, onEdgesChange, takeCoalescedSnapshot],
+  )
+
+  const handleNodeDragStart = useCallback(() => {
+    takeCoalescedSnapshot()
+  }, [takeCoalescedSnapshot])
+
+  const handleNodeDragStop = useCallback(() => {
+    releaseSnapshotSession()
+  }, [releaseSnapshotSession])
 
   const duplicateNode = useMemo(
     () =>
@@ -183,14 +318,53 @@ export function ReactFlowWrapper({
     [getNodes, getEdges, deleteElements, handleChanges, savingDraftAsync, t],
   )
 
+  const duplicateNodeWithHistory = useCallback(
+    async (sourceNode: FlowNode) => {
+      takeSnapshot()
+      await duplicateNode(sourceNode)
+    },
+    [duplicateNode, takeSnapshot],
+  )
+
+  const deleteNodeWithHistory = useCallback(
+    async (nodeId: string) => {
+      takeSnapshot()
+      await deleteNode(nodeId)
+    },
+    [deleteNode, takeSnapshot],
+  )
+
   const flowMutationValue = useMemo(
-    () => ({ isFlowMutating, duplicateNode, deleteNode }),
-    [isFlowMutating, duplicateNode, deleteNode],
+    () => ({
+      deleteNode: deleteNodeWithHistory,
+      duplicateNode: duplicateNodeWithHistory,
+      isFlowMutating,
+    }),
+    [isFlowMutating, duplicateNodeWithHistory, deleteNodeWithHistory],
   )
 
   useEffect(() => {
+    const serialized = serializeFlow(nodes, edges as Edge[])
+    if (serialized === lastSavedSerializedRef.current) {
+      return
+    }
+
+    lastSavedSerializedRef.current = serialized
     handleChanges(nodes, edges)
   }, [nodes, edges, handleChanges])
+
+  useEffect(() => {
+    onAutosaveFlushChange(handleChanges.flush)
+
+    return () => onAutosaveFlushChange(null)
+  }, [handleChanges.flush, onAutosaveFlushChange])
+
+  useEffect(
+    () => () => {
+      releaseSnapshotSession.cancel()
+    },
+    [releaseSnapshotSession],
+  )
 
   const handleNodeClick = useCallback(() => {
     setOpenNodeDetailSheet(true)
@@ -215,7 +389,8 @@ export function ReactFlowWrapper({
   )
 
   const onConnect = useCallback(
-    (params: Connection) =>
+    (params: Connection) => {
+      takeCoalescedSnapshot()
       setEdges((eds) =>
         addEdge(
           {
@@ -224,8 +399,9 @@ export function ReactFlowWrapper({
           },
           eds,
         ),
-      ),
-    [setEdges],
+      )
+    },
+    [setEdges, takeCoalescedSnapshot],
   )
 
   const connectButtonToNode = useCallback(
@@ -234,6 +410,7 @@ export function ReactFlowWrapper({
         return
       }
 
+      takeCoalescedSnapshot()
       const fromNodeId = connectionState.fromNode.id
       const handleId = connectionState.fromHandle?.id
       const data = connectionState.fromNode.data as FlowNode["data"]
@@ -254,7 +431,7 @@ export function ReactFlowWrapper({
           viewOnly: true,
         })
         step.buttons[buttonIndex] = targetButton
-        updateNodeData(fromNodeId, data)
+        updateNodeDataWithHistory(fromNodeId, data)
         return true
       }
 
@@ -277,7 +454,7 @@ export function ReactFlowWrapper({
               viewOnly: true,
             })
             elements[elementIndex] = element
-            updateNodeData(fromNodeId, data)
+            updateNodeDataWithHistory(fromNodeId, data)
             return true
           }
         }
@@ -296,7 +473,7 @@ export function ReactFlowWrapper({
         }
       }
     },
-    [updateNodeData],
+    [takeCoalescedSnapshot, updateNodeDataWithHistory],
   )
 
   const onConnectEnd = useCallback(
@@ -334,6 +511,7 @@ export function ReactFlowWrapper({
               name: `Send Message #${messageNodesLength + 1}`,
             },
           })
+          takeCoalescedSnapshot()
           addNodes([newNode])
 
           addEdges({
@@ -379,6 +557,7 @@ export function ReactFlowWrapper({
               (edge) => edge.sourceHandle === connectionState.fromHandle?.id,
             )
 
+            takeCoalescedSnapshot()
             deleteElements({
               edges: connectedEdges.map((edge) => ({
                 id: edge.id,
@@ -406,6 +585,7 @@ export function ReactFlowWrapper({
       getEdges,
       connectButtonToNode,
       screenToFlowPosition,
+      takeCoalescedSnapshot,
     ],
   )
 
@@ -433,6 +613,8 @@ export function ReactFlowWrapper({
 
   const onEdgesDelete = useCallback(
     (edges: Edge[]) => {
+      takeCoalescedSnapshot()
+
       for (const edge of edges) {
         // if the edge is from node to node, do nothing
         if (edge.source === edge.sourceHandle) {
@@ -463,7 +645,7 @@ export function ReactFlowWrapper({
                 null
 
               // update the node data
-              updateNodeData(foundedNode.id, data)
+              updateNodeDataWithHistory(foundedNode.id, data)
             }
             continue
           }
@@ -481,7 +663,7 @@ export function ReactFlowWrapper({
                 element.beforeStep.id === edge.sourceHandle
               ) {
                 Object.assign(element, { buttonType: null, beforeStep: null })
-                updateNodeData(foundedNode.id, data)
+                updateNodeDataWithHistory(foundedNode.id, data)
                 elementFound = true
                 break
               }
@@ -493,7 +675,7 @@ export function ReactFlowWrapper({
         }
       }
     },
-    [getNodes, updateNodeData],
+    [getNodes, takeCoalescedSnapshot, updateNodeDataWithHistory],
   )
 
   return (
@@ -521,16 +703,17 @@ export function ReactFlowWrapper({
         onConnectEnd={onConnectEnd}
         onEdgeMouseEnter={onEdgeMouseEnter}
         onEdgeMouseLeave={onEdgeMouseLeave}
-        onEdgesChange={onEdgesChange}
+        onEdgesChange={handleEdgesChange}
         onEdgesDelete={onEdgesDelete}
         onNodeClick={handleNodeClick}
+        onNodeDragStart={handleNodeDragStart}
+        onNodeDragStop={handleNodeDragStop}
         onNodeMouseEnter={onNodeMouseEnter}
         onNodeMouseLeave={onNodeMouseLeave}
-        onNodesChange={onNodesChange}
+        onNodesChange={handleNodesChange}
         onPaneClick={handlePaneClick}
         proOptions={{ hideAttribution: true }}
       >
-        {/* <MiniMap /> */}
         {isFlowMutating && (
           <div
             className="absolute inset-0 z-50 cursor-wait bg-white/40 dark:bg-black/40"

--- a/apps/builder/src/features/flows/react-flow/stores/__tests__/flow-history-store.test.ts
+++ b/apps/builder/src/features/flows/react-flow/stores/__tests__/flow-history-store.test.ts
@@ -1,0 +1,170 @@
+import type { Edge, Node } from "@xyflow/react"
+import { describe, expect, test } from "vitest"
+import { createFlowHistoryStore } from "../flow-history-store"
+
+const node = (
+  id: string,
+  label = id,
+  extraData: Record<string, unknown> = {},
+) =>
+  ({
+    id,
+    data: { label, ...extraData },
+    position: { x: 0, y: 0 },
+  }) as Node
+
+const edge = (id: string) =>
+  ({
+    id,
+    source: "source",
+    target: "target",
+  }) as Edge
+
+describe("createFlowHistoryStore", () => {
+  test("moves the current canvas state to future when undoing", () => {
+    const store = createFlowHistoryStore()
+    const previous = { nodes: [node("previous")], edges: [edge("previous")] }
+    const current = { nodes: [node("current")], edges: [edge("current")] }
+
+    store.getState().takeSnapshot(previous.nodes, previous.edges)
+
+    expect(store.getState().undo(current)).toEqual(previous)
+    expect(store.getState().past).toEqual([])
+    expect(store.getState().future).toEqual([current])
+  })
+
+  test("restores redo snapshots in the order they were undone", () => {
+    const store = createFlowHistoryStore()
+    const first = { nodes: [node("first")], edges: [] }
+    const second = { nodes: [node("second")], edges: [] }
+    const third = { nodes: [node("third")], edges: [] }
+
+    store.getState().takeSnapshot(first.nodes, first.edges)
+    store.getState().takeSnapshot(second.nodes, second.edges)
+
+    expect(store.getState().undo(third)).toEqual(second)
+    expect(store.getState().undo(second)).toEqual(first)
+    expect(store.getState().redo(first)).toEqual(second)
+    expect(store.getState().redo(second)).toEqual(third)
+  })
+
+  test("clears redo history when taking a new snapshot", () => {
+    const store = createFlowHistoryStore()
+    const first = { nodes: [node("first")], edges: [] }
+    const second = { nodes: [node("second")], edges: [] }
+    const third = { nodes: [node("third")], edges: [] }
+
+    store.getState().takeSnapshot(first.nodes, first.edges)
+    store.getState().undo(second)
+    store.getState().takeSnapshot(third.nodes, third.edges)
+
+    expect(store.getState().future).toEqual([])
+    expect(store.getState().redo(third)).toBeNull()
+  })
+
+  test("reset clears both history stacks without touching restore handlers", () => {
+    const store = createFlowHistoryStore()
+    store.getState().setRestoreHandlers({
+      setNodes: () => {
+        // no-op
+      },
+      setEdges: () => {
+        // no-op
+      },
+    })
+
+    store.getState().takeSnapshot([node("first")], [])
+    store.getState().undo({ nodes: [node("current")], edges: [] })
+    store.getState().reset()
+
+    expect(store.getState().past).toEqual([])
+    expect(store.getState().future).toEqual([])
+    expect(store.getState().restoreHandlers).not.toBeNull()
+  })
+
+  test("clones snapshots so later live mutations do not change history", () => {
+    const store = createFlowHistoryStore()
+    const liveNodes = [node("live", "before")]
+    const liveEdges = [edge("live")]
+
+    store.getState().takeSnapshot(liveNodes, liveEdges)
+    liveNodes[0].data = { label: "after" }
+    liveEdges[0].target = "changed"
+
+    expect(
+      store.getState().undo({ nodes: [node("current")], edges: [] }),
+    ).toEqual({
+      nodes: [node("live", "before")],
+      edges: [edge("live")],
+    })
+  })
+
+  test("caps past history at fifty snapshots", () => {
+    const store = createFlowHistoryStore()
+
+    for (let index = 0; index < 51; index += 1) {
+      store.getState().takeSnapshot([node(`node-${index}`)], [])
+    }
+
+    expect(store.getState().past).toHaveLength(50)
+    expect(store.getState().past[0].nodes[0].id).toBe("node-1")
+  })
+
+  test("evicts oldest snapshots when the byte budget is exceeded", () => {
+    const store = createFlowHistoryStore()
+    const payload = "x".repeat(1024 * 1024)
+
+    for (let index = 0; index < 6; index += 1) {
+      store
+        .getState()
+        .takeSnapshot(
+          [node(`large-${index}`, `large-${index}`, { payload })],
+          [],
+        )
+    }
+
+    expect(store.getState().past).toHaveLength(5)
+    expect(store.getState().past[0].nodes[0].id).toBe("large-1")
+  })
+
+  test("returns null and leaves stacks untouched when there is nothing to undo or redo", () => {
+    const store = createFlowHistoryStore()
+    const current = { nodes: [node("current")], edges: [] }
+
+    expect(store.getState().undo(current)).toBeNull()
+    expect(store.getState().redo(current)).toBeNull()
+    expect(store.getState().past).toEqual([])
+    expect(store.getState().future).toEqual([])
+  })
+
+  test("applies restored snapshots through the registered handlers", () => {
+    const store = createFlowHistoryStore()
+    const appliedNodes: Node[][] = []
+    store.getState().setRestoreHandlers({
+      setNodes: (nodes) => appliedNodes.push(nodes),
+      setEdges: () => {
+        // edges asserted via nodes; ignore here
+      },
+    })
+
+    const first = { nodes: [node("first")], edges: [] }
+    const second = { nodes: [node("second")], edges: [] }
+
+    store.getState().takeSnapshot(first.nodes, first.edges)
+    store.getState().undo(second)
+    store.getState().redo(first)
+
+    // undo restores `first`, redo restores `second` (the state undo shelved).
+    expect(appliedNodes[0]).toEqual(first.nodes)
+    expect(appliedNodes[1]).toEqual(second.nodes)
+  })
+
+  test("does not throw when restoring without registered handlers", () => {
+    const store = createFlowHistoryStore()
+    store.getState().takeSnapshot([node("first")], [])
+
+    expect(() =>
+      store.getState().undo({ nodes: [node("current")], edges: [] }),
+    ).not.toThrow()
+  })
+})

--- a/apps/builder/src/features/flows/react-flow/stores/__tests__/flow-history-store.test.ts
+++ b/apps/builder/src/features/flows/react-flow/stores/__tests__/flow-history-store.test.ts
@@ -60,6 +60,14 @@ describe("createFlowHistoryStore", () => {
 
     expect(store.getState().future).toEqual([])
     expect(store.getState().redo(third)).toBeNull()
+    expect(store.getState().branchClearedCount).toBe(1)
+  })
+
+  test("does not mark a branch clear when no redo history exists", () => {
+    const store = createFlowHistoryStore()
+    store.getState().takeSnapshot([node("first")], [])
+
+    expect(store.getState().branchClearedCount).toBe(0)
   })
 
   test("reset clears both history stacks without touching restore handlers", () => {

--- a/apps/builder/src/features/flows/react-flow/stores/flow-history-store-provider.tsx
+++ b/apps/builder/src/features/flows/react-flow/stores/flow-history-store-provider.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { createContext, type ReactNode, useContext, useRef } from "react"
+import { useStore } from "zustand"
+import {
+  createFlowHistoryStore,
+  type FlowHistoryStore,
+} from "./flow-history-store"
+
+export type FlowHistoryStoreApi = ReturnType<typeof createFlowHistoryStore>
+
+export const FlowHistoryStoreContext = createContext<
+  FlowHistoryStoreApi | undefined
+>(undefined)
+
+export const FlowHistoryStoreProvider = ({
+  children,
+}: {
+  children: ReactNode
+}) => {
+  const storeRef = useRef<FlowHistoryStoreApi>(null)
+  if (!storeRef.current) {
+    storeRef.current = createFlowHistoryStore()
+  }
+
+  return (
+    <FlowHistoryStoreContext.Provider value={storeRef.current}>
+      {children}
+    </FlowHistoryStoreContext.Provider>
+  )
+}
+
+/**
+ * Returns the stable store API (identity-stable for the provider's lifetime).
+ * Callers that need the *current* state inside an event handler should call
+ * `api.getState()` at call time rather than subscribing, so reading transient
+ * flags like `isRestoring` doesn't force a re-render on every history change.
+ */
+export const useFlowHistoryStoreApi = (): FlowHistoryStoreApi => {
+  const context = useContext(FlowHistoryStoreContext)
+
+  if (!context) {
+    throw new Error(
+      "useFlowHistoryStore must be used within FlowHistoryStoreProvider",
+    )
+  }
+
+  return context
+}
+
+export const useFlowHistoryStore = <T,>(
+  selector: (store: FlowHistoryStore) => T,
+): T => useStore(useFlowHistoryStoreApi(), selector)

--- a/apps/builder/src/features/flows/react-flow/stores/flow-history-store.ts
+++ b/apps/builder/src/features/flows/react-flow/stores/flow-history-store.ts
@@ -47,10 +47,11 @@ export type FlowHistoryState = {
   past: Snapshot[]
   future: Snapshot[]
   restoreHandlers: RestoreHandlers | null
+  branchClearedCount: number
 }
 
 export type FlowHistoryStore = FlowHistoryState & {
-  takeSnapshot: (nodes: Node[], edges: Edge[]) => void
+  takeSnapshot: (nodes: Node[], edges: Edge[]) => boolean
   undo: (current: Snapshot) => Snapshot | null
   redo: (current: Snapshot) => Snapshot | null
   reset: () => void
@@ -76,13 +77,19 @@ export const createFlowHistoryStore = () =>
       past: [],
       future: [],
       restoreHandlers: null,
+      branchClearedCount: 0,
 
       takeSnapshot: (nodes, edges) => {
         const snapshot = cloneSnapshot({ nodes, edges })
+        const hadRedoHistory = get().future.length > 0
         set((state) => ({
           past: appendPast(state.past, snapshot),
           future: [],
+          branchClearedCount: hadRedoHistory
+            ? state.branchClearedCount + 1
+            : state.branchClearedCount,
         }))
+        return hadRedoHistory
       },
 
       undo: (current) => {

--- a/apps/builder/src/features/flows/react-flow/stores/flow-history-store.ts
+++ b/apps/builder/src/features/flows/react-flow/stores/flow-history-store.ts
@@ -1,0 +1,120 @@
+import type { Edge, Node } from "@xyflow/react"
+import { createStore } from "zustand"
+
+export type Snapshot = { nodes: Node[]; edges: Edge[] }
+
+/**
+ * Applies a restored snapshot back onto the canvas. The wrapper registers its
+ * local `useNodesState`/`useEdgesState` setters here so undo/redo write through
+ * the *controlled* `nodes`/`edges` props. React Flow's `StoreUpdater` then syncs
+ * those props into its internal store WITHOUT emitting `onNodesChange`/
+ * `onEdgesChange` — so restoring never re-enters `takeSnapshot` and can't clobber
+ * the redo (`future`) stack. Restoring via `useReactFlow().setNodes` would instead
+ * round-trip through the change handlers and corrupt history.
+ */
+export type RestoreHandlers = {
+  setNodes: (nodes: Node[]) => void
+  setEdges: (edges: Edge[]) => void
+}
+
+const MAX_HISTORY = 50
+const MAX_HISTORY_BYTES = 5.5 * 1024 * 1024
+
+const cloneSnapshot = (snapshot: Snapshot): Snapshot =>
+  JSON.parse(JSON.stringify(snapshot)) as Snapshot
+
+const snapshotBytes = (snapshot: Snapshot) => JSON.stringify(snapshot).length
+
+const appendPast = (past: Snapshot[], snapshot: Snapshot) => {
+  const nextPast = [...past.slice(-MAX_HISTORY + 1), snapshot]
+  let totalBytes = nextPast.reduce(
+    (sum, entry) => sum + snapshotBytes(entry),
+    0,
+  )
+
+  while (nextPast.length > 0 && totalBytes > MAX_HISTORY_BYTES) {
+    const removed = nextPast.shift()
+    if (!removed) {
+      break
+    }
+    totalBytes -= snapshotBytes(removed)
+  }
+
+  return nextPast
+}
+
+export type FlowHistoryState = {
+  past: Snapshot[]
+  future: Snapshot[]
+  restoreHandlers: RestoreHandlers | null
+}
+
+export type FlowHistoryStore = FlowHistoryState & {
+  takeSnapshot: (nodes: Node[], edges: Edge[]) => void
+  undo: (current: Snapshot) => Snapshot | null
+  redo: (current: Snapshot) => Snapshot | null
+  reset: () => void
+  setRestoreHandlers: (handlers: RestoreHandlers | null) => void
+}
+
+export const createFlowHistoryStore = () =>
+  createStore<FlowHistoryStore>()((set, get) => {
+    const applySnapshot = (snapshot: Snapshot) => {
+      const { restoreHandlers } = get()
+      if (!restoreHandlers) {
+        return
+      }
+      // Clone before handing to React Flow so later in-place mutations of live
+      // nodes/edges (several handlers mutate node data directly) don't corrupt
+      // the copy still held in the history stacks.
+      const restored = cloneSnapshot(snapshot)
+      restoreHandlers.setNodes(restored.nodes)
+      restoreHandlers.setEdges(restored.edges)
+    }
+
+    return {
+      past: [],
+      future: [],
+      restoreHandlers: null,
+
+      takeSnapshot: (nodes, edges) => {
+        const snapshot = cloneSnapshot({ nodes, edges })
+        set((state) => ({
+          past: appendPast(state.past, snapshot),
+          future: [],
+        }))
+      },
+
+      undo: (current) => {
+        const { past } = get()
+        const snapshot = past.at(-1)
+        if (!snapshot) {
+          return null
+        }
+        set((state) => ({
+          past: state.past.slice(0, -1),
+          future: [cloneSnapshot(current), ...state.future],
+        }))
+        applySnapshot(snapshot)
+        return snapshot
+      },
+
+      redo: (current) => {
+        const { future } = get()
+        const snapshot = future[0]
+        if (!snapshot) {
+          return null
+        }
+        set((state) => ({
+          future: state.future.slice(1),
+          past: appendPast(state.past, cloneSnapshot(current)),
+        }))
+        applySnapshot(snapshot)
+        return snapshot
+      },
+
+      reset: () => set({ past: [], future: [] }),
+
+      setRestoreHandlers: (handlers) => set({ restoreHandlers: handlers }),
+    }
+  })

--- a/apps/builder/src/features/flows/react-flow/stores/use-flow-history.ts
+++ b/apps/builder/src/features/flows/react-flow/stores/use-flow-history.ts
@@ -1,0 +1,44 @@
+"use client"
+
+import { type Edge, type Node, useReactFlow } from "@xyflow/react"
+import { useCallback } from "react"
+import {
+  useFlowHistoryStore,
+  useFlowHistoryStoreApi,
+} from "./flow-history-store-provider"
+
+type TakeSnapshot = {
+  (): void
+  (nodes: Node[], edges: Edge[]): void
+}
+
+export const useFlowHistory = () => {
+  const { getEdges, getNodes } = useReactFlow()
+  const store = useFlowHistoryStoreApi()
+  const canUndo = useFlowHistoryStore((state) => state.past.length > 0)
+  const canRedo = useFlowHistoryStore((state) => state.future.length > 0)
+
+  const takeSnapshot = useCallback(
+    ((nodes?: Node[], edges?: Edge[]) => {
+      store.getState().takeSnapshot(nodes ?? getNodes(), edges ?? getEdges())
+    }) as TakeSnapshot,
+    [store, getNodes, getEdges],
+  )
+
+  // Restoration is applied inside the store via the wrapper-registered handlers
+  // (its local useNodesState/useEdgesState setters), so undo/redo never round-trip
+  // through onNodesChange and can't clear the redo stack.
+  const undo = useCallback(() => {
+    store.getState().undo({ nodes: getNodes(), edges: getEdges() })
+  }, [store, getNodes, getEdges])
+
+  const redo = useCallback(() => {
+    store.getState().redo({ nodes: getNodes(), edges: getEdges() })
+  }, [store, getNodes, getEdges])
+
+  const reset = useCallback(() => {
+    store.getState().reset()
+  }, [store])
+
+  return { canRedo, canUndo, redo, reset, takeSnapshot, undo }
+}

--- a/apps/builder/src/features/flows/react-flow/stores/use-flow-history.ts
+++ b/apps/builder/src/features/flows/react-flow/stores/use-flow-history.ts
@@ -15,6 +15,11 @@ type TakeSnapshot = {
 export const useFlowHistory = () => {
   const { getEdges, getNodes } = useReactFlow()
   const store = useFlowHistoryStoreApi()
+  const pastCount = useFlowHistoryStore((state) => state.past.length)
+  const futureCount = useFlowHistoryStore((state) => state.future.length)
+  const branchClearedCount = useFlowHistoryStore(
+    (state) => state.branchClearedCount,
+  )
   const canUndo = useFlowHistoryStore((state) => state.past.length > 0)
   const canRedo = useFlowHistoryStore((state) => state.future.length > 0)
 
@@ -40,5 +45,15 @@ export const useFlowHistory = () => {
     store.getState().reset()
   }, [store])
 
-  return { canRedo, canUndo, redo, reset, takeSnapshot, undo }
+  return {
+    branchClearedCount,
+    canRedo,
+    canUndo,
+    futureCount,
+    pastCount,
+    redo,
+    reset,
+    takeSnapshot,
+    undo,
+  }
 }

--- a/packages/ui/src/hooks/__tests__/create-debounced-fn.test.ts
+++ b/packages/ui/src/hooks/__tests__/create-debounced-fn.test.ts
@@ -4,6 +4,7 @@ import { createDebouncedFn } from "../create-debounced-fn"
 describe("createDebouncedFn", () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    vi.setSystemTime(0)
   })
 
   afterEach(() => {
@@ -68,6 +69,50 @@ describe("createDebouncedFn", () => {
     const debounced = createDebouncedFn(spy, 1000)
 
     debounced.flush()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  test("fires at maxWait during a continuous burst", () => {
+    const spy = vi.fn()
+    const debounced = createDebouncedFn(spy, 1000, 2500)
+
+    debounced("a")
+    vi.advanceTimersByTime(900)
+    debounced("b")
+    vi.advanceTimersByTime(900)
+    debounced("c")
+
+    vi.advanceTimersByTime(700)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith("c")
+  })
+
+  test("flush() uses the latest args even when maxWait is configured", () => {
+    const spy = vi.fn()
+    const debounced = createDebouncedFn(spy, 1000, 2500)
+
+    debounced("a")
+    vi.advanceTimersByTime(900)
+    debounced("b")
+    debounced.flush()
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith("b")
+
+    vi.advanceTimersByTime(5000)
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  test("cancel() clears a pending maxWait invocation", () => {
+    const spy = vi.fn()
+    const debounced = createDebouncedFn(spy, 1000, 2500)
+
+    debounced("a")
+    vi.advanceTimersByTime(900)
+    debounced("b")
+    debounced.cancel()
+
+    vi.advanceTimersByTime(5000)
     expect(spy).not.toHaveBeenCalled()
   })
 })

--- a/packages/ui/src/hooks/create-debounced-fn.ts
+++ b/packages/ui/src/hooks/create-debounced-fn.ts
@@ -5,6 +5,10 @@ export type DebouncedFn<T extends (...args: never[]) => unknown> = ((
   flush: () => void
 }
 
+type DebounceOptions = {
+  maxWait?: number
+}
+
 /**
  * Framework-free debouncer. Returns a callable that delays `callback` by `delay`
  * ms, plus `cancel()` (drop the pending call) and `flush()` (run it now with the
@@ -13,34 +17,74 @@ export type DebouncedFn<T extends (...args: never[]) => unknown> = ((
 export function createDebouncedFn<T extends (...args: never[]) => unknown>(
   callback: T,
   delay: number,
+  maxWaitOrOptions?: number | DebounceOptions,
 ): DebouncedFn<T> {
   let timer: ReturnType<typeof setTimeout> | undefined
   let lastArgs: Parameters<T> | undefined
+  let burstStartTime: number | undefined
+
+  const maxWait =
+    typeof maxWaitOrOptions === "number"
+      ? maxWaitOrOptions
+      : maxWaitOrOptions?.maxWait
+
+  const clearTimer = () => {
+    clearTimeout(timer)
+    timer = undefined
+  }
+
+  const resetBurst = () => {
+    burstStartTime = undefined
+    lastArgs = undefined
+  }
+
+  const invoke = () => {
+    if (!lastArgs) {
+      clearTimer()
+      resetBurst()
+      return
+    }
+
+    const args = lastArgs
+    clearTimer()
+    resetBurst()
+    callback(...args)
+  }
+
+  const schedule = () => {
+    const now = Date.now()
+    const maxWaitRemaining =
+      maxWait === undefined || burstStartTime === undefined
+        ? undefined
+        : Math.max(0, maxWait - (now - burstStartTime))
+    const timeout =
+      maxWaitRemaining === undefined
+        ? delay
+        : Math.min(delay, maxWaitRemaining)
+
+    clearTimer()
+    timer = setTimeout(invoke, timeout)
+  }
 
   const debounced = ((...args: Parameters<T>) => {
     lastArgs = args
-    clearTimeout(timer)
-    timer = setTimeout(() => {
-      timer = undefined
-      callback(...(lastArgs as Parameters<T>))
-    }, delay)
+    if (burstStartTime === undefined) {
+      burstStartTime = Date.now()
+    }
+
+    schedule()
   }) as DebouncedFn<T>
 
   debounced.cancel = () => {
-    clearTimeout(timer)
-    timer = undefined
-    lastArgs = undefined
+    clearTimer()
+    resetBurst()
   }
 
   debounced.flush = () => {
     if (timer === undefined) {
       return
     }
-    clearTimeout(timer)
-    timer = undefined
-    if (lastArgs) {
-      callback(...lastArgs)
-    }
+    invoke()
   }
 
   return debounced

--- a/packages/ui/src/hooks/use-debounced-callback.ts
+++ b/packages/ui/src/hooks/use-debounced-callback.ts
@@ -3,9 +3,14 @@ import * as React from "react"
 import { useCallbackRef } from "@chatbotx.io/ui/hooks/use-callback-ref"
 import { createDebouncedFn, type DebouncedFn } from "./create-debounced-fn"
 
+type DebounceOptions = {
+  maxWait?: number
+}
+
 export function useDebouncedCallback<T extends (...args: never[]) => unknown>(
   callback: T,
   delay: number,
+  maxWaitOrOptions?: number | DebounceOptions,
 ): DebouncedFn<T> {
   const handleCallback = useCallbackRef(callback)
 
@@ -13,8 +18,8 @@ export function useDebouncedCallback<T extends (...args: never[]) => unknown>(
   // debounced fn is stable across renders. Stability matters: the autosave effect
   // in react-flow-wrapper depends on this returned function.
   const debounced = React.useMemo(
-    () => createDebouncedFn(handleCallback as T, delay),
-    [handleCallback, delay],
+    () => createDebouncedFn(handleCallback as T, delay, maxWaitOrOptions),
+    [handleCallback, delay, maxWaitOrOptions],
   )
 
   React.useEffect(() => () => debounced.cancel(), [debounced])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4634,12 +4634,6 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
-
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
@@ -13105,11 +13099,11 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
@@ -14468,7 +14462,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.1.4':


### PR DESCRIPTION
## Summary
- Add undo/redo history to the flow builder so users can revert canvas and node edits.
- Fix the snapshot-on-open bug: opening a node editor no longer pushes onto the undo stack or clears the redo stack (React Flow node measurement changes were being misread as user edits).
- Isolate the editor's form-value → flow syncing and harden the shared debounce utility.

## Changes
- `stores/flow-history-store.ts` + `flow-history-store-provider.tsx` + `use-flow-history.ts` — zustand-backed snapshot/undo/redo with byte- and count-capped stacks and controlled-state restore handlers.
- `react-flow-wrapper.tsx` — wire history into the canvas; only structural node changes (add/remove), drags, connects, and deletes snapshot. `react-flow-node-change.ts` — shared change-type helper.
- `nodes/editor.tsx` + `nodes/node-detail-sheet.tsx` — type-gated snapshot on real field edits; isolated value syncing.
- `flow-edit-toolbar.tsx` + `frame.tsx` — undo/redo toolbar controls; `messages/en.json`, `messages/vi.json` — i18n strings.
- `packages/ui/hooks/create-debounced-fn.ts` + `use-debounced-callback.ts` — maxWait, cancel/flush hardening.
- Tests: `stores/__tests__/flow-history-store.test.ts`, `__tests__/react-flow-wrapper.test.ts`, `hooks/__tests__/create-debounced-fn.test.ts`.

## Test plan
- [ ] pnpm lint
- [ ] pnpm --filter builder check-types
- [ ] pnpm --filter builder test flow-history-store
- [ ] Manual: open a node (no edit) → undo stays disabled, redo not cleared
- [ ] Manual: edit a field / drag / add / delete node / connect / delete edge → undo & redo work
- [ ] Manual: button-editor dialog save propagates into the node without adding history