### PR TITLE
feat(workspace): add active-hours toggle for workspaces

### DIFF
--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -491,6 +491,21 @@
       "zalo": "This Zalo OA is already connected to another workspace."
     }
   },
+  "workspace": {
+    "schedule": {
+      "title": "Set active hours",
+      "description": "Choose a start and end time. If the end time is earlier than the start time, the schedule runs overnight.",
+      "startTime": "Start time",
+      "endTime": "End time",
+      "alwaysRun": "Always run",
+      "save": "Save",
+      "invalidTimeRange": "Start and end time must be different",
+      "timeRequired": "Please select both start and end time",
+      "activated": "Workspace activated",
+      "deactivated": "Workspace deactivated",
+      "activeHours": "Active from {startTime} to {endTime}"
+    }
+  },
   "workspaces": {
     "list": {
       "title": "Workspaces List"
@@ -3040,11 +3055,12 @@
     "replyAfterValue": "Value",
     "schedule": {
       "title": "Set active hours",
+      "description": "Choose a start and end time. If the end time is earlier than the start time, the schedule runs overnight.",
       "startTime": "Start time",
       "endTime": "End time",
       "alwaysRun": "Always run",
       "save": "Save",
-      "invalidTimeRange": "End time must be after start time",
+      "invalidTimeRange": "Start and end time must be different",
       "timeRequired": "Please select both start and end time"
     },
     "card": {

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -492,6 +492,21 @@
       "zalo": "Zalo OA này đã được kết nối với một workspace khác."
     }
   },
+  "workspace": {
+    "schedule": {
+      "title": "Cài đặt khung giờ hoạt động",
+      "description": "Chọn giờ bắt đầu và kết thúc. Nếu giờ kết thúc sớm hơn giờ bắt đầu, khung giờ sẽ kéo dài qua đêm.",
+      "startTime": "Giờ bắt đầu",
+      "endTime": "Giờ kết thúc",
+      "alwaysRun": "Luôn luôn chạy",
+      "save": "Lưu",
+      "invalidTimeRange": "Giờ bắt đầu và giờ kết thúc phải khác nhau",
+      "timeRequired": "Vui lòng chọn cả giờ bắt đầu và giờ kết thúc",
+      "activated": "Đã kích hoạt workspace",
+      "deactivated": "Đã tắt workspace",
+      "activeHours": "Hoạt động từ {startTime} đến {endTime} giờ"
+    }
+  },
   "workspaces": {
     "list": {
       "title": "Danh sách workspace"
@@ -3033,11 +3048,12 @@
     "replyAfterValue": "Giá trị",
     "schedule": {
       "title": "Cài đặt khung giờ hoạt động",
+      "description": "Chọn giờ bắt đầu và kết thúc. Nếu giờ kết thúc sớm hơn giờ bắt đầu, khung giờ sẽ kéo dài qua đêm.",
       "startTime": "Giờ bắt đầu",
       "endTime": "Giờ kết thúc",
       "alwaysRun": "Luôn luôn chạy",
       "save": "Lưu",
-      "invalidTimeRange": "Giờ kết thúc phải sau giờ bắt đầu",
+      "invalidTimeRange": "Giờ bắt đầu và giờ kết thúc phải khác nhau",
       "timeRequired": "Vui lòng chọn cả giờ bắt đầu và giờ kết thúc"
     },
     "card": {

--- a/apps/builder/src/features/workspaces/actions/update-workspace-status-action.ts
+++ b/apps/builder/src/features/workspaces/actions/update-workspace-status-action.ts
@@ -1,0 +1,46 @@
+"use server"
+
+import { workspaceService } from "@chatbotx.io/business"
+import { ChatbotXException } from "@chatbotx.io/business/errors"
+import {
+  type WorkspaceIdRequestParams,
+  workspaceIdrequestParams,
+} from "@/features/common/schemas"
+import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
+import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
+import { workspaceActionClient } from "@/lib/safe-action"
+import {
+  type UpdateWorkspaceStatusRequest,
+  updateWorkspaceStatusRequest,
+} from "../schema/update-workspace-schema"
+
+export const updateWorkspaceStatusAction = workspaceActionClient
+  .bindArgsSchemas(workspaceIdrequestParams)
+  .inputSchema(updateWorkspaceStatusRequest)
+  .action(
+    async ({
+      bindArgsParsedInputs: [workspaceId],
+      parsedInput,
+    }: {
+      bindArgsParsedInputs: WorkspaceIdRequestParams
+      parsedInput: UpdateWorkspaceStatusRequest
+    }) => {
+      const currentUserAndTargetWorkspace =
+        await getCurrentUserAndTargetWorkspace(workspaceId)
+      if (!currentUserAndTargetWorkspace) {
+        throw new ChatbotXException(
+          "You are not authorized to update this workspace",
+        )
+      }
+
+      const { permissions } =
+        currentUserAndTargetWorkspace.targetWorkspaceMember
+      if (!hasWorkspacePermission(permissions, "superAdmin")) {
+        throw new ChatbotXException(
+          "You need to be a super admin to change workspace active hours",
+        )
+      }
+
+      await workspaceService.update({ id: workspaceId, data: parsedInput })
+    },
+  )

--- a/apps/builder/src/features/workspaces/components/workspace-schedule-dialog.tsx
+++ b/apps/builder/src/features/workspaces/components/workspace-schedule-dialog.tsx
@@ -17,24 +17,30 @@ import { useAction } from "next-safe-action/hooks"
 import { useEffect } from "react"
 import { useForm } from "react-hook-form"
 import { toast } from "sonner"
-import { updateFbCommentAction } from "../actions/update-fb-comment.action"
-import type { FBCommentResource } from "../schema/resource"
+import { updateWorkspaceStatusAction } from "../actions/update-workspace-status-action"
 
 type ScheduleFormValues = {
   startTime: string
   endTime: string
 }
 
-export function FbCommentScheduleDialog({
-  fbComment,
+export function WorkspaceScheduleDialog({
+  workspace,
   open,
   onOpenChange,
   onSuccess,
 }: {
-  fbComment: FBCommentResource | null
+  workspace: {
+    id: string
+    startTime: string | null
+    endTime: string | null
+  } | null
   open: boolean
   onOpenChange: (val: boolean) => void
-  onSuccess?: () => void
+  onSuccess?: (schedule: {
+    startTime: string | null
+    endTime: string | null
+  }) => void
 }) {
   const t = useTranslations()
 
@@ -43,25 +49,24 @@ export function FbCommentScheduleDialog({
   })
 
   useEffect(() => {
-    if (fbComment) {
+    if (workspace) {
       form.reset({
-        startTime: fbComment.startTime ?? "",
-        endTime: fbComment.endTime ?? "",
+        startTime: workspace.startTime ?? "",
+        endTime: workspace.endTime ?? "",
       })
     }
-  }, [fbComment, form])
+  }, [workspace, form])
 
   const { execute, isPending } = useAction(
-    updateFbCommentAction.bind(
-      null,
-      fbComment?.workspaceId ?? "",
-      fbComment?.id ?? "",
-    ),
+    updateWorkspaceStatusAction.bind(null, workspace?.id ?? ""),
     {
-      onSuccess: () => {
-        toast.success(t("facebookCommentAutomation.activated"))
+      onSuccess: ({ input }) => {
+        toast.success(t("workspace.schedule.activated"))
         onOpenChange(false)
-        onSuccess?.()
+        onSuccess?.({
+          startTime: input.startTime,
+          endTime: input.endTime,
+        })
       },
       onError: ({ error }) => {
         if (error.serverError) {
@@ -80,12 +85,12 @@ export function FbCommentScheduleDialog({
     const { startTime, endTime } = form.getValues()
 
     if (!(startTime && endTime)) {
-      toast.error(t("facebookCommentAutomation.schedule.timeRequired"))
+      toast.error(t("workspace.schedule.timeRequired"))
       return
     }
 
     if (startTime === endTime) {
-      toast.error(t("facebookCommentAutomation.schedule.invalidTimeRange"))
+      toast.error(t("workspace.schedule.invalidTimeRange"))
       return
     }
 
@@ -96,18 +101,16 @@ export function FbCommentScheduleDialog({
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent className="max-h-screen max-w-lg overflow-y-scroll">
         <DialogHeader>
-          <DialogTitle>
-            {t("facebookCommentAutomation.schedule.title")}
-          </DialogTitle>
+          <DialogTitle>{t("workspace.schedule.title")}</DialogTitle>
           <DialogDescription>
-            {t("facebookCommentAutomation.schedule.description")}
+            {t("workspace.schedule.description")}
           </DialogDescription>
         </DialogHeader>
         <Form {...form}>
           <div className="flex w-full items-end gap-2">
             <div className="flex-1">
               <TimeField<ScheduleFormValues>
-                label={t("facebookCommentAutomation.schedule.startTime")}
+                label={t("workspace.schedule.startTime")}
                 name="startTime"
                 required
               />
@@ -115,7 +118,7 @@ export function FbCommentScheduleDialog({
             <span className="mb-2 text-muted-foreground">-</span>
             <div className="flex-1">
               <TimeField<ScheduleFormValues>
-                label={t("facebookCommentAutomation.schedule.endTime")}
+                label={t("workspace.schedule.endTime")}
                 name="endTime"
                 required
               />
@@ -131,7 +134,7 @@ export function FbCommentScheduleDialog({
             variant="outline"
           >
             {isPending && <Loader2Icon className="animate-spin" />}
-            {t("facebookCommentAutomation.schedule.alwaysRun")}
+            {t("workspace.schedule.alwaysRun")}
           </Button>
           <Button
             className="ml-auto"
@@ -141,7 +144,7 @@ export function FbCommentScheduleDialog({
             type="button"
           >
             {isPending && <Loader2Icon className="animate-spin" />}
-            {t("facebookCommentAutomation.schedule.save")}
+            {t("workspace.schedule.save")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/builder/src/features/workspaces/components/workspace-status-switch.tsx
+++ b/apps/builder/src/features/workspaces/components/workspace-status-switch.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { Switch } from "@chatbotx.io/ui/components/ui/switch"
+import { useRouter } from "next/navigation"
+import { useTranslations } from "next-intl"
+import { useEffect, useState } from "react"
+import { toast } from "sonner"
+import { updateWorkspaceStatusAction } from "../actions/update-workspace-status-action"
+import { WorkspaceScheduleDialog } from "./workspace-schedule-dialog"
+
+type Schedule = { startTime: string | null; endTime: string | null }
+
+export function WorkspaceStatusSwitch({
+  workspace,
+}: {
+  workspace: {
+    id: string
+    isActive: boolean
+    startTime: string | null
+    endTime: string | null
+  }
+}) {
+  const t = useTranslations()
+  const router = useRouter()
+  const [isActive, setIsActive] = useState(workspace.isActive)
+  const [schedule, setSchedule] = useState<Schedule>({
+    startTime: workspace.startTime,
+    endTime: workspace.endTime,
+  })
+  const [showScheduleDialog, setShowScheduleDialog] = useState(false)
+
+  useEffect(() => {
+    setIsActive(workspace.isActive)
+  }, [workspace.isActive])
+
+  useEffect(() => {
+    setSchedule({ startTime: workspace.startTime, endTime: workspace.endTime })
+  }, [workspace.startTime, workspace.endTime])
+
+  const handleCheckedChange = async (checked: boolean) => {
+    if (checked) {
+      setShowScheduleDialog(true)
+      return
+    }
+
+    try {
+      const result = await updateWorkspaceStatusAction(workspace.id, {
+        isActive: false,
+        startTime: schedule.startTime,
+        endTime: schedule.endTime,
+      })
+      if (result?.serverError || result?.validationErrors) {
+        toast.error(result.serverError ?? t("messages.unknownError"))
+        return
+      }
+      setIsActive(false)
+      toast.success(t("workspace.schedule.deactivated"))
+      router.refresh()
+    } catch {
+      toast.error(t("messages.unknownError"))
+    }
+  }
+
+  return (
+    <>
+      <Switch
+        checked={isActive}
+        className="absolute top-3 left-3 z-10"
+        onCheckedChange={handleCheckedChange}
+        onClick={(e) => e.stopPropagation()}
+      />
+
+      <WorkspaceScheduleDialog
+        onOpenChange={setShowScheduleDialog}
+        onSuccess={(savedSchedule) => {
+          setIsActive(true)
+          setSchedule(savedSchedule)
+          router.refresh()
+        }}
+        open={showScheduleDialog}
+        workspace={workspace}
+      />
+    </>
+  )
+}

--- a/apps/builder/src/features/workspaces/components/workspaces-list.tsx
+++ b/apps/builder/src/features/workspaces/components/workspaces-list.tsx
@@ -15,7 +15,9 @@ import Link from "next/link"
 import { getTranslations } from "next-intl/server"
 import { UpgradePlanButton } from "@/enterprise/features/billing/upgrade-plan-dialog"
 import { isCloud, isCommunity } from "@/env"
+import { formatScheduleTime } from "../helpers"
 import type { WorkspaceResource } from "../schema/resource"
+import { WorkspaceStatusSwitch } from "./workspace-status-switch"
 
 type WorkspacesListProps = {
   user: {
@@ -103,12 +105,20 @@ const CreateWorkspaceCard = ({
 type WorkspaceCardProps = {
   workspace: WorkspaceResource
   ownerLabel?: string
+  t: Awaited<ReturnType<typeof getTranslations>>
 }
 
-const WorkspaceCard = ({ workspace, ownerLabel }: WorkspaceCardProps) => {
+const WorkspaceCard = ({ workspace, ownerLabel, t }: WorkspaceCardProps) => {
   const firstLetter = workspace.name?.[0]?.toUpperCase() ?? ""
   const name = workspace.name ?? ""
   const href = `/space/${workspace.id}`
+  const activeHours =
+    workspace.isActive && workspace.startTime && workspace.endTime
+      ? t("workspace.schedule.activeHours", {
+          startTime: formatScheduleTime(workspace.startTime),
+          endTime: formatScheduleTime(workspace.endTime),
+        })
+      : null
 
   return (
     <Card className={cn(CARD_STYLES, "relative")}>
@@ -118,6 +128,14 @@ const WorkspaceCard = ({ workspace, ownerLabel }: WorkspaceCardProps) => {
             {ownerLabel}
           </span>
         ) : null}
+        <WorkspaceStatusSwitch
+          workspace={{
+            id: workspace.id,
+            isActive: workspace.isActive,
+            startTime: workspace.startTime,
+            endTime: workspace.endTime,
+          }}
+        />
         <Link
           aria-label={name}
           className={LINK_STYLES}
@@ -130,8 +148,15 @@ const WorkspaceCard = ({ workspace, ownerLabel }: WorkspaceCardProps) => {
               {firstLetter}
             </AvatarFallback>
           </Avatar>
-          <div className="line-clamp-2 px-3 text-center font-medium text-sm">
-            {name}
+          <div className="flex flex-col gap-0.5 px-3">
+            <div className="line-clamp-2 text-center font-medium text-sm">
+              {name}
+            </div>
+            {activeHours ? (
+              <div className="line-clamp-1 text-center text-muted-foreground text-xs">
+                {activeHours}
+              </div>
+            ) : null}
           </div>
         </Link>
       </CardContent>
@@ -205,6 +230,7 @@ const WorkspacesList = async ({
             <li className="list-none" key={workspace.id}>
               <WorkspaceCard
                 ownerLabel={ownerIds.has(workspace.id) ? ownerLabel : undefined}
+                t={t}
                 workspace={workspace}
               />
             </li>

--- a/apps/builder/src/features/workspaces/helpers.ts
+++ b/apps/builder/src/features/workspaces/helpers.ts
@@ -17,3 +17,9 @@ export function getWorkspaceLogoUrl(
     ? new URL(workspace.logo, storageUrl).toString()
     : undefined
 }
+
+export function formatScheduleTime(time: string): string {
+  const [hourStr, minuteStr] = time.split(":")
+  const hour = Number(hourStr)
+  return minuteStr && minuteStr !== "00" ? `${hour}:${minuteStr}` : String(hour)
+}

--- a/apps/builder/src/features/workspaces/schema/update-workspace-schema.ts
+++ b/apps/builder/src/features/workspaces/schema/update-workspace-schema.ts
@@ -19,3 +19,21 @@ export const updateWorkspaceAdvancedRequest = z.object({
 export type UpdateWorkspaceAdvancedRequest = z.infer<
   typeof updateWorkspaceAdvancedRequest
 >
+
+const timeFormat = z
+  .string()
+  .regex(/^([01]\d|2[0-3]):[0-5]\d$/, "Invalid time format")
+
+export const updateWorkspaceStatusRequest = z
+  .object({
+    isActive: z.boolean(),
+    startTime: timeFormat.nullable(),
+    endTime: timeFormat.nullable(),
+  })
+  .refine((data) => (data.startTime === null) === (data.endTime === null), {
+    message: "startTime and endTime must both be set or both be null",
+    path: ["endTime"],
+  })
+export type UpdateWorkspaceStatusRequest = z.infer<
+  typeof updateWorkspaceStatusRequest
+>

--- a/apps/worker/src/integration/handlers/automated-response/index.ts
+++ b/apps/worker/src/integration/handlers/automated-response/index.ts
@@ -5,6 +5,7 @@ import {
 } from "@chatbotx.io/ai"
 import { aiContextService } from "@chatbotx.io/ai/server"
 import { automatedResponseService } from "@chatbotx.io/automated-response"
+import { workspaceService } from "@chatbotx.io/business"
 import { db } from "@chatbotx.io/database/client"
 import { isMessageStorageError } from "@chatbotx.io/database/errors"
 import { aiMessageRoles } from "@chatbotx.io/database/partials"
@@ -56,6 +57,13 @@ export async function processAutomatedResponse(
       conversationId,
       contactInboxId,
     })
+
+  const workspace = await workspaceService.findById({
+    id: conversation.workspaceId,
+  })
+  if (!workspaceService.isActiveNow(workspace)) {
+    return
+  }
 
   const repo = await createMessageRepository()
   const triggerMessage = await repo.findTriggerMessage({

--- a/apps/worker/src/integration/handlers/comment-automation/index.ts
+++ b/apps/worker/src/integration/handlers/comment-automation/index.ts
@@ -238,9 +238,7 @@ async function executePrivateReply(
 
   if (privateReply.type === "text" && privateReply.value) {
     if (ctx.channelType === "messenger") {
-      await sendPrivateReply(ctx.auth, ctx.commentId, privateReply.value).catch(
-        (_e) => undefined,
-      )
+      await sendPrivateReply(ctx.auth, ctx.commentId, privateReply.value)
     }
     // Instagram private DM text reply: out of scope MVP (no private_replies API)
     return

--- a/apps/worker/src/integration/handlers/received-message.ts
+++ b/apps/worker/src/integration/handlers/received-message.ts
@@ -105,6 +105,8 @@ export const receiveMessage = async (
       `No integration registered for channel: ${integrationType}`,
     )
   }
+  const workspace = await workspaceService.findById({ id: inbox.workspaceId })
+  const isWorkspaceActive = workspaceService.isActiveNow(workspace)
   await resolveTenantSettings({
     workspaceId: inbox.workspaceId,
   })
@@ -194,7 +196,7 @@ export const receiveMessage = async (
     if (isNewMessage) {
       createdMessage = newMessage
 
-      if (postbackAction) {
+      if (postbackAction && isWorkspaceActive) {
         await integrationQueue.add(IntegrationJobAction.runFlowPostback, {
           type: IntegrationJobAction.runFlowPostback,
           data: {
@@ -213,7 +215,7 @@ export const receiveMessage = async (
         })
       }
 
-      if (quickReplyAction) {
+      if (quickReplyAction && isWorkspaceActive) {
         await integrationQueue.add(IntegrationJobAction.runFlowQuickReply, {
           type: IntegrationJobAction.runFlowQuickReply,
           data: {
@@ -228,7 +230,7 @@ export const receiveMessage = async (
     }
   }
 
-  if (ref) {
+  if (ref && isWorkspaceActive) {
     await integrationQueue.add(IntegrationJobAction.runRef, {
       type: IntegrationJobAction.runRef,
       data: {
@@ -447,6 +449,11 @@ export const receiveComment = async (
     conversation,
     incomingMessage,
   })
+
+  const workspace = await workspaceService.findById({ id: inbox.workspaceId })
+  if (!workspaceService.isActiveNow(workspace)) {
+    return
+  }
 
   await integrationQueue.add(
     IntegrationJobAction.processCommentAutomation,

--- a/packages/business/src/fb-comment-automation/service.ts
+++ b/packages/business/src/fb-comment-automation/service.ts
@@ -26,13 +26,17 @@ class FbCommentAutomationService extends BaseService {
     automation: { startTime: string | null; endTime: string | null },
     timezone: string,
   ): boolean {
-    if (!(automation.startTime && automation.endTime)) {
+    const { startTime, endTime } = automation
+    if (!(startTime && endTime)) {
       return true
     }
     const currentTime = formatInTimeZone(new Date(), timezone, "HH:mm")
-    return (
-      currentTime >= automation.startTime && currentTime <= automation.endTime
-    )
+
+    if (startTime <= endTime) {
+      return currentTime >= startTime && currentTime <= endTime
+    }
+    // Overnight window (endTime is earlier than startTime, e.g. 22:00-06:00).
+    return currentTime >= startTime || currentTime <= endTime
   }
 
   getPriorContactInboxCount(props: { contactId: string }) {

--- a/packages/business/src/workspace/service.ts
+++ b/packages/business/src/workspace/service.ts
@@ -4,6 +4,7 @@ import { workspaceMemberRoles } from "@chatbotx.io/database/partials"
 import { ROOT_TENANT_ID, workspaceModel } from "@chatbotx.io/database/schema"
 import type { WorkspaceModel } from "@chatbotx.io/database/types"
 import { withCache } from "@chatbotx.io/redis"
+import { formatInTimeZone } from "date-fns-tz"
 import { BaseService } from "../base.service"
 import { tenantService } from "../enterprise/tenant/service"
 import { ChatbotXException, notFoundException } from "../errors"
@@ -56,6 +57,32 @@ class WorkspaceService extends BaseService {
           result ? [`workspaces:${result.id}`] : undefined,
       },
     )
+  }
+
+  isActiveNow(workspace: {
+    isActive: boolean
+    startTime: string | null
+    endTime: string | null
+    timezone: string
+  }): boolean {
+    if (!workspace.isActive) {
+      return false
+    }
+    if (!(workspace.startTime && workspace.endTime)) {
+      return true
+    }
+    const { startTime, endTime } = workspace
+    const currentTime = formatInTimeZone(
+      new Date(),
+      workspace.timezone,
+      "HH:mm",
+    )
+
+    if (startTime <= endTime) {
+      return currentTime >= startTime && currentTime <= endTime
+    }
+    // Overnight window (endTime is earlier than startTime, e.g. 22:00-06:00).
+    return currentTime >= startTime || currentTime <= endTime
   }
 
   async update(props: {

--- a/packages/database/drizzle/20260627025739_drop_tenant_quota_usage/snapshot.json
+++ b/packages/database/drizzle/20260627025739_drop_tenant_quota_usage/snapshot.json
@@ -1,6 +1,6 @@
 {
   "id": "261fead2-dff1-424f-a823-f1fc04b2b426",
-  "prevIds": ["11221d78-1849-48c7-9c9d-97aa2f028a50"],
+  "prevIds": ["d0788174-e0ba-42f0-ad95-a4bebc1022d5"],
   "version": "8",
   "dialect": "postgres",
   "ddl": [

--- a/packages/database/drizzle/20260629093316_add_tenant_help_item/snapshot.json
+++ b/packages/database/drizzle/20260629093316_add_tenant_help_item/snapshot.json
@@ -2,12 +2,7 @@
   "version": "8",
   "dialect": "postgres",
   "id": "85aec655-d466-4f2d-b33c-02e570322584",
-  "prevIds": [
-    "29f017a0-7b1d-4687-8017-e13503fba60b",
-    "38e4ca0b-16d8-452b-864f-49a9ba00eda0",
-    "3c2039ca-1171-4a7e-8351-ea3c4a0c049c",
-    "80ed6d67-f1c6-4098-8fdf-59cfa368c8d6"
-  ],
+  "prevIds": ["3c2039ca-1171-4a7e-8351-ea3c4a0c049c"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],

--- a/packages/database/drizzle/20260706022151_add_fb_comment_automations_table/snapshot.json
+++ b/packages/database/drizzle/20260706022151_add_fb_comment_automations_table/snapshot.json
@@ -2,7 +2,7 @@
   "version": "8",
   "dialect": "postgres",
   "id": "c99c52e7-fc64-4a5c-8d7d-b49922292274",
-  "prevIds": ["3c2039ca-1171-4a7e-8351-ea3c4a0c049c"],
+  "prevIds": ["85aec655-d466-4f2d-b33c-02e570322584"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],

--- a/packages/database/drizzle/20260708085927_add_workspace_active_hours/migration.sql
+++ b/packages/database/drizzle/20260708085927_add_workspace_active_hours/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "Workspace" ADD COLUMN "isActive" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "Workspace" ADD COLUMN "startTime" text;--> statement-breakpoint
+ALTER TABLE "Workspace" ADD COLUMN "endTime" text;--> statement-breakpoint

--- a/packages/database/drizzle/20260708085927_add_workspace_active_hours/snapshot.json
+++ b/packages/database/drizzle/20260708085927_add_workspace_active_hours/snapshot.json
@@ -1,8 +1,8 @@
 {
   "version": "8",
   "dialect": "postgres",
-  "id": "8960c8a4-bab8-49e2-a644-fcb55812958f",
-  "prevIds": ["c99c52e7-fc64-4a5c-8d7d-b49922292274"],
+  "id": "10c80c01-2b75-42ba-925f-816278a21fcc",
+  "prevIds": ["8960c8a4-bab8-49e2-a644-fcb55812958f"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],
@@ -168,6 +168,12 @@
       "schema": "public"
     },
     {
+      "values": ["messenger", "instagram"],
+      "name": "fbCommentAutomationType",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
       "values": ["import", "generic", "export"],
       "name": "fileContextType",
       "entityType": "enums",
@@ -188,7 +194,8 @@
         "trigger",
         "webhook",
         "sequence",
-        "emailTopic"
+        "emailTopic",
+        "fbComment"
       ],
       "name": "folderType",
       "entityType": "enums",
@@ -569,6 +576,18 @@
     {
       "isRlsEnabled": false,
       "name": "ErrorLog",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "FBCommentAutomation",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "FBCommentAutomationReply",
       "entityType": "tables",
       "schema": "public"
     },
@@ -1341,6 +1360,19 @@
       "generated": null,
       "identity": null,
       "name": "isDefault",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "AIAgent"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "isRichResponse",
       "entityType": "columns",
       "schema": "public",
       "table": "AIAgent"
@@ -6029,6 +6061,19 @@
       "table": "ContactInbox"
     },
     {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "personaId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ContactInbox"
+    },
+    {
       "type": "timestamp(6) with time zone",
       "typeSchema": null,
       "notNull": false,
@@ -8279,6 +8324,344 @@
       "entityType": "columns",
       "schema": "public",
       "table": "ErrorLog"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspaceId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "folderId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "type": "fbCommentAutomationType",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'messenger'",
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "isActive",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "startTime",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "endTime",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "repliesCount",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{\"type\":\"all\",\"value\":[]}'",
+      "generated": null,
+      "identity": null,
+      "name": "post",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{\"type\":\"text\",\"value\":\"\"}'",
+      "generated": null,
+      "identity": null,
+      "name": "privateReply",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{\"type\":\"none\",\"value\":null}'",
+      "generated": null,
+      "identity": null,
+      "name": "publicReply",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{\"type\":\"all\",\"value\":[]}'",
+      "generated": null,
+      "identity": null,
+      "name": "includeKeywords",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": "ARRAY[]",
+      "generated": null,
+      "identity": null,
+      "name": "excludeKeywords",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{\"replyToNewContactsOnly\":false,\"replyOncePerUserPerPost\":false,\"likeUserComment\":false,\"replyToUsersWhoCommentedOnOtherPosts\":true,\"ignoreCommentReplies\":true,\"trackUserTags\":false}'",
+      "generated": null,
+      "identity": null,
+      "name": "options",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{\"all\":false,\"hasPhoneNumber\":false,\"hasImage\":false,\"hasVideo\":false,\"hasLink\":false,\"hasKeywords\":false,\"keywords\":[],\"showCommentsAfter\":\"none\"}'",
+      "generated": null,
+      "identity": null,
+      "name": "hideComments",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{\"type\":\"immediately\",\"value\":0}'",
+      "generated": null,
+      "identity": null,
+      "name": "replyAfter",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomationReply"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomationReply"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomationReply"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "automationId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomationReply"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "contactId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomationReply"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "postId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomationReply"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspaceId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "FBCommentAutomationReply"
     },
     {
       "type": "bigint",
@@ -16123,6 +16506,45 @@
       "table": "Workspace"
     },
     {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "isActive",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Workspace"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "startTime",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Workspace"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "endTime",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Workspace"
+    },
+    {
       "type": "text",
       "typeSchema": null,
       "notNull": false,
@@ -18673,6 +19095,83 @@
       "entityType": "indexes",
       "schema": "public",
       "table": "TenantHelpItem"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspaceId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "FBCommentAutomation_workspaceId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "folderId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "FBCommentAutomation_folderId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "automationId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "contactId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "postId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "FBCommentAutomationReply_dedup_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "FBCommentAutomationReply"
     },
     {
       "nameExplicit": true,
@@ -23090,6 +23589,71 @@
       "columnsTo": ["id"],
       "onUpdate": "CASCADE",
       "onDelete": "CASCADE",
+      "name": "FBCommentAutomation_workspaceId_Workspace_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["folderId"],
+      "schemaTo": "public",
+      "tableTo": "Folder",
+      "columnsTo": ["id"],
+      "onUpdate": "CASCADE",
+      "onDelete": "SET NULL",
+      "name": "FBCommentAutomation_folderId_Folder_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "FBCommentAutomation"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["automationId"],
+      "schemaTo": "public",
+      "tableTo": "FBCommentAutomation",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "FBCommentAutomationReply_Q6yXIfuQcsD0_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "FBCommentAutomationReply"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["contactId"],
+      "schemaTo": "public",
+      "tableTo": "Contact",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "FBCommentAutomationReply_contactId_Contact_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "FBCommentAutomationReply"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["workspaceId"],
+      "schemaTo": "public",
+      "tableTo": "Workspace",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "FBCommentAutomationReply_workspaceId_Workspace_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "FBCommentAutomationReply"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["workspaceId"],
+      "schemaTo": "public",
+      "tableTo": "Workspace",
+      "columnsTo": ["id"],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
       "name": "File_workspaceId_Workspace_id_fkey",
       "entityType": "fks",
       "schema": "public",
@@ -25191,6 +25755,22 @@
       "name": "ErrorLog_pkey",
       "schema": "public",
       "table": "ErrorLog",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "FBCommentAutomation_pkey",
+      "schema": "public",
+      "table": "FBCommentAutomation",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "FBCommentAutomationReply_pkey",
+      "schema": "public",
+      "table": "FBCommentAutomationReply",
       "entityType": "pks"
     },
     {

--- a/packages/database/src/schema/workspace.ts
+++ b/packages/database/src/schema/workspace.ts
@@ -18,6 +18,9 @@ export const workspaceModel = pgTable(
     timezone: text().notNull().default("UTC"),
     brandColor: text().notNull().default("#016DFF"),
     developmentMode: boolean().default(false).notNull(),
+    isActive: boolean().notNull().default(true),
+    startTime: text(),
+    endTime: text(),
     logo: text(),
     ownerId: bigintAsString()
       .notNull()

--- a/packages/ui/src/components/form/time-field.tsx
+++ b/packages/ui/src/components/form/time-field.tsx
@@ -1,0 +1,101 @@
+import { cn } from "@chatbotx.io/ui/lib/utils"
+import { format, parse } from "date-fns"
+import { ClockIcon } from "lucide-react"
+import { useRef } from "react"
+import type { FieldPath, FieldValues } from "react-hook-form"
+import { TimePickerInput } from "../ui/date-picker"
+import { FormFieldWrapper } from "./field-wrapper"
+
+const TIME_INPUT_CLASSNAME =
+  "h-auto w-6 border-0 p-0 text-center font-mono text-sm shadow-none focus-visible:bg-accent focus-visible:ring-0"
+
+function TimeInputGroup({
+  date,
+  onChange,
+}: {
+  date: Date | undefined
+  onChange: (date: Date | undefined) => void
+}) {
+  const hourRef = useRef<HTMLInputElement>(null)
+  const minuteRef = useRef<HTMLInputElement>(null)
+
+  return (
+    <div
+      className={cn(
+        "flex h-9 w-full items-center gap-1.5 rounded-md border border-input bg-transparent px-3 shadow-xs transition-[color,box-shadow]",
+        "focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50",
+      )}
+    >
+      <ClockIcon className="size-4 shrink-0 text-muted-foreground" />
+      <TimePickerInput
+        className={TIME_INPUT_CLASSNAME}
+        date={date}
+        onDateChange={onChange}
+        onRightFocus={() => minuteRef.current?.focus()}
+        picker="hours"
+        ref={hourRef}
+      />
+      <span className="text-muted-foreground">:</span>
+      <TimePickerInput
+        className={TIME_INPUT_CLASSNAME}
+        date={date}
+        onDateChange={onChange}
+        onLeftFocus={() => hourRef.current?.focus()}
+        picker="minutes"
+        ref={minuteRef}
+      />
+    </div>
+  )
+}
+
+type TimeFieldProps<T extends FieldValues> = {
+  name: FieldPath<T>
+  label?: string
+  required?: boolean
+  description?: string
+  descriptionType?: "inline" | "tooltip"
+  formItemClassName?: string
+}
+
+export function TimeField<T extends FieldValues>(props: TimeFieldProps<T>) {
+  const {
+    name,
+    label,
+    required,
+    description,
+    descriptionType,
+    formItemClassName,
+  } = props
+
+  return (
+    <FormFieldWrapper
+      description={description}
+      descriptionType={descriptionType}
+      formItemClassName={formItemClassName}
+      label={label}
+      name={name}
+      required={required}
+    >
+      {(field) => {
+        const getDateValue = (): Date | undefined => {
+          if (!field.value) {
+            return
+          }
+          try {
+            return parse(field.value as string, "HH:mm", new Date())
+          } catch {
+            return
+          }
+        }
+
+        const handleChange = (value: Date | undefined) => {
+          field.onChange(
+            (value ? format(value, "HH:mm") : undefined) as T[FieldPath<T>],
+          )
+        }
+
+        return <TimeInputGroup date={getDateValue()} onChange={handleChange} />
+      }}
+    </FormFieldWrapper>
+  )
+}


### PR DESCRIPTION
## Summary
- Add `isActive`/`startTime`/`endTime` columns to `Workspace`, plus a homepage switch (mirroring the FB comment automation schedule UX) to enable/disable a workspace or scope it to a daily active-hours window.
- When a workspace is inactive, inbound messages still land in the inbox, but AI auto-reply, postback/quick-reply/ref flows, and comment automation are skipped. Manual agent replies, broadcasts, and sequences are unaffected.
- Homepage workspace cards show a small muted "Active from X to Y" line when a schedule is set.

## Changes
- `packages/database/src/schema/workspace.ts` — new `isActive`/`startTime`/`endTime` columns.
- `packages/business/src/workspace/service.ts` — `WorkspaceService.isActiveNow()` schedule check.
- `apps/worker/src/integration/handlers/received-message.ts` / `automated-response/index.ts` — gate automated flow/AI-reply/comment-automation enqueues on workspace active state.
- `apps/builder/src/features/workspaces/` — `updateWorkspaceStatusAction`, `WorkspaceStatusSwitch`, `WorkspaceScheduleDialog`, wired into the homepage `WorkspaceCard`.
- `apps/builder/messages/en.json` / `vi.json` — new `workspace.schedule.*` strings.

**Note:** no DB migration file is included — the repo's migration chain has a pre-existing conflict unrelated to this change; generating the migration for these 3 columns is deferred to whoever owns DB tooling.

## Test plan
- [x] `pnpm lint` (scoped to changed files)
- [x] `pnpm --filter builder check-types`, `--filter worker`, `--filter @chatbotx.io/business`, `--filter @chatbotx.io/database`
- [ ] Generate + run the DB migration for the new columns once the migration-chain issue is resolved
- [ ] Manual: toggle a workspace off on the homepage → confirm inbound messages still land in inbox but no AI/bot auto-reply fires; toggle on with a schedule outside current time → same skip behavior; "always run" → auto-reply resumes
