### PR TITLE
fix(comment-automation): stop silent failures in FB comment auto-reply

### DIFF
--- a/apps/worker/src/chat/handlers/send-message.ts
+++ b/apps/worker/src/chat/handlers/send-message.ts
@@ -60,7 +60,10 @@ export async function sendMessageToChannel(
         ...message,
         contentAttributes: {
           ...message.contentAttributes,
-          replyToCommentId: parentMsg?.sourceId ?? null,
+          replyToCommentId:
+            parentMsg?.sourceId ??
+            message.contentAttributes?.replyToCommentId ??
+            null,
         },
       }
     }

--- a/apps/worker/src/integration/handlers/comment-automation/index.ts
+++ b/apps/worker/src/integration/handlers/comment-automation/index.ts
@@ -359,6 +359,10 @@ export async function processCommentAutomation(
     where: { id: contactInboxId },
   })
   if (!contactInbox) {
+    logger.warn(
+      { contactInboxId, workspaceId, commentId },
+      "Comment automation skipped: contactInbox not found",
+    )
     return
   }
 
@@ -425,13 +429,6 @@ export async function processCommentAutomation(
         }
       }
 
-      await fbCommentAutomationService.insertDedup({
-        automationId: automation.id,
-        contactId: contactInbox.contactId,
-        postId,
-        workspaceId,
-      })
-
       const delay = computeDelayMs(automation.replyAfter)
 
       const messageRepo = await createMessageRepository()
@@ -494,43 +491,64 @@ export async function processCommentAutomation(
         )
       }
 
-      executePublicReply(automation.publicReply, {
-        auth,
-        commentId,
-        channelType,
-        conversationId,
-        contactInboxId,
-        delay,
-        workspaceId,
-        contactInbox,
-        parentMessageId,
-        parentMessageCreatedAt,
-      }).catch((err) =>
+      let dispatchFailed = false
+
+      try {
+        await executePublicReply(automation.publicReply, {
+          auth,
+          commentId,
+          channelType,
+          conversationId,
+          contactInboxId,
+          delay,
+          workspaceId,
+          contactInbox,
+          parentMessageId,
+          parentMessageCreatedAt,
+        })
+      } catch (err) {
         logger.error(
           { err, automationId: automation.id, commentId },
           "Failed to send public reply",
-        ),
-      )
+        )
+        if (willSendReply(automation.publicReply)) {
+          dispatchFailed = true
+        }
+      }
 
-      executePrivateReply(automation.privateReply, {
-        auth,
-        commentId,
-        channelType,
-        conversationId,
-        contactInboxId,
-        delay,
-      }).catch((err) =>
+      try {
+        await executePrivateReply(automation.privateReply, {
+          auth,
+          commentId,
+          channelType,
+          conversationId,
+          contactInboxId,
+          delay,
+        })
+      } catch (err) {
         logger.error(
           { err, automationId: automation.id, commentId },
           "Failed to send private reply",
-        ),
-      )
+        )
+        if (willSendReply(automation.privateReply)) {
+          dispatchFailed = true
+        }
+      }
 
-      if (
-        willSendReply(automation.publicReply) ||
-        willSendReply(automation.privateReply)
-      ) {
-        await fbCommentAutomationService.incrementRepliesCount(automation.id)
+      if (!dispatchFailed) {
+        await fbCommentAutomationService.insertDedup({
+          automationId: automation.id,
+          contactId: contactInbox.contactId,
+          postId,
+          workspaceId,
+        })
+
+        if (
+          willSendReply(automation.publicReply) ||
+          willSendReply(automation.privateReply)
+        ) {
+          await fbCommentAutomationService.incrementRepliesCount(automation.id)
+        }
       }
     } catch (err) {
       logger.error(

--- a/apps/worker/src/integration/handlers/received-message.ts
+++ b/apps/worker/src/integration/handlers/received-message.ts
@@ -455,6 +455,14 @@ export const receiveComment = async (
     return
   }
 
+  const processCommentAutomationJobId = `comment-auto-${commentData.commentId}`
+  const existingJob = await integrationQueue.getJob(
+    processCommentAutomationJobId,
+  )
+  if (existingJob && (await existingJob.isFailed())) {
+    await existingJob.remove()
+  }
+
   await integrationQueue.add(
     IntegrationJobAction.processCommentAutomation,
     {
@@ -473,7 +481,7 @@ export const receiveComment = async (
         createdTime: commentData.createdTime,
       },
     },
-    { jobId: `comment-auto-${commentData.commentId}` },
+    { jobId: processCommentAutomationJobId },
   )
 }
 

--- a/integrations/messenger/src/handlers/webhook.ts
+++ b/integrations/messenger/src/handlers/webhook.ts
@@ -1,6 +1,7 @@
 import type { ContextQueue, HandleRequestProps } from "@chatbotx.io/sdk"
 import z from "zod"
 import { MessengerWebhookException } from "../exception"
+import { logger } from "../lib/logger"
 import { hmacSha256Hex, timingSafeStringEqual } from "../lib/webhook"
 import {
   incomingWebhookEventSchema,
@@ -83,12 +84,20 @@ const handleWebhookEvent = async (
       return
     }
 
-    const feedChange = entry.changes?.find(
-      (c: { field: string }) => c.field === "feed",
-    )
-    if (feedChange) {
-      const parsed = messengerFeedCommentValueSchema.safeParse(feedChange.value)
-      if (parsed.success) {
+    const feedChanges =
+      entry.changes?.filter((c: { field: string }) => c.field === "feed") ?? []
+    if (feedChanges.length > 0) {
+      for (const feedChange of feedChanges) {
+        const parsed = messengerFeedCommentValueSchema.safeParse(
+          feedChange.value,
+        )
+        if (!parsed.success) {
+          logger.warn(
+            { issues: parsed.error.issues, value: feedChange.value },
+            "Unrecognized feed webhook payload",
+          )
+          continue
+        }
         const value = parsed.data
         if (value.verb === "add" && value.from.id !== entry.id) {
           // New comment from an external user — route to inbox

--- a/packages/worker-config/src/lib/connection.ts
+++ b/packages/worker-config/src/lib/connection.ts
@@ -48,4 +48,5 @@ export const defaultWorkerOptions = {
 export const fakeQueue = {
   add: () => Promise.resolve(""),
   addBulk: () => Promise.resolve(""),
+  getJob: () => Promise.resolve(undefined),
 }


### PR DESCRIPTION
## Summary
- Facebook comment automations could silently stop replying on production despite correct config, with zero error trace — this fixes 4 concrete bugs found while auditing the full webhook → automation → send pipeline against `origin/main`.
- Fixes 3 permanent-failure bugs: a fixed BullMQ `jobId` per comment that permanently blackholes retries after 2 failures, a "reply once per user/post" dedup row written *before* the send was attempted (permanently locking out a contact after any transient failure), and a `replyToCommentId` that got silently overwritten to `null` on a DB lookup miss.
- Fixes 2 silent-drop bugs: only the first `feed` change per webhook entry was processed (dropping batched comments), and unrecognized feed payloads / missing `contactInbox` lookups failed with no log line.

## Changes
- `apps/worker/src/integration/handlers/received-message.ts` — remove a stale failed `processCommentAutomation` job (same `jobId`) before re-enqueuing, so a Facebook webhook redelivery can actually retry.
- `apps/worker/src/integration/handlers/comment-automation/index.ts` — move dedup insertion to after a configured reply channel dispatches without throwing; log a warning when `contactInbox` lookup misses instead of returning silently.
- `apps/worker/src/chat/handlers/send-message.ts` — fall back to the existing `replyToCommentId` instead of forcing `null` when the parent-comment lookup misses.
- `integrations/messenger/src/handlers/webhook.ts` — iterate all `feed` changes in a webhook entry (not just the first); log unrecognized feed payloads instead of dropping them silently.
- `packages/worker-config/src/lib/connection.ts` — add `getJob` to the build-time `fakeQueue` stub so the new job-cleanup check type-checks.

## Test plan
- [x] `npx biome check` on all 5 changed files
- [x] `pnpm --filter worker check-types`
- [x] `pnpm --filter @chatbotx.io/integration-messenger check-types`
- [x] full `pnpm typecheck` via pre-commit hook (all 49 packages pass)
- [ ] manual verification on a comment automation with "reply once per user/post" enabled: force a transient send failure, confirm retry still delivers the reply
- [ ] manual verification: send a webhook batch with 2+ `feed` changes, confirm both comments land in the inbox
