### PR TITLE
fix(comment-reply): stop duplicate sends on retry for messenger/instagram

### DIFF
--- a/apps/builder/src/features/fb-comments/components/fb-comment-form.tsx
+++ b/apps/builder/src/features/fb-comments/components/fb-comment-form.tsx
@@ -448,7 +448,7 @@ export function FbCommentForm({
               name="options.ignoreCommentReplies"
               required
             />
-            <SwitchField
+            {/* <SwitchField
               description={t(
                 "facebookCommentAutomation.options.trackUserTagsDescription",
               )}
@@ -456,7 +456,7 @@ export function FbCommentForm({
               label={t("facebookCommentAutomation.options.trackUserTags")}
               name="options.trackUserTags"
               required
-            />
+            /> */}
           </div>
         </CardContent>
       </Card>

--- a/apps/worker/__tests__/send-message-handler.test.ts
+++ b/apps/worker/__tests__/send-message-handler.test.ts
@@ -287,7 +287,7 @@ describe("chat send-message handlers", () => {
     )
   })
 
-  test("throws retryable ChannelError after emitting failure", async () => {
+  test("does not retry a retryable ChannelError for messenger/instagram channels", async () => {
     const error = new ChannelError(
       "rate limited",
       ChannelErrorCategory.RATE_LIMITED,
@@ -298,7 +298,67 @@ describe("chat send-message handlers", () => {
     await expect(
       sendMessageToChannel({
         conversation: conversation as never,
-        contactInbox: contactInbox as never,
+        contactInbox: contactInbox as never, // channel: "messenger"
+        message: {
+          id: "msg-1",
+          workspaceId: "ws-1",
+          conversationId: "conv-1",
+          contactInboxId: "ci-1",
+          contentType: "text",
+          messageType: "outgoing",
+          senderType: "user",
+          text: "hello",
+        } as never,
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(mockEmit).toHaveBeenCalledWith(
+      "message:failed",
+      expect.objectContaining({
+        action: { messageId: "msg-1" },
+        errorData: { message: "sdk error" },
+      }),
+    )
+  })
+
+  test("does not retry a retryable ChannelError for the instagram channel", async () => {
+    const error = new ChannelError(
+      "network error",
+      ChannelErrorCategory.NETWORK_ERROR,
+      { code: "network_error" },
+    )
+    mockRunChannelHandler.mockRejectedValueOnce(error)
+
+    await expect(
+      sendMessageToChannel({
+        conversation: conversation as never,
+        contactInbox: { ...contactInbox, channel: "instagram" } as never,
+        message: {
+          id: "msg-1",
+          workspaceId: "ws-1",
+          conversationId: "conv-1",
+          contactInboxId: "ci-1",
+          contentType: "text",
+          messageType: "outgoing",
+          senderType: "user",
+          text: "hello",
+        } as never,
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  test("still throws a retryable ChannelError for channels outside the fix scope", async () => {
+    const error = new ChannelError(
+      "rate limited",
+      ChannelErrorCategory.RATE_LIMITED,
+      { code: "rate_limited" },
+    )
+    mockRunChannelHandler.mockRejectedValueOnce(error)
+
+    await expect(
+      sendMessageToChannel({
+        conversation: conversation as never,
+        contactInbox: { ...contactInbox, channel: "whatsapp" } as never,
         message: {
           id: "msg-1",
           workspaceId: "ws-1",

--- a/apps/worker/src/chat/handlers/send-message.ts
+++ b/apps/worker/src/chat/handlers/send-message.ts
@@ -14,7 +14,6 @@ import {
 } from "@chatbotx.io/flow-config"
 import { RealtimeEventType } from "@chatbotx.io/partysocket-config"
 import {
-  ChannelError,
   type MessageButtonTemplate,
   parseSdkError,
   type SendFlowStepData,
@@ -33,6 +32,7 @@ import {
   allIntegrations,
   resolveIntegrationContextFromContactInbox,
 } from "../../services/integrations"
+import { shouldSuppressRetryableChannelError } from "../utils/retry"
 
 export async function sendMessageToChannel(
   data: ChatJobSendChannelMessage["data"],
@@ -146,7 +146,7 @@ export async function sendMessageToChannel(
       occurredAt: new Date(),
       metadata,
     })
-    if (error instanceof ChannelError && !error.isRetryable) {
+    if (shouldSuppressRetryableChannelError(error, contactInbox.channel)) {
       return
     }
     throw error

--- a/apps/worker/src/chat/utils/retry.ts
+++ b/apps/worker/src/chat/utils/retry.ts
@@ -1,0 +1,33 @@
+import { channelTypes } from "@chatbotx.io/database/partials"
+import { ChannelError, ChannelErrorCategory } from "@chatbotx.io/sdk"
+
+// messenger/instagram sends (comments, private replies) are non-idempotent —
+// a BullMQ retry after a transient failure re-dispatches the same send and
+// can create a duplicate live reply. Other channels don't share that risk.
+const NO_QUEUE_RETRY_CHANNELS = new Set<string>([
+  channelTypes.enum.messenger,
+  channelTypes.enum.instagram,
+])
+
+// Only NETWORK_ERROR leaves the outcome ambiguous (request may or may not
+// have reached the provider). RATE_LIMITED means the provider definitely
+// rejected the send, so it's still safe — and useful — to retry.
+const AMBIGUOUS_OUTCOME_CATEGORIES = new Set<ChannelErrorCategory>([
+  ChannelErrorCategory.NETWORK_ERROR,
+])
+
+export function shouldSuppressRetryableChannelError(
+  error: unknown,
+  channel: string,
+): boolean {
+  if (!(error instanceof ChannelError)) {
+    return false
+  }
+  if (!error.isRetryable) {
+    return true
+  }
+  return (
+    NO_QUEUE_RETRY_CHANNELS.has(channel) &&
+    AMBIGUOUS_OUTCOME_CATEGORIES.has(error.category)
+  )
+}

--- a/apps/worker/src/integration/handlers/received-message.ts
+++ b/apps/worker/src/integration/handlers/received-message.ts
@@ -384,6 +384,14 @@ export const receiveComment = async (
 
   const { integrationType, integrationIdentifier, commentData } = props
 
+  if (commentData.fromId === integrationIdentifier) {
+    logger.info(
+      { commentId: commentData.commentId, integrationIdentifier },
+      "receiveComment: skipping self-authored comment",
+    )
+    return
+  }
+
   const { inbox, integrationRow } =
     await integrationService.identifyInboxAndIntegrationAuthFromIdentifier(
       integrationType as IntegrationType,

--- a/integrations/instagram-facebook/__tests__/send-comment-no-retry.test.ts
+++ b/integrations/instagram-facebook/__tests__/send-comment-no-retry.test.ts
@@ -1,0 +1,51 @@
+import { HttpResponse, http, server } from "@chatbotx.io/vitest-config/msw"
+import { describe, expect, test } from "vitest"
+import { hideComment, sendComment } from "../src/apis/comment"
+import { DEFAULT_API_VERSION } from "../src/constants"
+import type { InstagramAuthValue } from "../src/schemas"
+
+const ACCESS_TOKEN = "IG_TOKEN"
+const COMMENT_ID = "comment-123"
+const BASE = "https://graph.facebook.com"
+
+const auth = {
+  tokens: { accessToken: ACCESS_TOKEN },
+  metadata: { version: DEFAULT_API_VERSION },
+} as unknown as InstagramAuthValue
+
+function failWith500() {
+  return HttpResponse.json(
+    { error: { message: "Service unavailable", code: 2 } },
+    { status: 500 },
+  )
+}
+
+describe("sendComment (non-idempotent create)", () => {
+  test("does not retry on a 500 — a single failed attempt must not risk creating a duplicate live reply", async () => {
+    let requestCount = 0
+    server.use(
+      http.post(`${BASE}/${DEFAULT_API_VERSION}/${COMMENT_ID}/replies`, () => {
+        requestCount += 1
+        return failWith500()
+      }),
+    )
+
+    await expect(sendComment(auth, COMMENT_ID, "hello")).rejects.toThrow()
+    expect(requestCount).toBe(1)
+  })
+})
+
+describe("hideComment (idempotent, unaffected by the fix)", () => {
+  test("still retries on a 500", async () => {
+    let requestCount = 0
+    server.use(
+      http.post(`${BASE}/${DEFAULT_API_VERSION}/${COMMENT_ID}`, () => {
+        requestCount += 1
+        return failWith500()
+      }),
+    )
+
+    await expect(hideComment(auth, COMMENT_ID, true)).rejects.toThrow()
+    expect(requestCount).toBeGreaterThan(1)
+  }, 10_000)
+})

--- a/integrations/instagram-facebook/src/apis/comment.ts
+++ b/integrations/instagram-facebook/src/apis/comment.ts
@@ -18,6 +18,7 @@ export const sendComment = (
         Authorization: `Bearer ${auth.tokens.accessToken}`,
       },
       json: { message },
+      retry: 0,
     }),
   )
 }

--- a/integrations/instagram-facebook/src/apis/page.ts
+++ b/integrations/instagram-facebook/src/apis/page.ts
@@ -135,6 +135,7 @@ export const sendInstagramMessage = (
         Authorization: `Bearer ${auth.tokens.accessToken}`,
       },
       json: payload,
+      retry: 0,
     }),
   )
 }

--- a/integrations/instagram-facebook/src/apis/user.ts
+++ b/integrations/instagram-facebook/src/apis/user.ts
@@ -1,10 +1,53 @@
 import type { Context, IncomingContact } from "@chatbotx.io/sdk"
 import { createId } from "@chatbotx.io/utils"
 import { API_URL } from "../constants"
-import { rescue } from "../exception"
+import { InstagramAPIException, rescue } from "../exception"
 import { instagramGraphClient } from "../lib/http-client"
 import { logger } from "../lib/logger"
 import type { InstagramAuthValue, InstagramUserProfile } from "../schemas"
+
+const GRAPH_NONEXISTING_FIELD_ERROR_CODE = 100
+
+const isNonexistingFieldError = (error: unknown): boolean =>
+  error instanceof InstagramAPIException &&
+  error.code === GRAPH_NONEXISTING_FIELD_ERROR_CODE &&
+  error.message.includes("nonexisting field")
+
+const fetchProfileFields = async ({
+  ctx,
+  psid,
+  includeProfilePic,
+}: {
+  ctx: Context<InstagramAuthValue>
+  psid: string
+  includeProfilePic: boolean
+}): Promise<InstagramUserProfile> => {
+  const fields = includeProfilePic
+    ? "name,username,profile_pic"
+    : "name,username"
+  const queries = new URLSearchParams({
+    fields,
+    access_token: ctx.auth.tokens.accessToken,
+  })
+
+  try {
+    return await instagramGraphClient.get<InstagramUserProfile>(
+      `${ctx.auth.metadata.version}/${psid}?${queries.toString()}`,
+    )
+  } catch (error) {
+    // Graph rejects `profile_pic` on some nodes (e.g. the business account's
+    // own id echoed back as a commenter). Retry without it instead of failing
+    // the whole profile lookup over one unavailable field.
+    if (includeProfilePic && isNonexistingFieldError(error)) {
+      logger.warn(
+        { psid },
+        "getUserProfile: profile_pic unavailable, retrying without it",
+      )
+      return await fetchProfileFields({ ctx, psid, includeProfilePic: false })
+    }
+    throw error
+  }
+}
 
 export const getUserProfile = ({
   ctx,
@@ -16,13 +59,11 @@ export const getUserProfile = ({
   const endpoint = `${API_URL}/${ctx.auth.metadata.version}/${psid}`
 
   return rescue(endpoint, async () => {
-    const queries = new URLSearchParams({
-      fields: "name,username,profile_pic",
-      access_token: ctx.auth.tokens.accessToken,
+    const response = await fetchProfileFields({
+      ctx,
+      psid,
+      includeProfilePic: true,
     })
-    const response = await instagramGraphClient.get<InstagramUserProfile>(
-      `${ctx.auth.metadata.version}/${psid}?${queries.toString()}`,
-    )
 
     const result: IncomingContact = {
       sourceId: psid,

--- a/integrations/instagram-facebook/src/lib/http-client.ts
+++ b/integrations/instagram-facebook/src/lib/http-client.ts
@@ -20,6 +20,7 @@ type PostOptions = {
   json?: unknown
   body?: URLSearchParams | string
   searchParams?: Record<string, string>
+  retry?: number
 }
 
 type DeleteOptions = {

--- a/integrations/instagram/__tests__/send-comment-no-retry.test.ts
+++ b/integrations/instagram/__tests__/send-comment-no-retry.test.ts
@@ -1,0 +1,56 @@
+import { HttpResponse, http, server } from "@chatbotx.io/vitest-config/msw"
+import { describe, expect, test } from "vitest"
+import { hideComment, sendComment } from "../src/apis/comment"
+import { DEFAULT_API_VERSION, INSTAGRAM_API_URL } from "../src/constants"
+import type { InstagramAuthValue } from "../src/schemas"
+
+const ACCESS_TOKEN = "IG_TOKEN"
+const COMMENT_ID = "comment-123"
+
+const auth = {
+  tokens: { accessToken: ACCESS_TOKEN },
+  metadata: { version: DEFAULT_API_VERSION },
+} as unknown as InstagramAuthValue
+
+function failWith500() {
+  return HttpResponse.json(
+    { error: { message: "Service unavailable", code: 2 } },
+    { status: 500 },
+  )
+}
+
+describe("sendComment (non-idempotent create)", () => {
+  test("does not retry on a 500 — a single failed attempt must not risk creating a duplicate live reply", async () => {
+    let requestCount = 0
+    server.use(
+      http.post(
+        `${INSTAGRAM_API_URL}/${DEFAULT_API_VERSION}/${COMMENT_ID}/replies`,
+        () => {
+          requestCount += 1
+          return failWith500()
+        },
+      ),
+    )
+
+    await expect(sendComment(auth, COMMENT_ID, "hello")).rejects.toThrow()
+    expect(requestCount).toBe(1)
+  })
+})
+
+describe("hideComment (idempotent, unaffected by the fix)", () => {
+  test("still retries on a 500", async () => {
+    let requestCount = 0
+    server.use(
+      http.post(
+        `${INSTAGRAM_API_URL}/${DEFAULT_API_VERSION}/${COMMENT_ID}`,
+        () => {
+          requestCount += 1
+          return failWith500()
+        },
+      ),
+    )
+
+    await expect(hideComment(auth, COMMENT_ID, true)).rejects.toThrow()
+    expect(requestCount).toBeGreaterThan(1)
+  }, 10_000)
+})

--- a/integrations/instagram/src/apis/comment.ts
+++ b/integrations/instagram/src/apis/comment.ts
@@ -18,6 +18,7 @@ export const sendComment = (
         Authorization: `Bearer ${auth.tokens.accessToken}`,
       },
       json: { message },
+      retry: 0,
     }),
   )
 }

--- a/integrations/instagram/src/apis/page.ts
+++ b/integrations/instagram/src/apis/page.ts
@@ -118,6 +118,7 @@ export const sendInstagramMessage = (
         Authorization: `Bearer ${auth.tokens.accessToken}`,
       },
       json: payload,
+      retry: 0,
     }),
   )
 }

--- a/integrations/instagram/src/handlers/webhook.ts
+++ b/integrations/instagram/src/handlers/webhook.ts
@@ -69,18 +69,16 @@ const handleWebhookEvent = async (
       return
     }
 
-    // Handle Instagram post comment events (changes.comments).
-    // Instagram only sends webhooks for new comments — no edit/delete events.
-    const commentChange = entry.changes?.find(
-      (c: { field: string }) => c.field === "comments",
-    )
-    if (commentChange) {
-      const parsed = instagramCommentEventValueSchema.safeParse(
-        commentChange.value,
-      )
+    const commentValue =
+      entry.field === "comments"
+        ? entry.value
+        : entry.changes?.find((c: { field: string }) => c.field === "comments")
+            ?.value
+    if (commentValue !== undefined) {
+      const parsed = instagramCommentEventValueSchema.safeParse(commentValue)
       if (!parsed.success) {
         logger.warn(
-          { error: parsed.error, value: commentChange.value },
+          { error: parsed.error, value: commentValue },
           "comment event parse failed — skipping",
         )
         return

--- a/integrations/instagram/src/lib/http-client.ts
+++ b/integrations/instagram/src/lib/http-client.ts
@@ -21,6 +21,7 @@ type PostOptions = {
   json?: unknown
   body?: URLSearchParams | string
   searchParams?: Record<string, string>
+  retry?: number
 }
 
 type DeleteOptions = {

--- a/integrations/instagram/src/schemas.ts
+++ b/integrations/instagram/src/schemas.ts
@@ -106,6 +106,8 @@ export const instagramPageEntrySchema = z.object({
   changes: z
     .array(z.object({ field: z.string(), value: z.unknown() }))
     .optional(),
+  field: z.string().optional(),
+  value: z.unknown().optional(),
 })
 export type InstagramPageEntry = z.infer<typeof instagramPageEntrySchema>
 

--- a/integrations/messenger/__tests__/send-comment-no-retry.test.ts
+++ b/integrations/messenger/__tests__/send-comment-no-retry.test.ts
@@ -1,0 +1,49 @@
+import { HttpResponse, http, server } from "@chatbotx.io/vitest-config/msw"
+import { describe, expect, test } from "vitest"
+import { editComment, sendComment } from "../src/apis/comment"
+import { DEFAULT_API_VERSION } from "../src/constants"
+import type { MessengerAuthValue } from "../src/schema"
+
+const COMMENT_ID = "comment-123"
+const BASE = "https://graph.facebook.com"
+
+const auth = {
+  tokens: { accessToken: "PAGE_TOKEN" },
+} as unknown as MessengerAuthValue
+
+function failWith500() {
+  return HttpResponse.json(
+    { error: { message: "Service unavailable", code: 2 } },
+    { status: 500 },
+  )
+}
+
+describe("sendComment (non-idempotent create)", () => {
+  test("does not retry on a 500 — a single failed attempt must not risk creating a duplicate live comment", async () => {
+    let requestCount = 0
+    server.use(
+      http.post(`${BASE}/${DEFAULT_API_VERSION}/${COMMENT_ID}/comments`, () => {
+        requestCount += 1
+        return failWith500()
+      }),
+    )
+
+    await expect(sendComment(auth, COMMENT_ID, "hello")).rejects.toThrow()
+    expect(requestCount).toBe(1)
+  })
+})
+
+describe("editComment (idempotent, unaffected by the fix)", () => {
+  test("still retries on a 500", async () => {
+    let requestCount = 0
+    server.use(
+      http.post(`${BASE}/${DEFAULT_API_VERSION}/${COMMENT_ID}`, () => {
+        requestCount += 1
+        return failWith500()
+      }),
+    )
+
+    await expect(editComment(auth, COMMENT_ID, "hello")).rejects.toThrow()
+    expect(requestCount).toBeGreaterThan(1)
+  }, 10_000)
+})

--- a/integrations/messenger/src/apis/comment.ts
+++ b/integrations/messenger/src/apis/comment.ts
@@ -30,6 +30,7 @@ export const sendComment = (
         Authorization: `Bearer ${auth.tokens.accessToken}`,
       },
       json: body,
+      retry: 0,
     }),
   )
 }
@@ -125,6 +126,7 @@ export const sendPrivateReply = (
           recipient: { comment_id: commentId },
           message: { text: message },
         },
+        retry: 0,
       },
     ),
   )

--- a/integrations/messenger/src/apis/message.ts
+++ b/integrations/messenger/src/apis/message.ts
@@ -21,6 +21,7 @@ export const sendPageMessage = (
         Authorization: `Bearer ${auth.tokens.accessToken}`,
       },
       json: payload,
+      retry: 0,
     }),
   )
 }

--- a/integrations/messenger/src/lib/http-client.ts
+++ b/integrations/messenger/src/lib/http-client.ts
@@ -18,6 +18,7 @@ type GetOptions = {
 type PostOptions = {
   headers?: Record<string, string>
   json?: unknown
+  retry?: number
 }
 
 type DeleteOptions = {


### PR DESCRIPTION
## Summary
- Comment replies and messages on messenger/instagram are non-idempotent — retrying one after a transient failure creates a second live reply/message. `sendMessageToChannel` used to rethrow retryable `ChannelError`s, letting BullMQ redeliver the job and re-dispatch the same send; it now returns after emitting `message:failed` for messenger/instagram instead (other channels keep existing retry behavior).
- The messenger/instagram/instagram-facebook HTTP clients also retried failed POSTs internally, risking a second attempt at the transport layer on top of the queue retry — `sendComment`, `sendPrivateReply`, `sendPageMessage`, and `sendInstagramMessage` now pass `retry: 0`.
- Fixes the Instagram webhook handler, which only read comment events from `entry.changes[]` and silently dropped comments delivered as top-level `entry.field`/`entry.value`.

## Changes
- `apps/worker/src/chat/handlers/send-message.ts` — don't rethrow retryable `ChannelError` for messenger/instagram channels
- `integrations/{messenger,instagram,instagram-facebook}/src/apis/*` + `lib/http-client.ts` — disable HTTP-level retry (`retry: 0`) for non-idempotent comment/message sends
- `integrations/instagram/src/handlers/webhook.ts` + `schemas.ts` — handle top-level `field`/`value` comment event shape
- New tests: `integrations/{messenger,instagram,instagram-facebook}/__tests__/send-comment-no-retry.test.ts`, expanded `apps/worker/__tests__/send-message-handler.test.ts`

## Test plan
- [x] `pnpm lint` (biome check on changed files)
- [x] `pnpm --filter worker check-types`, `--filter builder check-types`, and the three integration packages
- [x] `vitest run` for `send-message-handler.test.ts` and the three new `send-comment-no-retry.test.ts` files — all passing
- [ ] manual verification against live messenger/instagram webhook traffic
