### PR TITLE
feat(workspace): gate channel create/edit routes on superAdmin permission

### DIFF
--- a/apps/builder/__tests__/channel-route-guards.test.ts
+++ b/apps/builder/__tests__/channel-route-guards.test.ts
@@ -1,0 +1,338 @@
+// @vitest-environment node
+
+import { renderToStaticMarkup } from "react-dom/server"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+  mockResolveGuardedWorkspaceId,
+  mockRequireWorkspacePermission,
+  mockGetCurrentUserAndTargetWorkspace,
+  mockGetCurrentUserId,
+  mockNotFound,
+  mockRedirect,
+  mockInboxCardList,
+} = vi.hoisted(() => ({
+  mockResolveGuardedWorkspaceId: vi.fn(async () => "ws-1"),
+  mockRequireWorkspacePermission: vi.fn(async () => undefined),
+  mockGetCurrentUserAndTargetWorkspace: vi.fn(),
+  mockGetCurrentUserId: vi.fn(),
+  mockNotFound: vi.fn(() => {
+    throw new Error("not found")
+  }),
+  mockRedirect: vi.fn(),
+  mockInboxCardList: vi.fn(() => null),
+}))
+
+vi.mock("@/lib/auth/require-workspace-permission", () => ({
+  requireWorkspacePermission: mockRequireWorkspacePermission,
+  resolveGuardedWorkspaceId: mockResolveGuardedWorkspaceId,
+}))
+
+vi.mock("@/lib/auth/utils", () => ({
+  getCurrentUserAndTargetWorkspace: mockGetCurrentUserAndTargetWorkspace,
+  getCurrentUserId: mockGetCurrentUserId,
+}))
+
+vi.mock("next/navigation", () => ({
+  notFound: mockNotFound,
+  redirect: mockRedirect,
+}))
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: vi.fn(async () => (key: string) => key),
+}))
+
+vi.mock("@chatbotx.io/analytics-nextjs/components/base-dashboard", () => ({
+  BaseDashboard: () => null,
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  platformCredentialService: {
+    resolveForOwner: vi.fn(async () => null),
+  },
+  workspaceService: {
+    find: vi.fn(async () => ({ ownerId: "owner-1" })),
+  },
+}))
+
+vi.mock("@/features/inboxes/components/inbox-card-list", () => ({
+  InboxCardList: mockInboxCardList,
+}))
+
+vi.mock("@/features/inboxes/queries", () => ({
+  listInboxes: vi.fn(async () => ({ data: [] })),
+}))
+
+vi.mock("@/features/inboxes/components/inbox-select-card", () => ({
+  default: () => null,
+}))
+
+vi.mock(
+  "@/features/integration-instagram/components/instagram-login-select",
+  () => ({
+    InstagramLoginSelect: () => null,
+  }),
+)
+
+vi.mock("@/features/integration-instagram/libs/oauth", () => ({
+  generateInstagramRedirectUri: vi.fn(async () => ""),
+}))
+
+vi.mock("@/features/integration-instagram/libs/oauth-facebook", () => ({
+  generateInstagramFacebookRedirectUri: vi.fn(async () => ""),
+}))
+
+vi.mock("@/features/integration-messenger/libs/oauth", () => ({
+  generateMessengerRedirectUri: vi.fn(async () => ""),
+}))
+
+vi.mock("@/features/integration-telegram/components/telegram-connect", () => ({
+  TelegramConnect: () => null,
+}))
+
+vi.mock("@/features/integration-tiktok/libs/tiktok", () => ({
+  generateTiktokRedirectUri: vi.fn(async () => ""),
+}))
+
+vi.mock("@/features/integration-webchat/simple-create-webchat", () => ({
+  SimpleCreateWebchat: () => null,
+}))
+
+vi.mock("@/features/integration-whatsapp/components/whatsapp-create", () => ({
+  default: () => null,
+}))
+
+vi.mock("@/features/integration-zalo/libs/zalo", () => ({
+  generateZaloRedirectUri: vi.fn(async () => ""),
+}))
+
+vi.mock("@/features/flows/provider/flow-store-context", () => ({
+  FlowStoreProvider: ({ children }: { children: unknown }) => children,
+}))
+
+vi.mock("@/features/custom-fields/provider/custom-field-store-context", () => ({
+  CustomFieldStoreProvider: ({ children }: { children: unknown }) => children,
+}))
+
+vi.mock(
+  "@/features/integration-webchat/components/create-webchat-form",
+  () => ({
+    CreateWebchatForm: () => null,
+  }),
+)
+
+vi.mock(
+  "@/features/integration-webchat/components/update-webchat-form",
+  () => ({
+    UpdateWebchatForm: () => null,
+  }),
+)
+
+vi.mock("@/features/integration-webchat/queries", () => ({
+  findIntegrationWebchat: vi.fn(async () => ({})),
+}))
+
+vi.mock(
+  "@/features/integration-instagram/components/update-instagram-form",
+  () => ({
+    UpdateInstagramForm: () => null,
+  }),
+)
+
+vi.mock("@/features/integration-instagram/queries", () => ({
+  findIntegrationInstagram: vi.fn(async () => ({})),
+}))
+
+vi.mock("@/components/app-breadcrumb", () => ({
+  AppBreadcrumb: () => null,
+}))
+
+vi.mock(
+  "@/features/integration-messenger/components/messenger-setting-tabs",
+  () => ({
+    MessengerSettingTabs: () => null,
+  }),
+)
+
+vi.mock(
+  "@/features/integration-whatsapp/components/whatsapp-setting-tabs",
+  () => ({
+    WhatsappSettingTabs: () => null,
+  }),
+)
+
+vi.mock("@chatbotx.io/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@chatbotx.io/utils")>()
+
+  return {
+    ...actual,
+    getIdFromParams: (
+      params: Record<string, string | null | undefined>,
+      key: string,
+    ) => params[key] ?? null,
+  }
+})
+
+vi.mock(
+  "@/features/integration-whatsapp/profile/update-whatsapp-profile",
+  () => ({
+    UpdateWhatsappProfile: () => null,
+  }),
+)
+
+const { default: CreateChannelPage } = await import(
+  "../src/app/(no-sidebar)/channels/create/page"
+)
+const { default: DashboardPage } = await import(
+  "../src/app/space/[workspaceId]/dashboard/page"
+)
+const { default: MessengerLayout } = await import(
+  "../src/app/space/[workspaceId]/messengers/[id]/layout"
+)
+const { default: UpdateInstagramPage } = await import(
+  "../src/app/space/[workspaceId]/instagrams/[id]/edit/page"
+)
+const { default: WebchatEditPage } = await import(
+  "../src/app/space/[workspaceId]/webchats/[id]/edit/page"
+)
+const { default: CreateWebchatPage } = await import(
+  "../src/app/space/[workspaceId]/webchats/create/page"
+)
+const { default: WhatsappLayout } = await import(
+  "../src/app/space/[workspaceId]/(integrations)/whatsapps/[id]/layout"
+)
+
+const basePermissions = {
+  superAdmin: false,
+  analytics: false,
+  flows: false,
+  contacts: false,
+  onlyAssignedContacts: false,
+  emailAndPhone: false,
+  broadcast: false,
+  ecommerce: false,
+}
+
+describe("channel route guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetCurrentUserId.mockResolvedValue("user-1")
+  })
+
+  test("guards workspace-scoped channel creation on /channels/create", async () => {
+    await expect(
+      CreateChannelPage({
+        searchParams: Promise.resolve({
+          channel: "whatsapp",
+          workspaceId: "ws-1",
+        }),
+      }),
+    ).resolves.toBeDefined()
+
+    expect(mockRequireWorkspacePermission).toHaveBeenCalledWith(
+      "ws-1",
+      "superAdmin",
+    )
+  })
+
+  test("does not require workspace permission for the new-workspace flow", async () => {
+    await expect(
+      CreateChannelPage({
+        searchParams: Promise.resolve({
+          channel: "whatsapp",
+          workspaceId: null,
+        }),
+      }),
+    ).resolves.toBeDefined()
+
+    expect(mockRequireWorkspacePermission).not.toHaveBeenCalled()
+  })
+
+  test("hides the dashboard add-channel card for non-superAdmins", async () => {
+    mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
+      targetWorkspaceMember: {
+        permissions: {
+          ...basePermissions,
+          analytics: true,
+        },
+      },
+    })
+
+    const dashboardTree = await DashboardPage({
+      params: Promise.resolve({ workspaceId: "ws-1" }),
+    })
+    renderToStaticMarkup(dashboardTree)
+
+    expect(mockInboxCardList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowAddNew: false,
+        workspaceId: "ws-1",
+      }),
+      undefined,
+    )
+  })
+
+  test("shows the dashboard add-channel card for superAdmins", async () => {
+    mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
+      targetWorkspaceMember: {
+        permissions: {
+          ...basePermissions,
+          analytics: true,
+          superAdmin: true,
+        },
+      },
+    })
+
+    const dashboardTree = await DashboardPage({
+      params: Promise.resolve({ workspaceId: "ws-1" }),
+    })
+    renderToStaticMarkup(dashboardTree)
+
+    expect(mockInboxCardList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowAddNew: true,
+        workspaceId: "ws-1",
+      }),
+      undefined,
+    )
+  })
+
+  test("guards messenger, instagram, webchat and whatsapp edit surfaces for superAdmins", async () => {
+    await expect(
+      MessengerLayout({
+        children: null,
+        params: Promise.resolve({ workspaceId: "ws-1", id: "msg-1" }),
+      }),
+    ).resolves.toBeDefined()
+    await expect(
+      UpdateInstagramPage({
+        params: Promise.resolve({ workspaceId: "ws-1", id: "ig-1" }),
+      }),
+    ).resolves.toBeDefined()
+    await expect(
+      WebchatEditPage({
+        params: Promise.resolve({ workspaceId: "ws-1", id: "wc-1" }),
+      }),
+    ).resolves.toBeDefined()
+    await expect(
+      CreateWebchatPage({
+        params: Promise.resolve({ workspaceId: "ws-1" }),
+      }),
+    ).resolves.toBeDefined()
+    await expect(
+      WhatsappLayout({
+        children: null,
+        params: Promise.resolve({ workspaceId: "ws-1", id: "wa-1" }),
+      }),
+    ).resolves.toBeDefined()
+
+    expect(mockResolveGuardedWorkspaceId).toHaveBeenCalledWith(
+      expect.any(Promise),
+      "superAdmin",
+    )
+    expect(mockRequireWorkspacePermission).toHaveBeenCalledWith(
+      "ws-1",
+      "superAdmin",
+    )
+  })
+})

--- a/apps/builder/__tests__/workspace-status-guard.test.tsx
+++ b/apps/builder/__tests__/workspace-status-guard.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import { renderToStaticMarkup } from "react-dom/server"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockUseRouter, mockUseTranslations } = vi.hoisted(() => ({
+  mockUseRouter: vi.fn(),
+  mockUseTranslations: vi.fn(),
+}))
+
+vi.mock("next/navigation", () => ({
+  useRouter: mockUseRouter,
+}))
+
+vi.mock("next-intl", () => ({
+  useTranslations: mockUseTranslations,
+}))
+
+vi.mock("@/features/workspaces/components/workspace-schedule-dialog", () => ({
+  WorkspaceScheduleDialog: () => null,
+}))
+
+vi.mock(
+  "../src/features/workspaces/actions/update-workspace-status-action",
+  () => ({
+    updateWorkspaceStatusAction: vi.fn(),
+  }),
+)
+
+const { WorkspaceStatusSwitch } = await import(
+  "../src/features/workspaces/components/workspace-status-switch"
+)
+
+describe("workspace status guard", () => {
+  beforeEach(() => {
+    mockUseRouter.mockReturnValue({ refresh: vi.fn() })
+    mockUseTranslations.mockReturnValue((key: string) => key)
+  })
+
+  test("disables the switch for members without super admin access", () => {
+    const html = renderToStaticMarkup(
+      <WorkspaceStatusSwitch
+        canManageStatus={false}
+        workspace={{
+          id: "ws-1",
+          isActive: false,
+          startTime: null,
+          endTime: null,
+        }}
+      />,
+    )
+
+    const container = document.createElement("div")
+    container.innerHTML = html
+
+    const switchElement = container.querySelector('[role="switch"]')
+
+    expect(switchElement).not.toBeNull()
+    expect(switchElement?.hasAttribute("disabled")).toBe(true)
+  })
+
+  test("keeps the switch enabled for super admins", () => {
+    const html = renderToStaticMarkup(
+      <WorkspaceStatusSwitch
+        canManageStatus
+        workspace={{
+          id: "ws-1",
+          isActive: false,
+          startTime: null,
+          endTime: null,
+        }}
+      />,
+    )
+
+    const container = document.createElement("div")
+    container.innerHTML = html
+
+    const switchElement = container.querySelector('[role="switch"]')
+
+    expect(switchElement).not.toBeNull()
+    expect(switchElement?.hasAttribute("disabled")).toBe(false)
+  })
+})

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -505,7 +505,8 @@
       "timeRequired": "Please select both start and end time",
       "activated": "Workspace activated",
       "deactivated": "Workspace deactivated",
-      "activeHours": "Active from {startTime} to {endTime}"
+      "activeHours": "Active from {startTime} to {endTime}",
+      "permissionRequired": "Only a super admin can change workspace active hours"
     }
   },
   "workspaces": {

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -506,7 +506,8 @@
       "timeRequired": "Vui lòng chọn cả giờ bắt đầu và giờ kết thúc",
       "activated": "Đã kích hoạt workspace",
       "deactivated": "Đã tắt workspace",
-      "activeHours": "Hoạt động từ {startTime} đến {endTime} giờ"
+      "activeHours": "Hoạt động từ {startTime} đến {endTime} giờ",
+      "permissionRequired": "Chỉ super admin mới có thể thay đổi khung giờ hoạt động của workspace"
     }
   },
   "workspaces": {

--- a/apps/builder/src/app/(no-sidebar)/channels/create/page.tsx
+++ b/apps/builder/src/app/(no-sidebar)/channels/create/page.tsx
@@ -15,6 +15,7 @@ import { generateTiktokRedirectUri } from "@/features/integration-tiktok/libs/ti
 import { SimpleCreateWebchat } from "@/features/integration-webchat/simple-create-webchat"
 import WhatsappCreate from "@/features/integration-whatsapp/components/whatsapp-create"
 import { generateZaloRedirectUri } from "@/features/integration-zalo/libs/zalo"
+import { requireWorkspacePermission } from "@/lib/auth/require-workspace-permission"
 import { getCurrentUserId } from "@/lib/auth/utils"
 
 export const dynamic = "force-dynamic"
@@ -29,6 +30,11 @@ type CreateChannelPageProps = {
 export default async function CreateChannelPage(props: CreateChannelPageProps) {
   const searchParams = await props.searchParams
   const workspaceId = getIdFromParams(searchParams, "workspaceId")
+
+  if (workspaceId) {
+    await requireWorkspacePermission(workspaceId, "superAdmin")
+  }
+
   const selectedChannel = searchParams.channel
 
   if (selectedChannel === "telegram") {

--- a/apps/builder/src/app/page.tsx
+++ b/apps/builder/src/app/page.tsx
@@ -8,6 +8,7 @@ import { notFound, redirect } from "next/navigation"
 import { isCloud } from "@/env"
 import { AccountRail } from "@/features/workspaces/components/account-rail"
 import WorkspacesList from "@/features/workspaces/components/workspaces-list"
+import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
 import { enforcePasswordCurrent } from "@/lib/auth/require-password-current"
 import { getCurrentUserAndAllLinkedWorkspaces } from "@/lib/auth/utils"
 import { buildQuotaMetrics, resolveTrialEndsAt } from "@/lib/quota-metrics"
@@ -37,6 +38,11 @@ export default async function MainPage() {
   const ownerWorkspaceIds = allWorkspaceMembers
     .filter((member) => member.role === "owner")
     .map((member) => member.workspace.id)
+  const superAdminWorkspaceIds = allWorkspaceMembers
+    .filter((member) =>
+      hasWorkspacePermission(member.permissions, "superAdmin"),
+    )
+    .map((member) => member.workspace.id)
 
   // Self-managed trial gate (cloud only): a consumed trial can't reach
   // workspaces. Derived from the quota already fetched above — no extra query.
@@ -63,6 +69,7 @@ export default async function MainPage() {
       <WorkspacesList
         isAtLimit={atLimit?.workspaces ?? false}
         ownerWorkspaceIds={ownerWorkspaceIds}
+        superAdminWorkspaceIds={superAdminWorkspaceIds}
         user={userInfo}
         workspaces={allWorkspaces}
         workspacesLimit={usageSummary?.workspaces.limit ?? null}

--- a/apps/builder/src/app/space/[workspaceId]/(integrations)/whatsapps/[id]/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(integrations)/whatsapps/[id]/layout.tsx
@@ -1,9 +1,8 @@
-import { getIdFromParams } from "@chatbotx.io/utils"
-import { notFound } from "next/navigation"
 import { getTranslations } from "next-intl/server"
 import type { ReactNode } from "react"
 import { AppBreadcrumb } from "@/components/app-breadcrumb"
 import { WhatsappSettingTabs } from "@/features/integration-whatsapp/components/whatsapp-setting-tabs"
+import { resolveGuardedWorkspaceId } from "@/lib/auth/require-workspace-permission"
 
 type LayoutProps = {
   children: ReactNode
@@ -15,10 +14,7 @@ export default async function WhatsappLayout({
   params,
 }: LayoutProps) {
   const t = await getTranslations()
-  const workspaceId = getIdFromParams(await params, "workspaceId")
-  if (!workspaceId) {
-    return notFound()
-  }
+  const workspaceId = await resolveGuardedWorkspaceId(params, "superAdmin")
 
   return (
     <>

--- a/apps/builder/src/app/space/[workspaceId]/dashboard/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/dashboard/page.tsx
@@ -4,7 +4,8 @@ import { getIdFromParams } from "@chatbotx.io/utils"
 import { notFound } from "next/navigation"
 import { InboxCardList } from "@/features/inboxes/components/inbox-card-list"
 import { listInboxes } from "@/features/inboxes/queries"
-import { requireWorkspacePermission } from "@/lib/auth/require-workspace-permission"
+import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
+import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
 
 export default async function Dashboard({
   params,
@@ -15,7 +16,19 @@ export default async function Dashboard({
   if (!workspaceId) {
     return notFound()
   }
-  await requireWorkspacePermission(workspaceId, "analytics")
+
+  const userAndWorkspace = await getCurrentUserAndTargetWorkspace(workspaceId)
+  if (
+    !(
+      userAndWorkspace &&
+      hasWorkspacePermission(
+        userAndWorkspace.targetWorkspaceMember.permissions,
+        "analytics",
+      )
+    )
+  ) {
+    return notFound()
+  }
 
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
 
@@ -28,7 +41,14 @@ export default async function Dashboard({
 
   return (
     <div className="flex flex-col gap-4">
-      <InboxCardList inboxes={inboxes} workspaceId={workspaceId} />
+      <InboxCardList
+        allowAddNew={hasWorkspacePermission(
+          userAndWorkspace.targetWorkspaceMember.permissions,
+          "superAdmin",
+        )}
+        inboxes={inboxes}
+        workspaceId={workspaceId}
+      />
 
       <BaseDashboard
         defaultSearchParams={{

--- a/apps/builder/src/app/space/[workspaceId]/instagrams/[id]/edit/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/instagrams/[id]/edit/page.tsx
@@ -2,11 +2,13 @@ import { CustomFieldStoreProvider } from "@/features/custom-fields/provider/cust
 import { FlowStoreProvider } from "@/features/flows/provider/flow-store-context"
 import { UpdateInstagramForm } from "@/features/integration-instagram/components/update-instagram-form"
 import { findIntegrationInstagram } from "@/features/integration-instagram/queries"
+import { requireWorkspacePermission } from "@/lib/auth/require-workspace-permission"
 
 export default async function UpdateInstagramPage(props: {
   params: Promise<{ workspaceId: string; id: string }>
 }) {
   const { workspaceId, id } = await props.params
+  await requireWorkspacePermission(workspaceId, "superAdmin")
 
   const integrationInstagram = await findIntegrationInstagram({
     id,

--- a/apps/builder/src/app/space/[workspaceId]/messengers/[id]/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/messengers/[id]/layout.tsx
@@ -4,6 +4,7 @@ import { getTranslations } from "next-intl/server"
 import type { ReactNode } from "react"
 import { AppBreadcrumb } from "@/components/app-breadcrumb"
 import { MessengerSettingTabs } from "@/features/integration-messenger/components/messenger-setting-tabs"
+import { resolveGuardedWorkspaceId } from "@/lib/auth/require-workspace-permission"
 
 type LayoutProps = {
   children: ReactNode
@@ -16,10 +17,7 @@ export default async function MessengerLayout({
 }: LayoutProps) {
   const t = await getTranslations()
   const resolvedParams = await params
-  const workspaceId = getIdFromParams(resolvedParams, "workspaceId")
-  if (!workspaceId) {
-    return notFound()
-  }
+  const workspaceId = await resolveGuardedWorkspaceId(params, "superAdmin")
   const integrationId = getIdFromParams(resolvedParams, "id")
   if (!integrationId) {
     return notFound()

--- a/apps/builder/src/app/space/[workspaceId]/webchats/[id]/edit/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/webchats/[id]/edit/page.tsx
@@ -4,6 +4,7 @@ import { FlowStoreProvider } from "@/features/flows/provider/flow-store-context"
 import { UpdateWebchatForm } from "@/features/integration-webchat/components/update-webchat-form"
 import { findIntegrationWebchat } from "@/features/integration-webchat/queries"
 import { withWorkspaceIdAndIdSchema } from "@/features/workspaces/schema/resource"
+import { requireWorkspacePermission } from "@/lib/auth/require-workspace-permission"
 
 export default async function WebchatEditPage({
   params,
@@ -14,6 +15,7 @@ export default async function WebchatEditPage({
   if (!data) {
     return notFound()
   }
+  await requireWorkspacePermission(data.workspaceId, "superAdmin")
 
   const integrationWebchat = await findIntegrationWebchat({
     id: data.id,

--- a/apps/builder/src/app/space/[workspaceId]/webchats/create/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/webchats/create/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation"
 import { Suspense } from "react"
 import { FlowStoreProvider } from "@/features/flows/provider/flow-store-context"
 import { CreateWebchatForm } from "@/features/integration-webchat/components/create-webchat-form"
+import { requireWorkspacePermission } from "@/lib/auth/require-workspace-permission"
 
 export default async function CreateWebchatPage({
   params,
@@ -13,6 +14,7 @@ export default async function CreateWebchatPage({
   if (!workspaceId) {
     return notFound()
   }
+  await requireWorkspacePermission(workspaceId, "superAdmin")
 
   return (
     <Suspense fallback={<div>Loading...</div>}>

--- a/apps/builder/src/components/nav-main.tsx
+++ b/apps/builder/src/components/nav-main.tsx
@@ -47,7 +47,12 @@ export function NavMain({
               >
                 {crossZone || item.crossZone ? (
                   // Cross-zone: use <a> to force full navigation outside the Next router
-                  <a className={linkClass} href={item.url}>
+                  <a
+                    className={linkClass}
+                    href={item.url}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
                     {item.icon && <item.icon className="size-5 shrink-0" />}
                     <span>{item.title}</span>
                   </a>

--- a/apps/builder/src/features/workspace-members/workspace-members-table.tsx
+++ b/apps/builder/src/features/workspace-members/workspace-members-table.tsx
@@ -23,7 +23,12 @@ import {
 import { useDataTable } from "@chatbotx.io/ui/hooks/use-data-table"
 import type { DataTableRowAction } from "@chatbotx.io/ui/types/data-table"
 import type { ColumnDef } from "@tanstack/react-table"
-import { CheckCircle2Icon, MoreHorizontalIcon, XCircleIcon } from "lucide-react"
+import {
+  CheckCircle2Icon,
+  CircleDashedIcon,
+  MoreHorizontalIcon,
+  XCircleIcon,
+} from "lucide-react"
 import { useTranslations } from "next-intl"
 import { use, useMemo, useState } from "react"
 import { DeleteWorkspaceMemberDialog } from "./components/delete-workspace-member"
@@ -43,6 +48,38 @@ const renderPermissionCell = (enabled: boolean) =>
   ) : (
     <XCircleIcon className="size-5" />
   )
+
+const renderContactsCell = (
+  contacts: boolean,
+  onlyAssignedContacts: boolean,
+  t: ReturnType<typeof useTranslations>,
+) => {
+  if (contacts) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <CheckCircle2Icon className="size-5 text-primary" />
+        </TooltipTrigger>
+        <TooltipContent>{t("fields.permissions.contacts")}</TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  if (onlyAssignedContacts) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <CircleDashedIcon className="size-5 text-primary" />
+        </TooltipTrigger>
+        <TooltipContent>
+          {t("fields.permissions.onlyAssignedContacts")}
+        </TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  return <XCircleIcon className="size-5" />
+}
 
 export function WorkspaceMembersTable({
   promises,
@@ -137,19 +174,11 @@ export function WorkspaceMembersTable({
           />
         ),
         cell: ({ row }) =>
-          renderPermissionCell(row.original.permissions.contacts),
-        enableHiding: false,
-      },
-      {
-        id: "onlyAssignedContacts",
-        header: ({ column }) => (
-          <DataTableColumnHeader
-            column={column}
-            title={t("fields.permissions.onlyAssignedContacts")}
-          />
-        ),
-        cell: ({ row }) =>
-          renderPermissionCell(row.original.permissions.onlyAssignedContacts),
+          renderContactsCell(
+            row.original.permissions.contacts,
+            row.original.permissions.onlyAssignedContacts,
+            t,
+          ),
         enableHiding: false,
       },
       {

--- a/apps/builder/src/features/workspaces/components/workspace-status-switch.tsx
+++ b/apps/builder/src/features/workspaces/components/workspace-status-switch.tsx
@@ -1,6 +1,11 @@
 "use client"
 
 import { Switch } from "@chatbotx.io/ui/components/ui/switch"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@chatbotx.io/ui/components/ui/tooltip"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { useEffect, useState } from "react"
@@ -11,8 +16,10 @@ import { WorkspaceScheduleDialog } from "./workspace-schedule-dialog"
 type Schedule = { startTime: string | null; endTime: string | null }
 
 export function WorkspaceStatusSwitch({
+  canManageStatus,
   workspace,
 }: {
+  canManageStatus: boolean
   workspace: {
     id: string
     isActive: boolean
@@ -61,14 +68,32 @@ export function WorkspaceStatusSwitch({
     }
   }
 
+  const switchElement = (
+    <Switch
+      checked={isActive}
+      className="absolute top-3 left-3 z-10"
+      disabled={!canManageStatus}
+      onCheckedChange={canManageStatus ? handleCheckedChange : undefined}
+      onClick={(e) => e.stopPropagation()}
+    />
+  )
+
   return (
     <>
-      <Switch
-        checked={isActive}
-        className="absolute top-3 left-3 z-10"
-        onCheckedChange={handleCheckedChange}
-        onClick={(e) => e.stopPropagation()}
-      />
+      {canManageStatus ? (
+        switchElement
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="absolute top-3 left-3 z-10 inline-flex">
+              {switchElement}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            {t("workspace.schedule.permissionRequired")}
+          </TooltipContent>
+        </Tooltip>
+      )}
 
       <WorkspaceScheduleDialog
         onOpenChange={setShowScheduleDialog}

--- a/apps/builder/src/features/workspaces/components/workspaces-list.tsx
+++ b/apps/builder/src/features/workspaces/components/workspaces-list.tsx
@@ -29,6 +29,7 @@ type WorkspacesListProps = {
   workspacesLimit?: number | null
   isAtLimit?: boolean
   ownerWorkspaceIds?: string[]
+  superAdminWorkspaceIds?: string[]
 }
 
 const CARD_STYLES =
@@ -105,10 +106,16 @@ const CreateWorkspaceCard = ({
 type WorkspaceCardProps = {
   workspace: WorkspaceResource
   ownerLabel?: string
+  canManageStatus: boolean
   t: Awaited<ReturnType<typeof getTranslations>>
 }
 
-const WorkspaceCard = ({ workspace, ownerLabel, t }: WorkspaceCardProps) => {
+const WorkspaceCard = ({
+  workspace,
+  ownerLabel,
+  canManageStatus,
+  t,
+}: WorkspaceCardProps) => {
   const firstLetter = workspace.name?.[0]?.toUpperCase() ?? ""
   const name = workspace.name ?? ""
   const href = `/space/${workspace.id}`
@@ -129,6 +136,7 @@ const WorkspaceCard = ({ workspace, ownerLabel, t }: WorkspaceCardProps) => {
           </span>
         ) : null}
         <WorkspaceStatusSwitch
+          canManageStatus={canManageStatus}
           workspace={{
             id: workspace.id,
             isActive: workspace.isActive,
@@ -170,6 +178,7 @@ const WorkspacesList = async ({
   workspacesLimit,
   isAtLimit = false,
   ownerWorkspaceIds = [],
+  superAdminWorkspaceIds = [],
 }: WorkspacesListProps) => {
   const t = await getTranslations()
   const createLabel = t("actions.createFeature", {
@@ -177,6 +186,7 @@ const WorkspacesList = async ({
   })
   const showCreateCard = !isCommunity()
   const ownerIds = new Set(ownerWorkspaceIds)
+  const superAdminIds = new Set(superAdminWorkspaceIds)
   const ownerLabel = t("home.owner")
 
   const usedCount = workspaces.length
@@ -229,6 +239,7 @@ const WorkspacesList = async ({
           {workspaces.map((workspace) => (
             <li className="list-none" key={workspace.id}>
               <WorkspaceCard
+                canManageStatus={superAdminIds.has(workspace.id)}
                 ownerLabel={ownerIds.has(workspace.id) ? ownerLabel : undefined}
                 t={t}
                 workspace={workspace}

--- a/docs/developer/workspace-permission-guards.md
+++ b/docs/developer/workspace-permission-guards.md
@@ -57,11 +57,26 @@ await requireContactsAccess(workspaceId)
 Existing examples:
 
 - `apps/builder/src/app/space/[workspaceId]/dashboard/page.tsx` gates analytics
-  with `requireWorkspacePermission(workspaceId, "analytics")`.
+  access and additionally reads the member's raw `permissions` (via
+  `getCurrentUserAndTargetWorkspace`) to decide whether to show the "add
+  channel" card (`allowAddNew`, gated on `superAdmin`). Read the raw
+  permissions object directly — instead of `requireWorkspacePermission` — when
+  a page needs more than a pass/fail gate.
+- `apps/builder/src/features/workspaces/components/workspace-status-switch.tsx`
+  reads the raw member permissions on the home page, threads a `canManageStatus`
+  boolean down from the list, and disables the toggle for non-super admins
+  instead of failing after a click.
 - `apps/builder/src/app/space/[workspaceId]/broadcasts/layout.tsx` gates
   broadcasts with `resolveGuardedWorkspaceId(params, "broadcast")`.
 - `apps/builder/src/app/space/[workspaceId]/contacts/page.tsx` gates contacts
   with `requireContactsAccess(workspaceId)`.
+- Channel create/edit surfaces outside the superAdmin-gated settings tree are
+  gated on `superAdmin` directly: `apps/builder/src/app/(no-sidebar)/channels/create/page.tsx`
+  (when a `workspaceId` query param is present),
+  `apps/builder/src/app/space/[workspaceId]/messengers/[id]/layout.tsx` and
+  `.../(integrations)/whatsapps/[id]/layout.tsx` (via
+  `resolveGuardedWorkspaceId`), and the instagram/webchat edit and
+  webchat-create pages (via `requireWorkspacePermission`).
 
 ## Contact data scoping
 
@@ -150,6 +165,7 @@ Useful tests:
 
 - `apps/builder/__tests__/workspace-permission-routes.test.ts`
 - `apps/builder/__tests__/require-workspace-permission.test.ts`
+- `apps/builder/__tests__/channel-route-guards.test.ts`
 - `apps/builder/__tests__/contacts-route-guards.test.ts`
 - `apps/builder/__tests__/contacts-permissions.test.ts`
 - `apps/worker/__tests__/export-contacts-where.test.ts`


### PR DESCRIPTION
## Summary
- Require `superAdmin` permission before creating or editing WhatsApp, Messenger, Instagram, and webchat integrations (page/layout guards)
- Add an `allowAddNew` gate on the dashboard's inbox card list, driven by the member's raw permissions instead of a pass/fail check
- Disable the workspace status switch for non-super admins, with a tooltip explaining the permission requirement
- Split the workspace-members "contacts" column into a single cell distinguishing full vs. only-assigned contact access
- Open cross-zone nav links in a new tab with `rel="noopener noreferrer"`

## Changes
- `apps/builder/src/app/(no-sidebar)/channels/create/page.tsx`, `webchats/create`, `webchats/[id]/edit`, `instagrams/[id]/edit`, `messengers/[id]/layout.tsx`, `whatsapps/[id]/layout.tsx` — guard with `requireWorkspacePermission`/`resolveGuardedWorkspaceId` on `superAdmin`
- `apps/builder/src/app/space/[workspaceId]/dashboard/page.tsx` — reads raw member permissions to gate `allowAddNew` on `InboxCardList`
- `apps/builder/src/app/page.tsx`, `features/workspaces/components/workspaces-list.tsx`, `workspace-status-switch.tsx` — thread `superAdminWorkspaceIds`/`canManageStatus` down to disable the status switch for non-super admins
- `apps/builder/src/features/workspace-members/workspace-members-table.tsx` — merged contacts/onlyAssignedContacts into one cell
- `apps/builder/src/components/nav-main.tsx` — cross-zone links open in a new tab
- `docs/developer/workspace-permission-guards.md` — documents the new guard patterns
- Adds `channel-route-guards.test.ts` and `workspace-status-guard.test.tsx`

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [ ] Manual verification: non-super-admin cannot open channel create/edit routes directly by URL
- [ ] Manual verification: workspace status switch is disabled with tooltip for non-super-admin members