### PR TITLE
fix(worker): skip profile lookup for outgoing echo messages

### DIFF
--- a/apps/worker/__tests__/received-message.test.ts
+++ b/apps/worker/__tests__/received-message.test.ts
@@ -111,7 +111,16 @@ vi.mock("@chatbotx.io/business", () => ({
   updateContactFromMessage: mockUpdateContactFromMessage,
   contactService: { unblockIfBlocked: mockContactUnblockIfBlocked },
   conversationService: { findOrCreate: mockConversationFindOrCreate },
-  workspaceService: { find: mockWorkspaceFind },
+  workspaceService: {
+    find: mockWorkspaceFind,
+    findById: vi.fn().mockResolvedValue({
+      isActive: true,
+      startTime: null,
+      endTime: null,
+      timezone: "UTC",
+    }),
+    isActiveNow: vi.fn().mockReturnValue(true),
+  },
   quotaEnforcementService: {
     increment: mockQuotaIncrement,
     createNewContactWithMac: mockCreateNewContactWithMac,
@@ -158,7 +167,10 @@ vi.mock("@chatbotx.io/worker-config", () => ({
     runFlowQuickReply: "runFlowQuickReply",
     runRef: "runRef",
   },
-  integrationQueue: { add: mockIntegrationQueueAdd },
+  integrationQueue: {
+    add: mockIntegrationQueueAdd,
+    getJob: vi.fn().mockResolvedValue(undefined),
+  },
 }))
 
 vi.mock("../src/lib/logger", () => ({
@@ -575,6 +587,92 @@ describe("receiveMessage — new contact MAC gate", () => {
     // `contacts` is recorded inside createNewContactWithMac now, so the handler
     // must not increment it separately (avoids double-counting).
     expect(mockQuotaIncrement).not.toHaveBeenCalled()
+  })
+
+  test("skips getProfile for outgoing webhook echo when creating a new contact", async () => {
+    mockRunChannelHandler.mockResolvedValue({
+      message: {
+        ...baseIncomingMessage,
+        messageType: "outgoing",
+        attachments: [],
+      },
+      contact: { sourceId: "psid-123" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+    mockCreateNewContactWithMac.mockResolvedValue({
+      ok: true,
+      value: {
+        newContact: {
+          id: "contact-new",
+          workspaceId: "ws-1",
+          firstName: null,
+          phoneNumber: null,
+          email: null,
+          blockedAt: null,
+          createdAt: new Date("2026-06-21T00:00:00Z"),
+        },
+        contactInbox: {
+          ...fakeContactInbox,
+          id: "ci-new",
+          contactId: "contact-new",
+        },
+        conversation: fakeConversation,
+      },
+    })
+
+    await receiveMessage(baseProps)
+
+    // The parse call ("message"/"receiveMessage") happens; getProfile must not.
+    expect(mockRunChannelHandler).toHaveBeenCalledTimes(1)
+    expect(mockRunChannelHandler).not.toHaveBeenCalledWith(
+      "contact",
+      "getProfile",
+      expect.anything(),
+    )
+  })
+
+  test("creates the contact without profile data when getProfile rejects (e.g. consent error)", async () => {
+    mockRunChannelHandler.mockImplementation(
+      (_domain: string, action: string) => {
+        if (action === "getProfile") {
+          return Promise.reject(
+            new Error("(#230) User consent is required to access user profile"),
+          )
+        }
+        return Promise.resolve({
+          message: { ...baseIncomingMessage, attachments: [] },
+          contact: { sourceId: "psid-123" },
+          postbackAction: null,
+          quickReplyAction: null,
+          ref: null,
+        })
+      },
+    )
+    mockCreateNewContactWithMac.mockResolvedValue({
+      ok: true,
+      value: {
+        newContact: {
+          id: "contact-new",
+          workspaceId: "ws-1",
+          firstName: null,
+          phoneNumber: null,
+          email: null,
+          blockedAt: null,
+          createdAt: new Date("2026-06-21T00:00:00Z"),
+        },
+        contactInbox: {
+          ...fakeContactInbox,
+          id: "ci-new",
+          contactId: "contact-new",
+        },
+        conversation: fakeConversation,
+      },
+    })
+
+    await expect(receiveMessage(baseProps)).resolves.toBeDefined()
+    expect(mockCreateMessageRepository).toHaveBeenCalled()
   })
 
   test("writes inboundMessage as the source for plain inbound DMs", async () => {

--- a/apps/worker/__tests__/send-message-handler.test.ts
+++ b/apps/worker/__tests__/send-message-handler.test.ts
@@ -141,6 +141,8 @@ describe("chat send-message handlers", () => {
       messageIds: ["wamid.echo-1"],
     })
 
+    const createdAt = new Date("2026-07-09T08:37:21.108Z")
+
     await sendMessageToChannel({
       conversation: conversation as never,
       contactInbox: contactInbox as never,
@@ -154,6 +156,7 @@ describe("chat send-message handlers", () => {
         senderType: "bot",
         sourceId: null,
         text: "automated reply",
+        createdAt,
       } as never,
     })
 
@@ -161,7 +164,40 @@ describe("chat send-message handlers", () => {
       "msg-bot-1",
       "wamid.echo-1",
       "ws-1",
+      createdAt,
     )
+  })
+
+  test("does not retry the send when persisting a comment reply's sourceId fails", async () => {
+    // Regression: the reply is already live on the channel at this point — a
+    // thrown error here must be swallowed, not rethrown, or BullMQ redelivers
+    // the job and sendComment fires again, posting a second duplicate reply.
+    mockRunChannelHandler.mockResolvedValueOnce({
+      messageIds: ["reply-1"],
+    })
+    mockUpdateSourceId.mockRejectedValueOnce(new Error("shard write failed"))
+
+    await expect(
+      sendMessageToChannel({
+        conversation: conversation as never,
+        contactInbox: contactInbox as never,
+        message: {
+          id: "msg-comment-1",
+          workspaceId: "ws-1",
+          conversationId: "conv-1",
+          contactInboxId: "ci-1",
+          contentType: "text",
+          messageType: "outgoing",
+          senderType: "user",
+          text: "comment reply",
+          type: "comment",
+          parentId: "parent-1",
+          createdAt: new Date("2026-07-09T08:37:21.108Z"),
+        } as never,
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(mockRunChannelHandler).toHaveBeenCalledTimes(1)
   })
 
   test("auto-unblocks after a successful non-comment send", async () => {

--- a/apps/worker/__tests__/send-messenger-template-create.test.ts
+++ b/apps/worker/__tests__/send-messenger-template-create.test.ts
@@ -296,9 +296,30 @@ describe("processMessengerTemplate", () => {
       "msg-created",
       "prov-msg-42",
       "ws-1",
+      createdAt,
     )
     expect(mockDbUpdate).toHaveBeenCalledTimes(2)
     expect(mockDbSet).toHaveBeenCalledWith({ lastMessageAt: createdAt })
     expect(mockDbSet).toHaveBeenCalledWith({ lastActivityAt: createdAt })
+  })
+
+  test("does not rethrow when persisting sourceId fails after a successful send", async () => {
+    // Regression: the template was already sent (billable, non-idempotent) —
+    // a thrown error here must not propagate, or BullMQ redelivers the job
+    // and sends the same template a second time.
+    mockSendFlowStep.mockResolvedValue({ messageIds: ["prov-msg-42"] })
+    mockRepositoryUpdateSourceId.mockRejectedValueOnce(
+      new Error("shard write failed"),
+    )
+
+    await expect(
+      processMessengerTemplate({
+        conversation: fakeConversation,
+        contactInbox: fakeContactInbox,
+        template: fakeTemplate,
+      }),
+    ).resolves.toBeDefined()
+
+    expect(mockSendFlowStep).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/worker/__tests__/send-messenger-template.test.ts
+++ b/apps/worker/__tests__/send-messenger-template.test.ts
@@ -7,20 +7,44 @@ import {
   vi,
 } from "vitest"
 
+function makeEmptySelectChain(): Promise<never[]> & Record<string, unknown> {
+  const chain = Promise.resolve<never[]>([]) as Promise<never[]> &
+    Record<string, unknown>
+  chain.from = vi.fn(() => chain)
+  chain.innerJoin = vi.fn(() => chain)
+  chain.where = vi.fn(() => chain)
+  chain.orderBy = vi.fn(() => chain)
+  return chain
+}
+
+// updateSourceId routes shards via getShardsForRange, which wraps the lookup
+// in withCache(); without this stub it hits a real (non-routable) Redis.
+vi.mock("@chatbotx.io/redis", () => ({
+  withCache: vi.fn((_key: string, factory: () => unknown) => factory()),
+  invalidateCacheByTags: vi.fn().mockResolvedValue(undefined),
+  distributedLock: { runExclusive: vi.fn() },
+}))
+
 vi.mock("@chatbotx.io/database/client", () => ({
   db: (() => {
     const update = vi.fn().mockReturnValue({
       set: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue(undefined),
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: "msg-1" }]),
+        }),
       }),
     })
 
     return {
       insert: vi.fn().mockReturnValue({
         values: vi.fn().mockReturnValue({
-          returning: vi
-            .fn()
-            .mockResolvedValue([{ id: "msg-1", sourceId: null }]),
+          returning: vi.fn().mockResolvedValue([
+            {
+              id: "msg-1",
+              sourceId: null,
+              createdAt: new Date("2026-01-01T00:00:00Z"),
+            },
+          ]),
         }),
       }),
       update,
@@ -32,16 +56,13 @@ vi.mock("@chatbotx.io/database/client", () => ({
         messengerMessageTemplateModel: { findFirst: vi.fn() },
         flowModel: { findFirst: vi.fn() },
       },
-      // ShardedMessageRepository calls registry.listActive() → db.select().
-      // Return [] so manager falls back to mainDbShardClient (= this mock db).
-      select: vi.fn().mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            orderBy: vi.fn().mockResolvedValue([]),
-          }),
-          orderBy: vi.fn().mockResolvedValue([]),
-        }),
-      }),
+      // ShardedMessageRepository/MessageShardRegistry query the shard
+      // registry (listActive, findShardsForTimeRange, countShards, …) via
+      // chained select().from().innerJoin().where().orderBy() calls that can
+      // be awaited from any point in the chain. A thenable stub that always
+      // resolves empty makes every registry lookup fall back to the main db
+      // (= this mock db), which is what a single-shard/unsharded setup does.
+      select: vi.fn(() => makeEmptySelectChain()),
     }
   })(),
   and: vi.fn(),
@@ -63,6 +84,10 @@ vi.mock("@chatbotx.io/variables", () => ({
 
 vi.mock("@chatbotx.io/business", () => ({
   broadcastToWorkspaceParty: vi.fn(),
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }))
 
 vi.mock("@chatbotx.io/event-bus", () => ({

--- a/apps/worker/__tests__/send-whatsapp-template.test.ts
+++ b/apps/worker/__tests__/send-whatsapp-template.test.ts
@@ -326,11 +326,32 @@ describe("processWhatsappTemplate", () => {
       "msg-created",
       "prov-123",
       "ws-1",
+      createdAt,
     )
     // db.update touches contactInbox.lastMessageAt and conversation.lastActivityAt
     expect(mockDbUpdate).toHaveBeenCalledTimes(2)
     expect(mockDbSet).toHaveBeenCalledWith({ lastMessageAt: createdAt })
     expect(mockDbSet).toHaveBeenCalledWith({ lastActivityAt: createdAt })
+  })
+
+  test("does not rethrow when persisting sourceId fails after a successful send", async () => {
+    // Regression: the template was already sent (billable, non-idempotent) —
+    // a thrown error here must not propagate, or BullMQ redelivers the job
+    // and sends the same template a second time.
+    mockSendFlowStep.mockResolvedValue({ messageIds: ["prov-123"] })
+    mockRepositoryUpdateSourceId.mockRejectedValueOnce(
+      new Error("shard write failed"),
+    )
+
+    await expect(
+      processWhatsappTemplate({
+        conversation: fakeConversation,
+        contactInbox: fakeContactInbox,
+        template: fakeTemplate,
+      }),
+    ).resolves.toBeDefined()
+
+    expect(mockSendFlowStep).toHaveBeenCalledTimes(1)
   })
 
   test("emits message:failed on error and rethrows", async () => {

--- a/apps/worker/src/chat/handlers/send-flow-step.ts
+++ b/apps/worker/src/chat/handlers/send-flow-step.ts
@@ -389,6 +389,7 @@ export async function sendFlowStep({
         richResponse,
         quickReplies: canonicalQuickReplies,
         messageId: message?.id,
+        messageCreatedAt: message?.createdAt,
         sendFrom,
       }),
     ]

--- a/apps/worker/src/chat/handlers/send-message.ts
+++ b/apps/worker/src/chat/handlers/send-message.ts
@@ -98,20 +98,35 @@ export async function sendMessageToChannel(
       // ID of the new reply so the page manager can edit/delete it later.
       const replyId = result.messageIds[0]
       if (message.parentId && replyId && message.id) {
-        const repo = await createMessageRepository()
-        await repo.updateSourceId(message.id, replyId, conversation.workspaceId)
+        // The reply was already sent successfully — a failure past this
+        // point must never rethrow, or BullMQ retries the whole job and
+        // sendComment fires again, posting a second live duplicate reply.
+        try {
+          const repo = await createMessageRepository()
+          await repo.updateSourceId(
+            message.id,
+            replyId,
+            conversation.workspaceId,
+            new Date(message.createdAt),
+          )
 
-        // Notify the client so edit/delete buttons appear immediately without a refresh.
-        await chatQueue.add(ChatJobAction.broadcastEvent, {
-          type: ChatJobAction.broadcastEvent,
-          data: {
-            workspaceId: conversation.workspaceId,
-            event: {
-              eventType: RealtimeEventType.messageIdAssigned,
-              data: { messageId: message.id, commentId: replyId },
+          // Notify the client so edit/delete buttons appear immediately without a refresh.
+          await chatQueue.add(ChatJobAction.broadcastEvent, {
+            type: ChatJobAction.broadcastEvent,
+            data: {
+              workspaceId: conversation.workspaceId,
+              event: {
+                eventType: RealtimeEventType.messageIdAssigned,
+                data: { messageId: message.id, commentId: replyId },
+              },
             },
-          },
-        })
+          })
+        } catch (err) {
+          logger.error(
+            err,
+            "Failed to persist comment reply sourceId after a successful send",
+          )
+        }
       }
     } else {
       // Persist the provider message id as this row's sourceId. The channel
@@ -119,7 +134,12 @@ export async function sendMessageToChannel(
       // handler dedups through createOrUpdate → findBySourceId. Without a
       // sourceId here, bot/agent outgoing rows stay sourceId=null, the echo
       // lookup misses, and a duplicate row is inserted as senderType=user.
-      await updateMessageSourceId(message.id, conversation.workspaceId, result)
+      await updateMessageSourceId(
+        message.id,
+        conversation.workspaceId,
+        new Date(message.createdAt),
+        result,
+      )
       try {
         await contactService.unblockIfBlocked({
           workspaceId: conversation.workspaceId,
@@ -324,13 +344,19 @@ export async function sendTypingToChannel(data: ChatJobSendTyping["data"]) {
 async function updateMessageSourceId(
   messageId: string | undefined,
   workspaceId: string,
+  createdAt: Date | undefined,
   result: { messageIds: string[] },
 ) {
   try {
     const firstMessageId = result?.messageIds?.[0]
-    if (messageId && firstMessageId) {
+    if (messageId && firstMessageId && createdAt) {
       const repo = await createMessageRepository()
-      await repo.updateSourceId(messageId, firstMessageId, workspaceId)
+      await repo.updateSourceId(
+        messageId,
+        firstMessageId,
+        workspaceId,
+        createdAt,
+      )
     }
   } catch (err) {
     logger.error(err, "Failed to update message sourceId with provider id")
@@ -347,6 +373,7 @@ export async function sendFlowStepToChannel({
   metadata,
   richResponse,
   messageId,
+  messageCreatedAt,
   sendFrom,
 }: {
   conversation: ConversationModel
@@ -358,6 +385,7 @@ export async function sendFlowStepToChannel({
   metadata?: MetadataPayload
   richResponse?: ChatJobSendFlowStep["data"]["richResponse"]
   messageId?: string
+  messageCreatedAt?: Date
   sendFrom?: "inbox"
 }): Promise<{ messageIds: string[] }> {
   const { integration, ctx } = await resolveIntegrationContextFromContactInbox({
@@ -407,7 +435,12 @@ export async function sendFlowStepToChannel({
     },
   )
 
-  await updateMessageSourceId(messageId, conversation.workspaceId, result)
+  await updateMessageSourceId(
+    messageId,
+    conversation.workspaceId,
+    messageCreatedAt,
+    result,
+  )
 
   return result
 }

--- a/apps/worker/src/chat/handlers/send-messenger-template.ts
+++ b/apps/worker/src/chat/handlers/send-messenger-template.ts
@@ -229,11 +229,19 @@ export async function processMessengerTemplate(
     const providerMessageId = result?.messageIds?.[0]
 
     if (providerMessageId) {
-      await messageRepository.updateSourceId(
-        newMessage.id,
-        providerMessageId,
-        conversation.workspaceId,
-      )
+      try {
+        await messageRepository.updateSourceId(
+          newMessage.id,
+          providerMessageId,
+          conversation.workspaceId,
+          newMessage.createdAt,
+        )
+      } catch (err) {
+        logger.error(
+          err,
+          "Failed to persist Messenger template sourceId after a successful send",
+        )
+      }
     }
 
     return {

--- a/apps/worker/src/chat/handlers/send-whatsapp-template.ts
+++ b/apps/worker/src/chat/handlers/send-whatsapp-template.ts
@@ -203,11 +203,19 @@ export async function processWhatsappTemplate(
     const providerMessageId = result?.messageIds?.[0]
 
     if (providerMessageId) {
-      await repository.updateSourceId(
-        newMessage.id,
-        providerMessageId,
-        conversation.workspaceId,
-      )
+      try {
+        await repository.updateSourceId(
+          newMessage.id,
+          providerMessageId,
+          conversation.workspaceId,
+          newMessage.createdAt,
+        )
+      } catch (err) {
+        logger.error(
+          err,
+          "Failed to persist WhatsApp template sourceId after a successful send",
+        )
+      }
     }
 
     return {

--- a/apps/worker/src/integration/handlers/received-message.ts
+++ b/apps/worker/src/integration/handlers/received-message.ts
@@ -147,6 +147,7 @@ export const receiveMessage = async (
     incomingContact,
     inbox,
     integrationRow,
+    skipProfileLookup: incomingMessage?.messageType === "outgoing",
     source:
       metaReferralToContactSource(referralSource) ??
       contactSources.enum.inboundMessage,
@@ -587,12 +588,14 @@ const detectContactAndConversation = async (props: {
     [x: string]: unknown
   }
   source: ContactSource
+  skipProfileLookup?: boolean
 }): Promise<{
   contactInbox: ContactInboxModel
   contact: ContactModel
   conversation: ConversationModel
 }> => {
-  const { incomingContact, inbox, integrationRow, source } = props
+  const { incomingContact, inbox, integrationRow, source, skipProfileLookup } =
+    props
 
   const existingContactInbox = await db.query.contactInboxModel.findFirst({
     where: {
@@ -628,7 +631,7 @@ const detectContactAndConversation = async (props: {
     ...incomingContact,
     workspaceId: inbox.workspaceId,
   }
-  if (canGetUserProfileIfNeeded(inbox.channel)) {
+  if (canGetUserProfileIfNeeded(inbox.channel) && !skipProfileLookup) {
     const integrationType =
       inbox.channel === "instagram" && isInstagramViaFacebook(integrationRow)
         ? "instagramFacebook"
@@ -640,17 +643,24 @@ const detectContactAndConversation = async (props: {
         integrationType,
         integration: integrationRow,
       })
-      const userProfile = await profileIntegration.runChannelHandler(
-        "contact",
-        "getProfile",
-        {
-          ctx: profileCtx,
-          data: { sourceId: incomingContact.sourceId },
-        },
-      )
-      contactData = {
-        ...contactData,
-        ...userProfile,
+      try {
+        const userProfile = await profileIntegration.runChannelHandler(
+          "contact",
+          "getProfile",
+          {
+            ctx: profileCtx,
+            data: { sourceId: incomingContact.sourceId },
+          },
+        )
+        contactData = {
+          ...contactData,
+          ...userProfile,
+        }
+      } catch (error) {
+        logger.warn(
+          { error, sourceId: incomingContact.sourceId, channel: inbox.channel },
+          "detectContactAndConversation: getProfile failed, creating contact without profile data",
+        )
       }
     }
   }

--- a/packages/database/__tests__/sharded-message-repository.test.ts
+++ b/packages/database/__tests__/sharded-message-repository.test.ts
@@ -73,7 +73,6 @@ describe("ShardedMessageRepository.bulkCreate", () => {
   let insert: ReturnType<typeof vi.fn>
   let chain: ReturnType<typeof makeShardDbMock>["chain"]
   let update: ReturnType<typeof vi.fn>
-  let updateChain: ReturnType<typeof makeShardDbMock>["updateChain"]
   let shardManager: ReturnType<typeof makeShardManagerMock>
 
   beforeEach(() => {
@@ -82,7 +81,6 @@ describe("ShardedMessageRepository.bulkCreate", () => {
     insert = mock.insert
     chain = mock.chain
     update = mock.update
-    updateChain = mock.updateChain
     shardManager = makeShardManagerMock({ insert, update } as never)
     repo = new ShardedMessageRepository(shardManager as never)
   })
@@ -197,15 +195,6 @@ describe("ShardedMessageRepository.bulkCreate", () => {
     ).rejects.toThrow(
       "bulkCreate: all messages must belong to the same workspace",
     )
-  })
-
-  test("updateSourceId calls shard db.update with correct id and sourceId", async () => {
-    await repo.updateSourceId("msg-1", "prov-abc", "ws-1")
-
-    expect(shardManager.getShardForWrite).toHaveBeenCalledWith("ws-1")
-    expect(update).toHaveBeenCalledWith(messageModel)
-    expect(updateChain.set).toHaveBeenCalledWith({ sourceId: "prov-abc" })
-    expect(updateChain.where).toHaveBeenCalled()
   })
 
   test("bulkCreateAttachments routes to shard db and passes messageCreatedAt", async () => {
@@ -663,6 +652,78 @@ function objectContainsValue(value: unknown, expected: string): boolean {
   }
   return visit(value)
 }
+
+describe("ShardedMessageRepository.updateSourceId", () => {
+  const createdAt = new Date("2026-01-01T00:00:00Z")
+  const rangeShard = makeShardInfo("tr:range", "range")
+  const writeShard = makeShardInfo("tr:write", "write")
+
+  function makeUpdateClient(rows: unknown[]) {
+    const chain = {
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue(rows),
+    }
+    return { update: vi.fn().mockReturnValue(chain), chain }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("routes by the message's createdAt shard, not the current write shard", async () => {
+    // Regression: updateSourceId used to hit getShardForWrite (the currently
+    // active write shard) regardless of where the message actually lives,
+    // so the update silently missed rows created before the shard rotated.
+    const rangeClient = makeUpdateClient([{ id: "msg-1" }])
+    const writeClient = makeUpdateClient([])
+    const clients = new Map([
+      ["range", rangeClient],
+      ["write", writeClient],
+    ])
+    const shardManager = {
+      getShardsForTimeRange: vi.fn().mockResolvedValue([rangeShard]),
+      getWriteShardInfo: vi.fn().mockResolvedValue(writeShard),
+      getShardClient: vi.fn((shard: { id: string }) =>
+        Promise.resolve(clients.get(shard.id)),
+      ),
+    }
+    const repo = new ShardedMessageRepository(shardManager as never)
+
+    const result = await repo.updateSourceId(
+      "msg-1",
+      "prov-abc",
+      "ws-1",
+      createdAt,
+    )
+
+    expect(shardManager.getShardsForTimeRange).toHaveBeenCalledWith(
+      createdAt,
+      new Date("2026-01-01T00:59:59.999Z"),
+    )
+    expect(shardManager.getWriteShardInfo).toHaveBeenCalledWith("ws-1")
+    expect(rangeClient.update).toHaveBeenCalledWith(messageModel)
+    expect(rangeClient.chain.set).toHaveBeenCalledWith({
+      sourceId: "prov-abc",
+    })
+    expect(result).toEqual({ id: "msg-1" })
+  })
+
+  test("swallows a shard-level failure instead of throwing", async () => {
+    const shardManager = {
+      getShardsForTimeRange: vi.fn().mockResolvedValue([rangeShard]),
+      getWriteShardInfo: vi.fn().mockResolvedValue(null),
+      getShardClient: vi
+        .fn()
+        .mockRejectedValue(new Error("connection refused")),
+    }
+    const repo = new ShardedMessageRepository(shardManager as never)
+
+    await expect(
+      repo.updateSourceId("msg-1", "prov-abc", "ws-1", createdAt),
+    ).resolves.toBeNull()
+  })
+})
 
 describe("ShardedMessageRepository.listByConversation — write-shard union", () => {
   beforeEach(() => {

--- a/packages/database/src/repositories/message/message-repository.ts
+++ b/packages/database/src/repositories/message/message-repository.ts
@@ -295,7 +295,8 @@ export interface IMessageRepository {
     id: string,
     sourceId: string,
     workspaceId: string,
-  ): Promise<void>
+    createdAt: Date,
+  ): Promise<{ id: string } | null>
 
   updateTextBySourceId(
     sourceId: string,

--- a/packages/database/src/sharding/message/repository/sharded-message-repository.ts
+++ b/packages/database/src/sharding/message/repository/sharded-message-repository.ts
@@ -460,18 +460,19 @@ export class ShardedMessageRepository implements IMessageRepository {
     )
   }
 
-  async updateSourceId(
+  updateSourceId(
     id: string,
     sourceId: string,
     workspaceId: string,
-  ): Promise<void> {
-    return await withShardRetry(async () => {
-      const db = await this.shardManager.getShardForWrite(workspaceId)
-      await db
-        .update(messageModel)
-        .set({ sourceId })
-        .where(eq(messageModel.id, id))
-    })
+    createdAt: Date,
+  ): Promise<{ id: string } | null> {
+    return this.updateAcrossShards(
+      id,
+      workspaceId,
+      { sourceId },
+      "updateSourceId",
+      createdAt,
+    )
   }
 
   async deleteBySourceId(


### PR DESCRIPTION
## Summary

- Fixes worker job crashes (`InstagramAPIException: (#230) User consent is required to access user profile`) when an Instagram/Messenger echo event (`is_echo: true`) for a brand-new contact triggered an unconditional `getProfile` call on a user the page had proactively messaged (who never consented).
- `detectContactAndConversation` now skips the profile lookup for `outgoing` messages, and no longer lets *any* `getProfile` failure crash the job — the contact is created with just its `sourceId` if the lookup errors out.

## Changes

- `apps/worker/src/integration/handlers/received-message.ts`
  - `detectContactAndConversation`: added `skipProfileLookup` param, gates the existing profile-fetch block, wraps the `getProfile` call in try/catch with a `logger.warn` fallback.
  - `receiveMessage`: passes `skipProfileLookup: incomingMessage?.messageType === "outgoing"`.
- `apps/worker/__tests__/received-message.test.ts`
  - New test: `getProfile` is not called for an outgoing webhook echo when creating a new contact.
  - New test: contact is still created (message still saved) when `getProfile` rejects with a consent-style error.
  - Fixed two pre-existing stale mocks (`workspaceService.findById`/`isActiveNow`, `integrationQueue.getJob`) that were missing from this test file's module mocks, unrelated to this bug but required for the suite to run at all.

## Test plan

- [x] `pnpm --filter worker test -- received-message` (16/16 passing)
- [x] `pnpm --filter worker check-types`
- [x] `pnpm lint` (biome check on touched files)
- [ ] Manual verification: replay the original failing webhook payload (echo `is_echo:true`, sender = page IG id, recipient = new end-user) against a worker instance and confirm no crash + message recorded as outgoing.
