### PR TITLE
fix(messenger): include Business Manager owned/client pages in getUserPages

### DIFF
--- a/integrations/messenger/__tests__/get-user-pages.test.ts
+++ b/integrations/messenger/__tests__/get-user-pages.test.ts
@@ -1,0 +1,155 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  type MockInstance,
+  test,
+  vi,
+} from "vitest"
+
+vi.mock("../src/lib/http-client", () => ({
+  facebookGraphClient: {
+    get: vi.fn(),
+  },
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn() },
+}))
+
+// Dynamic imports ensure vi.mock is fully applied before loading these modules
+const { getUserPages } = await import("../src/apis/auth")
+const { facebookGraphClient } = await import("../src/lib/http-client")
+
+const mockGet = facebookGraphClient.get as MockInstance
+
+const directPage = {
+  id: "page-direct",
+  name: "Direct Page",
+  access_token: "direct-token",
+}
+
+describe("getUserPages", () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+  })
+
+  test("no businesses — returns /me/accounts data unchanged", async () => {
+    mockGet
+      .mockResolvedValueOnce({ data: [directPage] }) // /me/accounts
+      .mockResolvedValueOnce({ data: [] }) // /me/businesses
+
+    const result = await getUserPages("user-token")
+
+    expect(result).toEqual([directPage])
+    expect(mockGet).toHaveBeenCalledTimes(2)
+  })
+
+  test("BM owned/client pages with non-overlapping ids are merged in", async () => {
+    const ownedPage = {
+      id: "page-owned",
+      name: "Owned Page",
+      access_token: "owned-token",
+    }
+    const clientPage = {
+      id: "page-client",
+      name: "Client Page",
+      access_token: "client-token",
+    }
+
+    mockGet
+      .mockResolvedValueOnce({ data: [directPage] }) // /me/accounts
+      .mockResolvedValueOnce({ data: [{ id: "biz1", name: "Biz 1" }] }) // /me/businesses
+      .mockResolvedValueOnce({ data: [ownedPage] }) // owned_pages
+      .mockResolvedValueOnce({ data: [clientPage] }) // client_pages
+
+    const result = await getUserPages("user-token")
+
+    expect(result).toEqual(
+      expect.arrayContaining([directPage, ownedPage, clientPage]),
+    )
+    expect(result).toHaveLength(3)
+  })
+
+  test("page id colliding with /me/accounts keeps the direct-accounts record", async () => {
+    const bmDuplicate = {
+      id: directPage.id,
+      name: "Stale BM Name",
+      access_token: "bm-token",
+    }
+
+    mockGet
+      .mockResolvedValueOnce({ data: [directPage] }) // /me/accounts
+      .mockResolvedValueOnce({ data: [{ id: "biz1", name: "Biz 1" }] }) // /me/businesses
+      .mockResolvedValueOnce({ data: [bmDuplicate] }) // owned_pages
+      .mockResolvedValueOnce({ data: [] }) // client_pages
+
+    const result = await getUserPages("user-token")
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual(directPage)
+  })
+
+  test("BM page missing access_token is excluded", async () => {
+    const pageWithoutToken = { id: "page-no-token", name: "No Token Page" }
+
+    mockGet
+      .mockResolvedValueOnce({ data: [] }) // /me/accounts
+      .mockResolvedValueOnce({ data: [{ id: "biz1", name: "Biz 1" }] }) // /me/businesses
+      .mockResolvedValueOnce({ data: [pageWithoutToken] }) // owned_pages
+      .mockResolvedValueOnce({ data: [] }) // client_pages
+
+    const result = await getUserPages("user-token")
+
+    expect(result).toEqual([])
+  })
+
+  test("BM fetch failure falls back silently to direct pages only", async () => {
+    mockGet
+      .mockResolvedValueOnce({ data: [directPage] }) // /me/accounts
+      .mockRejectedValueOnce(new Error("business_management not granted")) // /me/businesses
+
+    const result = await getUserPages("user-token")
+
+    expect(result).toEqual([directPage])
+  })
+
+  test("paginates /me/businesses and owned_pages until cursors are exhausted", async () => {
+    const ownedPage1 = {
+      id: "page-owned-1",
+      name: "Owned 1",
+      access_token: "t1",
+    }
+    const ownedPage2 = {
+      id: "page-owned-2",
+      name: "Owned 2",
+      access_token: "t2",
+    }
+
+    mockGet
+      .mockResolvedValueOnce({ data: [] }) // /me/accounts
+      .mockResolvedValueOnce({
+        data: [{ id: "biz1", name: "Biz 1" }],
+        paging: {
+          cursors: { after: "biz-cursor" },
+          next: "https://graph.facebook.com/v23.0/me/businesses?after=biz-cursor",
+        },
+      }) // /me/businesses page 1
+      .mockResolvedValueOnce({ data: [] }) // /me/businesses page 2 (no more)
+      .mockResolvedValueOnce({
+        data: [ownedPage1],
+        paging: {
+          cursors: { after: "owned-cursor" },
+          next: "https://graph.facebook.com/v23.0/biz1/owned_pages?after=owned-cursor",
+        },
+      }) // owned_pages page 1
+      .mockResolvedValueOnce({ data: [ownedPage2] }) // owned_pages page 2
+      .mockResolvedValueOnce({ data: [] }) // client_pages
+
+    const result = await getUserPages("user-token")
+
+    expect(result).toEqual(expect.arrayContaining([ownedPage1, ownedPage2]))
+    expect(result).toHaveLength(2)
+    expect(mockGet).toHaveBeenCalledTimes(6)
+  })
+})

--- a/integrations/messenger/src/apis/auth.ts
+++ b/integrations/messenger/src/apis/auth.ts
@@ -1,7 +1,113 @@
 import { DEFAULT_API_VERSION } from "../constants"
 import { rescue } from "../exception"
 import { facebookGraphClient } from "../lib/http-client"
+import { logger } from "../lib/logger"
 import type { FacebookPage } from "../schema"
+
+type FacebookBusiness = { id: string; name: string }
+
+const MAX_PAGES = 20
+
+/**
+ * Exhausts a Graph API cursor-paginated edge, following `paging.next` /
+ * `paging.cursors.after` until pages run out or MAX_PAGES is hit.
+ */
+async function fetchAllPages<T>(
+  endpoint: string,
+  fields: string,
+  accessToken: string,
+): Promise<T[]> {
+  const results: T[] = []
+  let cursor: string | undefined
+  let pageCount = 0
+
+  while (pageCount < MAX_PAGES) {
+    const res: {
+      data: T[]
+      paging?: { cursors?: { after?: string }; next?: string }
+    } = await facebookGraphClient.get(endpoint, {
+      searchParams: {
+        fields,
+        access_token: accessToken,
+        ...(cursor ? { after: cursor } : {}),
+      },
+    })
+    results.push(...res.data)
+    pageCount++
+    cursor = res.paging?.next ? res.paging.cursors?.after : undefined
+    if (!cursor) {
+      break
+    }
+  }
+  return results
+}
+
+function getUserBusinesses(
+  userAccessToken: string,
+  version: string,
+): Promise<FacebookBusiness[]> {
+  return fetchAllPages<FacebookBusiness>(
+    `${version}/me/businesses`,
+    "id,name",
+    userAccessToken,
+  )
+}
+
+async function getBusinessPages(
+  businessId: string,
+  userAccessToken: string,
+  version: string,
+): Promise<FacebookPage[]> {
+  const fields = "id,name,access_token,category,tasks"
+  const [owned, client] = await Promise.all([
+    fetchAllPages<FacebookPage>(
+      `${version}/${businessId}/owned_pages`,
+      fields,
+      userAccessToken,
+    ),
+    fetchAllPages<FacebookPage>(
+      `${version}/${businessId}/client_pages`,
+      fields,
+      userAccessToken,
+    ),
+  ])
+  return [...owned, ...client]
+}
+
+/**
+ * Pages reachable only through a Business Manager role (not a direct page
+ * role) are invisible to /me/accounts. Best-effort: any failure here (user
+ * not in a Business Manager, missing permission, Graph error) falls back to
+ * an empty list rather than blocking the direct-accounts result.
+ */
+async function getBusinessManagedPages(
+  userAccessToken: string,
+  version: string,
+): Promise<FacebookPage[]> {
+  try {
+    const businesses = await getUserBusinesses(userAccessToken, version)
+    const pagesPerBusiness = await Promise.all(
+      businesses.map((business) =>
+        getBusinessPages(business.id, userAccessToken, version).catch(
+          (error) => {
+            logger.warn(
+              error,
+              `Failed to fetch BM pages for business ${business.id}`,
+            )
+            return []
+          },
+        ),
+      ),
+    )
+    return pagesPerBusiness.flat()
+  } catch (error) {
+    logger.warn(
+      error,
+      "Failed to fetch Business Manager pages, falling back to direct accounts",
+    )
+    return []
+  }
+}
 
 const FACEBOOK_OAUTH_BASE = "https://www.facebook.com"
 
@@ -65,15 +171,14 @@ export function exchangeCodeForToken(
   })
 }
 
-export function getUserPages(
+export async function getUserPages(
   userAccessToken: string,
   version: string = DEFAULT_API_VERSION,
 ): Promise<FacebookPage[]> {
-  const endpoint = `${version}/me/accounts`
-
-  return rescue(endpoint, async () => {
+  const directPagesEndpoint = `${version}/me/accounts`
+  const directPages = await rescue(directPagesEndpoint, async () => {
     const res: { data: FacebookPage[] } = await facebookGraphClient.get(
-      endpoint,
+      directPagesEndpoint,
       {
         searchParams: {
           fields: "id,name,access_token,category,tasks",
@@ -83,4 +188,17 @@ export function getUserPages(
     )
     return res.data
   })
+
+  const businessPages = await getBusinessManagedPages(userAccessToken, version)
+
+  const merged = new Map<string, FacebookPage>()
+  for (const page of directPages) {
+    merged.set(page.id, page)
+  }
+  for (const page of businessPages) {
+    if (page.access_token && !merged.has(page.id)) {
+      merged.set(page.id, page)
+    }
+  }
+  return Array.from(merged.values())
 }


### PR DESCRIPTION
## Summary
- `getUserPages` only called `/me/accounts`, which returns pages the user has a *direct* role on. Pages reachable only through a Business Manager role (agency/enterprise setups, common) never appeared in the Messenger page-select flow.
- Adds paginated `/me/businesses` + `/{business_id}/owned_pages` + `/{business_id}/client_pages` lookups, merged with the direct `/me/accounts` result.
- No OAuth scope changes needed — `pages_show_list` and `business_management` were already requested.

## Changes
- `integrations/messenger/src/apis/auth.ts`: added `fetchAllPages` pagination helper, `getUserBusinesses`/`getBusinessPages`/`getBusinessManagedPages` internal helpers, and extended `getUserPages` to merge direct + Business-Manager pages (direct pages win on id collisions; BM pages missing `access_token` are dropped). BM lookup failures are logged and fall back silently to the direct-accounts result — no scope, call-site, or UI changes required.
- `integrations/messenger/__tests__/get-user-pages.test.ts`: new test suite covering no-BM baseline, merge of non-overlapping pages, id-collision precedence, missing-access_token filtering, silent fallback on BM fetch failure, and pagination.

## Test plan
- [x] `pnpm --filter @chatbotx.io/integration-messenger test`
- [x] `pnpm --filter @chatbotx.io/integration-messenger check-types`
- [x] `pnpm --filter builder check-types`
- [x] `pnpm lint` (scoped to changed files)
- [ ] Manual QA: connect Messenger with a user who only has a Business Manager role (no direct page role) and confirm the page now appears in the page-select list
