### PR TITLE
fix(whatsapp): open the correct Meta screen for each connect mode

### DIFF
--- a/apps/builder/__tests__/whatsapp-embedded-signup.test.ts
+++ b/apps/builder/__tests__/whatsapp-embedded-signup.test.ts
@@ -53,9 +53,10 @@ describe("buildFacebookOAuthDialogUrl", () => {
     const state = decodeOAuthState(result.searchParams.get("state") ?? "")
     expect(state).toEqual({ referer: RESELLER_ORIGIN, locale: "vi" })
 
-    // transferPhoneNumber drives the coexist onboarding featureType in extras.
+    // transferPhoneNumber sends the user to Meta's existing-WABA sharing screen,
+    // which is where a number hosted by another provider is migrated from.
     const extras = JSON.parse(result.searchParams.get("extras") ?? "{}")
-    expect(extras.featureType).toBe("whatsapp_business_app_onboarding")
+    expect(extras.featureType).toBe("only_waba_sharing")
   })
 
   test("falls back to the builder origin when no broker is configured", async () => {
@@ -112,7 +113,7 @@ describe("encodeOAuthState / decodeOAuthState", () => {
 })
 
 describe("resolveEmbeddedSignupFeatureType", () => {
-  test("returns the coexist onboarding type when transferring a phone", async () => {
+  test("returns WABA sharing when transferring a phone from another provider", async () => {
     const { resolveEmbeddedSignupFeatureType, EMBEDDED_SIGNUP_FEATURE_TYPES } =
       await loadWith({ NEXT_PUBLIC_BROKER_URL: BROKER_URL })
 
@@ -121,10 +122,10 @@ describe("resolveEmbeddedSignupFeatureType", () => {
         connectExisting: false,
         transferPhoneNumber: true,
       }),
-    ).toBe(EMBEDDED_SIGNUP_FEATURE_TYPES.WHATSAPP_BUSINESS_APP_ONBOARDING)
+    ).toBe(EMBEDDED_SIGNUP_FEATURE_TYPES.ONLY_WABA_SHARING)
   })
 
-  test("returns WABA sharing when connecting an existing account", async () => {
+  test("returns the coexist onboarding type when connecting an existing account", async () => {
     const { resolveEmbeddedSignupFeatureType, EMBEDDED_SIGNUP_FEATURE_TYPES } =
       await loadWith({ NEXT_PUBLIC_BROKER_URL: BROKER_URL })
 
@@ -133,7 +134,7 @@ describe("resolveEmbeddedSignupFeatureType", () => {
         connectExisting: true,
         transferPhoneNumber: false,
       }),
-    ).toBe(EMBEDDED_SIGNUP_FEATURE_TYPES.ONLY_WABA_SHARING)
+    ).toBe(EMBEDDED_SIGNUP_FEATURE_TYPES.WHATSAPP_BUSINESS_APP_ONBOARDING)
   })
 
   test("returns undefined for a fresh signup", async () => {
@@ -147,5 +148,75 @@ describe("resolveEmbeddedSignupFeatureType", () => {
         transferPhoneNumber: false,
       }),
     ).toBeUndefined()
+  })
+
+  test("lets the transfer intent win when both toggles are set", async () => {
+    const { resolveEmbeddedSignupFeatureType, EMBEDDED_SIGNUP_FEATURE_TYPES } =
+      await loadWith({ NEXT_PUBLIC_BROKER_URL: BROKER_URL })
+
+    expect(
+      resolveEmbeddedSignupFeatureType({
+        connectExisting: true,
+        transferPhoneNumber: true,
+      }),
+    ).toBe(EMBEDDED_SIGNUP_FEATURE_TYPES.ONLY_WABA_SHARING)
+  })
+})
+
+describe("isCoexistOnboardingIntent", () => {
+  test("is true only when Meta was asked for the coexist onboarding flow", async () => {
+    const { isCoexistOnboardingIntent } = await loadWith({
+      NEXT_PUBLIC_BROKER_URL: BROKER_URL,
+    })
+
+    expect(
+      isCoexistOnboardingIntent({
+        connectExisting: true,
+        transferPhoneNumber: false,
+      }),
+    ).toBe(true)
+  })
+
+  test("is false for a manual connect, which never opens the Meta dialog", async () => {
+    const { isCoexistOnboardingIntent } = await loadWith({
+      NEXT_PUBLIC_BROKER_URL: BROKER_URL,
+    })
+
+    // The manualConnect toggle is only reachable with connectExisting on, so the
+    // coexist gate must exclude it explicitly.
+    expect(
+      isCoexistOnboardingIntent({
+        connectExisting: true,
+        transferPhoneNumber: false,
+        manualConnect: true,
+      }),
+    ).toBe(false)
+  })
+
+  test("is false for a transfer, a fresh signup, and an ambiguous both-on form", async () => {
+    const { isCoexistOnboardingIntent } = await loadWith({
+      NEXT_PUBLIC_BROKER_URL: BROKER_URL,
+    })
+
+    expect(
+      isCoexistOnboardingIntent({
+        connectExisting: false,
+        transferPhoneNumber: true,
+      }),
+    ).toBe(false)
+    expect(
+      isCoexistOnboardingIntent({
+        connectExisting: false,
+        transferPhoneNumber: false,
+      }),
+    ).toBe(false)
+    // Both on resolves to only_waba_sharing, so the server must not run the
+    // coexist eligibility check for it.
+    expect(
+      isCoexistOnboardingIntent({
+        connectExisting: true,
+        transferPhoneNumber: true,
+      }),
+    ).toBe(false)
   })
 })

--- a/apps/builder/src/features/integration-whatsapp/actions/connect.action.ts
+++ b/apps/builder/src/features/integration-whatsapp/actions/connect.action.ts
@@ -40,7 +40,10 @@ import { updateWorkspaceLogo } from "@/features/workspaces/actions/upload-logo"
 import { logger } from "@/lib/log"
 import { buildBrokerCallbackUrl, getBrokerOrigin } from "@/lib/oauth-broker"
 import { authActionClient } from "@/lib/safe-action"
-import { WHATSAPP_OAUTH_CALLBACK_PATH } from "../libs/embedded-signup"
+import {
+  isCoexistOnboardingIntent,
+  WHATSAPP_OAUTH_CALLBACK_PATH,
+} from "../libs/embedded-signup"
 import {
   type ConnectWhatsappResult,
   type ConnectWhatsappSchema,
@@ -429,14 +432,15 @@ export const connectWhatsappAction = authActionClient
           await setupOAuthResources(auth, whatsappSettings)
         }
 
-        // Resolve Meta-truth eligibility: form field `transferPhoneNumber` is
-        // user intent, but Meta only places the phone in coexist mode when the
-        // app's config_id is registered for the whatsapp_business_app_onboarding
-        // solution AND the number is a WhatsApp Business App number. Calling
-        // /smb_app_data on a non-eligible phone yields error 131000/10.
+        // Resolve Meta-truth eligibility: the form only carries user intent, but
+        // Meta only places the phone in coexist mode when the app's config_id is
+        // registered for the whatsapp_business_app_onboarding solution AND the
+        // number is a WhatsApp Business App number. Calling /smb_app_data on a
+        // non-eligible phone yields error 131000/10. Gate on the same helper the
+        // browser used to pick `featureType`, so the two can never disagree.
         let isCoexist = false
         let platformType = ""
-        if (parsedInput.transferPhoneNumber === true) {
+        if (isCoexistOnboardingIntent(parsedInput)) {
           try {
             const eligibility = await getCoexistEligibility({
               phoneNumberId: phoneNumber.id,

--- a/apps/builder/src/features/integration-whatsapp/libs/embedded-signup.ts
+++ b/apps/builder/src/features/integration-whatsapp/libs/embedded-signup.ts
@@ -66,21 +66,53 @@ export function decodeOAuthState(raw: string): WhatsappOAuthState | null {
   }
 }
 
-/**
- * Derive Meta's embedded-signup `featureType` from the user's intent. Mirrors the
- * original inline logic: transfer (coexist) onboarding vs. existing-WABA sharing.
- */
-export function resolveEmbeddedSignupFeatureType(params: {
+export type EmbeddedSignupIntent = {
   connectExisting: boolean
   transferPhoneNumber: boolean
-}): string | undefined {
+  /** Manual connect bypasses embedded signup entirely. */
+  manualConnect?: boolean
+}
+
+/**
+ * Derive Meta's embedded-signup `featureType` from the user's intent.
+ *
+ * - Transferring a number hosted by another provider means the WABA already
+ *   exists elsewhere, so Meta must open the existing-WABA sharing screen.
+ * - Connecting an existing account means the number is live on the WhatsApp
+ *   Business App, which is Meta's coexistence onboarding screen.
+ *
+ * When both are set the transfer wins — sharing a foreign WABA cannot also be a
+ * coexist onboarding.
+ */
+export function resolveEmbeddedSignupFeatureType(
+  params: EmbeddedSignupIntent,
+): string | undefined {
   if (params.transferPhoneNumber) {
-    return EMBEDDED_SIGNUP_FEATURE_TYPES.WHATSAPP_BUSINESS_APP_ONBOARDING
-  }
-  if (params.connectExisting) {
     return EMBEDDED_SIGNUP_FEATURE_TYPES.ONLY_WABA_SHARING
   }
+  if (params.connectExisting) {
+    return EMBEDDED_SIGNUP_FEATURE_TYPES.WHATSAPP_BUSINESS_APP_ONBOARDING
+  }
   return
+}
+
+/**
+ * Whether this intent asked Meta for the coexistence flow. The server keys its
+ * coexist eligibility check on this, so it stays in lockstep with the
+ * `featureType` the browser actually sent to Meta. A manual connect never opens
+ * the dialog, so it is never a coexist onboarding — even though the form leaves
+ * `connectExisting` on behind it.
+ */
+export function isCoexistOnboardingIntent(
+  params: EmbeddedSignupIntent,
+): boolean {
+  if (params.manualConnect) {
+    return false
+  }
+  return (
+    resolveEmbeddedSignupFeatureType(params) ===
+    EMBEDDED_SIGNUP_FEATURE_TYPES.WHATSAPP_BUSINESS_APP_ONBOARDING
+  )
 }
 
 /** The exact embedded-signup `extras` object Meta expects. */


### PR DESCRIPTION
## Problem

The two connect toggles opened each other's Meta screen:

- **Transfer phone from another Whatsapp provider** opened the Co-Existence screen.
- **Connect an existing WhatsApp Business Account** opened the another-provider screen.

## Changes

- Swap the `featureType` sent to Meta so each option opens the screen its label promises.
- Move the server's coexist check onto the same helper the browser uses, so client and server always agree.
- Exclude manual connect from the coexist check. The `manualConnect` toggle is only reachable with `connectExisting` on, so a manual connect submits `connectExisting: true` from a hidden field.
- No UI or label changes.

## Behaviour

| Toggle | featureType | Meta screen |
|--------|-------------|-------------|
| *(none)* | *(none)* | default signup |
| Connect an existing WhatsApp Business Account | `whatsapp_business_app_onboarding` | Co-Existence |
| Transfer phone from another Whatsapp provider | `only_waba_sharing` | another provider |
| Manual connect using System User Access token | *(no dialog)* | — |

Only the two middle rows change. New signup and manual connect behave exactly as before.

## Test plan

- [x] `pnpm --filter builder test` — 516 passing, up from 512. The 16 failures are pre-existing on `main`.
- [x] `pnpm --filter builder check-types` — no new errors.
- [x] `biome check` clean on all touched files.
- [ ] Verify on a real WhatsApp Business App number that coexistence still completes and `/register` stays skipped.
- [ ] Verify a transfer reaches the WABA-sharing screen. Completing the migration may still need the OBO step, which is out of scope.
