### PR TITLE
fix(worker): don't skip fb comment automation on top-level comments

### DIFF
--- a/apps/worker/__tests__/comment-automation.test.ts
+++ b/apps/worker/__tests__/comment-automation.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// Hoist mock references
+// ---------------------------------------------------------------------------
+
+const {
+  mockFindContactInboxBy,
+  mockFindActiveAutomations,
+  mockIsWithinSchedule,
+  mockFindDedup,
+  mockInsertDedup,
+  mockIncrementRepliesCount,
+  mockGetPriorContactInboxCount,
+  mockWorkspaceFindById,
+  mockIdentifyInboxAndIntegrationAuth,
+  mockCreateMessageRepository,
+  mockLoggerInfo,
+} = vi.hoisted(() => ({
+  mockFindContactInboxBy: vi.fn(),
+  mockFindActiveAutomations: vi.fn(),
+  mockIsWithinSchedule: vi.fn(),
+  mockFindDedup: vi.fn(),
+  mockInsertDedup: vi.fn(),
+  mockIncrementRepliesCount: vi.fn(),
+  mockGetPriorContactInboxCount: vi.fn(),
+  mockWorkspaceFindById: vi.fn(),
+  mockIdentifyInboxAndIntegrationAuth: vi.fn(),
+  mockCreateMessageRepository: vi.fn(),
+  mockLoggerInfo: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  broadcastToWorkspaceParty: vi.fn(),
+  contactInboxService: { findBy: mockFindContactInboxBy },
+  fbCommentAutomationService: {
+    findActiveAutomations: mockFindActiveAutomations,
+    isWithinSchedule: mockIsWithinSchedule,
+    findDedup: mockFindDedup,
+    insertDedup: mockInsertDedup,
+    incrementRepliesCount: mockIncrementRepliesCount,
+    getPriorContactInboxCount: mockGetPriorContactInboxCount,
+  },
+  workspaceService: { findById: mockWorkspaceFindById },
+}))
+
+vi.mock("@chatbotx.io/database/repositories", () => ({
+  createMessageRepository: mockCreateMessageRepository,
+}))
+
+vi.mock("@chatbotx.io/integration-messenger", () => ({
+  sendPrivateReply: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/partysocket-config", () => ({
+  RealtimeEventType: { messageCreated: "messageCreated" },
+}))
+
+vi.mock("@chatbotx.io/worker-config", () => ({
+  ChatJobAction: { changeChannelMessageState: "changeChannelMessageState" },
+  chatQueue: { add: vi.fn().mockResolvedValue(undefined) },
+  IntegrationJobAction: {
+    processCommentAutomation: "processCommentAutomation",
+  },
+  integrationQueue: { add: vi.fn().mockResolvedValue(undefined) },
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: mockLoggerInfo,
+    debug: vi.fn(),
+  },
+}))
+
+vi.mock("../src/services/integrations", () => ({
+  integrationService: {
+    identifyInboxAndIntegrationAuthFromIdentifier:
+      mockIdentifyInboxAndIntegrationAuth,
+  },
+}))
+
+vi.mock(
+  "../src/integration/handlers/comment-automation/comment-attachment",
+  () => ({
+    createAttachmentInfoResolver: vi
+      .fn()
+      .mockReturnValue(
+        vi.fn().mockResolvedValue({ hasImage: false, hasVideo: false }),
+      ),
+    needsAttachmentInfo: vi.fn().mockReturnValue(false),
+  }),
+)
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { isCommentReply, processCommentAutomation } = await import(
+  "../src/integration/handlers/comment-automation"
+)
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PAGE_ID = "2094067177305463"
+const POST_ID = `${PAGE_ID}_2357494887629356`
+const COMMENT_ID = "2357494887629356_1544045903933592"
+const OTHER_COMMENT_ID = "2357494887629356_9999999999999999"
+
+function buildAutomation(options: Partial<Record<string, boolean>> = {}) {
+  return {
+    id: "automation-1",
+    post: { type: "all", value: [] },
+    includeKeywords: { type: "all", value: [] },
+    excludeKeywords: [],
+    publicReply: { type: "none", value: null },
+    privateReply: { type: "none", value: null },
+    options: {
+      replyToNewContactsOnly: false,
+      replyOncePerUserPerPost: false,
+      likeUserComment: false,
+      replyToUsersWhoCommentedOnOtherPosts: true,
+      ignoreCommentReplies: true,
+      trackUserTags: false,
+      ...options,
+    },
+    hideComments: {
+      all: false,
+      hasPhoneNumber: false,
+      hasImage: false,
+      hasVideo: false,
+      hasLink: false,
+      hasKeywords: false,
+      keywords: [],
+      showCommentsAfter: "none",
+    },
+    replyAfter: { type: "immediately", value: 0 },
+  }
+}
+
+function buildJobData(parentId: string | undefined) {
+  return {
+    integrationType: "messenger",
+    integrationIdentifier: PAGE_ID,
+    workspaceId: "workspace-1",
+    conversationId: "conversation-1",
+    contactInboxId: "contact-inbox-1",
+    commentId: COMMENT_ID,
+    postId: POST_ID,
+    parentId,
+    fromId: "user-1",
+    message: "2",
+    createdTime: 1_783_674_105,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockIdentifyInboxAndIntegrationAuth.mockResolvedValue({
+    integrationRow: { auth: { accessToken: "token" } },
+  })
+  mockFindContactInboxBy.mockResolvedValue({
+    id: "contact-inbox-1",
+    contactId: "contact-1",
+  })
+  mockWorkspaceFindById.mockResolvedValue({ timezone: "UTC" })
+  mockIsWithinSchedule.mockReturnValue(true)
+  mockCreateMessageRepository.mockResolvedValue({
+    findBySourceId: vi.fn().mockResolvedValue(null),
+  })
+  mockInsertDedup.mockResolvedValue(undefined)
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("isCommentReply", () => {
+  test("top-level comment: parentId equals postId", () => {
+    expect(isCommentReply(POST_ID, POST_ID)).toBe(false)
+  })
+
+  test("reply: parentId is another comment id", () => {
+    expect(isCommentReply(OTHER_COMMENT_ID, POST_ID)).toBe(true)
+  })
+
+  test("no parentId", () => {
+    expect(isCommentReply(undefined, POST_ID)).toBe(false)
+  })
+})
+
+describe("processCommentAutomation reply filtering", () => {
+  test("runs the automation for a top-level comment whose parentId equals postId (production Facebook payload)", async () => {
+    mockFindActiveAutomations.mockResolvedValue([buildAutomation()])
+
+    await processCommentAutomation(buildJobData(POST_ID) as any)
+
+    expect(mockInsertDedup).toHaveBeenCalledWith({
+      automationId: "automation-1",
+      contactId: "contact-1",
+      postId: POST_ID,
+      workspaceId: "workspace-1",
+    })
+  })
+
+  test("skips a real comment reply when ignoreCommentReplies is on", async () => {
+    mockFindActiveAutomations.mockResolvedValue([buildAutomation()])
+
+    await processCommentAutomation(buildJobData(OTHER_COMMENT_ID) as any)
+
+    expect(mockInsertDedup).not.toHaveBeenCalled()
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "comment is a reply" }),
+      "Comment automation skipped",
+    )
+  })
+
+  test("runs the automation for a real comment reply when ignoreCommentReplies is off", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({ ignoreCommentReplies: false }),
+    ])
+
+    await processCommentAutomation(buildJobData(OTHER_COMMENT_ID) as any)
+
+    expect(mockInsertDedup).toHaveBeenCalled()
+  })
+
+  test("runs the automation when the payload has no parentId", async () => {
+    mockFindActiveAutomations.mockResolvedValue([buildAutomation()])
+
+    await processCommentAutomation(buildJobData(undefined) as any)
+
+    expect(mockInsertDedup).toHaveBeenCalled()
+  })
+})

--- a/apps/worker/src/integration/handlers/comment-automation/index.ts
+++ b/apps/worker/src/integration/handlers/comment-automation/index.ts
@@ -97,6 +97,16 @@ function matchKeywords(
   return true
 }
 
+// Facebook feed webhooks set parent_id on every comment: for a top-level
+// comment it equals the post id, and only a reply to another comment carries
+// that comment's id instead.
+export function isCommentReply(
+  parentId: string | undefined,
+  postId: string,
+): boolean {
+  return Boolean(parentId) && parentId !== postId
+}
+
 function willSendReply(reply: FBCommentReply): boolean {
   if (reply.type === "none") {
     return false
@@ -390,12 +400,36 @@ export async function processCommentAutomation(
           workspace.timezone,
         )
       ) {
+        logAutomationSkipped({
+          automationId: automation.id,
+          commentId,
+          postId,
+          workspaceId,
+          reason: "outside schedule",
+        })
         continue
       }
       if (!matchPost(automation.post, postId)) {
+        logAutomationSkipped({
+          automationId: automation.id,
+          commentId,
+          postId,
+          workspaceId,
+          reason: "post does not match",
+        })
         continue
       }
-      if (automation.options.ignoreCommentReplies && parentId) {
+      if (
+        automation.options.ignoreCommentReplies &&
+        isCommentReply(parentId, postId)
+      ) {
+        logAutomationSkipped({
+          automationId: automation.id,
+          commentId,
+          postId,
+          workspaceId,
+          reason: "comment is a reply",
+        })
         continue
       }
       if (
@@ -405,6 +439,13 @@ export async function processCommentAutomation(
           message,
         )
       ) {
+        logAutomationSkipped({
+          automationId: automation.id,
+          commentId,
+          postId,
+          workspaceId,
+          reason: "keywords do not match",
+        })
         continue
       }
 
@@ -414,6 +455,13 @@ export async function processCommentAutomation(
             contactId: contactInbox.contactId,
           })
         if (priorCount > 1) {
+          logAutomationSkipped({
+            automationId: automation.id,
+            commentId,
+            postId,
+            workspaceId,
+            reason: "contact is not new",
+          })
           continue
         }
       }
@@ -425,6 +473,13 @@ export async function processCommentAutomation(
           postId,
         })
         if (existing) {
+          logAutomationSkipped({
+            automationId: automation.id,
+            commentId,
+            postId,
+            workspaceId,
+            reason: "already replied to this user on this post",
+          })
           continue
         }
       }
@@ -557,4 +612,23 @@ export async function processCommentAutomation(
       )
     }
   }
+}
+
+const logAutomationSkipped = ({
+  automationId,
+  commentId,
+  postId,
+  workspaceId,
+  reason,
+}: {
+  automationId: string
+  commentId: string
+  postId: string
+  workspaceId: string
+  reason: string
+}) => {
+  logger.info(
+    { automationId, commentId, postId, workspaceId, reason },
+    "Comment automation skipped",
+  )
 }


### PR DESCRIPTION
## Summary
- Facebook `feed` webhooks set `parent_id` on every comment, including top-level ones (`parent_id` equals `post_id` for a top-level comment). The handler treated any `parentId` as "this is a reply", so with the default `ignoreCommentReplies=true` option, every top-level comment on production was silently skipped and no automation ran.
- Added `isCommentReply(parentId, postId)` — only true when `parentId` differs from `postId` — and use it in place of the bare `parentId` truthiness check.
- Added `logger.info` at every `continue` branch in the per-automation loop (schedule, post mismatch, reply, keywords, new-contact, dedup) so future skips are diagnosable from logs instead of silently returning `null`.

## Changes
- `apps/worker/src/integration/handlers/comment-automation/index.ts` — `isCommentReply` helper, fixed reply-skip condition, skip-reason logging
- `apps/worker/__tests__/comment-automation.test.ts` — new tests covering top-level vs. reply comments and the `ignoreCommentReplies` toggle

## Test plan
- [x] `pnpm --filter worker vitest run __tests__/comment-automation.test.ts` (7 passed)
- [x] `pnpm --filter worker check-types`
- [x] `pnpm lint` (clean on changed files; one pre-existing unrelated formatting error in `apps/builder/messages/en.d.json.ts`)
- [ ] Manual verification in production: comment on a post, confirm automation fires and reason logs appear for any skips
