### PR TITLE
feat(contacts): add Contact Id column to contact export

### DIFF
--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -853,7 +853,7 @@
       "label": "Country Code"
     },
     "contactId": {
-      "label": "Contact ID / Subscriber ID / PSID"
+      "label": "Contact ID"
     },
     "flow": {
       "label": "Flow"

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -861,7 +861,7 @@
       "label": "Mã quốc gia"
     },
     "contactId": {
-      "label": "ID Liên hệ / ID Người đăng ký / PSID"
+      "label": "ID Liên hệ"
     },
     "flow": {
       "label": "Luồng"

--- a/apps/builder/src/features/contacts/export-contact-dialog.tsx
+++ b/apps/builder/src/features/contacts/export-contact-dialog.tsx
@@ -75,6 +75,10 @@ export function ExportContactDialog({
       heading: t("fields.botFields.label"),
       options: [
         {
+          label: t("fields.contactId.label"),
+          value: `${contactPrefix}:contactId`,
+        },
+        {
           label: t("fields.firstName.label"),
           value: `${contactPrefix}:firstName`,
         },
@@ -123,7 +127,8 @@ export function ExportContactDialog({
         formProps: {
           mode: "onChange",
           defaultValues: {
-            fields: options[0].options.slice(0, 5).map((opt) => opt.value),
+            // All built-in bot fields (incl. Contact Id) are selected by default.
+            fields: options[0].options.map((opt) => opt.value),
             ...(exportAll ? { exportAll: true, filter } : { contactIds }),
           },
         },

--- a/apps/worker/__tests__/export-contacts-csv.test.ts
+++ b/apps/worker/__tests__/export-contacts-csv.test.ts
@@ -333,6 +333,34 @@ describe("buildCsvChunk", () => {
     expect(result).toBe('"No"\n')
   })
 
+  test("renders the Contact Id from the first contactInbox sourceId", () => {
+    // Arrange
+    const fields: SelectedField[] = [
+      { type: "contact", value: "contactId", header: "Contact ID" },
+    ]
+    const contacts = [{ id: "1", contactInboxes: [{ sourceId: "psid-123" }] }]
+
+    // Act
+    const result = buildCsvChunk(contacts, fields)
+
+    // Assert
+    expect(result).toBe('"psid-123"\n')
+  })
+
+  test("renders an empty string for Contact Id when the contact has no inbox", () => {
+    // Arrange
+    const fields: SelectedField[] = [
+      { type: "contact", value: "contactId", header: "Contact ID" },
+    ]
+    const contacts = [{ id: "1", contactInboxes: [] }, { id: "2" }]
+
+    // Act
+    const result = buildCsvChunk(contacts, fields)
+
+    // Assert — both a present-but-empty relation and an absent one yield ""
+    expect(result).toBe('""\n""\n')
+  })
+
   test("produces multiple rows separated by newlines for multiple contacts", () => {
     // Arrange
     const fields: SelectedField[] = [

--- a/apps/worker/__tests__/export-contacts-fields.test.ts
+++ b/apps/worker/__tests__/export-contacts-fields.test.ts
@@ -105,9 +105,25 @@ describe("buildSelectedFields", () => {
       ])
     })
 
+    test("resolves the virtual contactId field to the Contact ID header", async () => {
+      // Arrange
+      const fields = ["sys:contactId"]
+
+      // Act
+      const result = await buildSelectedFields(fields, WORKSPACE_ID)
+
+      // Assert
+      expect(result).toEqual([
+        { type: "contact", value: "contactId", header: "Contact ID" },
+      ])
+      expect(findManyTags).not.toHaveBeenCalled()
+      expect(findManyCustomFields).not.toHaveBeenCalled()
+    })
+
     test("maps all known contact column keys to their correct display headers", async () => {
       // Arrange
       const cases: [string, string][] = [
+        ["contactId", "Contact ID"],
         ["firstName", "First Name"],
         ["lastName", "Last Name"],
         ["fullName", "Full Name"],

--- a/apps/worker/src/default/handlers/export-contacts.ts
+++ b/apps/worker/src/default/handlers/export-contacts.ts
@@ -21,8 +21,14 @@ const contactFieldPrefix = "sys:"
 const customFieldPrefix = "cus:"
 const tagPrefix = "tag:"
 
+// Virtual contact column backed by the first ContactInbox.sourceId (the
+// platform-native id: WhatsApp wa_id, Messenger PSID, …). It is not a column on
+// the Contact row, so renderCell resolves it from the contactInboxes relation.
+const contactIdField = "contactId"
+
 // Human-readable headers for built-in contact columns.
 const headerNames: Record<string, string> = {
+  contactId: "Contact ID",
   firstName: "First Name",
   lastName: "Last Name",
   fullName: "Full Name",
@@ -43,6 +49,7 @@ type ContactRow = {
   [key: string]: unknown
   contactCustomFields?: (typeof contactCustomFieldModel.$inferSelect)[]
   tags?: { id: string }[]
+  contactInboxes?: { sourceId: string }[]
 }
 
 // ── CSV serialization ─────────────────────────────────────────────────────────
@@ -69,6 +76,12 @@ export const escapeCsvValue = (value: string): string => {
 /** Renders one selected field of one contact into a CSV cell. */
 const renderCell = (contact: ContactRow, field: SelectedField): string => {
   if (field.type === "contact") {
+    // The Contact Id column is not stored on the Contact row — it comes from the
+    // contact's first (earliest) inbox connection's platform-native sourceId.
+    if (field.value === contactIdField) {
+      const sourceId = contact.contactInboxes?.[0]?.sourceId
+      return sourceId ? escapeCsvValue(sourceId) : '""'
+    }
     const rawValue = contact[field.value]
     if (rawValue instanceof Date) {
       return escapeCsvValue(rawValue.toISOString())
@@ -274,7 +287,16 @@ const fetchContactPage = (
 ) =>
   db.query.contactModel.findMany({
     where: lastId ? { AND: [baseWhere, { id: { gt: lastId } }] } : baseWhere,
-    with: { contactCustomFields: true, tags: true },
+    with: {
+      contactCustomFields: true,
+      tags: true,
+      // Only the earliest inbox connection is needed for the Contact Id column.
+      contactInboxes: {
+        columns: { sourceId: true },
+        orderBy: { id: "asc" },
+        limit: 1,
+      },
+    },
     limit: loopableItemsCount,
     orderBy: { id: "asc" },
   })


### PR DESCRIPTION
## Problem

The contact CSV export did not include the platform-native contact identifier, so exported rows could not be matched back to a contact on the source channel (WhatsApp `wa_id`, Messenger PSID, etc.).

## Solution

- Add a **Contact Id** column to the Export Contacts dialog, sourced from `ContactInbox.sourceId`.
- The column is included in the default field selection.
- For contacts linked to multiple inboxes, the value comes from the earliest inbox connection (`orderBy id asc, limit 1`) so the export is deterministic.
- Reuses the existing `fields.contactId` translation key — no hardcoded strings.

## Test plan

- [x] `pnpm --filter worker exec vitest run export-contacts` — 81 passing
- [x] `pnpm --filter worker check-types` — clean
- [x] `pnpm --filter builder check-types` — clean
- [x] `pnpm lint` — clean
- [ ] Manual: export contacts and confirm the **Contact Id** column contains each contact's `sourceId`
