### PR TITLE
fix(storage): unify public file url building in a shared helper

### DIFF
--- a/apps/builder/src/features/contacts/utils.ts
+++ b/apps/builder/src/features/contacts/utils.ts
@@ -1,3 +1,4 @@
+import { getPublicFileUrl } from "@chatbotx.io/utils"
 import { useTenantSettings } from "@/features/tenant"
 import type { ContactResource } from "./schemas/resource"
 
@@ -25,6 +26,6 @@ export function useAvatarUrl(
   }
 
   return contact.avatar
-    ? new URL(contact.avatar, storageUrl).toString()
+    ? getPublicFileUrl(contact.avatar, storageUrl)
     : undefined
 }

--- a/packages/business/src/utils.ts
+++ b/packages/business/src/utils.ts
@@ -1,4 +1,4 @@
+// Single source of truth for building public storage URLs — shared with the
+// browser (useAvatarUrl) so inbox avatars and server-rendered URLs stay in sync.
+export { getPublicFileUrl } from "@chatbotx.io/utils"
 export * from "./inbox/utils"
-
-export const getPublicFileUrl = (path: string, baseUrl: string) =>
-  new URL(path, baseUrl).toString()

--- a/packages/utils/__tests__/storage.test.ts
+++ b/packages/utils/__tests__/storage.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest"
+import { getPublicFileUrl } from "../src/storage"
+
+// The base of interest carries a bucket path segment (e.g. RustFS/S3 proxy),
+// which is exactly the shape `new URL` silently drops when misused.
+const BUCKET_BASE = "https://filesystem.example.com/chatbotx/"
+
+describe("getPublicFileUrl", () => {
+  test("joins a bare object key under the bucket base", () => {
+    expect(getPublicFileUrl("public/space/1/avatar/abc", BUCKET_BASE)).toBe(
+      "https://filesystem.example.com/chatbotx/public/space/1/avatar/abc",
+    )
+  })
+
+  test("keeps the bucket even when the key has a leading slash", () => {
+    // Naive `new URL("/public/...", base)` would drop "/chatbotx".
+    expect(getPublicFileUrl("/public/space/1/avatar/abc", BUCKET_BASE)).toBe(
+      "https://filesystem.example.com/chatbotx/public/space/1/avatar/abc",
+    )
+  })
+
+  test("keeps the bucket even when the base has no trailing slash", () => {
+    expect(
+      getPublicFileUrl(
+        "public/space/1/avatar/abc",
+        "https://filesystem.example.com/chatbotx",
+      ),
+    ).toBe("https://filesystem.example.com/chatbotx/public/space/1/avatar/abc")
+  })
+
+  test("works with a bucket-less CDN base", () => {
+    expect(getPublicFileUrl("public/x.png", "https://cdn.example.com/")).toBe(
+      "https://cdn.example.com/public/x.png",
+    )
+  })
+
+  test("returns an already-absolute http(s) path unchanged", () => {
+    const absolute = "https://scontent.fbcdn.net/v/t1/avatar.jpg"
+    expect(getPublicFileUrl(absolute, BUCKET_BASE)).toBe(absolute)
+  })
+})

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./encode"
 export * from "./id"
 export * from "./request"
+export * from "./storage"
 export * from "./zod"

--- a/packages/utils/src/storage.ts
+++ b/packages/utils/src/storage.ts
@@ -1,0 +1,16 @@
+const LEADING_SLASHES_RE = /^\/+/
+
+/**
+ * Join a stored object key onto a public storage base URL.
+ *
+ * `new URL(path, base)` is deceptively fragile here: a leading slash on `path`,
+ * or a missing trailing slash on `base`, silently drops the base's own path
+ * segment — e.g. the bucket in `https://cdn.example.com/chatbotx/`. Normalizing
+ * both sides keeps the base (bucket prefix included) intact.
+ *
+ * An already-absolute `path` (http/https) is returned unchanged.
+ */
+export const getPublicFileUrl = (path: string, baseUrl: string): string => {
+  const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`
+  return new URL(path.replace(LEADING_SLASHES_RE, ""), base).toString()
+}


### PR DESCRIPTION
## Problem

Public file URLs were built with `new URL(path, storageUrl)` in several places, and the inbox avatar (`useAvatarUrl`) duplicated that logic inline. `new URL()` silently drops the base's path segment (e.g. the storage bucket in `https://host/chatbotx/`) when the key has a leading slash or the base is missing a trailing slash, so the same URL could be built inconsistently.

## Solution

- Add a single `getPublicFileUrl` helper in `@chatbotx.io/utils` that normalizes the base (trailing slash) and the key (no leading slash) so the bucket path is always preserved.
- Server helper `@chatbotx.io/business/utils` now re-exports it, so every existing caller (including `toPublicStorageUrl`) uses the same implementation with no import changes.
- The inbox avatar (`useAvatarUrl`) now uses the shared helper instead of its own inline `new URL`.

Behaviour is unchanged for the normal case (bare object key + trailing-slash base); the helper only adds safety for the fragile cases and removes the duplication.

## Test plan

- [x] `pnpm --filter @chatbotx.io/utils exec vitest run storage` — 5 passing (covers leading slash and missing trailing slash)
- [x] `pnpm --filter @chatbotx.io/utils check-types` / `@chatbotx.io/business` / `builder` / `@chatbotx.io/variables` — clean
- [x] `pnpm lint` — clean
- [ ] Manual: verify inbox avatars and contact `profile_pic`/`avatar` variables resolve to the same URL
