### PR TITLE
fix(broadcast): stop retrying permanent template errors

### DIFF
--- a/apps/worker/__tests__/send-messenger-template-create.test.ts
+++ b/apps/worker/__tests__/send-messenger-template-create.test.ts
@@ -130,9 +130,13 @@ vi.mock("@chatbotx.io/partysocket-config", () => ({
   RealtimeEventType: { messageCreated: "messageCreated" },
 }))
 
-vi.mock("@chatbotx.io/sdk", () => ({
-  parseSdkError: vi.fn().mockResolvedValue({ message: "sdk error" }),
-}))
+vi.mock("@chatbotx.io/sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@chatbotx.io/sdk")>()
+  return {
+    ...actual,
+    parseSdkError: vi.fn().mockResolvedValue({ message: "sdk error" }),
+  }
+})
 
 vi.mock("@chatbotx.io/utils", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@chatbotx.io/utils")>()
@@ -176,9 +180,10 @@ vi.mock("@chatbotx.io/flow-config", async (importOriginal) => {
 
 import type { ProcessMessengerTemplateParams } from "../src/chat/handlers/send-messenger-template"
 
-const { processMessengerTemplate } = await import(
+const { processMessengerTemplate, sendMessengerTemplateMessage } = await import(
   "../src/chat/handlers/send-messenger-template"
 )
+const { ChannelError, ChannelErrorCategory } = await import("@chatbotx.io/sdk")
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -205,6 +210,20 @@ const fakeTemplate = {
   params: {} as ProcessMessengerTemplateParams["template"]["params"],
   inboxId: "inbox-1",
 } as ProcessMessengerTemplateParams["template"]
+
+const broadcastTemplateJobData: Parameters<
+  typeof sendMessengerTemplateMessage
+>[0] = {
+  conversation: fakeConversation,
+  contactInbox: {
+    ...fakeContactInbox,
+    contactId: "contact-1",
+  },
+  templateId: "tmpl-1",
+  broadcastId: "broadcast-1",
+  templateData: {},
+  metadata: { type: "broadcast", broadcastId: "broadcast-1" },
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -328,6 +347,36 @@ describe("processMessengerTemplate", () => {
         template: fakeTemplate,
       }),
     ).resolves.toBeDefined()
+
+    expect(mockSendFlowStep).toHaveBeenCalledTimes(1)
+  })
+
+  test("does not throw permanent ChannelError from broadcast template send", async () => {
+    const error = new ChannelError(
+      "(#551) This person isn't available at the moment.",
+      ChannelErrorCategory.USER_BLOCKED,
+      { code: 551 },
+    )
+    mockSendFlowStep.mockRejectedValueOnce(error)
+
+    await expect(
+      sendMessengerTemplateMessage(broadcastTemplateJobData),
+    ).resolves.toBeUndefined()
+
+    expect(mockSendFlowStep).toHaveBeenCalledTimes(1)
+    expect(mockEmit).toHaveBeenCalledWith(
+      "message:failed",
+      expect.objectContaining({ occurredAt: expect.any(Date) }),
+    )
+  })
+
+  test("rethrows non-ChannelError from Messenger broadcast template send", async () => {
+    const error = new Error("unexpected provider failure")
+    mockSendFlowStep.mockRejectedValueOnce(error)
+
+    await expect(
+      sendMessengerTemplateMessage(broadcastTemplateJobData),
+    ).rejects.toBe(error)
 
     expect(mockSendFlowStep).toHaveBeenCalledTimes(1)
   })

--- a/apps/worker/__tests__/send-whatsapp-template.test.ts
+++ b/apps/worker/__tests__/send-whatsapp-template.test.ts
@@ -134,9 +134,13 @@ vi.mock("@chatbotx.io/partysocket-config", () => ({
   RealtimeEventType: { messageCreated: "messageCreated" },
 }))
 
-vi.mock("@chatbotx.io/sdk", () => ({
-  parseSdkError: mockParseSdkError,
-}))
+vi.mock("@chatbotx.io/sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@chatbotx.io/sdk")>()
+  return {
+    ...actual,
+    parseSdkError: mockParseSdkError,
+  }
+})
 
 vi.mock("@chatbotx.io/utils", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@chatbotx.io/utils")>()
@@ -184,9 +188,10 @@ vi.mock("../src/chat/handlers/send-flow-step", () => ({
 
 import type { ProcessWhatsappTemplateParams } from "../src/chat/handlers/send-whatsapp-template"
 
-const { processWhatsappTemplate } = await import(
+const { processWhatsappTemplate, sendWhatsappTemplateMessage } = await import(
   "../src/chat/handlers/send-whatsapp-template"
 )
+const { ChannelError, ChannelErrorCategory } = await import("@chatbotx.io/sdk")
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -209,6 +214,20 @@ const fakeTemplate: ProcessWhatsappTemplateParams["template"] = {
   name: "wa-template",
   language: "en",
   params: {},
+}
+
+const broadcastTemplateJobData: Parameters<
+  typeof sendWhatsappTemplateMessage
+>[0] = {
+  conversation: fakeConversation,
+  contactInbox: {
+    ...fakeContactInbox,
+    contactId: "contact-1",
+  },
+  templateId: "tmpl-wa-1",
+  broadcastId: "broadcast-1",
+  templateData: {},
+  metadata: { type: "broadcast", broadcastId: "broadcast-1" },
 }
 
 // ---------------------------------------------------------------------------
@@ -377,5 +396,50 @@ describe("processWhatsappTemplate", () => {
       "message:failed",
       expect.objectContaining({ occurredAt: expect.any(Date) }),
     )
+  })
+
+  test("does not throw permanent ChannelError from broadcast template send", async () => {
+    const error = new ChannelError(
+      "integration auth failed",
+      ChannelErrorCategory.AUTH_FAILED,
+      { code: "auth_failed" },
+    )
+    mockSendFlowStep.mockRejectedValueOnce(error)
+
+    await expect(
+      sendWhatsappTemplateMessage(broadcastTemplateJobData),
+    ).resolves.toBeUndefined()
+
+    expect(mockSendFlowStep).toHaveBeenCalledTimes(1)
+    expect(mockEmit).toHaveBeenCalledWith(
+      "message:failed",
+      expect.objectContaining({ occurredAt: expect.any(Date) }),
+    )
+  })
+
+  test("rethrows retryable ChannelError from WhatsApp broadcast template send", async () => {
+    const error = new ChannelError(
+      "rate limited",
+      ChannelErrorCategory.RATE_LIMITED,
+      { code: "rate_limited" },
+    )
+    mockSendFlowStep.mockRejectedValueOnce(error)
+
+    await expect(
+      sendWhatsappTemplateMessage(broadcastTemplateJobData),
+    ).rejects.toBe(error)
+
+    expect(mockSendFlowStep).toHaveBeenCalledTimes(1)
+  })
+
+  test("rethrows non-ChannelError from WhatsApp broadcast template send", async () => {
+    const error = new Error("unexpected provider failure")
+    mockSendFlowStep.mockRejectedValueOnce(error)
+
+    await expect(
+      sendWhatsappTemplateMessage(broadcastTemplateJobData),
+    ).rejects.toBe(error)
+
+    expect(mockSendFlowStep).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/worker/src/chat/handlers/send-messenger-template.ts
+++ b/apps/worker/src/chat/handlers/send-messenger-template.ts
@@ -39,6 +39,7 @@ import {
   validateMessengerTemplate,
 } from "../../integration/handlers/messenger-template-handler"
 import { logger } from "../../lib/logger"
+import { shouldSuppressRetryableChannelError } from "../utils/retry"
 import { sendFlowStepToChannel } from "./send-message"
 
 export interface ProcessMessengerTemplateParams {
@@ -290,7 +291,7 @@ export async function processMessengerTemplate(
 
 export async function sendMessengerTemplateMessage(
   data: ChatJobSendMessengerTemplateMessage["data"],
-) {
+): Promise<ProcessMessengerTemplateResult | undefined> {
   const {
     conversation,
     templateId,
@@ -419,6 +420,9 @@ export async function sendMessengerTemplateMessage(
       },
       "Error sending Messenger template message for broadcast",
     )
+    if (shouldSuppressRetryableChannelError(error, contactInbox.channel)) {
+      return
+    }
     throw error
   }
 }

--- a/apps/worker/src/chat/handlers/send-whatsapp-template.ts
+++ b/apps/worker/src/chat/handlers/send-whatsapp-template.ts
@@ -34,6 +34,7 @@ import {
   validateWhatsappTemplate,
 } from "../../integration/handlers/wa-template-handler"
 import { logger } from "../../lib/logger"
+import { shouldSuppressRetryableChannelError } from "../utils/retry"
 import { convertButtonsToTemplate } from "./send-flow-step"
 import { sendFlowStepToChannel } from "./send-message"
 
@@ -263,7 +264,7 @@ export async function processWhatsappTemplate(
 
 export async function sendWhatsappTemplateMessage(
   data: ChatJobSendWhatsappTemplateMessage["data"],
-) {
+): Promise<ProcessWhatsappTemplateResult | undefined> {
   const {
     conversation,
     templateId,
@@ -328,8 +329,6 @@ export async function sendWhatsappTemplateMessage(
 
     return result
   } catch (error) {
-    console.error(error)
-
     logger.error(
       {
         error,
@@ -339,6 +338,9 @@ export async function sendWhatsappTemplateMessage(
       },
       "Error sending WhatsApp template message for broadcast",
     )
+    if (shouldSuppressRetryableChannelError(error, contactInbox.channel)) {
+      return
+    }
     throw error
   }
 }


### PR DESCRIPTION
## Summary
- suppress BullMQ retries for permanent channel errors in direct broadcast template sends
- reuse the existing channel retry suppression policy for Messenger and WhatsApp template handlers
- remove duplicate WhatsApp console error logging and add regression coverage for retry behavior

## Validation
- pnpm lint
- pnpm --filter worker check-types
- pnpm --filter worker exec vitest run __tests__/send-whatsapp-template.test.ts __tests__/send-messenger-template-create.test.ts
- pre-commit full workspace typecheck

## Notes
- Manual staging verification for a Messenger blocked-contact broadcast remains recommended: confirm one worker attempt, failed broadcast analytics, and a single outgoing template message row.