### PR TITLE
feat(worker): add AI agent reply support to comment automation

### DIFF
--- a/.agents/skills/fb-comment-automation/SKILL.md
+++ b/.agents/skills/fb-comment-automation/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: fb-comment-automation
+description: >-
+  Work on Facebook/Messenger comment automation — the feature that auto-replies to,
+  likes, or hides comments on Facebook Page posts. Use when changing the comment
+  webhook path, the automation matching/filter logic, reply dispatch (text/flow/AI
+  agent), hide rules, post targeting, or the fb-comments builder feature. Read this
+  BEFORE editing anything under comment-automation to avoid the silent-failure traps.
+---
+
+# Facebook Comment Automation
+
+Full reference: [`docs/fb-comment-automation.md`](../../../docs/fb-comment-automation.md).
+Read it before non-trivial changes. This skill is the quick map + the traps.
+
+## Where things live
+
+| Concern | Path |
+|---|---|
+| Automation loop, filters, dispatch | `apps/worker/src/integration/handlers/comment-automation/index.ts` |
+| AI-agent reply (generate + deliver) | `apps/worker/src/integration/handlers/comment-automation/ai-reply.ts` |
+| Attachment info (image/video for hide) | `apps/worker/src/integration/handlers/comment-automation/comment-attachment.ts` |
+| Receive comment + enqueue automation | `apps/worker/src/integration/handlers/received-message.ts` (`receiveComment`) |
+| Webhook parse + enqueue | `integrations/messenger/src/handlers/webhook.ts` |
+| Webhook value schema | `integrations/messenger/src/schema.ts` (`messengerFeedCommentValueSchema`) |
+| DB queries (match/dedup/schedule) | `packages/business/src/fb-comment-automation/service.ts` |
+| Schema + option/reply Zod partials | `packages/database/src/schema/fb-comment-automation.ts`, `.../partials/fb-comment-automation.ts` |
+| Dedup ledger | `packages/database/src/schema/fb-comment-automation-reply.ts` |
+| Job types | `packages/worker-config/src/queues/integration/index.ts` |
+| Builder feature (form, actions) | `apps/builder/src/features/fb-comments/` |
+| Tests | `apps/worker/__tests__/comment-automation.test.ts` |
+
+## Data-flow in one line
+
+`feed webhook (verb "add") → incomingComment → receiveComment → processCommentAutomation → (AIAgent) commentAIReply`.
+
+## The traps (read before editing)
+
+1. **`parent_id` is ALWAYS present and equals `post_id` for top-level comments.** A truthy
+   `parentId` does NOT mean "reply." Use `isCommentReply(parentId, postId)`
+   (`parentId !== postId`). Breaking this + default `ignoreCommentReplies: true` silently
+   drops every top-level comment.
+
+2. **Post ids are composite `{pageId}_{storyId}`**; the picker stores 3 different formats
+   (published/ads composite, reels bare id, manual free-text). Always compare through
+   `normalizePostId` (trailing story id). Never `post.value.includes(rawPostId)`.
+
+3. **Every skip must log.** The loop uses `logAutomationSkipped(..., reason)` before each
+   `continue`. `processCommentAutomation` returns `void` → BullMQ always logs
+   `returnValue: null`, so a skip with no log is undebuggable in production. Add a skip log
+   for any new filter.
+
+4. **AIAgent reply ≠ DM auto-responder.** `publicReply`/`privateReply` of type `AIAgent`
+   store the **selected agent id** in `value`. Generation uses `generateAIReplyText`
+   (tools + rich OFF, returns text only); the comment handler routes public → public
+   comment reply (`type:"comment"` + `replyToCommentId`), private → DM. Do NOT route
+   through `processAutomatedResponse` — it uses the workspace *default* agent and always
+   sends a DM.
+
+5. **Dedup ledger is dual-purpose.** `fbCommentAutomationReplyModel` rows
+   (`automationId, contactId, postId`) are written after every successful reply and read by
+   both `replyOncePerUserPerPost` (same post) and `replyToUsersWhoCommentedOnOtherPosts`
+   (other post). The unique index `FBCommentAutomationReply_dedup_idx` already serves
+   `(automationId, contactId)` + `postId != ?` queries — no new index needed; use a
+   `LIMIT 1` existence check, not `$count`.
+
+6. **Instagram is not implemented.** Builder never sets `type`, so it defaults to
+   `messenger`. Don't add IG-only behavior expecting it to run. IG private-DM text is out
+   of scope.
+
+7. **`options.trackUserTags` is a no-op** (defined, not implemented). Every other option
+   (including `replyToUsersWhoCommentedOnOtherPosts`) IS enforced — see the option table in
+   the docs.
+
+## Adding a new filter option (recipe)
+
+1. Add the field to `fbCommentOptionsSchema` (partials) + DB default in the schema file
+   (`jsonb` default string).
+2. If it needs a DB lookup, add a method to `fbCommentAutomationService` (reuse the dedup
+   table + its index where possible; prefer `LIMIT 1` existence checks).
+3. Add the guard inside the loop in `processCommentAutomation`, **with a
+   `logAutomationSkipped(..., reason)` before `continue`**.
+4. Surface the toggle in `apps/builder/src/features/fb-comments/components/fb-comment-form.tsx`
+   and add i18n keys to `apps/builder/messages/en.json` + `vi.json`.
+5. Extend `apps/worker/__tests__/comment-automation.test.ts`.
+
+## Adding a new reply type (recipe)
+
+1. Extend `fbCommentReplySchema.type` (partials).
+2. Handle it in BOTH `executePublicReply` and `executePrivateReply` (`index.ts`). Public =
+   message `type:"comment"` + `replyToCommentId` via `sendChannelMessage`; private =
+   `sendPrivateReply` (messenger only).
+3. Update `willSendReply` so dedup/`repliesCount` only count when a reply is actually
+   dispatchable (e.g. require `value`).
+4. If it needs async work (like AIAgent), add a dedicated job in worker-config, a handler,
+   and a `case` in `apps/worker/src/integration/worker.ts` (the `never` exhaustiveness
+   guard forces this — type + dispatch + handler land together).
+
+## Verify
+
+```bash
+pnpm --filter worker vitest run __tests__/comment-automation.test.ts
+pnpm --filter worker check-types
+pnpm lint
+```
+
+Production sanity after deploy: comment on (a) a normal post, (b) a reel, (c) a comment
+with a bare-domain link + hide-link on, (d) an automation with reply = AI Agent — and
+confirm each fires or logs a clear skip reason.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,7 @@ See **`.agents/rules/git.md`** for the full canonical rules (commit format, bran
 - Tech stack details: `docs/tech-stack.md`
 - Request flow diagrams: `docs/request-workflow.md`
 - White-label tenancy model: `docs/tenancy.md`
+- Facebook comment automation: `docs/fb-comment-automation.md` (skill: `.agents/skills/fb-comment-automation/`)
 - Enterprise licensing (offline Ed25519 license keys): `docs/licensing.md`
 
 When unsure, search the codebase for an existing feature that resembles the request and mirror its structure, imports, and error-handling style.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@
 | New background job or queue | `worker-development` |
 | New channel integration | `integration-channel` |
 | Contact filter field/operator, filter SQL, or contact-based audience | `contact-filter` |
+| Facebook/Messenger comment automation (auto-reply/like/hide on Page post comments) | `fb-comment-automation` |
 | New flow step with states (success/error/skip routing) | `flow-step-development` |
 | Dev/build/lint commands | `turborepo-workflow` |
 | Approved implementation plan | `implement-plan` |

--- a/apps/worker/__tests__/comment-automation.test.ts
+++ b/apps/worker/__tests__/comment-automation.test.ts
@@ -12,10 +12,20 @@ const {
   mockInsertDedup,
   mockIncrementRepliesCount,
   mockGetPriorContactInboxCount,
+  mockHasRepliedOnOtherPost,
   mockWorkspaceFindById,
+  mockIsActiveNow,
+  mockAiAgentFindBy,
+  mockConversationFindBy,
   mockIdentifyInboxAndIntegrationAuth,
   mockCreateMessageRepository,
+  mockMessageCreate,
+  mockIntegrationQueueAdd,
+  mockChatQueueAdd,
+  mockSendPrivateReply,
+  mockGenerateAIReplyText,
   mockLoggerInfo,
+  mockLoggerWarn,
 } = vi.hoisted(() => ({
   mockFindContactInboxBy: vi.fn(),
   mockFindActiveAutomations: vi.fn(),
@@ -24,15 +34,27 @@ const {
   mockInsertDedup: vi.fn(),
   mockIncrementRepliesCount: vi.fn(),
   mockGetPriorContactInboxCount: vi.fn(),
+  mockHasRepliedOnOtherPost: vi.fn(),
   mockWorkspaceFindById: vi.fn(),
+  mockIsActiveNow: vi.fn(),
+  mockAiAgentFindBy: vi.fn(),
+  mockConversationFindBy: vi.fn(),
   mockIdentifyInboxAndIntegrationAuth: vi.fn(),
   mockCreateMessageRepository: vi.fn(),
+  mockMessageCreate: vi.fn(),
+  mockIntegrationQueueAdd: vi.fn(),
+  mockChatQueueAdd: vi.fn(),
+  mockSendPrivateReply: vi.fn(),
+  mockGenerateAIReplyText: vi.fn(),
   mockLoggerInfo: vi.fn(),
+  mockLoggerWarn: vi.fn(),
 }))
 
 vi.mock("@chatbotx.io/business", () => ({
-  broadcastToWorkspaceParty: vi.fn(),
+  broadcastToWorkspaceParty: vi.fn().mockResolvedValue(undefined),
   contactInboxService: { findBy: mockFindContactInboxBy },
+  aiAgentService: { findBy: mockAiAgentFindBy },
+  conversationService: { findBy: mockConversationFindBy },
   fbCommentAutomationService: {
     findActiveAutomations: mockFindActiveAutomations,
     isWithinSchedule: mockIsWithinSchedule,
@@ -40,8 +62,12 @@ vi.mock("@chatbotx.io/business", () => ({
     insertDedup: mockInsertDedup,
     incrementRepliesCount: mockIncrementRepliesCount,
     getPriorContactInboxCount: mockGetPriorContactInboxCount,
+    hasRepliedOnOtherPost: mockHasRepliedOnOtherPost,
   },
-  workspaceService: { findById: mockWorkspaceFindById },
+  workspaceService: {
+    findById: mockWorkspaceFindById,
+    isActiveNow: mockIsActiveNow,
+  },
 }))
 
 vi.mock("@chatbotx.io/database/repositories", () => ({
@@ -49,7 +75,7 @@ vi.mock("@chatbotx.io/database/repositories", () => ({
 }))
 
 vi.mock("@chatbotx.io/integration-messenger", () => ({
-  sendPrivateReply: vi.fn(),
+  sendPrivateReply: mockSendPrivateReply,
 }))
 
 vi.mock("@chatbotx.io/partysocket-config", () => ({
@@ -57,18 +83,23 @@ vi.mock("@chatbotx.io/partysocket-config", () => ({
 }))
 
 vi.mock("@chatbotx.io/worker-config", () => ({
-  ChatJobAction: { changeChannelMessageState: "changeChannelMessageState" },
-  chatQueue: { add: vi.fn().mockResolvedValue(undefined) },
+  ChatJobAction: {
+    changeChannelMessageState: "changeChannelMessageState",
+    sendChannelMessage: "sendChannelMessage",
+  },
+  chatQueue: { add: mockChatQueueAdd },
   IntegrationJobAction: {
     processCommentAutomation: "processCommentAutomation",
+    commentAIReply: "commentAIReply",
+    sendFlow: "sendFlow",
   },
-  integrationQueue: { add: vi.fn().mockResolvedValue(undefined) },
+  integrationQueue: { add: mockIntegrationQueueAdd },
 }))
 
 vi.mock("../src/lib/logger", () => ({
   logger: {
     error: vi.fn(),
-    warn: vi.fn(),
+    warn: mockLoggerWarn,
     info: mockLoggerInfo,
     debug: vi.fn(),
   },
@@ -93,6 +124,10 @@ vi.mock(
   }),
 )
 
+vi.mock("../src/integration/handlers/automated-response/replies", () => ({
+  generateAIReplyText: mockGenerateAIReplyText,
+}))
+
 // ---------------------------------------------------------------------------
 // Import after mocks
 // ---------------------------------------------------------------------------
@@ -100,24 +135,36 @@ vi.mock(
 const { isCommentReply, processCommentAutomation } = await import(
   "../src/integration/handlers/comment-automation"
 )
+const { processCommentAIReply } = await import(
+  "../src/integration/handlers/comment-automation/ai-reply"
+)
 
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
 
 const PAGE_ID = "2094067177305463"
-const POST_ID = `${PAGE_ID}_2357494887629356`
-const COMMENT_ID = "2357494887629356_1544045903933592"
-const OTHER_COMMENT_ID = "2357494887629356_9999999999999999"
+const STORY_ID = "2357494887629356"
+const POST_ID = `${PAGE_ID}_${STORY_ID}`
+const COMMENT_ID = `${STORY_ID}_1544045903933592`
+const OTHER_COMMENT_ID = `${STORY_ID}_9999999999999999`
 
-function buildAutomation(options: Partial<Record<string, boolean>> = {}) {
+type AutomationOverrides = {
+  options?: Record<string, boolean>
+  post?: { type: string; value: string[] }
+  publicReply?: { type: string; value: string | null }
+  privateReply?: { type: string; value: string | null }
+  hideComments?: Record<string, unknown>
+}
+
+function buildAutomation(overrides: AutomationOverrides = {}) {
   return {
     id: "automation-1",
-    post: { type: "all", value: [] },
+    post: overrides.post ?? { type: "all", value: [] },
     includeKeywords: { type: "all", value: [] },
     excludeKeywords: [],
-    publicReply: { type: "none", value: null },
-    privateReply: { type: "none", value: null },
+    publicReply: overrides.publicReply ?? { type: "none", value: null },
+    privateReply: overrides.privateReply ?? { type: "none", value: null },
     options: {
       replyToNewContactsOnly: false,
       replyOncePerUserPerPost: false,
@@ -125,7 +172,7 @@ function buildAutomation(options: Partial<Record<string, boolean>> = {}) {
       replyToUsersWhoCommentedOnOtherPosts: true,
       ignoreCommentReplies: true,
       trackUserTags: false,
-      ...options,
+      ...overrides.options,
     },
     hideComments: {
       all: false,
@@ -136,12 +183,15 @@ function buildAutomation(options: Partial<Record<string, boolean>> = {}) {
       hasKeywords: false,
       keywords: [],
       showCommentsAfter: "none",
+      ...overrides.hideComments,
     },
     replyAfter: { type: "immediately", value: 0 },
   }
 }
 
-function buildJobData(parentId: string | undefined) {
+function buildJobData(
+  overrides: { parentId?: string; postId?: string; message?: string } = {},
+) {
   return {
     integrationType: "messenger",
     integrationIdentifier: PAGE_ID,
@@ -149,10 +199,10 @@ function buildJobData(parentId: string | undefined) {
     conversationId: "conversation-1",
     contactInboxId: "contact-inbox-1",
     commentId: COMMENT_ID,
-    postId: POST_ID,
-    parentId,
+    postId: overrides.postId ?? POST_ID,
+    parentId: overrides.parentId,
     fromId: "user-1",
-    message: "2",
+    message: overrides.message ?? "2",
     createdTime: 1_783_674_105,
   }
 }
@@ -167,11 +217,25 @@ beforeEach(() => {
     contactId: "contact-1",
   })
   mockWorkspaceFindById.mockResolvedValue({ timezone: "UTC" })
+  mockIsActiveNow.mockReturnValue(true)
+  mockConversationFindBy.mockResolvedValue({
+    id: "conversation-1",
+    workspaceId: "workspace-1",
+    contactId: "contact-1",
+  })
   mockIsWithinSchedule.mockReturnValue(true)
+  mockHasRepliedOnOtherPost.mockResolvedValue(false)
+  mockMessageCreate.mockResolvedValue({
+    id: "message-1",
+    createdAt: new Date("2026-07-10T00:00:00Z"),
+  })
   mockCreateMessageRepository.mockResolvedValue({
     findBySourceId: vi.fn().mockResolvedValue(null),
+    create: mockMessageCreate,
   })
   mockInsertDedup.mockResolvedValue(undefined)
+  mockChatQueueAdd.mockResolvedValue(undefined)
+  mockIntegrationQueueAdd.mockResolvedValue(undefined)
 })
 
 // ---------------------------------------------------------------------------
@@ -196,7 +260,7 @@ describe("processCommentAutomation reply filtering", () => {
   test("runs the automation for a top-level comment whose parentId equals postId (production Facebook payload)", async () => {
     mockFindActiveAutomations.mockResolvedValue([buildAutomation()])
 
-    await processCommentAutomation(buildJobData(POST_ID) as any)
+    await processCommentAutomation(buildJobData({ parentId: POST_ID }) as any)
 
     expect(mockInsertDedup).toHaveBeenCalledWith({
       automationId: "automation-1",
@@ -209,7 +273,9 @@ describe("processCommentAutomation reply filtering", () => {
   test("skips a real comment reply when ignoreCommentReplies is on", async () => {
     mockFindActiveAutomations.mockResolvedValue([buildAutomation()])
 
-    await processCommentAutomation(buildJobData(OTHER_COMMENT_ID) as any)
+    await processCommentAutomation(
+      buildJobData({ parentId: OTHER_COMMENT_ID }) as any,
+    )
 
     expect(mockInsertDedup).not.toHaveBeenCalled()
     expect(mockLoggerInfo).toHaveBeenCalledWith(
@@ -220,10 +286,12 @@ describe("processCommentAutomation reply filtering", () => {
 
   test("runs the automation for a real comment reply when ignoreCommentReplies is off", async () => {
     mockFindActiveAutomations.mockResolvedValue([
-      buildAutomation({ ignoreCommentReplies: false }),
+      buildAutomation({ options: { ignoreCommentReplies: false } }),
     ])
 
-    await processCommentAutomation(buildJobData(OTHER_COMMENT_ID) as any)
+    await processCommentAutomation(
+      buildJobData({ parentId: OTHER_COMMENT_ID }) as any,
+    )
 
     expect(mockInsertDedup).toHaveBeenCalled()
   })
@@ -231,8 +299,343 @@ describe("processCommentAutomation reply filtering", () => {
   test("runs the automation when the payload has no parentId", async () => {
     mockFindActiveAutomations.mockResolvedValue([buildAutomation()])
 
-    await processCommentAutomation(buildJobData(undefined) as any)
+    await processCommentAutomation(buildJobData() as any)
 
     expect(mockInsertDedup).toHaveBeenCalled()
+  })
+})
+
+describe("processCommentAutomation matchPost normalization", () => {
+  test("matches a reel stored as a bare id against the composite webhook post_id", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({ post: { type: "postIds", value: [STORY_ID] } }),
+    ])
+
+    await processCommentAutomation(buildJobData() as any)
+
+    expect(mockInsertDedup).toHaveBeenCalled()
+  })
+
+  test("matches a manually entered id missing the pageId prefix", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({ post: { type: "postIds", value: [STORY_ID] } }),
+    ])
+
+    await processCommentAutomation(buildJobData() as any)
+
+    expect(mockInsertDedup).toHaveBeenCalled()
+  })
+
+  test("does not match a different post", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({ post: { type: "postIds", value: ["8888888888"] } }),
+    ])
+
+    await processCommentAutomation(buildJobData() as any)
+
+    expect(mockInsertDedup).not.toHaveBeenCalled()
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "post does not match" }),
+      "Comment automation skipped",
+    )
+  })
+})
+
+describe("processCommentAutomation replyToUsersWhoCommentedOnOtherPosts", () => {
+  test("skips when option is off and the user was replied on another post", async () => {
+    mockHasRepliedOnOtherPost.mockResolvedValue(true)
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({
+        options: { replyToUsersWhoCommentedOnOtherPosts: false },
+      }),
+    ])
+
+    await processCommentAutomation(buildJobData() as any)
+
+    expect(mockInsertDedup).not.toHaveBeenCalled()
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "user already engaged on another post",
+      }),
+      "Comment automation skipped",
+    )
+  })
+
+  test("runs when option is off but the user has not been replied elsewhere", async () => {
+    mockHasRepliedOnOtherPost.mockResolvedValue(false)
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({
+        options: { replyToUsersWhoCommentedOnOtherPosts: false },
+      }),
+    ])
+
+    await processCommentAutomation(buildJobData() as any)
+
+    expect(mockInsertDedup).toHaveBeenCalled()
+  })
+
+  test("does not query when option is on (default)", async () => {
+    mockFindActiveAutomations.mockResolvedValue([buildAutomation()])
+
+    await processCommentAutomation(buildJobData() as any)
+
+    expect(mockHasRepliedOnOtherPost).not.toHaveBeenCalled()
+  })
+})
+
+describe("processCommentAutomation AIAgent reply", () => {
+  test("public AIAgent enqueues a commentAIReply job with the selected agent + channel", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({ publicReply: { type: "AIAgent", value: "agent-1" } }),
+    ])
+
+    await processCommentAutomation(buildJobData() as any)
+
+    expect(mockIntegrationQueueAdd).toHaveBeenCalledWith(
+      "commentAIReply",
+      expect.objectContaining({
+        type: "commentAIReply",
+        data: expect.objectContaining({
+          agentId: "agent-1",
+          replyChannel: "public",
+          commentId: COMMENT_ID,
+        }),
+      }),
+      expect.anything(),
+    )
+    // no more silent sendFlow-without-flowId
+    expect(mockIntegrationQueueAdd).not.toHaveBeenCalledWith(
+      "sendFlow",
+      expect.anything(),
+      expect.anything(),
+    )
+  })
+
+  test("private AIAgent enqueues a commentAIReply job on the private channel", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({ privateReply: { type: "AIAgent", value: "agent-9" } }),
+    ])
+
+    await processCommentAutomation(buildJobData() as any)
+
+    expect(mockIntegrationQueueAdd).toHaveBeenCalledWith(
+      "commentAIReply",
+      expect.objectContaining({
+        data: expect.objectContaining({
+          agentId: "agent-9",
+          replyChannel: "private",
+        }),
+      }),
+      expect.anything(),
+    )
+  })
+
+  test("AIAgent with an empty value does not dispatch or count", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({ publicReply: { type: "AIAgent", value: null } }),
+    ])
+
+    await processCommentAutomation(buildJobData() as any)
+
+    expect(mockIntegrationQueueAdd).not.toHaveBeenCalledWith(
+      "commentAIReply",
+      expect.anything(),
+      expect.anything(),
+    )
+    expect(mockIncrementRepliesCount).not.toHaveBeenCalled()
+  })
+})
+
+describe("processCommentAIReply", () => {
+  beforeEach(() => {
+    mockAiAgentFindBy.mockResolvedValue({ id: "agent-1", prompt: "hi" })
+    mockGenerateAIReplyText.mockResolvedValue({
+      text: "AI answer",
+      provider: "openai",
+      modelId: "gpt",
+    })
+  })
+
+  function buildAIJobData(overrides: Partial<Record<string, unknown>> = {}) {
+    return {
+      integrationType: "messenger",
+      integrationIdentifier: PAGE_ID,
+      workspaceId: "workspace-1",
+      conversationId: "conversation-1",
+      contactInboxId: "contact-inbox-1",
+      commentId: COMMENT_ID,
+      agentId: "agent-1",
+      replyChannel: "public" as const,
+      channelType: "messenger" as const,
+      message: "hello",
+      parentMessageId: null,
+      parentMessageCreatedAt: null,
+      ...overrides,
+    }
+  }
+
+  test("public: posts an AI-generated public comment reply", async () => {
+    await processCommentAIReply(buildAIJobData() as any)
+
+    expect(mockMessageCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "comment",
+        text: "AI answer",
+        contentAttributes: { replyToCommentId: COMMENT_ID },
+      }),
+    )
+    expect(mockChatQueueAdd).toHaveBeenCalledWith(
+      "sendChannelMessage",
+      expect.objectContaining({ type: "sendChannelMessage" }),
+    )
+    expect(mockSendPrivateReply).not.toHaveBeenCalled()
+  })
+
+  test("private (messenger): sends an AI-generated DM", async () => {
+    await processCommentAIReply(
+      buildAIJobData({ replyChannel: "private" }) as any,
+    )
+
+    expect(mockSendPrivateReply).toHaveBeenCalledWith(
+      expect.anything(),
+      COMMENT_ID,
+      "AI answer",
+    )
+    expect(mockChatQueueAdd).not.toHaveBeenCalled()
+  })
+
+  test("image-only comment (no message) does not generate or send", async () => {
+    await processCommentAIReply(buildAIJobData({ message: "" }) as any)
+
+    expect(mockGenerateAIReplyText).not.toHaveBeenCalled()
+    expect(mockChatQueueAdd).not.toHaveBeenCalled()
+    expect(mockSendPrivateReply).not.toHaveBeenCalled()
+  })
+
+  test("missing agent logs a warning and does not send", async () => {
+    mockAiAgentFindBy.mockResolvedValue(undefined)
+
+    await processCommentAIReply(buildAIJobData() as any)
+
+    expect(mockGenerateAIReplyText).not.toHaveBeenCalled()
+    expect(mockChatQueueAdd).not.toHaveBeenCalled()
+    expect(mockLoggerWarn).toHaveBeenCalled()
+  })
+
+  test("no generated text does not send", async () => {
+    mockGenerateAIReplyText.mockResolvedValue(null)
+
+    await processCommentAIReply(buildAIJobData() as any)
+
+    expect(mockChatQueueAdd).not.toHaveBeenCalled()
+    expect(mockSendPrivateReply).not.toHaveBeenCalled()
+  })
+
+  test("workspace outside active hours logs and does not send", async () => {
+    mockIsActiveNow.mockReturnValue(false)
+
+    await processCommentAIReply(buildAIJobData() as any)
+
+    expect(mockGenerateAIReplyText).not.toHaveBeenCalled()
+    expect(mockChatQueueAdd).not.toHaveBeenCalled()
+    expect(mockSendPrivateReply).not.toHaveBeenCalled()
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ commentId: COMMENT_ID }),
+      "comment AI reply skipped: workspace outside active hours",
+    )
+  })
+
+  test("missing conversation logs a warning and does not send", async () => {
+    mockConversationFindBy.mockResolvedValue(undefined)
+
+    await processCommentAIReply(buildAIJobData() as any)
+
+    expect(mockGenerateAIReplyText).not.toHaveBeenCalled()
+    expect(mockChatQueueAdd).not.toHaveBeenCalled()
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: "conversation-1" }),
+      "comment AI reply skipped: conversation not found",
+    )
+  })
+
+  test("passes the full conversation through to generateAIReplyText", async () => {
+    await processCommentAIReply(buildAIJobData() as any)
+
+    expect(mockGenerateAIReplyText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversation: {
+          id: "conversation-1",
+          workspaceId: "workspace-1",
+          contactId: "contact-1",
+        },
+      }),
+    )
+  })
+})
+
+describe("applyHideComments case-insensitivity", () => {
+  test("hides a comment matching a keyword regardless of case", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({
+        hideComments: { hasKeywords: true, keywords: ["SPAM"] },
+      }),
+    ])
+    // hide only runs when the incoming comment DB message exists
+    mockCreateMessageRepository.mockResolvedValue({
+      findBySourceId: vi.fn().mockResolvedValue({
+        id: "message-1",
+        createdAt: new Date("2026-07-10T00:00:00Z"),
+      }),
+      create: mockMessageCreate,
+    })
+
+    await processCommentAutomation(
+      buildJobData({ message: "this is spam" }) as any,
+    )
+
+    expect(mockChatQueueAdd).toHaveBeenCalledWith(
+      "changeChannelMessageState",
+      expect.objectContaining({
+        type: "changeChannelMessageState",
+        data: expect.objectContaining({ hidden: true }),
+      }),
+    )
+  })
+})
+
+describe("applyHideComments link detection", () => {
+  async function runWithMessage(message: string) {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({ hideComments: { hasLink: true } }),
+    ])
+    mockCreateMessageRepository.mockResolvedValue({
+      findBySourceId: vi.fn().mockResolvedValue({
+        id: "message-1",
+        createdAt: new Date("2026-07-10T00:00:00Z"),
+      }),
+      create: mockMessageCreate,
+    })
+
+    await processCommentAutomation(buildJobData({ message }) as any)
+  }
+
+  test("hides a bare domain with no scheme", async () => {
+    await runWithMessage("check out yahoo.com for more")
+
+    expect(mockChatQueueAdd).toHaveBeenCalledWith(
+      "changeChannelMessageState",
+      expect.objectContaining({
+        data: expect.objectContaining({ hidden: true }),
+      }),
+    )
+  })
+
+  test("does not hide a run-on sentence with a capitalized continuation word", async () => {
+    await runWithMessage("Cam on ban.Shop co ship khong a")
+
+    expect(mockChatQueueAdd).not.toHaveBeenCalledWith(
+      "changeChannelMessageState",
+      expect.anything(),
+    )
   })
 })

--- a/apps/worker/src/integration/handlers/automated-response/replies.ts
+++ b/apps/worker/src/integration/handlers/automated-response/replies.ts
@@ -111,6 +111,113 @@ export async function replyByAI(
   return null
 }
 
+export type GenerateAIReplyProps = {
+  conversation: ConversationModel
+  contactInbox: ContactInboxModel
+  messages: ModelMessage[]
+  aiAgent: AIAgentModel
+}
+
+export type GeneratedAIReply = {
+  text: string
+  provider: ReplyAIProvider
+  modelId: string
+}
+
+/**
+ * Generate an AI agent reply as plain text WITHOUT sending it anywhere.
+ *
+ * Unlike `replyByAI`, this runs the provider-fallback loop with tools and rich
+ * mode disabled and returns the accumulated text, so the caller controls the
+ * delivery channel (e.g. a public Facebook comment reply vs a private DM). Tools
+ * are off so nothing can send out-of-band (the `sendMessage`/`triggerFlow`/
+ * handoff system tools all send DMs on their own). It mirrors the DM policy by
+ * only using auto-reply-enabled provider integrations.
+ */
+export async function generateAIReplyText(
+  props: GenerateAIReplyProps,
+): Promise<GeneratedAIReply | null> {
+  const { conversation, contactInbox, messages, aiAgent } = props
+  const providers = aiAgent.models as AIAgentProviderModels
+
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), aiTimeouts.aiTotal)
+
+  try {
+    const variables = await contactVariableService.getAll({
+      contactId: conversation.contactId,
+      contactInbox,
+      conversation,
+    })
+    const systemPrompt = aiAgent.prompt
+      ? await contactVariableService.replaceAll({
+          text: aiAgent.prompt,
+          variables,
+        })
+      : ""
+
+    for (const providerInfo of providers) {
+      const modelConfig = await createReplyModel({
+        workspaceId: conversation.workspaceId,
+        providerInfo,
+      })
+      if (!modelConfig) {
+        continue
+      }
+      const provider = getProviderName(providerInfo)
+
+      const result = await streamText({
+        model: modelConfig.model,
+        system: systemPrompt,
+        messages,
+        maxOutputTokens: aiAgent.maxOutputTokens,
+        temperature: aiAgent.temperature,
+        tools: {},
+        toolChoice: "none",
+        stopWhen: stepCountIs(1),
+        timeout: {
+          totalMs: aiTimeouts.aiTotal,
+          stepMs: aiTimeouts.aiStep,
+          chunkMs: aiTimeouts.aiChunk,
+        },
+        abortSignal: controller.signal,
+      })
+
+      const { fullText } = await processStreamingText(
+        result.textStream,
+        async () => {
+          // generate-only: never send
+        },
+        { sendParts: false },
+      ).catch((streamError) => {
+        logger.error(
+          {
+            provider,
+            modelId: providerInfo.model,
+            conversationId: conversation.id,
+            error: normalizeError(streamError),
+          },
+          "[comment-ai-reply] processStreamingText threw error",
+        )
+        return { fullText: "" }
+      })
+
+      const text = fullText.trim()
+      if (text) {
+        return {
+          text,
+          provider,
+          modelId: providerInfo.model,
+        }
+      }
+    }
+
+    return null
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
 function createReplyToolset(options: {
   abortSignal: AbortSignal
   directSendTracker: { sent: boolean; sentText: string }

--- a/apps/worker/src/integration/handlers/comment-automation/ai-reply.ts
+++ b/apps/worker/src/integration/handlers/comment-automation/ai-reply.ts
@@ -1,0 +1,127 @@
+import {
+  aiAgentService,
+  contactInboxService,
+  conversationService,
+  workspaceService,
+} from "@chatbotx.io/business"
+import type { IntegrationType } from "@chatbotx.io/database/partials"
+import {
+  type MessengerAuthValue,
+  sendPrivateReply,
+} from "@chatbotx.io/integration-messenger"
+import type { IntegrationJobCommentAIReply } from "@chatbotx.io/worker-config"
+import { logger } from "../../../lib/logger"
+import { integrationService } from "../../../services/integrations"
+import { generateAIReplyText } from "../automated-response/replies"
+import { postPublicCommentReply } from "."
+
+/**
+ * Generate an AI agent reply for a Facebook comment and deliver it on the
+ * requested channel: a public comment reply (message with `type: "comment"` +
+ * `replyToCommentId`) or a private DM. The generation is done here (not through
+ * the DM auto-responder pipeline) so the selected agent and the public/private
+ * channel are both honoured. Runs as its own delayed job so the AI call never
+ * blocks the comment-automation loop.
+ */
+export async function processCommentAIReply(
+  data: IntegrationJobCommentAIReply["data"],
+): Promise<void> {
+  if (!data.message?.trim()) {
+    // Image/sticker-only comment: nothing for the agent to answer.
+    return
+  }
+
+  const [workspace, agent, contactInbox, conversation] = await Promise.all([
+    workspaceService.findById({ id: data.workspaceId }),
+    aiAgentService.findBy({
+      where: { id: data.agentId, workspaceId: data.workspaceId },
+    }),
+    contactInboxService.findBy({ where: { id: data.contactInboxId } }),
+    conversationService.findBy({ where: { id: data.conversationId } }),
+  ])
+
+  if (!workspaceService.isActiveNow(workspace)) {
+    logger.info(
+      { workspaceId: data.workspaceId, commentId: data.commentId },
+      "comment AI reply skipped: workspace outside active hours",
+    )
+    return
+  }
+
+  if (!agent) {
+    logger.warn(
+      {
+        agentId: data.agentId,
+        workspaceId: data.workspaceId,
+        commentId: data.commentId,
+      },
+      "comment AI reply skipped: agent not found",
+    )
+    return
+  }
+
+  if (!contactInbox) {
+    logger.warn(
+      { contactInboxId: data.contactInboxId, commentId: data.commentId },
+      "comment AI reply skipped: contactInbox not found",
+    )
+    return
+  }
+
+  if (!conversation) {
+    logger.warn(
+      { conversationId: data.conversationId, commentId: data.commentId },
+      "comment AI reply skipped: conversation not found",
+    )
+    return
+  }
+
+  const generated = await generateAIReplyText({
+    conversation,
+    contactInbox,
+    messages: [{ role: "user", content: data.message }],
+    aiAgent: agent,
+  })
+  if (!generated?.text) {
+    logger.info(
+      {
+        agentId: data.agentId,
+        commentId: data.commentId,
+        workspaceId: data.workspaceId,
+      },
+      "comment AI reply skipped: no text produced",
+    )
+    return
+  }
+
+  if (data.replyChannel === "public") {
+    await postPublicCommentReply({
+      text: generated.text,
+      commentId: data.commentId,
+      conversationId: data.conversationId,
+      contactInboxId: data.contactInboxId,
+      workspaceId: data.workspaceId,
+      contactInbox,
+      parentMessageId: data.parentMessageId,
+      parentMessageCreatedAt: data.parentMessageCreatedAt
+        ? new Date(data.parentMessageCreatedAt)
+        : null,
+    })
+    return
+  }
+
+  // Private DM. Instagram private DM is out of scope (no private_replies API),
+  // same as the private text branch.
+  if (data.channelType === "messenger") {
+    const { integrationRow } =
+      await integrationService.identifyInboxAndIntegrationAuthFromIdentifier(
+        data.integrationType as IntegrationType,
+        data.integrationIdentifier,
+      )
+    await sendPrivateReply(
+      integrationRow.auth as MessengerAuthValue,
+      data.commentId,
+      generated.text,
+    )
+  }
+}

--- a/apps/worker/src/integration/handlers/comment-automation/index.ts
+++ b/apps/worker/src/integration/handlers/comment-automation/index.ts
@@ -47,7 +47,23 @@ const RANDOM_DELAY_MINUTES: Record<string, number> = {
 }
 
 const PHONE_RE = /\+?\d[\d\s\-().]{7,}/
-const LINK_RE = /https?:\/\//
+// `http(s)://`/`www.` links match case-insensitively — the scheme itself is
+// never meaningfully cased. Bare domains without a scheme (e.g. "example.com",
+// common since Facebook comments frequently omit `http(s)://`) are matched
+// case-SENSITIVELY on purpose: real domains are written lowercase, while a
+// missing space after a sentence-ending period produces a capitalized
+// continuation word (e.g. "ban.Shop", "ngay.Info") that would otherwise be
+// misdetected as a link. `co` is deliberately excluded from the bare list —
+// it's too common as a standalone lowercase word/abbreviation (e.g.
+// "picture.co founder") to distinguish from a real ".co" domain; a bare `.co`
+// link still needs `www.`/`http(s)://` to be caught.
+const SCHEME_LINK_RE = /https?:\/\/|www\./i
+const BARE_DOMAIN_RE =
+  /\b[a-z0-9-]+\.(?:com|net|org|io|vn|shop|store|info|biz)\b/
+
+function hasLink(text: string): boolean {
+  return SCHEME_LINK_RE.test(text) || BARE_DOMAIN_RE.test(text)
+}
 
 const UNHIDE_DELAY_MS: Record<string, number> = {
   "6h": 6 * 3_600_000,
@@ -64,14 +80,21 @@ const UNHIDE_DELAY_MS: Record<string, number> = {
   "10d": 10 * 86_400_000,
 }
 
+// Facebook post ids are composite `{pageId}_{storyId}`. The published/ads
+// pickers store that composite form, but the reels picker stores a bare id and
+// users pasting an id manually often omit the `{pageId}_` prefix. Compare on the
+// trailing story id (unique) so all three formats match the webhook `post_id`.
+function normalizePostId(id: string): string {
+  const idx = id.indexOf("_")
+  return idx === -1 ? id : id.slice(idx + 1)
+}
+
 function matchPost(post: FBCommentPost, postId: string): boolean {
-  if (post.type === "all") {
+  if (post.type !== "postIds") {
     return true
   }
-  if (post.type === "postIds") {
-    return post.value.includes(postId)
-  }
-  return true
+  const target = normalizePostId(postId)
+  return post.value.some((v) => v === postId || normalizePostId(v) === target)
 }
 
 function matchKeywords(
@@ -112,9 +135,7 @@ function willSendReply(reply: FBCommentReply): boolean {
   if (reply.type === "none") {
     return false
   }
-  if (reply.type === "AIAgent") {
-    return true
-  }
+  // text/flow need a value; AIAgent needs the selected agent id in `value`.
   return Boolean(reply.value)
 }
 
@@ -136,10 +157,74 @@ function computeDelayMs(replyAfter: FBCommentReplyAfter): number {
   return Math.floor(Math.random() * (minutes ?? 3) * 60_000)
 }
 
+/**
+ * Post a public Facebook comment reply: creates the outgoing DB message,
+ * broadcasts it over realtime, and enqueues the actual send. Shared by the
+ * `text` reply type (dispatched immediately, sends after `delay`) and
+ * `processCommentAIReply` (already runs inside a job delayed by the caller, so
+ * no further `delay` applies).
+ */
+export async function postPublicCommentReply(props: {
+  text: string
+  commentId: string
+  conversationId: string
+  contactInboxId: string
+  workspaceId: string
+  contactInbox: ContactInboxModel
+  parentMessageId?: string | null
+  parentMessageCreatedAt?: Date | null
+  delay?: number
+}): Promise<void> {
+  const repo = await createMessageRepository()
+  const messageInput = {
+    conversationId: props.conversationId,
+    contactInboxId: props.contactInboxId,
+    workspaceId: props.workspaceId,
+    messageType: "outgoing" as const,
+    contentType: "text" as const,
+    senderType: "bot" as const,
+    text: props.text,
+    type: "comment" as const,
+    contentAttributes: { replyToCommentId: props.commentId },
+    parentId: props.parentMessageId ?? null,
+    createdAt: new Date(),
+  }
+  const message = await repo.create(messageInput)
+  broadcastToWorkspaceParty(props.workspaceId, {
+    eventType: RealtimeEventType.messageCreated,
+    data: message,
+  }).catch((err: unknown) =>
+    logger.error(
+      { err, commentId: props.commentId },
+      "Unable to emit realtime message",
+    ),
+  )
+  await chatQueue.add(
+    ChatJobAction.sendChannelMessage,
+    {
+      type: ChatJobAction.sendChannelMessage,
+      data: {
+        conversation: {
+          id: props.conversationId,
+          workspaceId: props.workspaceId,
+        } as ConversationModel,
+        contactInbox: props.contactInbox,
+        message: {
+          ...message,
+          parentCreatedAt: props.parentMessageCreatedAt ?? null,
+        },
+      },
+    },
+    ...(props.delay === undefined ? [] : [{ delay: props.delay }]),
+  )
+}
+
 async function executePublicReply(
   publicReply: FBCommentReply,
   ctx: {
     auth: MessengerAuthValue
+    integrationType: string
+    integrationIdentifier: string
     commentId: string
     channelType: "messenger" | "instagram"
     conversationId: string
@@ -147,6 +232,7 @@ async function executePublicReply(
     delay: number
     workspaceId: string
     contactInbox: ContactInboxModel
+    message?: string
     parentMessageId?: string | null
     parentMessageCreatedAt?: Date | null
   },
@@ -156,48 +242,17 @@ async function executePublicReply(
   }
 
   if (publicReply.type === "text" && publicReply.value) {
-    const repo = await createMessageRepository()
-    const messageInput = {
+    await postPublicCommentReply({
+      text: publicReply.value,
+      commentId: ctx.commentId,
       conversationId: ctx.conversationId,
       contactInboxId: ctx.contactInboxId,
       workspaceId: ctx.workspaceId,
-      messageType: "outgoing" as const,
-      contentType: "text" as const,
-      senderType: "bot" as const,
-      text: publicReply.value,
-      type: "comment" as const,
-      contentAttributes: { replyToCommentId: ctx.commentId },
-      parentId: ctx.parentMessageId ?? null,
-      createdAt: new Date(),
-    }
-    const message = await repo.create(messageInput)
-    broadcastToWorkspaceParty(ctx.workspaceId, {
-      eventType: RealtimeEventType.messageCreated,
-      data: message,
-    }).catch((err: unknown) =>
-      logger.error(
-        { err, commentId: ctx.commentId },
-        "Unable to emit realtime message",
-      ),
-    )
-    await chatQueue.add(
-      ChatJobAction.sendChannelMessage,
-      {
-        type: ChatJobAction.sendChannelMessage,
-        data: {
-          conversation: {
-            id: ctx.conversationId,
-            workspaceId: ctx.workspaceId,
-          } as ConversationModel,
-          contactInbox: ctx.contactInbox,
-          message: {
-            ...message,
-            parentCreatedAt: ctx.parentMessageCreatedAt ?? null,
-          },
-        },
-      },
-      { delay: ctx.delay },
-    )
+      contactInbox: ctx.contactInbox,
+      parentMessageId: ctx.parentMessageId,
+      parentMessageCreatedAt: ctx.parentMessageCreatedAt,
+      delay: ctx.delay,
+    })
     return
   }
 
@@ -218,15 +273,25 @@ async function executePublicReply(
     return
   }
 
-  if (publicReply.type === "AIAgent") {
+  if (publicReply.type === "AIAgent" && publicReply.value) {
     await integrationQueue.add(
-      IntegrationJobAction.sendFlow,
+      IntegrationJobAction.commentAIReply,
       {
-        type: IntegrationJobAction.sendFlow,
+        type: IntegrationJobAction.commentAIReply,
         data: {
+          integrationType: ctx.integrationType,
+          integrationIdentifier: ctx.integrationIdentifier,
+          workspaceId: ctx.workspaceId,
           conversationId: ctx.conversationId,
           contactInboxId: ctx.contactInboxId,
-          origin: webhookChannelOrigin(),
+          commentId: ctx.commentId,
+          agentId: publicReply.value,
+          replyChannel: "public",
+          channelType: ctx.channelType,
+          message: ctx.message,
+          parentMessageId: ctx.parentMessageId ?? null,
+          parentMessageCreatedAt:
+            ctx.parentMessageCreatedAt?.toISOString() ?? null,
         },
       },
       { delay: ctx.delay },
@@ -238,11 +303,15 @@ async function executePrivateReply(
   privateReply: FBCommentReply,
   ctx: {
     auth: MessengerAuthValue
+    integrationType: string
+    integrationIdentifier: string
     commentId: string
     channelType: "messenger" | "instagram"
     conversationId: string
     contactInboxId: string
+    workspaceId: string
     delay: number
+    message?: string
   },
 ) {
   if (privateReply.type === "none") {
@@ -274,18 +343,27 @@ async function executePrivateReply(
     return
   }
 
-  if (privateReply.type === "AIAgent") {
+  if (privateReply.type === "AIAgent" && privateReply.value) {
     await integrationQueue.add(
-      IntegrationJobAction.sendFlow,
+      IntegrationJobAction.commentAIReply,
       {
-        type: IntegrationJobAction.sendFlow,
+        type: IntegrationJobAction.commentAIReply,
         data: {
+          integrationType: ctx.integrationType,
+          integrationIdentifier: ctx.integrationIdentifier,
+          workspaceId: ctx.workspaceId,
           conversationId: ctx.conversationId,
           contactInboxId: ctx.contactInboxId,
-          origin: webhookChannelOrigin(),
+          commentId: ctx.commentId,
+          agentId: privateReply.value,
+          replyChannel: "private",
+          channelType: ctx.channelType,
+          message: ctx.message,
         },
       },
-      { delay: ctx.delay },
+      {
+        delay: ctx.delay,
+      },
     )
   }
 }
@@ -304,13 +382,14 @@ async function applyHideComments(
   },
 ) {
   const text = message ?? ""
+  const lowerText = text.toLowerCase()
 
   const shouldHide =
     hideComments.all ||
     (hideComments.hasPhoneNumber && PHONE_RE.test(text)) ||
-    (hideComments.hasLink && LINK_RE.test(text)) ||
+    (hideComments.hasLink && hasLink(text)) ||
     (hideComments.hasKeywords &&
-      hideComments.keywords.some((k) => text.includes(k))) ||
+      hideComments.keywords.some((k) => lowerText.includes(k.toLowerCase()))) ||
     (hideComments.hasImage && ctx.hasImage) ||
     (hideComments.hasVideo && ctx.hasVideo)
 
@@ -489,6 +568,25 @@ export async function processCommentAutomation(
         }
       }
 
+      if (!automation.options.replyToUsersWhoCommentedOnOtherPosts) {
+        const repliedElsewhere =
+          await fbCommentAutomationService.hasRepliedOnOtherPost({
+            automationId: automation.id,
+            contactId: contactInbox.contactId,
+            postId,
+          })
+        if (repliedElsewhere) {
+          logAutomationSkipped({
+            automationId: automation.id,
+            commentId,
+            postId,
+            workspaceId,
+            reason: "user already engaged on another post",
+          })
+          continue
+        }
+      }
+
       const delay = computeDelayMs(automation.replyAfter)
 
       const messageRepo = await createMessageRepository()
@@ -556,6 +654,8 @@ export async function processCommentAutomation(
       try {
         await executePublicReply(automation.publicReply, {
           auth,
+          integrationType,
+          integrationIdentifier,
           commentId,
           channelType,
           conversationId,
@@ -563,6 +663,7 @@ export async function processCommentAutomation(
           delay,
           workspaceId,
           contactInbox,
+          message,
           parentMessageId,
           parentMessageCreatedAt,
         })
@@ -579,11 +680,15 @@ export async function processCommentAutomation(
       try {
         await executePrivateReply(automation.privateReply, {
           auth,
+          integrationType,
+          integrationIdentifier,
           commentId,
           channelType,
           conversationId,
           contactInboxId,
+          workspaceId,
           delay,
+          message,
         })
       } catch (err) {
         logger.error(
@@ -595,6 +700,12 @@ export async function processCommentAutomation(
         }
       }
 
+      // Dedup/count fire once dispatch is *enqueued*, not once an async reply
+      // (flow, AIAgent) actually succeeds — a later failure inside that job
+      // (e.g. agent misconfigured, no auto-reply-enabled provider) still
+      // counts as "replied" here and won't be retried. Fixing this properly
+      // requires threading the dedup write into the async job itself for
+      // every async-dispatch reply type, which is out of scope for now.
       if (!dispatchFailed) {
         await fbCommentAutomationService.insertDedup({
           automationId: automation.id,

--- a/apps/worker/src/integration/worker.ts
+++ b/apps/worker/src/integration/worker.ts
@@ -20,6 +20,7 @@ import { coexistMessengerSync } from "./handlers/coexist/messenger-sync"
 import { coexistWhatsappBuffer } from "./handlers/coexist/whatsapp-buffer"
 import { coexistWhatsappFlush } from "./handlers/coexist/whatsapp-flush"
 import { processCommentAutomation } from "./handlers/comment-automation"
+import { processCommentAIReply } from "./handlers/comment-automation/ai-reply"
 import { updateContactAvatar } from "./handlers/contact/update-avatar"
 import { agentMarkAsRead, contactMarkAsRead } from "./handlers/conversation"
 import {
@@ -194,6 +195,10 @@ async function startIntegrationWorker() {
           }
           case IntegrationJobAction.processCommentAutomation: {
             await processCommentAutomation(job.data.data)
+            return
+          }
+          case IntegrationJobAction.commentAIReply: {
+            await processCommentAIReply(job.data.data)
             return
           }
           case IntegrationJobAction.createMessage: {

--- a/docs/fb-comment-automation.md
+++ b/docs/fb-comment-automation.md
@@ -1,0 +1,141 @@
+# Facebook Comment Automation
+
+This document describes the Facebook/Messenger **comment automation** feature: how a
+comment on a Page post flows from the webhook to an automated reply, how each config
+option is matched and enforced, and the non-obvious pitfalls that have caused silent
+failures. It is the reference for anyone touching the comment-automation code.
+
+> Scope: **Facebook Pages via the Messenger integration.** Instagram comment automation
+> is not implemented — the builder always stores `type = "messenger"` (see
+> [Known gaps](#known-gaps--pitfalls)).
+
+## Tables
+
+| Table | File | Role |
+|---|---|---|
+| `fbCommentAutomationModel` | [`packages/database/src/schema/fb-comment-automation.ts`](../packages/database/src/schema/fb-comment-automation.ts) | One automation config per row: post targeting, keyword filters, public/private reply, hide rules, schedule, options. |
+| `fbCommentAutomationReplyModel` | [`packages/database/src/schema/fb-comment-automation-reply.ts`](../packages/database/src/schema/fb-comment-automation-reply.ts) | Dedup ledger: one row per `(automationId, contactId, postId)` written after every successful reply. Unique index `FBCommentAutomationReply_dedup_idx`. |
+
+Zod partials (option/reply/post/schedule shapes):
+[`packages/database/src/partials/fb-comment-automation.ts`](../packages/database/src/partials/fb-comment-automation.ts).
+
+## End-to-end flow
+
+```
+Facebook Page (comment added)
+  → webhook: integrations/messenger/src/handlers/webhook.ts   (field === "feed", verb === "add")
+  → BullMQ "incomingComment" job
+  → apps/worker/.../received-message.ts  receiveComment()      (save message, gate on active-hours)
+  → BullMQ "processCommentAutomation" job (jobId = comment-auto-${commentId})
+  → apps/worker/.../comment-automation/index.ts  processCommentAutomation()
+       loop over active automations → filters → dispatch public + private reply
+  → (AIAgent reply only) BullMQ "commentAIReply" job (delayed)
+  → apps/worker/.../comment-automation/ai-reply.ts  processCommentAIReply()
+```
+
+Key files:
+
+| Concern | File |
+|---|---|
+| Webhook parse + enqueue | [`integrations/messenger/src/handlers/webhook.ts`](../integrations/messenger/src/handlers/webhook.ts) |
+| Webhook value schema | [`integrations/messenger/src/schema.ts`](../integrations/messenger/src/schema.ts) (`messengerFeedCommentValueSchema`) |
+| Receive + enqueue automation | [`apps/worker/src/integration/handlers/received-message.ts`](../apps/worker/src/integration/handlers/received-message.ts) (`receiveComment`) |
+| Automation loop + filters + dispatch | [`apps/worker/src/integration/handlers/comment-automation/index.ts`](../apps/worker/src/integration/handlers/comment-automation/index.ts) |
+| AI reply generation + delivery | [`apps/worker/src/integration/handlers/comment-automation/ai-reply.ts`](../apps/worker/src/integration/handlers/comment-automation/ai-reply.ts) |
+| DB queries (match/dedup/schedule) | [`packages/business/src/fb-comment-automation/service.ts`](../packages/business/src/fb-comment-automation/service.ts) |
+| Builder form + actions | [`apps/builder/src/features/fb-comments/`](../apps/builder/src/features/fb-comments/) |
+| Job types | [`packages/worker-config/src/queues/integration/index.ts`](../packages/worker-config/src/queues/integration/index.ts) |
+
+## Facebook ID formats (critical)
+
+Facebook `feed` webhooks send composite ids. Getting these wrong is the #1 source of
+silent failures:
+
+| Field | Format | Example |
+|---|---|---|
+| `post_id` | `{pageId}_{storyId}` | `2094067177305463_2357494887629356` |
+| `comment_id` | `{storyId}_{commentId}` | `2357494887629356_1544045903933592` |
+| `parent_id` | **Always present.** For a **top-level** comment it equals `post_id`; only a **reply to another comment** carries that comment's id. | top-level → `2094067177305463_2357494887629356` |
+
+- `parent_id` presence does **not** mean "this is a reply." Use
+  `isCommentReply(parentId, postId)` (`index.ts`), which is true only when
+  `parentId !== postId`.
+- The post picker stores different formats per tab: **published/ads** store the composite
+  `{pageId}_{postId}`; **reels** store a bare video id; **manual entry** is whatever the
+  user pastes. `matchPost` normalizes both sides on the trailing story id
+  (`normalizePostId`) so all three match the webhook `post_id`.
+
+## Config options — matching & enforcement
+
+All matching happens in the automation loop in
+[`comment-automation/index.ts`](../apps/worker/src/integration/handlers/comment-automation/index.ts).
+Each filter that fails calls `logAutomationSkipped(..., reason)` (logged at `info`) and
+`continue`s to the next automation — so a skipped comment always leaves a log line.
+
+| Option / field | Meaning | Enforcement |
+|---|---|---|
+| `isActive` | Automation on/off | `findActiveAutomations` filters `isActive: true`. |
+| `type` | `messenger` \| `instagram` | `findActiveAutomations` filters `type === channelType`. Builder always writes `messenger`. |
+| `startTime`/`endTime` | Daily active window (workspace tz) | `isWithinSchedule` — lexicographic `"HH:mm"` compare, handles overnight windows; null → always within. |
+| `post` (`all` / `postIds`) | Which posts | `matchPost` — `all` always true; `postIds` matches via normalized trailing id. |
+| `options.ignoreCommentReplies` (default **true**) | Skip replies-to-comments | Skips only when `isCommentReply(parentId, postId)` is true. |
+| `includeKeywords` (`all`/`equal`/`contain`) | Text must match | `matchKeywords` — lowercased both sides. `equal` = whole comment equals a keyword; `contain` = substring. |
+| `excludeKeywords` | Text must not contain | `matchKeywords` — substring, lowercased. |
+| `options.replyToNewContactsOnly` | Only first-time contacts | `getPriorContactInboxCount(contactId) > 1` → skip. Counts `ContactInbox` rows. |
+| `options.replyOncePerUserPerPost` | Once per user per post | `findDedup(automationId, contactId, postId)` exists → skip. |
+| `options.replyToUsersWhoCommentedOnOtherPosts` (default **true**) | If off, only engage each user on their first post | When `false`, `hasRepliedOnOtherPost` (a dedup row with a different `postId`) → skip. |
+| `options.likeUserComment` | Auto-like the comment | Runs only if the incoming comment's DB message was found (`findBySourceId`). |
+| `hideComments.*` | Auto-hide matching comments | `applyHideComments` — `all`, `hasPhoneNumber` (PHONE_RE), `hasLink` (LINK_RE, matches bare domains too), `hasKeywords` (case-insensitive), `hasImage`/`hasVideo`. |
+| `hideComments.showCommentsAfter` | Auto-unhide delay | Enqueues a delayed unhide job (`jobId = unhide-comment-${commentId}`). |
+| `publicReply` / `privateReply` | The reply | See [Reply types](#reply-types). |
+| `replyAfter` | Delay before replying | `computeDelayMs` → passed as BullMQ `{ delay }`. |
+
+**All filters must pass** for a reply. After a successful dispatch, `insertDedup` writes a
+`(automationId, contactId, postId)` row (used by both `replyOncePerUserPerPost` and
+`replyToUsersWhoCommentedOnOtherPosts`) and `incrementRepliesCount` bumps the counter when
+`willSendReply` is true.
+
+## Reply types
+
+`publicReply` and `privateReply` each have a `type` and a `value`:
+
+| Type | `value` | Public reply behavior | Private reply behavior |
+|---|---|---|---|
+| `none` | — | no-op | no-op |
+| `text` | the text | Posts a public comment reply: message `type: "comment"` + `contentAttributes.replyToCommentId`, enqueued as `sendChannelMessage`. | `sendPrivateReply` (Messenger Send API DM). |
+| `flow` | flow id | Enqueues `sendFlow` with `flowId`. | Same. |
+| `AIAgent` | **AI agent id** | Enqueues a delayed `commentAIReply` job → `processCommentAIReply` generates text with the **selected** agent (`generateAIReplyText`, tools/rich off) and posts it as a **public comment reply**. | Same job, `replyChannel: "private"` → generated text sent as a **DM**. |
+
+The `AIAgent` path deliberately does **not** reuse the DM auto-responder pipeline
+(`processAutomatedResponse`), because that pipeline always uses the workspace *default*
+agent and always sends a DM. `generateAIReplyText` generates text only (no tools, no
+send), and the comment handler owns the channel routing.
+
+## Known gaps & pitfalls
+
+- **`parent_id` = `post_id` for top-level comments.** Never treat a truthy `parentId` as
+  "reply." (Fixed via `isCommentReply`; regression here silently drops every top-level
+  comment when `ignoreCommentReplies` is on.)
+- **Post-id formats differ by picker tab.** Always compare via `normalizePostId`. Reels
+  may still need verification that the stored `video_id` equals the webhook `story_id`.
+- **Instagram is not wired.** `type` is never set by the builder → always `messenger`.
+  Do not assume IG automations run. IG private-DM text replies are also out of scope
+  (no `private_replies` API).
+- **`options.trackUserTags` is defined but not implemented** — the toggle has no effect.
+- **`getPriorContactInboxCount` counts `ContactInbox` rows**, so a contact who DM'd via
+  another inbox is treated as "not new."
+- **Silent skips must log.** Every `continue` in the loop calls `logAutomationSkipped`. If
+  you add a new filter, add a skip log too — otherwise production debugging is blind
+  (`processCommentAutomation` returns `void`, so BullMQ always records `returnValue: null`
+  regardless of what happened).
+
+## Testing
+
+[`apps/worker/__tests__/comment-automation.test.ts`](../apps/worker/__tests__/comment-automation.test.ts)
+covers: `isCommentReply`, reply filtering, `matchPost` normalization, the
+`replyToUsersWhoCommentedOnOtherPosts` gate, AIAgent enqueue (public/private), the
+`processCommentAIReply` delivery paths, and hide-keyword case-insensitivity. Run:
+
+```bash
+pnpm --filter worker vitest run __tests__/comment-automation.test.ts
+```

--- a/packages/business/src/fb-comment-automation/service.ts
+++ b/packages/business/src/fb-comment-automation/service.ts
@@ -1,4 +1,4 @@
-import { db, eq, sql } from "@chatbotx.io/database/client"
+import { and, db, eq, ne, sql } from "@chatbotx.io/database/client"
 import {
   contactInboxModel,
   fbCommentAutomationModel,
@@ -70,6 +70,25 @@ class FbCommentAutomationService extends BaseService {
       .insert(fbCommentAutomationReplyModel)
       .values({ id: createId(), ...props })
       .onConflictDoNothing()
+  }
+
+  async hasRepliedOnOtherPost(props: {
+    automationId: string
+    contactId: string
+    postId: string
+  }): Promise<boolean> {
+    const rows = await db
+      .select({ one: sql`1` })
+      .from(fbCommentAutomationReplyModel)
+      .where(
+        and(
+          eq(fbCommentAutomationReplyModel.automationId, props.automationId),
+          eq(fbCommentAutomationReplyModel.contactId, props.contactId),
+          ne(fbCommentAutomationReplyModel.postId, props.postId),
+        ),
+      )
+      .limit(1)
+    return rows.length > 0
   }
 
   async incrementRepliesCount(automationId: string) {

--- a/packages/worker-config/src/queues/integration/index.ts
+++ b/packages/worker-config/src/queues/integration/index.ts
@@ -40,6 +40,7 @@ export const IntegrationJobAction = {
   updateContactAvatar: "updateContactAvatar",
   channelLabelChange: "channelLabelChange",
   processCommentAutomation: "processCommentAutomation",
+  commentAIReply: "commentAIReply",
 } as const
 
 export type IntegrationJobReceiveMessage = {
@@ -333,6 +334,24 @@ export type IntegrationJobProcessCommentAutomation = {
   }
 }
 
+export type IntegrationJobCommentAIReply = {
+  type: typeof IntegrationJobAction.commentAIReply
+  data: {
+    integrationType: string
+    integrationIdentifier: string
+    workspaceId: string
+    conversationId: string
+    contactInboxId: string
+    commentId: string
+    agentId: string
+    replyChannel: "public" | "private"
+    channelType: "messenger" | "instagram"
+    message?: string
+    parentMessageId?: string | null
+    parentMessageCreatedAt?: string | null
+  }
+}
+
 export type IntegrationJobData =
   | IntegrationJobReceiveMessage
   | IntegrationJobReceiveComment
@@ -356,6 +375,7 @@ export type IntegrationJobData =
   | IntegrationJobUpdateContactAvatar
   | IntegrationJobChannelLabelChange
   | IntegrationJobProcessCommentAutomation
+  | IntegrationJobCommentAIReply
 
 export const integrationQueue =
   process.env.NEXT_PHASE === "phase-production-build"


### PR DESCRIPTION
## Summary
- Adds AI-agent-generated replies to comment automation (public comment reply or private DM) via a new `commentAIReply` job
- Fixes post-id matching, link/keyword detection, and adds a cross-post reply dedup option

## Changes
- `apps/worker/src/integration/handlers/comment-automation/ai-reply.ts` — new job handler
- `apps/worker/src/integration/handlers/automated-response/replies.ts` — `generateAIReplyText` (tool-free AI generation)
- `apps/worker/src/integration/handlers/comment-automation/index.ts` — post-id normalization, link regex, case-insensitive keywords, cross-post skip
- `packages/business/src/fb-comment-automation/service.ts` — `hasRepliedOnOtherPost`
- `packages/worker-config/src/queues/integration/index.ts` — new job type
- `.agents/skills/fb-comment-automation/`, `docs/fb-comment-automation.md` — new skill/docs

## Test plan
- [x] pnpm lint
- [x] pnpm --filter worker check-types
- [x] pnpm --filter worker test comment-automation (22 passed)
- [ ] manual verification