### PR TITLE
fix(worker): trigger workspace defaultReply flow when bot can't answer

### DIFF
--- a/apps/worker/__tests__/automated-response-default-reply.test.ts
+++ b/apps/worker/__tests__/automated-response-default-reply.test.ts
@@ -1,0 +1,388 @@
+import type {
+  AIAgentModel,
+  ContactInboxModel,
+  ConversationModel,
+} from "@chatbotx.io/database/types"
+import { type ModelMessage, streamText } from "ai"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import { triggerDefaultReplyFlow } from "../src/integration/handlers/automated-response/default-reply"
+import { replyByAI } from "../src/integration/handlers/automated-response/replies"
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const findByFlowMock = vi.hoisted(() => vi.fn())
+const integrationQueueAddMock = vi.hoisted(() => vi.fn(async () => undefined))
+const sendMessageWithRenderMock = vi.hoisted(() => vi.fn(async () => undefined))
+const sendMessageAndWaitMock = vi.hoisted(() => vi.fn(async () => undefined))
+const appendHistoryMock = vi.hoisted(() => vi.fn(async () => undefined))
+const warnMock = vi.hoisted(() => vi.fn())
+const errorMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@chatbotx.io/business", () => ({
+  flowService: { findBy: findByFlowMock },
+  integrationOpenaiCompatibleService: {
+    findByWorkspaceIdAndId: vi.fn(),
+  },
+}))
+
+vi.mock("@chatbotx.io/worker-config", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@chatbotx.io/worker-config")>()
+  return {
+    ...actual,
+    integrationQueue: { add: integrationQueueAddMock },
+    chatQueue: { add: vi.fn(async () => undefined) },
+  }
+})
+
+vi.mock("@chatbotx.io/events/context", () => ({
+  webhookChannelOrigin: () => "webhook",
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: { warn: warnMock, error: errorMock, info: vi.fn() },
+}))
+
+vi.mock("@chatbotx.io/ai", () => ({
+  aiProviders: { openai: "openai" },
+  aiTimeouts: { aiTotal: 30_000, aiStep: 10_000, aiChunk: 5000 },
+  helpTexts: {
+    fallbackLookup:
+      "I've found some data, but I couldn't generate a complete answer yet.",
+    unavailable: "Sorry, I cannot help right now.",
+  },
+  processStreamingText: vi.fn(async () => ({ fullText: "", messageCount: 0 })),
+  systemFunctionNames: {
+    webSearch: "webSearch",
+    connectUserToHuman: "connectUserToHuman",
+    documentReader: "documentReader",
+    imageReader: "imageReader",
+    urlReader: "urlReader",
+  },
+  toolPrefixes: { enum: { sys: "sys", file: "file", fn: "fn", mcp: "mcp" } },
+  appendFabricationGuard: (p: string) => p,
+  appendHandoffPolicy: (p: string) => p,
+  appendKnowledgeBaseGuard: (p: string) => p,
+  appendToolOutputGuard: (p: string) => p,
+  appendUnavailableWebSearchPolicy: (p: string) => p,
+}))
+
+vi.mock("@chatbotx.io/ai/server", () => ({
+  aiContextService: { appendHistory: appendHistoryMock },
+  appendFabricationGuard: (p: string) => p,
+  appendHandoffPolicy: (p: string) => p,
+  appendKnowledgeBaseGuard: (p: string) => p,
+  appendToolOutputGuard: (p: string) => p,
+  appendUnavailableWebSearchPolicy: (p: string) => p,
+  createAIProviderInstance: vi.fn(() => () => ({ type: "fake-model" })),
+  createOpenaiCompatibleModelInstance: vi.fn(() => ({
+    type: "openai-compatible-model",
+  })),
+  getAIIntegrationInDB: vi.fn(async () => ({
+    id: "integration-1",
+    apiKey: "key",
+  })),
+  getAIToolset: vi.fn(async () => ({
+    tools: { some_tool: {} },
+    cleanup: undefined,
+    webSearchOmitReason: undefined,
+  })),
+  McpClient: vi.fn(),
+  normalizeAuthorizedWebSearchDomains: vi.fn(() => []),
+  normalizeMcpContent: vi.fn((c: unknown) => c),
+}))
+
+async function* emptyAsyncIterable() {
+  // intentionally empty — fake textStream for tests
+}
+
+vi.mock("ai", () => ({
+  streamText: vi.fn((opts: { onStepFinish?: (info: unknown) => void }) => {
+    opts.onStepFinish?.({
+      stepNumber: 0,
+      finishReason: "tool-calls",
+      rawFinishReason: "tool-calls",
+      toolCalls: [{ toolName: "some_tool" }],
+      toolResults: [{}],
+    })
+    return Promise.resolve({
+      textStream: emptyAsyncIterable(),
+      usage: Promise.resolve({ totalTokens: 0 }),
+    })
+  }),
+  stepCountIs: vi.fn(() => () => false),
+}))
+
+vi.mock(
+  "../src/integration/handlers/automated-response/replies",
+  (importOriginal) => importOriginal(),
+)
+
+vi.mock("../src/integration/utils/message", () => ({
+  sendMessageAndWait: sendMessageAndWaitMock,
+  sendMessageWithRender: sendMessageWithRenderMock,
+}))
+
+vi.mock("../../utils/message", () => ({
+  sendMessageAndWait: sendMessageAndWaitMock,
+  sendMessageWithRender: sendMessageWithRenderMock,
+}))
+
+vi.mock("@chatbotx.io/variables", () => ({
+  contactVariableService: {
+    getAll: vi.fn(async () => []),
+    replaceAll: vi.fn(async ({ text }: { text: string }) => text),
+  },
+}))
+
+vi.mock("../src/trigger/services/handoff-executor.service", () => ({
+  handoffExecutorService: { execute: vi.fn(async () => undefined) },
+}))
+
+vi.mock("@chatbotx.io/event-bus", () => ({
+  emit: vi.fn(async () => undefined),
+}))
+
+vi.mock(
+  "../src/integration/handlers/automated-response/system-tools/document-reader",
+  () => ({ createDocumentReaderExecutor: vi.fn(() => vi.fn()) }),
+)
+vi.mock(
+  "../src/integration/handlers/automated-response/system-tools/image-reader",
+  () => ({ createImageReaderExecutor: vi.fn(() => vi.fn()) }),
+)
+vi.mock(
+  "../src/integration/handlers/automated-response/system-tools/url-reader",
+  () => ({ createUrlReaderExecutor: vi.fn(() => vi.fn()) }),
+)
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeAIAgent(overrides?: Partial<AIAgentModel>): AIAgentModel {
+  return {
+    id: "agent-1",
+    workspaceId: "ws-1",
+    name: "Test Agent",
+    prompt: "You are a helpful assistant.",
+    messages: [],
+    isDefault: false,
+    isRichResponse: false,
+    tools: ["sys:some_tool"],
+    webSearchAuthorizedDomains: [],
+    models: [{ provider: "openai", model: "gpt-4o" }] as AIAgentModel["models"],
+    temperature: 0.7,
+    maxOutputTokens: 1000,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as AIAgentModel
+}
+
+function makeConversation(
+  overrides?: Partial<ConversationModel>,
+): ConversationModel {
+  return {
+    id: "conv-1",
+    workspaceId: "ws-1",
+    contactId: "contact-1",
+    channel: "webchat",
+    status: "open",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as ConversationModel
+}
+
+const contactInbox = {
+  id: "inbox-1",
+  contactId: "contact-1",
+  inboxId: "channel-inbox-1",
+  channel: "webchat",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} as ContactInboxModel
+
+const baseProps = {
+  conversation: makeConversation(),
+  contactInbox,
+  channel: "webchat",
+  messages: [] as ModelMessage[],
+  fileOnlyTrigger: false,
+  triggerMessageId: "msg-trigger-1",
+}
+
+beforeEach(() => {
+  findByFlowMock.mockReset()
+  integrationQueueAddMock.mockClear()
+  sendMessageWithRenderMock.mockClear()
+  sendMessageAndWaitMock.mockClear()
+  appendHistoryMock.mockClear()
+  warnMock.mockClear()
+  errorMock.mockClear()
+  vi.mocked(streamText).mockClear()
+})
+
+// ---------------------------------------------------------------------------
+// triggerDefaultReplyFlow — unit tests
+// ---------------------------------------------------------------------------
+
+describe("triggerDefaultReplyFlow", () => {
+  const conversation = makeConversation()
+
+  test("returns false and does not enqueue when no flow id is configured", async () => {
+    const result = await triggerDefaultReplyFlow({
+      workspaceId: "ws-1",
+      defaultReplyFlowId: null,
+      conversation,
+      contactInbox,
+    })
+
+    expect(result).toBe(false)
+    expect(findByFlowMock).not.toHaveBeenCalled()
+    expect(integrationQueueAddMock).not.toHaveBeenCalled()
+  })
+
+  test("returns false when the configured flow no longer exists", async () => {
+    findByFlowMock.mockResolvedValueOnce(undefined)
+
+    const result = await triggerDefaultReplyFlow({
+      workspaceId: "ws-1",
+      defaultReplyFlowId: "flow-missing",
+      conversation,
+      contactInbox,
+    })
+
+    expect(result).toBe(false)
+    expect(integrationQueueAddMock).not.toHaveBeenCalled()
+    expect(warnMock).toHaveBeenCalled()
+  })
+
+  test("returns false when the configured flow is inactive", async () => {
+    findByFlowMock.mockResolvedValueOnce({
+      id: "flow-1",
+      active: false,
+      currentVersionId: "v1",
+    })
+
+    const result = await triggerDefaultReplyFlow({
+      workspaceId: "ws-1",
+      defaultReplyFlowId: "flow-1",
+      conversation,
+      contactInbox,
+    })
+
+    expect(result).toBe(false)
+    expect(integrationQueueAddMock).not.toHaveBeenCalled()
+  })
+
+  test("returns false when the configured flow has no published version", async () => {
+    findByFlowMock.mockResolvedValueOnce({
+      id: "flow-1",
+      active: true,
+      currentVersionId: null,
+    })
+
+    const result = await triggerDefaultReplyFlow({
+      workspaceId: "ws-1",
+      defaultReplyFlowId: "flow-1",
+      conversation,
+      contactInbox,
+    })
+
+    expect(result).toBe(false)
+    expect(integrationQueueAddMock).not.toHaveBeenCalled()
+  })
+
+  test("enqueues a sendFlow job and returns true when the flow is valid", async () => {
+    findByFlowMock.mockResolvedValueOnce({
+      id: "flow-1",
+      active: true,
+      currentVersionId: "v1",
+    })
+
+    const result = await triggerDefaultReplyFlow({
+      workspaceId: "ws-1",
+      defaultReplyFlowId: "flow-1",
+      conversation,
+      contactInbox,
+    })
+
+    expect(result).toBe(true)
+    expect(integrationQueueAddMock).toHaveBeenCalledWith(
+      "sendFlow",
+      expect.objectContaining({
+        type: "sendFlow",
+        data: expect.objectContaining({
+          conversationId: conversation.id,
+          contactInboxId: contactInbox.id,
+          flowId: "flow-1",
+        }),
+      }),
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// replyByAI — last-resort fallback prefers the default reply flow
+// ---------------------------------------------------------------------------
+
+describe("replyByAI — default reply flow fallback", () => {
+  test("triggers the default reply flow instead of the canned fallback text when configured and valid", async () => {
+    findByFlowMock.mockResolvedValueOnce({
+      id: "flow-1",
+      active: true,
+      currentVersionId: "v1",
+    })
+
+    const result = await replyByAI({
+      ...baseProps,
+      aiAgent: makeAIAgent(),
+      defaultReplyFlowId: "flow-1",
+    })
+
+    expect(result?.usedFallbackText).toBe(true)
+    expect(integrationQueueAddMock).toHaveBeenCalledWith(
+      "sendFlow",
+      expect.objectContaining({
+        data: expect.objectContaining({ flowId: "flow-1" }),
+      }),
+    )
+    expect(sendMessageWithRenderMock).not.toHaveBeenCalled()
+  })
+
+  test("falls back to the canned help text when no default reply flow is configured", async () => {
+    const result = await replyByAI({
+      ...baseProps,
+      aiAgent: makeAIAgent(),
+      defaultReplyFlowId: null,
+    })
+
+    expect(result?.usedFallbackText).toBe(true)
+    expect(integrationQueueAddMock).not.toHaveBeenCalled()
+    expect(sendMessageWithRenderMock).toHaveBeenCalledWith(
+      baseProps.conversation.id,
+      expect.stringContaining("I've found some data"),
+    )
+  })
+
+  test("falls back to the canned help text when the configured default reply flow is invalid", async () => {
+    findByFlowMock.mockResolvedValueOnce(undefined)
+
+    const result = await replyByAI({
+      ...baseProps,
+      aiAgent: makeAIAgent(),
+      defaultReplyFlowId: "flow-missing",
+    })
+
+    expect(result?.usedFallbackText).toBe(true)
+    expect(integrationQueueAddMock).not.toHaveBeenCalled()
+    expect(sendMessageWithRenderMock).toHaveBeenCalledWith(
+      baseProps.conversation.id,
+      expect.stringContaining("I've found some data"),
+    )
+  })
+})

--- a/apps/worker/src/integration/handlers/automated-response/default-reply.ts
+++ b/apps/worker/src/integration/handlers/automated-response/default-reply.ts
@@ -1,0 +1,58 @@
+import { flowService } from "@chatbotx.io/business"
+import type {
+  ContactInboxModel,
+  ConversationModel,
+} from "@chatbotx.io/database/types"
+import { webhookChannelOrigin } from "@chatbotx.io/events/context"
+import {
+  type BotResponseTrackingContext,
+  IntegrationJobAction,
+  integrationQueue,
+} from "@chatbotx.io/worker-config"
+import { logger } from "../../../lib/logger"
+
+export async function triggerDefaultReplyFlow(props: {
+  workspaceId: string
+  defaultReplyFlowId: string | null | undefined
+  conversation: ConversationModel
+  contactInbox: ContactInboxModel
+  trackingContext?: BotResponseTrackingContext
+}): Promise<boolean> {
+  const {
+    workspaceId,
+    defaultReplyFlowId,
+    conversation,
+    contactInbox,
+    trackingContext,
+  } = props
+
+  if (!defaultReplyFlowId) {
+    return false
+  }
+
+  const flow = await flowService.findBy({
+    workspaceId,
+    id: defaultReplyFlowId,
+  })
+
+  if (!(flow?.active && flow.currentVersionId)) {
+    logger.warn(
+      { workspaceId, defaultReplyFlowId },
+      "[default-reply] configured default reply flow is missing, inactive, or has no published version",
+    )
+    return false
+  }
+
+  await integrationQueue.add(IntegrationJobAction.sendFlow, {
+    type: IntegrationJobAction.sendFlow,
+    data: {
+      conversationId: conversation.id,
+      contactInboxId: contactInbox.id,
+      flowId: flow.id,
+      origin: webhookChannelOrigin(),
+      trackingContext,
+    },
+  })
+
+  return true
+}

--- a/apps/worker/src/integration/handlers/automated-response/index.ts
+++ b/apps/worker/src/integration/handlers/automated-response/index.ts
@@ -29,6 +29,7 @@ import { normalizeError } from "universal-error-normalizer"
 import { sendTypingToChannel } from "../../../chat/handlers/send-message"
 import { detectConversationAndContactInbox } from "../../../lib/db"
 import { logger } from "../../../lib/logger"
+import { triggerDefaultReplyFlow } from "./default-reply"
 import { replyByAI } from "./replies"
 
 const TRIGGER_MESSAGE_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000
@@ -123,7 +124,24 @@ export async function processAutomatedResponse(
     })
 
     if (!aiAgent) {
-      if (messageId) {
+      const triggeredDefaultReplyFlow = await triggerDefaultReplyFlow({
+        workspaceId: conversation.workspaceId,
+        defaultReplyFlowId: workspace.defaultReply,
+        conversation,
+        contactInbox,
+        trackingContext: messageId
+          ? {
+              aiProvider: "none",
+              conversationId: conversation.id,
+              messageId,
+              responseType: "flow",
+              startTime: Date.now(),
+              triggerType: "bot_response_default_reply_flow_no_ai_agent",
+              workspaceId: conversation.workspaceId,
+            }
+          : undefined,
+      })
+      if (!triggeredDefaultReplyFlow && messageId) {
         await emit("analytics:dashboard", {
           eventType: "message:bot_received",
           workspaceId: conversation.workspaceId,
@@ -280,6 +298,7 @@ export async function processAutomatedResponse(
             })
           : undefined,
         summary,
+        defaultReplyFlowId: workspace.defaultReply,
       })
     } finally {
       clearInterval(typingIntervalId)
@@ -291,35 +310,56 @@ export async function processAutomatedResponse(
       return
     }
 
-    if (aiResult?.usedFallbackText && messageId) {
-      // AI used the canned fallback help text → fallback flow.
-      await emit("analytics:dashboard", {
-        eventType: "message:bot_received",
-        workspaceId: conversation.workspaceId,
-        conversationId: conversation.id,
-        messageId,
-        occurredAt: new Date(),
-        hasResponse: true,
-        responseType: "ai_agent",
-        routeType: "agent",
-        result: "fallback",
-        aiProvider: aiResult.provider,
-        metadata: {
-          latency: Date.now() - startTime,
-          fallbackReason: "no_intent_match",
-          toolStats: aiResult.toolStats,
-          triggerContext: {
-            triggerSource: "worker",
-            triggerHandler: "triggerAutomatedResponse",
-            triggerType: "bot_response_ai_agent_fallback_text",
+    if (aiResult?.usedFallbackText) {
+      // The tool-call fallback branch inside runAIReply already resolved
+      // this — either by sending the default reply flow or the canned
+      // fallback text — so don't trigger the default reply flow again here.
+      if (messageId) {
+        await emit("analytics:dashboard", {
+          eventType: "message:bot_received",
+          workspaceId: conversation.workspaceId,
+          conversationId: conversation.id,
+          messageId,
+          occurredAt: new Date(),
+          hasResponse: true,
+          responseType: "ai_agent",
+          routeType: "agent",
+          result: "fallback",
+          aiProvider: aiResult.provider,
+          metadata: {
+            latency: Date.now() - startTime,
+            fallbackReason: "no_intent_match",
+            toolStats: aiResult.toolStats,
+            triggerContext: {
+              triggerSource: "worker",
+              triggerHandler: "triggerAutomatedResponse",
+              triggerType: "bot_response_ai_agent_fallback_text",
+            },
           },
-        },
-      })
+        })
+      }
       return
     }
 
-    // AI agent exists but failed to produce a response → fallback flow.
-    if (messageId) {
+    // AI agent exists but failed to produce any response at all → fallback flow.
+    const triggeredDefaultReplyFlow = await triggerDefaultReplyFlow({
+      workspaceId: conversation.workspaceId,
+      defaultReplyFlowId: workspace.defaultReply,
+      conversation,
+      contactInbox,
+      trackingContext: messageId
+        ? {
+            aiProvider: "none",
+            conversationId: conversation.id,
+            messageId,
+            responseType: "flow",
+            startTime,
+            triggerType: "bot_response_default_reply_flow_ai_failed",
+            workspaceId: conversation.workspaceId,
+          }
+        : undefined,
+    })
+    if (!triggeredDefaultReplyFlow && messageId) {
       await emit("analytics:dashboard", {
         eventType: "message:bot_received",
         workspaceId: conversation.workspaceId,

--- a/apps/worker/src/integration/handlers/automated-response/replies.ts
+++ b/apps/worker/src/integration/handlers/automated-response/replies.ts
@@ -50,6 +50,7 @@ import { normalizeError } from "universal-error-normalizer"
 import { logger } from "../../../lib/logger"
 import { handoffExecutorService } from "../../../trigger/services/handoff-executor.service"
 import { sendMessageAndWait, sendMessageWithRender } from "../../utils/message"
+import { triggerDefaultReplyFlow } from "./default-reply"
 import { handleRichAIReply } from "./rich-reply"
 import { createDocumentReaderExecutor } from "./system-tools/document-reader"
 import { createImageReaderExecutor } from "./system-tools/image-reader"
@@ -65,6 +66,7 @@ export type ReplyByAIProps = {
   fileOnlyTrigger: boolean
   allowedSystemFunctionIds?: string[]
   summary?: string
+  defaultReplyFlowId?: string | null
 }
 
 export type ReplyByAIExecutionResult = {
@@ -859,9 +861,29 @@ async function runAIReply(
     }
 
     // Last-resort fallback: loop finished but no assistant text was produced.
-    // Do NOT leak raw tool outputs; ask a clarifying question instead.
+    // Do NOT leak raw tool outputs; prefer the workspace's configured default
+    // reply flow, and only fall back to a clarifying question if none is set.
     if (toolCallsCount > 0 || toolResultsCount > 0) {
-      await sendMessageWithRender(conversation.id, helpTexts.fallbackLookup)
+      const triggeredDefaultReplyFlow = await triggerDefaultReplyFlow({
+        workspaceId: conversation.workspaceId,
+        defaultReplyFlowId: props.defaultReplyFlowId,
+        conversation,
+        contactInbox: props.contactInbox,
+        trackingContext: props.triggerMessageId
+          ? {
+              aiProvider: provider,
+              conversationId: conversation.id,
+              messageId: props.triggerMessageId,
+              responseType: "flow",
+              startTime,
+              triggerType: "bot_response_ai_agent_default_reply_flow",
+              workspaceId: conversation.workspaceId,
+            }
+          : undefined,
+      })
+      if (!triggeredDefaultReplyFlow) {
+        await sendMessageWithRender(conversation.id, helpTexts.fallbackLookup)
+      }
       return {
         responded: true,
         provider,


### PR DESCRIPTION
## Summary
- `Workspace.defaultReply` (the Advanced Settings fallback-flow picker) was persisted to the DB but never read anywhere in the worker, so the option silently had no effect.
- Adds `triggerDefaultReplyFlow`, which validates the configured flow is active and published, then enqueues an `IntegrationJobAction.sendFlow` job to send it to the contact.
- Wires this into the three places the automated-response pipeline previously gave up: no default AI agent configured, AI agent produced no text/tool calls, and AI agent fell back to the hardcoded `helpTexts.fallbackLookup` text (now replaced by the flow when one is configured, so contacts aren't double-messaged).
- No-op when `defaultReply` is unset or the configured flow is missing/inactive/unpublished — falls back to the prior (unchanged) behavior.

## Changes
- `apps/worker/src/integration/handlers/automated-response/default-reply.ts` (new) — `triggerDefaultReplyFlow` helper
- `apps/worker/src/integration/handlers/automated-response/index.ts` — wires the helper into the "no AI agent" and "AI produced nothing" branches
- `apps/worker/src/integration/handlers/automated-response/replies.ts` — last-resort branch prefers the configured flow over the canned fallback text
- `apps/worker/__tests__/automated-response-default-reply.test.ts` (new) — unit tests for the helper plus `replyByAI` fallback-routing behavior

## Test plan
- [x] `pnpm --filter worker test automated-response-default-reply automated-response-rich-response` (21/21 passing)
- [x] `pnpm --filter worker check-types`
- [x] `pnpm lint`
- [x] `invariant-guard` review — no violations found
- [ ] Manual verification: configure a flow under Workspace → Advanced Settings → Default Reply, trigger a message the bot can't answer on a test channel, confirm the flow is delivered to the contact