### PR TITLE
fix(contacts): reliable search, audience filters, and broadcast template flow picker

### DIFF
--- a/apps/builder/__tests__/contacts-permissions.test.ts
+++ b/apps/builder/__tests__/contacts-permissions.test.ts
@@ -23,6 +23,24 @@ vi.mock("@chatbotx.io/database/client", () => ({
 
 vi.mock("@chatbotx.io/database/queries", () => ({
   applyContactFilter: (criteria: unknown) => applyContactFilterSpy(criteria),
+  buildSmartKeywordWhere: (
+    keyword: string,
+    options?: { includeEmailAndPhone?: boolean },
+  ) => {
+    const normalizedKeyword = keyword.toLowerCase()
+    return {
+      OR: [
+        { firstName: { ilike: `%${normalizedKeyword}%` } },
+        { lastName: { ilike: `%${normalizedKeyword}%` } },
+        ...(options?.includeEmailAndPhone === false
+          ? []
+          : [
+              { email: { ilike: `%${normalizedKeyword}%` } },
+              { phoneNumber: { ilike: `%${normalizedKeyword}%` } },
+            ]),
+      ],
+    }
+  },
 }))
 
 vi.mock("@chatbotx.io/database/schema", () => ({

--- a/apps/builder/src/features/ai-triggers/actions/list.action.ts
+++ b/apps/builder/src/features/ai-triggers/actions/list.action.ts
@@ -2,6 +2,7 @@ import { db, relationsFilterToSQL } from "@chatbotx.io/database/client"
 import { aiTriggerModel } from "@chatbotx.io/database/schema"
 import {
   getPaginationWithDefaults,
+  likeContains,
   parseOrderByAsObject,
 } from "@chatbotx.io/database/utils"
 import type {
@@ -19,7 +20,7 @@ export const listAITriggers = async (
     workspaceId: input.workspaceId,
     name: input.name
       ? {
-          ilike: `%${input.name.toLowerCase()}%`,
+          ilike: likeContains(input.name),
         }
       : undefined,
   }

--- a/apps/builder/src/features/broadcasts/queries/index.ts
+++ b/apps/builder/src/features/broadcasts/queries/index.ts
@@ -6,6 +6,7 @@ import {
 } from "@chatbotx.io/database/schema"
 import {
   getPaginationWithDefaults,
+  likeContains,
   parseOrderByAsObject,
 } from "@chatbotx.io/database/utils"
 import type { PaginatedResponse } from "@/features/common/schemas/pagination"
@@ -20,7 +21,7 @@ export async function listBroadcasts(
 
   const where = {
     workspaceId: input.workspaceId,
-    name: input.name ? { ilike: `%${input.name.toLowerCase()}%` } : undefined,
+    name: input.name ? { ilike: likeContains(input.name) } : undefined,
   }
 
   const pagination = getPaginationWithDefaults(input)

--- a/apps/builder/src/features/contacts/queries/__tests__/list-contacts.queries.test.ts
+++ b/apps/builder/src/features/contacts/queries/__tests__/list-contacts.queries.test.ts
@@ -11,6 +11,24 @@ vi.mock("@chatbotx.io/database/queries", () => ({
     conversation: { status: "open" },
     __filter: criteria,
   }),
+  buildSmartKeywordWhere: (
+    keyword: string,
+    options?: { includeEmailAndPhone?: boolean },
+  ) => {
+    const normalizedKeyword = keyword.toLowerCase()
+    return {
+      OR: [
+        { firstName: { ilike: `%${normalizedKeyword}%` } },
+        { lastName: { ilike: `%${normalizedKeyword}%` } },
+        ...(options?.includeEmailAndPhone === false
+          ? []
+          : [
+              { email: { ilike: `%${normalizedKeyword}%` } },
+              { phoneNumber: { ilike: `%${normalizedKeyword}%` } },
+            ]),
+      ],
+    }
+  },
 }))
 vi.mock("@chatbotx.io/database/schema", () => ({
   contactModel: { createdAt: "createdAt", fullName: "fullName" },

--- a/apps/builder/src/features/contacts/queries/list-contacts.queries.ts
+++ b/apps/builder/src/features/contacts/queries/list-contacts.queries.ts
@@ -4,7 +4,10 @@ import {
   countWithRelationsFilterCapped,
   db,
 } from "@chatbotx.io/database/client"
-import { applyContactFilter } from "@chatbotx.io/database/queries"
+import {
+  applyContactFilter,
+  buildSmartKeywordWhere,
+} from "@chatbotx.io/database/queries"
 import { contactModel } from "@chatbotx.io/database/schema"
 import {
   getPaginationWithDefaults,
@@ -227,25 +230,15 @@ export const generateWhere = (
   input: ListContactsRequest,
   scope?: ContactPermissionScope,
 ) => {
-  const keyword = input.keyword?.toLowerCase()
   const where: ContactWhere = {
     workspaceId: input.workspaceId,
   }
 
   const filters = [
-    keyword
-      ? {
-          OR: [
-            { firstName: { ilike: `%${keyword}%` } },
-            { lastName: { ilike: `%${keyword}%` } },
-            ...(scope?.canViewEmailAndPhone === false
-              ? []
-              : [
-                  { email: { ilike: `%${keyword}%` } },
-                  { phoneNumber: { ilike: `%${keyword}%` } },
-                ]),
-          ],
-        }
+    input.keyword
+      ? buildSmartKeywordWhere(input.keyword, {
+          includeEmailAndPhone: scope?.canViewEmailAndPhone !== false,
+        })
       : undefined,
     input.contactFilter ? applyContactFilter(input.contactFilter) : undefined,
   ].filter((filter): filter is ContactWhere =>

--- a/apps/builder/src/features/conversations/queries/__tests__/list-conversations.query.test.ts
+++ b/apps/builder/src/features/conversations/queries/__tests__/list-conversations.query.test.ts
@@ -12,6 +12,27 @@ vi.mock("@chatbotx.io/database/client", () => ({
 }))
 vi.mock("@chatbotx.io/database/queries", () => ({
   applyContactFilter: vi.fn(() => ({})),
+  buildSmartKeywordWhere: vi.fn(
+    (keyword: string, options?: { includeEmailAndPhone?: boolean }) => ({
+      OR: [
+        { firstName: { ilike: `%${keyword}%` } },
+        { lastName: { ilike: `%${keyword}%` } },
+        ...(options?.includeEmailAndPhone === false
+          ? []
+          : [{ email: { ilike: `%${keyword}%` } }]),
+      ],
+    }),
+  ),
+  parseConversationAssigneeValues: vi.fn((values: string[]) => ({
+    hasUnassigned: values.includes("unassigned"),
+    inboxTeamIds: values
+      .filter((value) => value.startsWith("t_"))
+      .map((value) => value.slice(2)),
+    userIds: values
+      .filter((value) => value.startsWith("u_"))
+      .map((value) => value.slice(2)),
+  })),
+  UNASSIGNED_ASSIGNEE_VALUE: "unassigned",
 }))
 vi.mock("@chatbotx.io/database/repositories", () => ({
   createMessageRepository: vi.fn(),
@@ -25,6 +46,9 @@ vi.mock("@/lib/pagination", () => ({
 }))
 
 const { buildConversationWhere } = await import("../build-conversation-where")
+const { applyContactFilter, buildSmartKeywordWhere } = await import(
+  "@chatbotx.io/database/queries"
+)
 
 const baseInput = {
   perPage: 20,
@@ -54,5 +78,56 @@ describe("buildConversationWhere channel filter", () => {
     )
 
     expect(where.contactInboxes).toEqual({ channel: "messenger" })
+  })
+
+  test("composes keyword and contact filter OR branches without overwriting either", () => {
+    vi.mocked(applyContactFilter).mockReturnValueOnce({
+      OR: [{ email: { ilike: "%ada%" } }],
+    })
+
+    const where = buildConversationWhere(
+      "1",
+      {
+        ...baseInput,
+        keyword: "ada",
+        contactFilter: { operator: "or", conditions: [] },
+      },
+      null,
+    )
+
+    expect(where.contact).toEqual({
+      AND: [
+        { blockedAt: { isNull: true } },
+        {
+          OR: [
+            { firstName: { ilike: "%ada%" } },
+            { lastName: { ilike: "%ada%" } },
+            { email: { ilike: "%ada%" } },
+          ],
+        },
+        { OR: [{ email: { ilike: "%ada%" } }] },
+      ],
+    })
+  })
+
+  test("forwards a restricted email/phone scope to the smart keyword search", () => {
+    buildConversationWhere("1", { ...baseInput, keyword: "ada@x.com" }, null, {
+      includeEmailAndPhone: false,
+    })
+
+    expect(vi.mocked(buildSmartKeywordWhere)).toHaveBeenCalledWith(
+      "ada@x.com",
+      {
+        includeEmailAndPhone: false,
+      },
+    )
+  })
+
+  test("defaults to including email/phone when no scope is provided", () => {
+    buildConversationWhere("1", { ...baseInput, keyword: "ada" }, null)
+
+    expect(vi.mocked(buildSmartKeywordWhere)).toHaveBeenCalledWith("ada", {
+      includeEmailAndPhone: true,
+    })
   })
 })

--- a/apps/builder/src/features/conversations/queries/build-conversation-where.ts
+++ b/apps/builder/src/features/conversations/queries/build-conversation-where.ts
@@ -2,6 +2,7 @@ import { sql } from "@chatbotx.io/database/client"
 import { channelTypes } from "@chatbotx.io/database/partials"
 import {
   applyContactFilter,
+  buildSmartKeywordWhere,
   parseConversationAssigneeValues,
   UNASSIGNED_ASSIGNEE_VALUE,
 } from "@chatbotx.io/database/queries"
@@ -12,11 +13,50 @@ type ConversationCursor = {
   id: string
 }
 
+type BuildConversationWhereOptions = {
+  includeEmailAndPhone?: boolean
+}
+
+type QueryWhere = Record<string, unknown>
+
+const isQueryWhere = (value: unknown): value is QueryWhere =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const hasWhereParts = (where: QueryWhere): boolean =>
+  Object.keys(where).length > 0
+
+const getAndParts = (where: QueryWhere): QueryWhere[] => {
+  if (Object.keys(where).length === 1 && Array.isArray(where.AND)) {
+    return where.AND.filter(isQueryWhere)
+  }
+
+  return [where]
+}
+
+const addContactWhere = (where: QueryWhere, contactWhere: QueryWhere): void => {
+  if (!hasWhereParts(contactWhere)) {
+    return
+  }
+
+  const currentContactWhere = isQueryWhere(where.contact)
+    ? where.contact
+    : undefined
+  if (!(currentContactWhere && hasWhereParts(currentContactWhere))) {
+    where.contact = contactWhere
+    return
+  }
+
+  where.contact = {
+    AND: [...getAndParts(currentContactWhere), ...getAndParts(contactWhere)],
+  }
+}
+
 export function buildConversationWhere(
   workspaceId: string,
   input: Omit<ListConversationsRequest, "workspaceId">,
   cursor: ConversationCursor | null,
-): Record<string, unknown> {
+  options: BuildConversationWhereOptions = {},
+): QueryWhere {
   const tags = input.tags ?? []
   const isArchiveView = tags.includes("archived")
 
@@ -88,18 +128,14 @@ export function buildConversationWhere(
     where.contactInboxes = { channel: input.channel }
   }
 
-  // ── keyword (contact firstName / lastName ILIKE) ─────────────────────────
+  // ── keyword (smart contact search, including sourceId) ───────────────────
   if (input.keyword) {
-    const keyword = input.keyword.toLowerCase()
-    where.contact = {
-      ...(typeof where.contact === "object" && where.contact !== null
-        ? where.contact
-        : {}),
-      OR: [
-        { firstName: { ilike: `%${keyword}%` } },
-        { lastName: { ilike: `%${keyword}%` } },
-      ],
-    }
+    addContactWhere(
+      where,
+      buildSmartKeywordWhere(input.keyword, {
+        includeEmailAndPhone: options.includeEmailAndPhone !== false,
+      }),
+    )
   }
 
   // ── tags ──────────────────────────────────────────────────────────────────
@@ -122,24 +158,14 @@ export function buildConversationWhere(
     where.archivedAt = { isNotNull: true }
   }
   if (tags.includes("blocked")) {
-    where.contact = {
-      ...(typeof where.contact === "object" && where.contact !== null
-        ? where.contact
-        : {}),
-      blockedAt: { isNotNull: true },
-    }
+    addContactWhere(where, { blockedAt: { isNotNull: true } })
   }
 
   // ── contactFilter (complex filter builder) ───────────────────────────────
   if (input.contactFilter) {
     const contactFilterWhere = applyContactFilter(input.contactFilter)
     if (Object.keys(contactFilterWhere).length > 0) {
-      where.contact = {
-        ...(typeof where.contact === "object" && where.contact !== null
-          ? where.contact
-          : {}),
-        ...contactFilterWhere,
-      }
+      addContactWhere(where, contactFilterWhere)
     }
   }
 

--- a/apps/builder/src/features/conversations/queries/list-conversations.query.ts
+++ b/apps/builder/src/features/conversations/queries/list-conversations.query.ts
@@ -7,8 +7,12 @@ import { zodBigintAsString } from "@chatbotx.io/utils"
 import { endOfHour } from "date-fns"
 import { groupBy } from "remeda"
 import z from "zod"
+import { canViewContactEmailAndPhone } from "@/features/contacts/permissions"
 import type { ListConversationsRequest } from "@/features/conversations/schema/query"
-import { assertCurrentUserCanAccessChatbot } from "@/lib/auth/utils"
+import {
+  assertCurrentUserCanAccessChatbot,
+  getCurrentUserAndTargetWorkspace,
+} from "@/lib/auth/utils"
 import { decodeCursor, encodeCursor } from "@/lib/pagination"
 import type {
   FindConversationRequest,
@@ -37,7 +41,19 @@ export const listConversations = async (
     ? decodeCursor(input.cursor, conversationCursorSchema)
     : null
 
-  const where = buildConversationWhere(workspaceId, input, cursor)
+  // Inbox keyword search must not become an email/phone oracle for agents who
+  // lack the emailAndPhone permission — resolve visibility from the member's
+  // permissions (independent of Contacts-section access) and thread it through.
+  const userAndWorkspace = await getCurrentUserAndTargetWorkspace(workspaceId)
+  const includeEmailAndPhone = userAndWorkspace
+    ? canViewContactEmailAndPhone(
+        userAndWorkspace.targetWorkspaceMember.permissions,
+      )
+    : false
+
+  const where = buildConversationWhere(workspaceId, input, cursor, {
+    includeEmailAndPhone,
+  })
 
   const conversations = await conversationService.findManyQuery({
     where,

--- a/apps/builder/src/features/error-logs/queries/index.ts
+++ b/apps/builder/src/features/error-logs/queries/index.ts
@@ -2,6 +2,7 @@ import { db, relationsFilterToSQL } from "@chatbotx.io/database/client"
 import { errorLogModel } from "@chatbotx.io/database/schema"
 import {
   getPaginationWithDefaults,
+  likeContains,
   parseOrderByAsObject,
 } from "@chatbotx.io/database/utils"
 import { assertCurrentUserCanAccessChatbot } from "@/lib/auth/utils"
@@ -20,8 +21,8 @@ export async function listErrorLogs(
     ...(input.keyword
       ? {
           OR: [
-            { action: { ilike: `%${input.keyword}%` } },
-            { detail: { ilike: `%${input.keyword}%` } },
+            { action: { ilike: likeContains(input.keyword) } },
+            { detail: { ilike: likeContains(input.keyword) } },
           ],
         }
       : {}),

--- a/apps/builder/src/features/fb-comments/queries/index.ts
+++ b/apps/builder/src/features/fb-comments/queries/index.ts
@@ -3,6 +3,7 @@ import { rootFolderId } from "@chatbotx.io/database/partials"
 import { fbCommentAutomationModel } from "@chatbotx.io/database/schema"
 import {
   getPaginationWithDefaults,
+  likeContains,
   parseOrderByAsObject,
 } from "@chatbotx.io/database/utils"
 import { assertCurrentUserCanAccessChatbot } from "@/lib/auth/utils"
@@ -29,7 +30,7 @@ export async function listFbComments(
     folderId: folderIdFilter,
     name: input.name
       ? {
-          ilike: `%${input.name}%`,
+          ilike: likeContains(input.name),
         }
       : undefined,
     isActive:

--- a/apps/builder/src/features/flows/actions/__tests__/filter-flow-action.test.ts
+++ b/apps/builder/src/features/flows/actions/__tests__/filter-flow-action.test.ts
@@ -1,0 +1,190 @@
+import { stepTypes } from "@chatbotx.io/flow-config"
+import { describe, expect, test } from "vitest"
+import type { FlowWithVersionsResource } from "../../schemas/resource"
+import {
+  filterFlowsByStartStepType,
+  filterFlowsByTemplateIds,
+  hasStartNode,
+} from "../filter-flow-action"
+
+const flowWithSteps = (
+  id: string,
+  steps: Array<{ stepType?: string; template?: { id?: string } }>,
+  options?: { isStartNode?: boolean },
+): FlowWithVersionsResource => ({
+  id,
+  name: `Flow ${id}`,
+  active: true,
+  enableInInbox: true,
+  workspaceId: "workspace-1",
+  folderId: null,
+  currentVersionId: null,
+  draftVersionId: null,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+  flowVersions: [
+    {
+      id: `${id}-version`,
+      flowId: id,
+      workspaceId: "workspace-1",
+      startNodeId: "node-1",
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      isDraft: true,
+      isLatest: false,
+      edges: [],
+      nodes: [
+        {
+          id: "node-1",
+          data: {
+            isStartNode: options?.isStartNode ?? true,
+            details: { steps },
+          },
+        },
+      ],
+    },
+  ],
+})
+
+describe("flow action filters", () => {
+  test("detects a step on the start node only", () => {
+    expect(
+      hasStartNode(
+        [
+          {
+            data: {
+              isStartNode: true,
+              details: {
+                steps: [{ stepType: stepTypes.enum.sendWaTemplateMessage }],
+              },
+            },
+          },
+        ],
+        stepTypes.enum.sendWaTemplateMessage,
+      ),
+    ).toBe(true)
+
+    expect(
+      hasStartNode(
+        [
+          {
+            data: {
+              isStartNode: false,
+              details: {
+                steps: [{ stepType: stepTypes.enum.sendWaTemplateMessage }],
+              },
+            },
+          },
+        ],
+        stepTypes.enum.sendWaTemplateMessage,
+      ),
+    ).toBe(false)
+
+    expect(hasStartNode(null, stepTypes.enum.sendWaTemplateMessage)).toBe(false)
+  })
+
+  test("filters flows by WhatsApp, Messenger, and legacy WhatsApp step types", () => {
+    const whatsappFlow = flowWithSteps("wa", [
+      { stepType: stepTypes.enum.sendWaTemplateMessage },
+    ])
+    const legacyWhatsappFlow = flowWithSteps("legacy-wa", [
+      { stepType: "WA_TM01" },
+    ])
+    const messengerFlow = flowWithSteps("messenger", [
+      { stepType: stepTypes.enum.sendMessengerTemplateMessage },
+    ])
+    const nonStartFlow = flowWithSteps(
+      "non-start",
+      [{ stepType: stepTypes.enum.sendWaTemplateMessage }],
+      { isStartNode: false },
+    )
+
+    expect(
+      filterFlowsByStartStepType(
+        [whatsappFlow, legacyWhatsappFlow, messengerFlow, nonStartFlow],
+        stepTypes.enum.sendWaTemplateMessage,
+      ).map((flow) => flow.id),
+    ).toEqual(["wa", "legacy-wa"])
+
+    expect(
+      filterFlowsByStartStepType(
+        [whatsappFlow, legacyWhatsappFlow, messengerFlow],
+        stepTypes.enum.sendMessengerTemplateMessage,
+      ).map((flow) => flow.id),
+    ).toEqual(["messenger"])
+  })
+
+  test("filters WhatsApp template ids across current and legacy step types", () => {
+    const currentTemplateFlow = flowWithSteps("current-template", [
+      {
+        stepType: stepTypes.enum.sendWaTemplateMessage,
+        template: { id: "template-1" },
+      },
+    ])
+    const legacyTemplateFlow = flowWithSteps("legacy-template", [
+      { stepType: "WA_TM01", template: { id: "template-1" } },
+    ])
+    const wrongTemplateFlow = flowWithSteps("wrong-template", [
+      {
+        stepType: stepTypes.enum.sendWaTemplateMessage,
+        template: { id: "template-2" },
+      },
+    ])
+    const wrongStartTemplateFlow = {
+      ...flowWithSteps("wrong-start-template", [
+        {
+          stepType: stepTypes.enum.sendWaTemplateMessage,
+          template: { id: "template-2" },
+        },
+      ]),
+      flowVersions: [
+        {
+          ...flowWithSteps("wrong-start-template", []).flowVersions[0],
+          nodes: [
+            {
+              id: "start-node",
+              data: {
+                isStartNode: true,
+                details: {
+                  steps: [
+                    {
+                      stepType: stepTypes.enum.sendWaTemplateMessage,
+                      template: { id: "template-2" },
+                    },
+                  ],
+                },
+              },
+            },
+            {
+              id: "non-start-node",
+              data: {
+                isStartNode: false,
+                details: {
+                  steps: [
+                    {
+                      stepType: stepTypes.enum.sendWaTemplateMessage,
+                      template: { id: "template-1" },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ],
+    } satisfies FlowWithVersionsResource
+
+    expect(
+      filterFlowsByTemplateIds(
+        [
+          currentTemplateFlow,
+          legacyTemplateFlow,
+          wrongTemplateFlow,
+          wrongStartTemplateFlow,
+        ],
+        ["template-1"],
+      ).map((flow) => flow.id),
+    ).toEqual(["current-template", "legacy-template"])
+
+    expect(filterFlowsByTemplateIds([currentTemplateFlow], [])).toEqual([])
+  })
+})

--- a/apps/builder/src/features/flows/actions/filter-flow-action.ts
+++ b/apps/builder/src/features/flows/actions/filter-flow-action.ts
@@ -1,31 +1,54 @@
+import { stepTypes } from "@chatbotx.io/flow-config"
 import type { FlowNode } from "../schemas/flow-node"
-import type { FlowWithVersionsResource } from "../schemas/resource"
 
-export function hasStartNode(nodes: FlowNode[], stepType: string): boolean {
+const LEGACY_STEP_TYPE_ALIASES: Record<string, readonly string[]> = {
+  [stepTypes.enum.sendWaTemplateMessage]: ["WA_TM01"],
+}
+
+export const resolveStepTypeMatches = (stepType: string): readonly string[] => [
+  stepType,
+  ...(LEGACY_STEP_TYPE_ALIASES[stepType] ?? []),
+]
+
+type StepWithTemplate = {
+  stepType?: string
+  template?: { id?: string }
+}
+
+type FlowWithNodeVersions = {
+  flowVersions: Array<{ nodes: unknown }>
+}
+
+const isFlowNode = (node: unknown): node is FlowNode =>
+  typeof node === "object" && node !== null
+
+export function hasStartNode(nodes: unknown, stepType: string): boolean {
   if (!Array.isArray(nodes)) {
     return false
   }
 
+  const stepTypeMatches = resolveStepTypeMatches(stepType)
+
   return nodes
+    .filter(isFlowNode)
     .filter((node) => node?.data?.isStartNode === true)
     .some((node) =>
-      node?.data?.details?.steps?.some((step) => step?.stepType === stepType),
+      node?.data?.details?.steps?.some((step) =>
+        stepTypeMatches.includes(step?.stepType ?? ""),
+      ),
     )
 }
 
-export function filterFlowsByStartStepType(
-  flows: FlowWithVersionsResource[],
+export function filterFlowsByStartStepType<T extends FlowWithNodeVersions>(
+  flows: T[],
   stepType: string,
-): FlowWithVersionsResource[] {
+): T[] {
   return flows.filter((flow) =>
-    flow.flowVersions.some((version) =>
-      // biome-ignore lint/suspicious/noExplicitAny: temporary any
-      hasStartNode(version.nodes as any[], stepType),
-    ),
+    flow.flowVersions.some((version) => hasStartNode(version.nodes, stepType)),
   )
 }
 
-export function filterFlowsByTemplateIds<T extends FlowWithVersionsResource>(
+export function filterFlowsByTemplateIds<T extends FlowWithNodeVersions>(
   flows: T[],
   templateIds: string[],
 ): T[] {
@@ -33,33 +56,37 @@ export function filterFlowsByTemplateIds<T extends FlowWithVersionsResource>(
     return []
   }
 
+  const whatsappTemplateStepTypes = resolveStepTypeMatches(
+    stepTypes.enum.sendWaTemplateMessage,
+  )
+
   return flows.filter((flow) =>
     flow.flowVersions.some((version) => {
       if (!Array.isArray(version.nodes)) {
         return false
       }
 
-      return version.nodes.some((node) => {
-        // biome-ignore lint/suspicious/noExplicitAny: temporary any
-        const steps = (node as any)?.data?.details?.steps
-        if (!Array.isArray(steps)) {
-          return false
-        }
-
-        return steps.some((step) => {
-          if (step?.stepType !== "WA_TM01") {
+      return version.nodes
+        .filter(isFlowNode)
+        .filter((node) => node.data?.isStartNode === true)
+        .some((node) => {
+          const steps = node.data?.details?.steps
+          if (!Array.isArray(steps)) {
             return false
           }
 
-          const stepWithTemplate = step as unknown as {
-            template?: { id?: string }
-          }
-          const templateId = stepWithTemplate?.template?.id
-          return (
-            typeof templateId === "string" && templateIds.includes(templateId)
-          )
+          return steps.some((step) => {
+            if (!whatsappTemplateStepTypes.includes(step?.stepType ?? "")) {
+              return false
+            }
+
+            const stepWithTemplate = step as StepWithTemplate
+            const templateId = stepWithTemplate?.template?.id
+            return (
+              typeof templateId === "string" && templateIds.includes(templateId)
+            )
+          })
         })
-      })
     }),
   )
 }

--- a/apps/builder/src/features/flows/queries/index.ts
+++ b/apps/builder/src/features/flows/queries/index.ts
@@ -3,11 +3,16 @@ import { db, relationsFilterToSQL } from "@chatbotx.io/database/client"
 import { rootFolderId } from "@chatbotx.io/database/partials"
 import { flowModel } from "@chatbotx.io/database/schema"
 import {
+  likeContains,
   parseOrderByAsObject,
   parsePagination,
 } from "@chatbotx.io/database/utils"
+import { stepTypes } from "@chatbotx.io/flow-config"
 import { assertCurrentUserCanAccessChatbot } from "@/lib/auth/utils"
-import { filterFlowsByTemplateIds } from "../actions/filter-flow-action"
+import {
+  filterFlowsByStartStepType,
+  filterFlowsByTemplateIds,
+} from "../actions/filter-flow-action"
 import type {
   FindFlowParams,
   ListFlowsRequest,
@@ -36,7 +41,7 @@ export async function listFlows(
       : undefined,
     name: input.name
       ? {
-          ilike: `%${input.name.toLowerCase()}%`,
+          ilike: likeContains(input.name),
         }
       : undefined,
     active: input.active === null ? undefined : input.active,
@@ -66,19 +71,23 @@ export async function listFlows(
     db.$count(flowModel, relationsFilterToSQL(flowModel, where)),
   ])
 
-  if (input.startType === "WA_TM01") {
-    if (input.integrationWhatsappId) {
-      const templates = await db.query.whatsappMessageTemplateModel.findMany({
-        where: { integrationWhatsappId: input.integrationWhatsappId },
-        columns: { id: true },
-      })
-      const templateIds = templates.map((t) => t.id)
-      data = filterFlowsByTemplateIds(data, templateIds)
-      total = data.length
-    } else {
-      data = []
-      total = 0
+  if (input.startType) {
+    data = filterFlowsByStartStepType(data, input.startType)
+
+    if (input.startType === stepTypes.enum.sendWaTemplateMessage) {
+      if (input.integrationWhatsappId) {
+        const templates = await db.query.whatsappMessageTemplateModel.findMany({
+          where: { integrationWhatsappId: input.integrationWhatsappId },
+          columns: { id: true },
+        })
+        const templateIds = templates.map((t) => t.id)
+        data = filterFlowsByTemplateIds(data, templateIds)
+      } else {
+        data = []
+      }
     }
+
+    total = data.length
   }
 
   const pageCount = pagination?.limit ? Math.ceil(total / pagination.limit) : 1

--- a/apps/builder/src/features/import/queries/list-imports.queries.ts
+++ b/apps/builder/src/features/import/queries/list-imports.queries.ts
@@ -11,6 +11,7 @@ import type { ImportStatus, ImportType } from "@chatbotx.io/database/partials"
 import { fileModel, importModel } from "@chatbotx.io/database/schema"
 import {
   getPaginationWithDefaults,
+  likeContains,
   parseOrderBy,
 } from "@chatbotx.io/database/utils"
 import { assertCurrentUserCanAccessChatbot } from "@/lib/auth/utils"
@@ -35,7 +36,7 @@ export async function listImports(
     conditions.push(eq(importModel.status, input.status))
   }
   if (keyword) {
-    conditions.push(ilike(fileModel.fileName, `%${keyword}%`))
+    conditions.push(ilike(fileModel.fileName, likeContains(keyword)))
   }
   const where = and(...conditions)
 

--- a/apps/builder/src/features/integration-messenger/message-templates/queries/index.ts
+++ b/apps/builder/src/features/integration-messenger/message-templates/queries/index.ts
@@ -7,7 +7,10 @@ import {
 } from "@chatbotx.io/database/client"
 import type { MessengerTemplateStatus } from "@chatbotx.io/database/partials"
 import { messengerMessageTemplateModel } from "@chatbotx.io/database/schema"
-import { getPaginationWithDefaults } from "@chatbotx.io/database/utils"
+import {
+  getPaginationWithDefaults,
+  likeContains,
+} from "@chatbotx.io/database/utils"
 import type { ListMessengerMessageTemplatesResponse } from "@/features/integration-messenger/message-templates/schema/query"
 
 type MessengerMessageTemplateListWhere = {
@@ -83,7 +86,7 @@ export const messengerMessageTemplateService = {
       where,
     })
     const queryWhere = {
-      name: where.name ? { ilike: `%${where.name}%` } : undefined,
+      name: where.name ? { ilike: likeContains(where.name) } : undefined,
       status: where.status,
       integrationMessengerId: resolvedIntegrationMessengerId,
       integrationMessenger: {
@@ -109,7 +112,10 @@ export const messengerMessageTemplateService = {
         messengerMessageTemplateModel,
         and(
           where.name
-            ? ilike(messengerMessageTemplateModel.name, `%${where.name}%`)
+            ? ilike(
+                messengerMessageTemplateModel.name,
+                likeContains(where.name),
+              )
             : undefined,
           where.status
             ? eq(messengerMessageTemplateModel.status, where.status)

--- a/apps/builder/src/features/magic-links/queries/index.ts
+++ b/apps/builder/src/features/magic-links/queries/index.ts
@@ -2,6 +2,7 @@ import { db, relationsFilterToSQL } from "@chatbotx.io/database/client"
 import { magicLinkModel } from "@chatbotx.io/database/schema"
 import {
   getPaginationWithDefaults,
+  likeContains,
   parseOrderByAsObject,
 } from "@chatbotx.io/database/utils"
 import { assertCurrentUserCanAccessChatbot } from "@/lib/auth/utils"
@@ -20,8 +21,8 @@ export async function listMagicLinks(
     ...(input.keyword
       ? {
           OR: [
-            { name: { ilike: `%${input.keyword}%` } },
-            { url: { ilike: `%${input.keyword}%` } },
+            { name: { ilike: likeContains(input.keyword) } },
+            { url: { ilike: likeContains(input.keyword) } },
           ],
         }
       : {}),

--- a/apps/builder/src/features/products/services/index.ts
+++ b/apps/builder/src/features/products/services/index.ts
@@ -20,6 +20,7 @@ import type {
   ProductVariantOptionModel,
 } from "@chatbotx.io/database/types"
 import {
+  likeContains,
   parseOrderByAsObject,
   parsePagination,
 } from "@chatbotx.io/database/utils"
@@ -113,7 +114,7 @@ class ProductService extends BaseService {
   ): Promise<ListProductsResponse> {
     const where = {
       workspaceId: input.workspaceId,
-      name: input.name ? { ilike: `%${input.name.toLowerCase()}%` } : undefined,
+      name: input.name ? { ilike: likeContains(input.name) } : undefined,
     }
     const pagination = parsePagination(input)
     const orderBy = parseOrderByAsObject(productModel, input)

--- a/apps/builder/src/features/qr-codes/queries/index.ts
+++ b/apps/builder/src/features/qr-codes/queries/index.ts
@@ -2,6 +2,7 @@ import { and, db, eq, ilike } from "@chatbotx.io/database/client"
 import { flowModel, reflinkModel } from "@chatbotx.io/database/schema"
 import {
   getPaginationWithDefaults,
+  likeContains,
   parseOrderBy,
 } from "@chatbotx.io/database/utils"
 import { withCache } from "@chatbotx.io/redis"
@@ -47,7 +48,7 @@ export async function listQrCodes(
         eq(reflinkModel.workspaceId, input.workspaceId),
         eq(reflinkModel.type, "qrCode"),
         input.keyword
-          ? ilike(reflinkModel.name, `%${input.keyword}%`)
+          ? ilike(reflinkModel.name, likeContains(input.keyword))
           : undefined,
       )
 

--- a/apps/builder/src/features/reflinks/queries/index.ts
+++ b/apps/builder/src/features/reflinks/queries/index.ts
@@ -2,6 +2,7 @@ import { db, relationsFilterToSQL } from "@chatbotx.io/database/client"
 import { reflinkModel } from "@chatbotx.io/database/schema"
 import {
   getPaginationWithDefaults,
+  likeContains,
   parseOrderByAsObject,
 } from "@chatbotx.io/database/utils"
 import { assertCurrentUserCanAccessChatbot } from "@/lib/auth/utils"
@@ -20,7 +21,7 @@ export async function listReflinks(
   const where = {
     workspaceId: input.workspaceId,
     type: "refLink" as const,
-    ...(input.keyword ? { name: { ilike: `%${input.keyword}%` } } : {}),
+    ...(input.keyword ? { name: { ilike: likeContains(input.keyword) } } : {}),
   }
 
   const pagination = getPaginationWithDefaults(input)

--- a/apps/builder/src/features/sequences/queries/index.ts
+++ b/apps/builder/src/features/sequences/queries/index.ts
@@ -7,6 +7,7 @@ import {
 } from "@chatbotx.io/database/schema"
 import {
   getPaginationWithDefaults,
+  likeContains,
   parseOrderByAsObject,
 } from "@chatbotx.io/database/utils"
 import { assertCurrentUserCanAccessChatbot } from "@/lib/auth/utils"
@@ -33,7 +34,7 @@ export async function listSequences(
     folderId: folderIdFilter,
     name: input.name
       ? {
-          ilike: `%${input.name}%`,
+          ilike: likeContains(input.name),
         }
       : undefined,
     active:

--- a/apps/builder/src/features/tags/queries/index.ts
+++ b/apps/builder/src/features/tags/queries/index.ts
@@ -2,6 +2,7 @@ import { db, eq, relationsFilterToSQL } from "@chatbotx.io/database/client"
 import { rootFolderId } from "@chatbotx.io/database/partials"
 import { contactsToTagsModel, tagModel } from "@chatbotx.io/database/schema"
 import {
+  likeContains,
   parseOrderByAsObject,
   parsePagination,
 } from "@chatbotx.io/database/utils"
@@ -27,7 +28,7 @@ export async function listTags(
   const where = {
     workspaceId: input.workspaceId,
     deletedAt: { isNull: true as const },
-    name: input.name ? { ilike: `%${input.name.toLowerCase()}%` } : undefined,
+    name: input.name ? { ilike: likeContains(input.name) } : undefined,
     folderId: input.folderId
       ? // biome-ignore lint/style/noNestedTernary: allow nested ternary
         input.folderId === rootFolderId

--- a/apps/builder/src/features/workspace-members/queries/index.ts
+++ b/apps/builder/src/features/workspace-members/queries/index.ts
@@ -2,7 +2,10 @@
 
 import { db, relationsFilterToSQL } from "@chatbotx.io/database/client"
 import { workspaceMemberModel } from "@chatbotx.io/database/schema"
-import { getPaginationWithDefaults } from "@chatbotx.io/database/utils"
+import {
+  getPaginationWithDefaults,
+  likeContains,
+} from "@chatbotx.io/database/utils"
 import { assertCurrentUserCanAccessChatbot } from "@/lib/auth/utils"
 import type {
   GetWorkspaceMemberRequest,
@@ -24,7 +27,7 @@ export async function listWorkspaceMembers(
     user: input.keyword
       ? {
           name: {
-            ilike: `%${input.keyword.toLowerCase()}%`,
+            ilike: likeContains(input.keyword),
           },
         }
       : undefined,

--- a/packages/business/src/ai-agent/service.ts
+++ b/packages/business/src/ai-agent/service.ts
@@ -11,6 +11,7 @@ import { aiAgentModel } from "@chatbotx.io/database/schema"
 import type { AIAgentModel } from "@chatbotx.io/database/types"
 import {
   getPaginationWithDefaults,
+  likeContains,
   parseOrderByAsObject,
 } from "@chatbotx.io/database/utils"
 import { withCache } from "@chatbotx.io/redis"
@@ -100,9 +101,7 @@ class AiAgentService extends BaseService {
       async () => {
         const where = {
           workspaceId: input.workspaceId,
-          name: input.name
-            ? { ilike: `%${input.name.toLowerCase()}%` }
-            : undefined,
+          name: input.name ? { ilike: likeContains(input.name) } : undefined,
         }
 
         const pagination = getPaginationWithDefaults(input)

--- a/packages/business/src/automated-response/service.ts
+++ b/packages/business/src/automated-response/service.ts
@@ -12,6 +12,7 @@ import { automatedResponseModel } from "@chatbotx.io/database/schema"
 import type { AutomatedResponseModel } from "@chatbotx.io/database/types"
 import {
   getPaginationWithDefaults,
+  likeContains,
   parseOrderByAsObject,
 } from "@chatbotx.io/database/utils"
 import { distributedStore } from "@chatbotx.io/redis"
@@ -89,7 +90,7 @@ class AutomatedResponseService extends BaseService {
     const where = {
       workspaceId: input.workspaceId,
       keywords: input.keyword
-        ? { ilike: `%${input.keyword.toLowerCase()}%` }
+        ? { ilike: likeContains(input.keyword) }
         : undefined,
       folderId: input.folderId
         ? // biome-ignore lint/style/noNestedTernary: allow nested ternary

--- a/packages/business/src/bot-field/service.ts
+++ b/packages/business/src/bot-field/service.ts
@@ -13,6 +13,7 @@ import {
 import { botFieldModel, customFieldModel } from "@chatbotx.io/database/schema"
 import type { BotFieldModel } from "@chatbotx.io/database/types"
 import {
+  likeContains,
   parseOrderByAsObject,
   parsePagination,
 } from "@chatbotx.io/database/utils"
@@ -56,7 +57,7 @@ class BotFieldService extends BaseService {
           ? { isNull: true as const }
           : input.folderId
         : undefined,
-      name: input.name ? { ilike: `%${input.name.toLowerCase()}%` } : undefined,
+      name: input.name ? { ilike: likeContains(input.name) } : undefined,
     }
 
     const orderBy = parseOrderByAsObject(customFieldModel, input)

--- a/packages/business/src/custom-field/service.ts
+++ b/packages/business/src/custom-field/service.ts
@@ -14,6 +14,7 @@ import {
 import { customFieldModel } from "@chatbotx.io/database/schema"
 import type { CustomFieldModel } from "@chatbotx.io/database/types"
 import {
+  likeContains,
   parseOrderByAsObject,
   parsePagination,
 } from "@chatbotx.io/database/utils"
@@ -54,7 +55,7 @@ class CustomFieldService extends BaseService {
           ? { isNull: true as const }
           : input.folderId
         : undefined,
-      name: input.name ? { ilike: `%${input.name.toLowerCase()}%` } : undefined,
+      name: input.name ? { ilike: likeContains(input.name) } : undefined,
     }
 
     const orderBy = parseOrderByAsObject(customFieldModel, input)

--- a/packages/business/src/email-topic/service.ts
+++ b/packages/business/src/email-topic/service.ts
@@ -10,6 +10,7 @@ import { rootFolderId } from "@chatbotx.io/database/partials"
 import { emailTopicModel } from "@chatbotx.io/database/schema"
 import type { EmailTopicModel } from "@chatbotx.io/database/types"
 import {
+  likeContains,
   parseOrderByAsObject,
   parsePagination,
 } from "@chatbotx.io/database/utils"
@@ -48,7 +49,7 @@ class EmailTopicService {
           ? { isNull: true as const }
           : input.folderId
         : undefined,
-      name: input.name ? { ilike: `%${input.name.toLowerCase()}%` } : undefined,
+      name: input.name ? { ilike: likeContains(input.name) } : undefined,
     }
 
     const orderBy = parseOrderByAsObject(emailTopicModel, input)

--- a/packages/database/__tests__/contact-filter.test.ts
+++ b/packages/database/__tests__/contact-filter.test.ts
@@ -6,9 +6,11 @@ import {
   applyContactFilter,
   buildContactInboxContactFilterSQL,
   buildContactWhere,
+  buildSmartKeywordWhere,
   parseConversationAssigneeValues,
 } from "../src/queries/contact-filter"
 import { contactInboxModel, contactModel } from "../src/schema"
+import { escapeLikePattern, likeContains } from "../src/utils"
 
 const renderContactWhere = (where: Record<string, unknown>) => {
   const sqlWhere = relationsFilterToSQL(contactModel, where as never)
@@ -26,6 +28,13 @@ const renderFirstRawCondition = (where: Record<string, unknown>) => {
     (raw as (table: typeof contactModel) => SQL)(contactModel),
   )
 }
+
+describe("LIKE pattern helpers", () => {
+  test("escapes LIKE metacharacters and wraps contains patterns", () => {
+    expect(escapeLikePattern("100%_ready\\")).toBe("100\\%\\_ready\\\\")
+    expect(likeContains("100%_ready\\")).toBe("%100\\%\\_ready\\\\%")
+  })
+})
 
 describe("applyContactFilter", () => {
   test("maps inbox filters to an EXISTS ContactInbox.inboxId subquery", () => {
@@ -201,6 +210,76 @@ describe("applyContactFilter", () => {
     )
 
     expect(query.params).toContain("%100\\%\\_ready\\\\ok%")
+  })
+
+  test("renders static free-text eq as wildcard-free case-insensitive SQL", () => {
+    const query = renderContactWhere(
+      applyContactFilter({
+        operator: "and",
+        conditions: [
+          {
+            field: "fullName",
+            operator: operatorTypes.enum.eq,
+            value: "JOHN%_DOE\\",
+          },
+        ],
+      }),
+    )
+
+    expect(query.sql).toContain('"Contact"."fullName" ILIKE')
+    expect(query.params).toContain("JOHN\\%\\_DOE\\\\")
+    expect(query.params).not.toContain("%JOHN\\%\\_DOE\\\\%")
+  })
+
+  test("renders static free-text ne as NOT ILIKE plus null fallback", () => {
+    const query = renderContactWhere(
+      applyContactFilter({
+        operator: "and",
+        conditions: [
+          {
+            field: "email",
+            operator: operatorTypes.enum.ne,
+            value: "John@Example.com",
+          },
+        ],
+      }),
+    )
+
+    expect(query.sql.toLowerCase()).toContain('"contact"."email" not ilike')
+    expect(query.sql.toLowerCase()).toContain('"contact"."email" is null')
+    expect(query.params).toContain("John@Example.com")
+  })
+
+  test("keeps enum and select equality case-sensitive", () => {
+    const genderQuery = renderContactWhere(
+      applyContactFilter({
+        operator: "and",
+        conditions: [
+          {
+            field: "gender",
+            operator: operatorTypes.enum.eq,
+            value: "male",
+          },
+        ],
+      }),
+    )
+    const countryQuery = renderContactWhere(
+      applyContactFilter({
+        operator: "and",
+        conditions: [
+          {
+            field: "country",
+            operator: operatorTypes.enum.eq,
+            value: "VN",
+          },
+        ],
+      }),
+    )
+
+    expect(genderQuery.sql).toContain('"Contact"."gender" =')
+    expect(genderQuery.sql.toLowerCase()).not.toContain("ilike")
+    expect(countryQuery.sql).toContain('"Contact"."country" =')
+    expect(countryQuery.sql.toLowerCase()).not.toContain("ilike")
   })
 
   test("maps dropdown eq/ne array values to EXISTS/NOT EXISTS IN subqueries", () => {
@@ -511,6 +590,115 @@ describe("applyContactFilter", () => {
     expect(query.sql).toContain('"Contact"."country" =')
     expect(query.sql).toContain('NOT ("Contact"."country" in')
     expect(query.params).toContain("VN")
+  })
+
+  test("renders lastComment text filters through ContactInbox and Message", () => {
+    const containsQuery = renderContactWhere(
+      applyContactFilter({
+        operator: "and",
+        conditions: [
+          {
+            field: "lastComment",
+            operator: operatorTypes.enum.contains,
+            value: "Need_%help\\",
+          },
+        ],
+      }),
+    )
+    const equalQuery = renderContactWhere(
+      applyContactFilter({
+        operator: "and",
+        conditions: [
+          {
+            field: "lastComment",
+            operator: operatorTypes.enum.eq,
+            value: "Exact_%comment\\",
+          },
+        ],
+      }),
+    )
+
+    expect(containsQuery.sql).toContain('EXISTS (SELECT 1 FROM "ContactInbox"')
+    expect(containsQuery.sql).toContain('FROM "Message"')
+    expect(containsQuery.sql).toContain('"ContactInbox"."lastCommentMessageId"')
+    expect(containsQuery.sql).toContain("CASE")
+    expect(containsQuery.sql).toContain("^[0-9]+$")
+    expect(containsQuery.sql).toContain("::bigint")
+    expect(containsQuery.sql).toContain('"Message"."text" ILIKE')
+    expect(containsQuery.params).toContain("%Need\\_\\%help\\\\%")
+    expect(equalQuery.params).toContain("Exact\\_\\%comment\\\\")
+  })
+
+  test("renders lastComment negative and empty operators with expected EXISTS semantics", () => {
+    const notContainsQuery = renderContactWhere(
+      applyContactFilter({
+        operator: "and",
+        conditions: [
+          {
+            field: "lastComment",
+            operator: operatorTypes.enum.notContains,
+            value: "spam",
+          },
+        ],
+      }),
+    )
+    const notEqualQuery = renderContactWhere(
+      applyContactFilter({
+        operator: "and",
+        conditions: [
+          {
+            field: "lastComment",
+            operator: operatorTypes.enum.ne,
+            value: "spam",
+          },
+        ],
+      }),
+    )
+    const emptyQuery = renderContactWhere(
+      applyContactFilter({
+        operator: "and",
+        conditions: [
+          { field: "lastComment", operator: operatorTypes.enum.isEmpty },
+        ],
+      }),
+    )
+    const notEmptyQuery = renderContactWhere(
+      applyContactFilter({
+        operator: "and",
+        conditions: [
+          { field: "lastComment", operator: operatorTypes.enum.isNotEmpty },
+        ],
+      }),
+    )
+
+    expect(notContainsQuery.sql).toContain(
+      'NOT EXISTS (SELECT 1 FROM "ContactInbox"',
+    )
+    expect(notContainsQuery.sql).toContain('"Message"."text" ILIKE')
+    expect(notEqualQuery.sql).toContain(
+      'NOT EXISTS (SELECT 1 FROM "ContactInbox"',
+    )
+    expect(notEqualQuery.sql).toContain('"Message"."text" ILIKE')
+    expect(emptyQuery.sql).toContain('NOT EXISTS (SELECT 1 FROM "ContactInbox"')
+    expect(emptyQuery.sql).toContain(
+      '"ContactInbox"."lastCommentMessageId" IS NOT NULL',
+    )
+    expect(notEmptyQuery.sql).toContain('EXISTS (SELECT 1 FROM "ContactInbox"')
+  })
+
+  test("ignores lastComment value operators with empty values", () => {
+    const where = applyContactFilter({
+      operator: "and",
+      conditions: [
+        {
+          field: "lastComment",
+          operator: operatorTypes.enum.contains,
+          value: "",
+        },
+      ],
+    })
+
+    expect(where).toEqual({})
   })
 
   test("renders lastSent as latest outbound contact-inbox datetime", () => {
@@ -860,22 +1048,19 @@ describe("applyContactFilter", () => {
       },
     })
 
-    expect(where).toEqual({
-      workspaceId: "ws-1",
-      AND: [
-        {
-          OR: [
-            { firstName: { ilike: "%acme%" } },
-            { lastName: { ilike: "%acme%" } },
-            { email: { ilike: "%acme%" } },
-            { phoneNumber: { ilike: "%acme%" } },
-          ],
-        },
-        {
-          OR: [{ fullName: { ilike: "%bob%" } }],
-        },
-      ],
-    })
+    const query = renderContactWhere(where)
+
+    expect(query.sql).toContain('"Contact"."workspaceId" =')
+    expect(query.sql.toLowerCase()).toContain('"contact"."firstname" ilike')
+    expect(query.sql.toLowerCase()).toContain('"contact"."lastname" ilike')
+    expect(query.sql).toContain('EXISTS (SELECT 1 FROM "ContactInbox"')
+    expect(query.sql).toContain('"ContactInbox"."sourceId" =')
+    expect(query.sql.toLowerCase()).toContain('"contact"."fullname" ilike')
+    expect(query.sql.toLowerCase()).not.toContain('"contact"."email" ilike')
+    expect(query.sql.toLowerCase()).not.toContain(
+      '"contact"."phonenumber" ilike',
+    )
+    expect(query.params).toEqual(["ws-1", "%acme%", "%acme%", "Acme", "%bob%"])
   })
 
   test("builds contact-inbox audience SQL from a contact-rooted filter", () => {
@@ -922,13 +1107,10 @@ const firstAnd = (
 
 describe("applyContactFilter — direct column fields", () => {
   test.each([
-    ["fullName", "fullName"],
-    ["email", "email"],
     ["gender", "gender"],
     ["country", "country"],
     ["locale", "locale"],
     ["timezone", "timezone"],
-    ["phone", "phoneNumber"],
   ])("maps %s eq to the %s column", (field, column) => {
     expect(firstAnd(field, operatorTypes.enum.eq, "x")).toEqual({
       [column]: "x",
@@ -936,14 +1118,24 @@ describe("applyContactFilter — direct column fields", () => {
   })
 
   test.each([
-    [operatorTypes.enum.eq, "Ada", { fullName: "Ada" }],
-    [
-      operatorTypes.enum.ne,
-      "Ada",
-      {
-        OR: [{ fullName: { ne: "Ada" } }, { fullName: { isNull: true } }],
-      },
-    ],
+    ["fullName", "fullName"],
+    ["email", "email"],
+    ["phone", "phoneNumber"],
+  ])("maps %s eq to case-insensitive %s SQL", (field, column) => {
+    const query = renderContactWhere(
+      applyContactFilter({
+        operator: "and",
+        conditions: [{ field, operator: operatorTypes.enum.eq, value: "x" }],
+      }),
+    )
+
+    expect(query.sql.toLowerCase()).toContain(
+      `"contact"."${column.toLowerCase()}" ilike`,
+    )
+    expect(query.params).toContain("x")
+  })
+
+  test.each([
     [operatorTypes.enum.eq, ["a", "b"], { fullName: { in: ["a", "b"] } }],
     [
       operatorTypes.enum.ne,
@@ -980,6 +1172,21 @@ describe("applyContactFilter — direct column fields", () => {
   })
 
   test.each([
+    [operatorTypes.enum.eq, "Ada", '"contact"."fullname" ilike'],
+    [operatorTypes.enum.ne, "Ada", '"contact"."fullname" not ilike'],
+  ])("maps fullName operator %s as case-insensitive SQL", (operator, value, expected) => {
+    const query = renderContactWhere(
+      applyContactFilter({
+        operator: "and",
+        conditions: [{ field: "fullName", operator, value }],
+      }),
+    )
+
+    expect(query.sql.toLowerCase()).toContain(expected)
+    expect(query.params).toContain(value)
+  })
+
+  test.each([
     [
       operatorTypes.enum.isEmpty,
       { OR: [{ fullName: { isNull: true } }, { fullName: "" }] },
@@ -995,17 +1202,44 @@ describe("applyContactFilter — direct column fields", () => {
   })
 
   test.each([
-    ["fullName", "fullName"],
-    ["email", "email"],
     ["gender", "gender"],
     ["country", "country"],
     ["locale", "locale"],
     ["timezone", "timezone"],
-    ["phone", "phoneNumber"],
   ])("includes NULL rows for %s negation operators", (field, column) => {
     expect(firstAnd(field, operatorTypes.enum.ne, "x")).toEqual({
       OR: [{ [column]: { ne: "x" } }, { [column]: { isNull: true } }],
     })
+    expect(firstAnd(field, operatorTypes.enum.notContains, "x")).toEqual({
+      OR: [{ [column]: { notIlike: "%x%" } }, { [column]: { isNull: true } }],
+    })
+  })
+
+  test.each([
+    ["fullName", "fullName"],
+    ["email", "email"],
+    ["phone", "phoneNumber"],
+  ])("includes NULL rows for %s case-insensitive ne", (field, column) => {
+    const query = renderContactWhere(
+      applyContactFilter({
+        operator: "and",
+        conditions: [{ field, operator: operatorTypes.enum.ne, value: "x" }],
+      }),
+    )
+
+    expect(query.sql.toLowerCase()).toContain(
+      `"contact"."${column.toLowerCase()}" not ilike`,
+    )
+    expect(query.sql.toLowerCase()).toContain(
+      `"contact"."${column.toLowerCase()}" is null`,
+    )
+  })
+
+  test.each([
+    ["fullName", "fullName"],
+    ["email", "email"],
+    ["phone", "phoneNumber"],
+  ])("includes NULL rows for %s notContains", (field, column) => {
     expect(firstAnd(field, operatorTypes.enum.notContains, "x")).toEqual({
       OR: [{ [column]: { notIlike: "%x%" } }, { [column]: { isNull: true } }],
     })
@@ -1745,9 +1979,11 @@ describe("applyContactFilter — operator combining", () => {
         { field: "email", operator: operatorTypes.enum.eq, value: "a@b.co" },
       ],
     })
-    expect(where).toEqual({
-      OR: [{ fullName: "Ada" }, { email: "a@b.co" }],
-    })
+    const query = renderContactWhere(where)
+
+    expect(query.sql.toLowerCase()).toContain('"contact"."fullname" ilike')
+    expect(query.sql.toLowerCase()).toContain('"contact"."email" ilike')
+    expect(query.params).toEqual(["Ada", "a@b.co"])
   })
 
   test("returns an empty object for empty conditions", () => {
@@ -1762,7 +1998,10 @@ describe("applyContactFilter — operator combining", () => {
         { field: "email", operator: operatorTypes.enum.eq, value: "a@b.co" },
       ],
     })
-    expect(where).toEqual({ AND: [{ email: "a@b.co" }] })
+    const query = renderContactWhere(where)
+
+    expect(query.sql.toLowerCase()).toContain('"contact"."email" ilike')
+    expect(query.params).toEqual(["a@b.co"])
   })
 })
 
@@ -1780,6 +2019,97 @@ describe("applyContactFilter — buildContactWhere base", () => {
         contactFilter: { operator: "and", conditions: [] },
       }),
     ).toEqual({ workspaceId: "ws-1" })
+  })
+})
+
+describe("buildSmartKeywordWhere", () => {
+  test("searches email-like input by email only when email is visible", () => {
+    expect(buildSmartKeywordWhere("john@x.com")).toEqual({
+      email: { ilike: "%john@x.com%" },
+    })
+  })
+
+  test("falls back to names and sourceId for email-like input when email is hidden", () => {
+    const query = renderContactWhere({
+      workspaceId: "ws-1",
+      ...buildSmartKeywordWhere("john@x.com", {
+        includeEmailAndPhone: false,
+      }),
+    })
+
+    expect(query.sql.toLowerCase()).toContain('"contact"."firstname" ilike')
+    expect(query.sql.toLowerCase()).toContain('"contact"."lastname" ilike')
+    expect(query.sql).toContain('"ContactInbox"."sourceId" =')
+    expect(query.sql.toLowerCase()).not.toContain('"contact"."email" ilike')
+  })
+
+  test("searches phone-like input by normalized phone only", () => {
+    expect(buildSmartKeywordWhere("+84 90-123-4567")).toEqual({
+      phoneNumber: { ilike: "%+84901234567%" },
+    })
+  })
+
+  test("falls back to names and sourceId for phone-like input when phone is hidden", () => {
+    const query = renderContactWhere({
+      workspaceId: "ws-1",
+      ...buildSmartKeywordWhere("+84 90-123-4567", {
+        includeEmailAndPhone: false,
+      }),
+    })
+
+    expect(query.sql.toLowerCase()).toContain('"contact"."firstname" ilike')
+    expect(query.sql.toLowerCase()).toContain('"contact"."lastname" ilike')
+    expect(query.sql).toContain('"ContactInbox"."sourceId" =')
+    expect(query.sql.toLowerCase()).not.toContain(
+      '"contact"."phonenumber" ilike',
+    )
+  })
+
+  test("searches pure digits across visible columns and exact sourceId", () => {
+    const query = renderContactWhere({
+      workspaceId: "ws-1",
+      ...buildSmartKeywordWhere("12345"),
+    })
+
+    expect(query.sql.toLowerCase()).toContain('"contact"."firstname" ilike')
+    expect(query.sql.toLowerCase()).toContain('"contact"."lastname" ilike')
+    expect(query.sql.toLowerCase()).toContain('"contact"."email" ilike')
+    expect(query.sql.toLowerCase()).toContain('"contact"."phonenumber" ilike')
+    expect(query.sql).toContain('"ContactInbox"."sourceId" =')
+    expect(query.params).toEqual([
+      "ws-1",
+      "%12345%",
+      "%12345%",
+      "%12345%",
+      "%12345%",
+      "12345",
+    ])
+  })
+
+  test("searches plain text by names and exact sourceId only", () => {
+    const query = renderContactWhere({
+      workspaceId: "ws-1",
+      ...buildSmartKeywordWhere("john"),
+    })
+
+    expect(query.sql.toLowerCase()).toContain('"contact"."firstname" ilike')
+    expect(query.sql.toLowerCase()).toContain('"contact"."lastname" ilike')
+    expect(query.sql).toContain('"ContactInbox"."sourceId" =')
+    expect(query.sql.toLowerCase()).not.toContain('"contact"."email" ilike')
+    expect(query.sql.toLowerCase()).not.toContain(
+      '"contact"."phonenumber" ilike',
+    )
+    expect(query.params).toEqual(["ws-1", "%john%", "%john%", "john"])
+  })
+
+  test("escapes LIKE metacharacters in keyword search", () => {
+    const query = renderContactWhere({
+      workspaceId: "ws-1",
+      ...buildSmartKeywordWhere("100%_ready\\"),
+    })
+
+    expect(query.params).toContain("%100\\%\\_ready\\\\%")
+    expect(query.params).toContain("100%_ready\\")
   })
 })
 

--- a/packages/database/src/queries/contact-filter/custom-field-predicates.ts
+++ b/packages/database/src/queries/contact-filter/custom-field-predicates.ts
@@ -1,6 +1,7 @@
 import { type SQL, sql } from "drizzle-orm"
 import { type OperatorType, operatorTypes } from "../../partials"
 import { contactCustomFieldModel } from "../../schema"
+import { escapeLikePattern, likeContains } from "../../utils"
 import { existsWhere } from "./exists"
 import type { ContactWhere } from "./types"
 
@@ -18,9 +19,6 @@ const NEGATION_TO_POSITIVE: Partial<Record<OperatorType, OperatorType>> = {
   [operatorTypes.enum.notBetween]: operatorTypes.enum.isBetween,
   [operatorTypes.enum.isEmpty]: operatorTypes.enum.isNotEmpty,
 }
-
-const escapeLikePattern = (value: string): string =>
-  value.replace(/[\\%_]/g, "\\$&")
 
 const isValidDateTimeFilterValue = (value: string): boolean =>
   DATETIME_VALUE_RE.test(value) && !Number.isNaN(Date.parse(value))
@@ -125,7 +123,7 @@ function buildNumberCustomFieldPredicate(
 
   switch (operator) {
     case operatorTypes.enum.contains:
-      return sql`${column} ILIKE ${`%${escapeLikePattern(value)}%`}`
+      return sql`${column} ILIKE ${likeContains(value)}`
     case operatorTypes.enum.startsWith:
       return sql`${column} ILIKE ${`${escapeLikePattern(value)}%`}`
     case operatorTypes.enum.endsWith:
@@ -217,7 +215,7 @@ function buildTextCustomFieldPredicate(
     case operatorTypes.enum.eq:
       return sql`${column} = ${value}`
     case operatorTypes.enum.contains:
-      return sql`${column} ILIKE ${`%${escapeLikePattern(value)}%`}`
+      return sql`${column} ILIKE ${likeContains(value)}`
     case operatorTypes.enum.startsWith:
       return sql`${column} ILIKE ${`${escapeLikePattern(value)}%`}`
     case operatorTypes.enum.endsWith:

--- a/packages/database/src/queries/contact-filter/exists.ts
+++ b/packages/database/src/queries/contact-filter/exists.ts
@@ -1,5 +1,6 @@
 import { type AnyColumn, type SQL, sql } from "drizzle-orm"
 import type { PgTable } from "drizzle-orm/pg-core"
+import { contactInboxModel } from "../../schema"
 import type { ContactWhere, RawTable, RelationExists } from "./types"
 
 export const existsWhere = (
@@ -22,3 +23,8 @@ export const joinTableExists =
           : sql`SELECT 1 FROM ${table} WHERE ${contactIdColumn} = ${contactId}`,
       negate,
     )
+
+export const contactInboxExists = joinTableExists(
+  contactInboxModel,
+  contactInboxModel.contactId,
+)

--- a/packages/database/src/queries/contact-filter/index.ts
+++ b/packages/database/src/queries/contact-filter/index.ts
@@ -11,10 +11,11 @@ import {
   contactModel,
   conversationModel,
 } from "../../schema"
+import { likeContains } from "../../utils"
 import { buildContinentWhere } from "./continent"
 import { parseConversationAssigneeValues } from "./conversation-assignee"
 import { buildCustomFieldWhere } from "./custom-field-predicates"
-import { joinTableExists } from "./exists"
+import { contactInboxExists, joinTableExists } from "./exists"
 import {
   buildBooleanColumn,
   buildBooleanFromTimestamp,
@@ -22,14 +23,14 @@ import {
   buildDateColumnWhere,
   buildExistingContactWhere,
   buildExistsBooleanWhere,
+  buildLastCommentWhere,
   buildLatestContactInboxDateWhere,
   buildLatestContactInboxMinutesAgoWhere,
   buildLatestContactInboxNumberWhere,
   buildMinutesAgoWhere,
   contactInboxInteractedWithin24hSQL as buildRecentInteractionPredicate,
-  escapeLikePattern,
 } from "./predicates"
-import { buildRelationSetWhere, contactInboxExists } from "./relation-sets"
+import { buildRelationSetWhere } from "./relation-sets"
 import type {
   ContactWhere,
   ContactFilterConditionInput as FilterConditionInput,
@@ -116,17 +117,77 @@ const buildConversationAssignedWhere = (
   return predicate ? conversationExists(predicate, negative) : {}
 }
 
-const buildKeywordWhere = (keyword: string): ContactWhere => {
-  const normalizedKeyword = `%${escapeLikePattern(keyword.toLowerCase())}%`
+const EMAIL_KEYWORD_PATTERN = /@/
+const PHONE_KEYWORD_PATTERN = /^[+\d\s\-()]+$/
+const PURE_DIGITS_KEYWORD_PATTERN = /^\d+$/
 
-  return {
+type SmartKeywordOptions = {
+  includeEmailAndPhone?: boolean
+  includeSourceId?: boolean
+}
+
+export const buildSmartKeywordWhere = (
+  keyword: string,
+  options: SmartKeywordOptions = {},
+): ContactWhere => {
+  const trimmedKeyword = keyword.trim()
+  if (trimmedKeyword === "") {
+    return {}
+  }
+
+  const includeEmailAndPhone = options.includeEmailAndPhone !== false
+  const includeSourceId = options.includeSourceId !== false
+  const normalizedKeyword = trimmedKeyword.toLowerCase()
+  const likeKeyword = likeContains(normalizedKeyword)
+  const sourceIdWhere = includeSourceId
+    ? contactInboxExists(
+        sql`${contactInboxModel.sourceId} = ${trimmedKeyword}`,
+        false,
+      )
+    : undefined
+
+  // When the scope hides email/phone, email- and phone-like inputs fall back
+  // here instead of returning {} — an empty where would silently drop the
+  // keyword and render a fully unfiltered list.
+  const namesAndSourceIdWhere: ContactWhere = {
     OR: [
-      { firstName: { ilike: normalizedKeyword } },
-      { lastName: { ilike: normalizedKeyword } },
-      { email: { ilike: normalizedKeyword } },
-      { phoneNumber: { ilike: normalizedKeyword } },
+      { firstName: { ilike: likeKeyword } },
+      { lastName: { ilike: likeKeyword } },
+      ...(sourceIdWhere ? [sourceIdWhere] : []),
     ],
   }
+
+  if (EMAIL_KEYWORD_PATTERN.test(trimmedKeyword)) {
+    return includeEmailAndPhone
+      ? { email: { ilike: likeKeyword } }
+      : namesAndSourceIdWhere
+  }
+
+  const digitCount = trimmedKeyword.replace(/\D/g, "").length
+  if (PURE_DIGITS_KEYWORD_PATTERN.test(trimmedKeyword)) {
+    return {
+      OR: [
+        { firstName: { ilike: likeKeyword } },
+        { lastName: { ilike: likeKeyword } },
+        ...(includeEmailAndPhone
+          ? [
+              { email: { ilike: likeKeyword } },
+              { phoneNumber: { ilike: likeKeyword } },
+            ]
+          : []),
+        ...(sourceIdWhere ? [sourceIdWhere] : []),
+      ],
+    }
+  }
+
+  if (PHONE_KEYWORD_PATTERN.test(trimmedKeyword) && digitCount >= 6) {
+    const normalizedPhoneKeyword = trimmedKeyword.replace(/[\s\-()]/g, "")
+    return includeEmailAndPhone
+      ? { phoneNumber: { ilike: likeContains(normalizedPhoneKeyword) } }
+      : namesAndSourceIdWhere
+  }
+
+  return namesAndSourceIdWhere
 }
 
 export function buildContactWhere(input: FilterWhereInput): ContactWhere {
@@ -135,7 +196,7 @@ export function buildContactWhere(input: FilterWhereInput): ContactWhere {
   }
 
   const filters = [
-    input.keyword ? buildKeywordWhere(input.keyword) : undefined,
+    input.keyword ? buildSmartKeywordWhere(input.keyword) : undefined,
     input.contactFilter ? applyContactFilter(input.contactFilter) : undefined,
   ].filter((filter): filter is ContactWhere =>
     filter ? hasWhereParts(filter) : false,
@@ -215,17 +276,26 @@ function buildConditionWhere(condition: FilterConditionInput): ContactWhere {
   switch (field) {
     case "fullName":
     case "email":
-    case "gender":
-    case "country":
-    case "locale":
-    case "timezone":
-      return buildColumnWhere(field, operator, value)
+      return buildColumnWhere(field, operator, value, {
+        caseInsensitiveEquality: true,
+      })
 
     case "continent":
       return buildContinentWhere(operator, value)
 
     case "phone":
-      return buildColumnWhere("phoneNumber", operator, value)
+      return buildColumnWhere("phoneNumber", operator, value, {
+        caseInsensitiveEquality: true,
+      })
+
+    case "lastComment":
+      return buildLastCommentWhere(operator, value)
+
+    case "gender":
+    case "country":
+    case "locale":
+    case "timezone":
+      return buildColumnWhere(field, operator, value)
 
     case "contactCreatedAt":
       return buildDateColumnWhere("createdAt", operator, value)

--- a/packages/database/src/queries/contact-filter/predicates.ts
+++ b/packages/database/src/queries/contact-filter/predicates.ts
@@ -1,6 +1,8 @@
 import { type AnyColumn, type SQL, sql } from "drizzle-orm"
 import { operatorTypes } from "../../partials"
-import { contactInboxModel } from "../../schema"
+import { contactInboxModel, messageModel } from "../../schema"
+import { escapeLikePattern, likeContains } from "../../utils"
+import { contactInboxExists } from "./exists"
 import type { ContactWhere, RawTable, RelationExists } from "./types"
 
 const NUMERIC_VALUE_PATTERN = /^-?\d+(\.\d+)?$/
@@ -18,9 +20,6 @@ const COLUMN_NEGATION_OPERATORS = new Set<string>([
   operatorTypes.enum.notContains,
 ])
 
-export const escapeLikePattern = (value: string): string =>
-  value.replace(/[\\%_]/g, "\\$&")
-
 export const contactInboxInteractedWithin24hSQL = (): SQL =>
   sql`${contactInboxModel.lastIncomingMessageAt} >= NOW() - INTERVAL '24 hours'`
 
@@ -35,7 +34,36 @@ export function buildColumnWhere(
   columnName: string,
   operator: string,
   value: unknown,
+  options?: { caseInsensitiveEquality?: boolean },
 ): ContactWhere {
+  if (
+    typeof value === "string" &&
+    value !== "" &&
+    options?.caseInsensitiveEquality &&
+    operator === operatorTypes.enum.eq
+  ) {
+    return buildRawColumnWhere(
+      columnName,
+      (column) => sql`${column} ILIKE ${escapeLikePattern(value)}`,
+    )
+  }
+
+  if (
+    typeof value === "string" &&
+    value !== "" &&
+    options?.caseInsensitiveEquality &&
+    operator === operatorTypes.enum.ne
+  ) {
+    const condition = buildRawColumnWhere(
+      columnName,
+      (column) => sql`${column} NOT ILIKE ${escapeLikePattern(value)}`,
+    )
+
+    return {
+      OR: [condition, { [columnName]: { isNull: true } }],
+    }
+  }
+
   if (
     typeof value === "string" &&
     value !== "" &&
@@ -336,6 +364,50 @@ export function buildExistsBooleanWhere(
   return exists(yesPredicate, isNo)
 }
 
+export function buildLastCommentWhere(
+  operator: string,
+  value: unknown,
+): ContactWhere {
+  if (operator === operatorTypes.enum.isEmpty) {
+    return contactInboxExists(
+      sql`${contactInboxModel.lastCommentMessageId} IS NOT NULL`,
+      true,
+    )
+  }
+
+  if (operator === operatorTypes.enum.isNotEmpty) {
+    return contactInboxExists(
+      sql`${contactInboxModel.lastCommentMessageId} IS NOT NULL`,
+      false,
+    )
+  }
+
+  if (typeof value !== "string" || value === "") {
+    return {}
+  }
+
+  const messageTextPredicate = buildLastCommentTextPredicate(operator, value)
+  if (!messageTextPredicate) {
+    return {}
+  }
+
+  const commentPredicate = sql`${contactInboxModel.lastCommentMessageId} ~ '^[0-9]+$' AND EXISTS (
+    SELECT 1
+    FROM ${messageModel}
+    WHERE ${messageModel.id} = CASE
+      WHEN ${contactInboxModel.lastCommentMessageId} ~ '^[0-9]+$'
+      THEN ${contactInboxModel.lastCommentMessageId}::bigint
+    END
+      AND ${messageTextPredicate}
+  )`
+
+  const shouldNegate =
+    operator === operatorTypes.enum.ne ||
+    operator === operatorTypes.enum.notContains
+
+  return contactInboxExists(commentPredicate, shouldNegate)
+}
+
 function buildDatetimeAggregateComparison(
   operator: string,
   value: unknown,
@@ -577,7 +649,7 @@ function canBuildMinutesAgoComparison(
   return isNonNegativeInteger(value)
 }
 
-function buildTextSearchComparison(
+export function buildTextSearchComparison(
   operator: string,
   value: string,
   textExpression: SQL,
@@ -585,15 +657,47 @@ function buildTextSearchComparison(
 ): SQL | undefined {
   switch (operator) {
     case operatorTypes.enum.contains:
-      return sql`${textExpression} ILIKE ${`%${escapeLikePattern(value)}%`}`
+      return sql`${textExpression} ILIKE ${likeContains(value)}`
     case operatorTypes.enum.notContains:
-      return sql`(${textExpression} NOT ILIKE ${`%${escapeLikePattern(value)}%`} OR ${emptyPredicate})`
+      return sql`(${textExpression} NOT ILIKE ${likeContains(value)} OR ${emptyPredicate})`
     case operatorTypes.enum.startsWith:
       return sql`${textExpression} ILIKE ${`${escapeLikePattern(value)}%`}`
     case operatorTypes.enum.endsWith:
       return sql`${textExpression} ILIKE ${`%${escapeLikePattern(value)}`}`
     default:
       return
+  }
+}
+
+function buildLastCommentTextPredicate(
+  operator: string,
+  value: string,
+): SQL | undefined {
+  const textExpression = sql`${messageModel.text}`
+  const emptyPredicate = sql`${messageModel.text} IS NULL OR ${messageModel.text} = ''`
+
+  switch (operator) {
+    // eq/ne both build the positive (case-insensitive equality) predicate; the
+    // caller applies NOT EXISTS for ne, so the SQL here is intentionally shared.
+    case operatorTypes.enum.eq:
+    case operatorTypes.enum.ne:
+      return sql`${textExpression} ILIKE ${escapeLikePattern(value)}`
+    // notContains builds the positive "contains" predicate; negation is applied
+    // by the caller's NOT EXISTS.
+    case operatorTypes.enum.notContains:
+      return buildTextSearchComparison(
+        operatorTypes.enum.contains,
+        value,
+        textExpression,
+        emptyPredicate,
+      )
+    default:
+      return buildTextSearchComparison(
+        operator,
+        value,
+        textExpression,
+        emptyPredicate,
+      )
   }
 }
 
@@ -655,9 +759,9 @@ function applyOperator(operator: string, value: unknown): unknown {
     case operatorTypes.enum.isNotEmpty:
       return { isNotNull: true }
     case operatorTypes.enum.contains:
-      return { ilike: `%${escapeLikePattern(String(value))}%` }
+      return { ilike: likeContains(String(value)) }
     case operatorTypes.enum.notContains:
-      return { notIlike: `%${escapeLikePattern(String(value))}%` }
+      return { notIlike: likeContains(String(value)) }
     case operatorTypes.enum.lt:
       return { lt: value }
     case operatorTypes.enum.lte:

--- a/packages/database/src/queries/contact-filter/relation-sets.ts
+++ b/packages/database/src/queries/contact-filter/relation-sets.ts
@@ -7,13 +7,9 @@ import {
   contactsToTagsModel,
   refLinkStatModel,
 } from "../../schema"
-import { joinTableExists } from "./exists"
+import { contactInboxExists, joinTableExists } from "./exists"
 import type { ContactWhere, RelationExists } from "./types"
 
-const contactInboxExists = joinTableExists(
-  contactInboxModel,
-  contactInboxModel.contactId,
-)
 const tagsExists = joinTableExists(
   contactsToTagsModel,
   contactsToTagsModel.contactId,
@@ -140,5 +136,3 @@ export function buildRelationSetWhere(
     !positive,
   )
 }
-
-export { contactInboxExists }

--- a/packages/database/src/utils.ts
+++ b/packages/database/src/utils.ts
@@ -1,4 +1,4 @@
-import { asc, desc, type SQL } from "drizzle-orm"
+import { type AnyColumn, asc, desc, type SQL } from "drizzle-orm"
 import type { PgTable } from "drizzle-orm/pg-core"
 
 type PaginationInput = {
@@ -17,6 +17,12 @@ export const defaultPagination = {
   limit: 20,
   offset: 0,
 }
+
+export const escapeLikePattern = (value: string): string =>
+  value.replace(/[\\%_]/g, "\\$&")
+
+export const likeContains = (value: string): string =>
+  `%${escapeLikePattern(value)}%`
 
 export const parsePagination = (
   input: PaginationInput,
@@ -65,13 +71,10 @@ export const parseOrderBy = (
 
   return input.sort.reduce((acc, sortItem) => {
     if (sortItem.id in modelSchema) {
-      acc.push(
-        sortItem.desc
-          ? // biome-ignore lint/suspicious/noExplicitAny: safe cast
-            desc((modelSchema as any)[sortItem.id])
-          : // biome-ignore lint/suspicious/noExplicitAny: safe cast
-            asc((modelSchema as any)[sortItem.id]),
-      )
+      const column = (modelSchema as unknown as Record<string, unknown>)[
+        sortItem.id
+      ] as AnyColumn
+      acc.push(sortItem.desc ? desc(column) : asc(column))
     }
     return acc
   }, [] as SQL[])


### PR DESCRIPTION
## Summary

Two follow-up fixes on top of the audience-filters work (#725, now merged) so contact search, audience filtering, and broadcast template sending all behave the way people expect.

## What's changed

### Contacts — search and audience filters

- **Smarter search.** Searching now understands what you type: an email searches by email, a phone number searches by phone, and a contact ID matches the person's channel ID. Plain names still match names.
- **Casing no longer matters.** Name, email, and phone filters find the right people whether you type in uppercase or lowercase.
- **"Last comment" filter works.** This audience filter used to be quietly ignored; it now actually filters.
- **Special characters are safe.** Typing symbols such as `%` or `_` in any search box no longer returns wrong results or fails.
- **Search respects permissions in the Inbox.** Team members who aren't allowed to see email and phone can no longer reveal them through Inbox search — matching how the Contacts page already works.

### Broadcasts — template flow picker

- When sending a WhatsApp or Messenger template broadcast, the flow picker was showing every flow. It now lists only flows that actually start with the matching template step, so the choices are relevant.
- For WhatsApp, the list also stays limited to the templates of the selected WhatsApp account.
- Flows created before a past internal change are still recognized, so nothing that used to appear goes missing.

## Test plan

- [x] Contact filter and search unit tests pass (name, email, phone, last comment, special characters, permission scope)
- [x] Broadcast template flow picker tests pass (WhatsApp, Messenger, and older flows)
- [x] Conversation and contact list query tests pass
- [x] Type-check passes across the affected apps and packages
- [x] Lint passes (no new issues)

Follow-up to #725.
