### PR TITLE
fix(messenger): show every facebook page a user manages when connecting a fanpage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,8 @@ These are the most common mistakes — read before writing any code:
 
 12. **Quota is single-source: the owner's `UserQuota` row IS the pool.** There is no separate `TenantQuotaUsage` table. For a reseller, the owner's `UserQuota.*Used` columns hold the aggregated usage across their entire tenant (owner's own resources carry the reseller `tenantId` so they are included automatically). Sub-accounts each have their own `UserQuota` row; enforcement gates both the sub-account's own row and the owner's pool row. Root-tenant users have only their own row — no pool. Never add a separate counter table for tenant-level usage; update `UserQuotaService` instead. See `docs/tenancy.md#quota-enforcement`.
 
+13. **Preserve client method binding when passing callbacks** — Do not pass instance methods as bare references to helpers (for example `get: facebookGraphClient.get`). JavaScript loses the receiver binding, and clients may crash at runtime when the method uses `this`. Use an arrow wrapper or explicit bind, e.g. `get: (endpoint, options) => facebookGraphClient.get(endpoint, options)`.
+
 ## Git conventions
 
 See **`.agents/rules/git.md`** for the full canonical rules (commit format, branch naming, staging, PRs, changelog).

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -2550,6 +2550,7 @@
       "noPagesDescription": "Pages inside a Business Manager require Business Manager access during connection. Reconnect Messenger and grant all requested permissions.",
       "bmLookupFailedTitle": "Business Manager pages may be missing",
       "bmLookupFailedDescription": "Reconnect Messenger and grant Business Manager access so pages managed through a Business Manager can be listed.",
+      "alreadyConnectedNote": "This page is already connected",
       "notAdminNote": "Full admin permission on the page is required to connect",
       "tryAgain": "Try reconnecting"
     },

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -2545,6 +2545,14 @@
     "reconnect": "Reconnect",
     "reconnectDescription": "Always reconnect your bot if your Messenger bot is not responding, or if you are seem any permission error on the error log.",
     "selectFacebookPage": "Select Facebook Page",
+    "selectPage": {
+      "noPagesTitle": "No Facebook Pages found",
+      "noPagesDescription": "Pages inside a Business Manager require Business Manager access during connection. Reconnect Messenger and grant all requested permissions.",
+      "bmLookupFailedTitle": "Business Manager pages may be missing",
+      "bmLookupFailedDescription": "Reconnect Messenger and grant Business Manager access so pages managed through a Business Manager can be listed.",
+      "notAdminNote": "Full admin permission on the page is required to connect",
+      "tryAgain": "Try reconnecting"
+    },
     "title": "Facebook Messenger",
     "tabs": {
       "generalSettings": "General Settings",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -2565,6 +2565,7 @@
       "noPagesDescription": "Các trang nằm trong Business Manager cần được cấp quyền Business Manager khi kết nối. Hãy kết nối lại Messenger và cấp tất cả quyền được yêu cầu.",
       "bmLookupFailedTitle": "Có thể thiếu trang trong Business Manager",
       "bmLookupFailedDescription": "Hãy kết nối lại Messenger và cấp quyền Business Manager để liệt kê các trang được quản lý qua Business Manager.",
+      "alreadyConnectedNote": "Trang này đã được kết nối",
       "notAdminNote": "Cần quyền quản trị đầy đủ trên trang để kết nối",
       "tryAgain": "Kết nối lại"
     },

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -2560,6 +2560,14 @@
     "reconnect": "Kết nối lại",
     "reconnectDescription": "Luôn kết nối lại bot của bạn nếu bot Messenger không phản hồi, hoặc nếu bạn thấy bất kỳ lỗi quyền nào trong nhật ký lỗi.",
     "selectFacebookPage": "Chọn trang Facebook",
+    "selectPage": {
+      "noPagesTitle": "Không tìm thấy trang Facebook",
+      "noPagesDescription": "Các trang nằm trong Business Manager cần được cấp quyền Business Manager khi kết nối. Hãy kết nối lại Messenger và cấp tất cả quyền được yêu cầu.",
+      "bmLookupFailedTitle": "Có thể thiếu trang trong Business Manager",
+      "bmLookupFailedDescription": "Hãy kết nối lại Messenger và cấp quyền Business Manager để liệt kê các trang được quản lý qua Business Manager.",
+      "notAdminNote": "Cần quyền quản trị đầy đủ trên trang để kết nối",
+      "tryAgain": "Kết nối lại"
+    },
     "title": "Facebook Messenger",
     "tabs": {
       "generalSettings": "Cài đặt chung",

--- a/apps/builder/src/app/(no-sidebar)/channels/messenger/select/page.tsx
+++ b/apps/builder/src/app/(no-sidebar)/channels/messenger/select/page.tsx
@@ -1,6 +1,8 @@
+import { findConnectedMessengerPageIds } from "@chatbotx.io/business"
 import { getUserPages } from "@chatbotx.io/integration-messenger"
 import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
+import type { PickerFacebookPage } from "@/features/integration-messenger/components/messenger-pages"
 import { SelectPage } from "@/features/integration-messenger/components/select-account"
 import type { FacebookAuthCallback } from "@/lib/facebook-pending-auth"
 import {
@@ -24,10 +26,18 @@ export default async function MessengerSelectPage() {
     auth.version,
   )
 
+  const connectedPageIds = new Set(
+    await findConnectedMessengerPageIds(pages.map((page) => page.id)),
+  )
+  const pickerPages: PickerFacebookPage[] = pages.map((page) => ({
+    ...page,
+    isAlreadyConnected: connectedPageIds.has(page.id),
+  }))
+
   return (
     <SelectPage
       bmLookupFailed={bmLookupFailed}
-      pages={pages}
+      pages={pickerPages}
       referer={auth.referer}
       workspaceId={auth.workspaceId}
     />

--- a/apps/builder/src/app/(no-sidebar)/channels/messenger/select/page.tsx
+++ b/apps/builder/src/app/(no-sidebar)/channels/messenger/select/page.tsx
@@ -19,10 +19,14 @@ export default async function MessengerSelectPage() {
     redirect("/channels/create")
   }
 
-  const pages = await getUserPages(auth.userToken, auth.version)
+  const { pages, bmLookupFailed } = await getUserPages(
+    auth.userToken,
+    auth.version,
+  )
 
   return (
     <SelectPage
+      bmLookupFailed={bmLookupFailed}
       pages={pages}
       referer={auth.referer}
       workspaceId={auth.workspaceId}

--- a/apps/builder/src/app/(no-sidebar)/channels/messenger/select/page.tsx
+++ b/apps/builder/src/app/(no-sidebar)/channels/messenger/select/page.tsx
@@ -12,6 +12,17 @@ import {
 
 export const dynamic = "force-dynamic"
 
+/**
+ * Picker ordering (mirrors v1): selectable pages first, then pages already
+ * connected elsewhere, then pages the user lacks admin permission on.
+ */
+function rankPickerPage(page: PickerFacebookPage): number {
+  if (page.isAlreadyConnected) {
+    return 1
+  }
+  return page.isConnectable ? 0 : 2
+}
+
 export default async function MessengerSelectPage() {
   const token = (await cookies()).get(FB_MESSENGER_PENDING_AUTH_COOKIE)?.value
 
@@ -29,10 +40,12 @@ export default async function MessengerSelectPage() {
   const connectedPageIds = new Set(
     await findConnectedMessengerPageIds(pages.map((page) => page.id)),
   )
-  const pickerPages: PickerFacebookPage[] = pages.map((page) => ({
-    ...page,
-    isAlreadyConnected: connectedPageIds.has(page.id),
-  }))
+  const pickerPages: PickerFacebookPage[] = pages
+    .map((page) => ({
+      ...page,
+      isAlreadyConnected: connectedPageIds.has(page.id),
+    }))
+    .sort((current, next) => rankPickerPage(current) - rankPickerPage(next))
 
   return (
     <SelectPage

--- a/apps/builder/src/app/integrations/[...integration]/callback.ts
+++ b/apps/builder/src/app/integrations/[...integration]/callback.ts
@@ -18,6 +18,7 @@ import {
 import { exchangeCodeForToken as exchangeInstagramCode } from "@chatbotx.io/integration-instagram"
 import { exchangeCodeForToken as exchangeInstagramFacebookCode } from "@chatbotx.io/integration-instagram-facebook"
 import { exchangeCodeForToken as exchangeMessengerCode } from "@chatbotx.io/integration-messenger"
+import { exchangeLongLivedToken as exchangeMessengerLongLivedToken } from "@chatbotx.io/integration-messenger/apis/page"
 import {
   AuthType,
   type AuthValue,
@@ -199,11 +200,25 @@ export const handleCallback = async (
         return redirect(safeReferer)
       }
 
-      const userToken = await exchangeMessengerCode(
+      const shortLivedToken = await exchangeMessengerCode(
         messengerCredential.config,
         code,
         callbackUrl,
       )
+      // Exchange for a long-lived user token before the page-select step so
+      // the pending-auth cookie stays usable even when the user leaves the
+      // picker open for a long time. Best-effort: the short-lived token still
+      // covers the normal flow if the exchange fails.
+      const userToken = await exchangeMessengerLongLivedToken(
+        messengerCredential.config,
+        shortLivedToken,
+      ).catch((error) => {
+        logger.warn(
+          { err: error },
+          "Messenger long-lived token exchange failed, using short-lived token",
+        )
+        return shortLivedToken
+      })
       const token = await encryptAuth({
         userToken,
         workspaceId: workspace.id,

--- a/apps/builder/src/features/integration-messenger/components/messenger-pages.tsx
+++ b/apps/builder/src/features/integration-messenger/components/messenger-pages.tsx
@@ -26,13 +26,30 @@ export type CoexistTrigger = {
   resolvedWorkspaceId: string
 }
 
+export type PickerFacebookPage = ConnectableFacebookPage & {
+  isAlreadyConnected: boolean
+}
+
+function getPageOptionNote(
+  page: PickerFacebookPage,
+  t: ReturnType<typeof useTranslations>,
+): string | undefined {
+  if (page.isAlreadyConnected) {
+    return t("messenger.selectPage.alreadyConnectedNote")
+  }
+  if (!page.isConnectable) {
+    return t("messenger.selectPage.notAdminNote")
+  }
+  return
+}
+
 export function FacebookPages({
   workspaceId,
   pages,
   onCoexistRequired,
 }: {
   workspaceId?: string | null
-  pages: ConnectableFacebookPage[]
+  pages: PickerFacebookPage[]
   onCoexistRequired: (trigger: CoexistTrigger) => void
 }) {
   const t = useTranslations()
@@ -117,10 +134,8 @@ export function FacebookPages({
             options={pages.map((page) => ({
               value: page.id,
               label: page.name,
-              disabled: !page.isConnectable,
-              description: page.isConnectable
-                ? undefined
-                : t("messenger.selectPage.notAdminNote"),
+              disabled: !page.isConnectable || page.isAlreadyConnected,
+              description: getPageOptionNote(page, t),
             }))}
             required
           />

--- a/apps/builder/src/features/integration-messenger/components/messenger-pages.tsx
+++ b/apps/builder/src/features/integration-messenger/components/messenger-pages.tsx
@@ -10,6 +10,7 @@ import {
 } from "@chatbotx.io/ui/components/ui/alert"
 import { Button } from "@chatbotx.io/ui/components/ui/button"
 import { Form } from "@chatbotx.io/ui/components/ui/form"
+import { ScrollArea } from "@chatbotx.io/ui/components/ui/scroll-area"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hooks"
 import { Loader2Icon } from "lucide-react"
@@ -127,19 +128,21 @@ export function FacebookPages({
           <InputField name="pageName" type="hidden" />
         </div>
 
-        <div className="max-h-75 overflow-y-auto pr-1">
-          <RadioGroupField
-            label={t("messenger.selectFacebookPage")}
-            name="pageId"
-            options={pages.map((page) => ({
-              value: page.id,
-              label: page.name,
-              disabled: !page.isConnectable || page.isAlreadyConnected,
-              description: getPageOptionNote(page, t),
-            }))}
-            required
-          />
-        </div>
+        <ScrollArea className="max-h-75" type="auto">
+          <div className="pr-3">
+            <RadioGroupField
+              label={t("messenger.selectFacebookPage")}
+              name="pageId"
+              options={pages.map((page) => ({
+                value: page.id,
+                label: page.name,
+                disabled: !page.isConnectable || page.isAlreadyConnected,
+                description: getPageOptionNote(page, t),
+              }))}
+              required
+            />
+          </div>
+        </ScrollArea>
 
         <div className="flex justify-end gap-2">
           <Button asChild size="sm" variant="ghost">

--- a/apps/builder/src/features/integration-messenger/components/messenger-pages.tsx
+++ b/apps/builder/src/features/integration-messenger/components/messenger-pages.tsx
@@ -1,8 +1,13 @@
 "use client"
 
-import type { FacebookPage } from "@chatbotx.io/integration-messenger/schema"
+import type { ConnectableFacebookPage } from "@chatbotx.io/integration-messenger/schema"
 import { InputField } from "@chatbotx.io/ui/components/form/input-field"
 import { RadioGroupField } from "@chatbotx.io/ui/components/form/radio-group-field"
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@chatbotx.io/ui/components/ui/alert"
 import { Button } from "@chatbotx.io/ui/components/ui/button"
 import { Form } from "@chatbotx.io/ui/components/ui/form"
 import { zodResolver } from "@hookform/resolvers/zod"
@@ -27,11 +32,12 @@ export function FacebookPages({
   onCoexistRequired,
 }: {
   workspaceId?: string | null
-  pages: FacebookPage[]
+  pages: ConnectableFacebookPage[]
   onCoexistRequired: (trigger: CoexistTrigger) => void
 }) {
   const t = useTranslations()
 
+  const cancelHref = `/space/${workspaceId}/settings/channels?channel=messenger`
   const { form, handleSubmitWithAction } = useHookFormAction(
     selectPageAction,
     zodResolver(selectPageRequest),
@@ -73,6 +79,29 @@ export function FacebookPages({
     setValue("pageName", selectPage?.name ?? "")
   }, [watchedPageId, setValue, pages])
 
+  if (pages.length === 0) {
+    return (
+      <div className="space-y-4">
+        <Alert variant="warning">
+          <AlertTitle>{t("messenger.selectPage.noPagesTitle")}</AlertTitle>
+          <AlertDescription>
+            {t("messenger.selectPage.noPagesDescription")}
+          </AlertDescription>
+        </Alert>
+        <div className="flex justify-end gap-2">
+          <Button asChild size="sm" variant="ghost">
+            <Link href={cancelHref}>{t("actions.cancel")}</Link>
+          </Button>
+          <Button asChild size="sm">
+            <Link href="/channels/create">
+              {t("messenger.selectPage.tryAgain")}
+            </Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <Form {...form}>
       <form className="space-y-6" onSubmit={handleSubmitWithAction}>
@@ -88,6 +117,10 @@ export function FacebookPages({
             options={pages.map((page) => ({
               value: page.id,
               label: page.name,
+              disabled: !page.isConnectable,
+              description: page.isConnectable
+                ? undefined
+                : t("messenger.selectPage.notAdminNote"),
             }))}
             required
           />
@@ -95,11 +128,7 @@ export function FacebookPages({
 
         <div className="flex justify-end gap-2">
           <Button asChild size="sm" variant="ghost">
-            <Link
-              href={`/space/${workspaceId}/settings/channels?channel=messenger`}
-            >
-              {t("actions.cancel")}
-            </Link>
+            <Link href={cancelHref}>{t("actions.cancel")}</Link>
           </Button>
           <Button
             disabled={!form.formState.isValid || form.formState.isSubmitting}

--- a/apps/builder/src/features/integration-messenger/components/messenger-pages.tsx
+++ b/apps/builder/src/features/integration-messenger/components/messenger-pages.tsx
@@ -128,7 +128,13 @@ export function FacebookPages({
           <InputField name="pageName" type="hidden" />
         </div>
 
-        <ScrollArea className="max-h-75" type="auto">
+        {/* Radix ScrollArea scrolls its viewport, not its root: a max-height
+            on the root is ignored (the viewport's 100% height resolves
+            against an auto-height parent), so cap the viewport directly. */}
+        <ScrollArea
+          className="[&>[data-slot=scroll-area-viewport]]:max-h-75"
+          type="auto"
+        >
           <div className="pr-3">
             <RadioGroupField
               label={t("messenger.selectFacebookPage")}

--- a/apps/builder/src/features/integration-messenger/components/messenger-pages.tsx
+++ b/apps/builder/src/features/integration-messenger/components/messenger-pages.tsx
@@ -10,7 +10,6 @@ import {
 } from "@chatbotx.io/ui/components/ui/alert"
 import { Button } from "@chatbotx.io/ui/components/ui/button"
 import { Form } from "@chatbotx.io/ui/components/ui/form"
-import { ScrollArea } from "@chatbotx.io/ui/components/ui/scroll-area"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hooks"
 import { Loader2Icon } from "lucide-react"
@@ -128,27 +127,21 @@ export function FacebookPages({
           <InputField name="pageName" type="hidden" />
         </div>
 
-        {/* Radix ScrollArea scrolls its viewport, not its root: a max-height
-            on the root is ignored (the viewport's 100% height resolves
-            against an auto-height parent), so cap the viewport directly. */}
-        <ScrollArea
-          className="[&>[data-slot=scroll-area-viewport]]:max-h-75"
-          type="auto"
-        >
-          <div className="pr-3">
-            <RadioGroupField
-              label={t("messenger.selectFacebookPage")}
-              name="pageId"
-              options={pages.map((page) => ({
-                value: page.id,
-                label: page.name,
-                disabled: !page.isConnectable || page.isAlreadyConnected,
-                description: getPageOptionNote(page, t),
-              }))}
-              required
-            />
-          </div>
-        </ScrollArea>
+        {/* Styling ::-webkit-scrollbar opts out of the OS overlay scrollbar,
+            so the bar stays visible whenever the list overflows. */}
+        <div className="max-h-75 overflow-y-auto pr-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar]:w-2">
+          <RadioGroupField
+            label={t("messenger.selectFacebookPage")}
+            name="pageId"
+            options={pages.map((page) => ({
+              value: page.id,
+              label: page.name,
+              disabled: !page.isConnectable || page.isAlreadyConnected,
+              description: getPageOptionNote(page, t),
+            }))}
+            required
+          />
+        </div>
 
         <div className="flex justify-end gap-2">
           <Button asChild size="sm" variant="ghost">

--- a/apps/builder/src/features/integration-messenger/components/select-account.tsx
+++ b/apps/builder/src/features/integration-messenger/components/select-account.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import type { FacebookPage } from "@chatbotx.io/integration-messenger/schema"
+import type { ConnectableFacebookPage } from "@chatbotx.io/integration-messenger/schema"
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@chatbotx.io/ui/components/ui/alert"
 import {
   Card,
   CardContent,
@@ -17,12 +22,18 @@ import {
 import { CoexistPopup } from "@/features/shared/coexist-popup"
 
 type SelectPageProps = {
-  pages: FacebookPage[]
+  pages: ConnectableFacebookPage[]
+  bmLookupFailed: boolean
   workspaceId: string
   referer: string
 }
 
-export function SelectPage({ pages, workspaceId, referer }: SelectPageProps) {
+export function SelectPage({
+  pages,
+  bmLookupFailed,
+  workspaceId,
+  referer,
+}: SelectPageProps) {
   const t = useTranslations()
   const router = useRouter()
   const [coexist, setCoexist] = useState<CoexistTrigger | null>(null)
@@ -51,7 +62,17 @@ export function SelectPage({ pages, workspaceId, referer }: SelectPageProps) {
             {t("actions.connectFeature", { feature: "Messenger" })}
           </CardTitle>
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-4">
+          {bmLookupFailed && (
+            <Alert variant="warning">
+              <AlertTitle>
+                {t("messenger.selectPage.bmLookupFailedTitle")}
+              </AlertTitle>
+              <AlertDescription>
+                {t("messenger.selectPage.bmLookupFailedDescription")}
+              </AlertDescription>
+            </Alert>
+          )}
           <FacebookPages
             onCoexistRequired={handleCoexistRequired}
             pages={pages}

--- a/apps/builder/src/features/integration-messenger/components/select-account.tsx
+++ b/apps/builder/src/features/integration-messenger/components/select-account.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import type { ConnectableFacebookPage } from "@chatbotx.io/integration-messenger/schema"
 import {
   Alert,
   AlertDescription,
@@ -18,11 +17,12 @@ import { useState } from "react"
 import {
   type CoexistTrigger,
   FacebookPages,
+  type PickerFacebookPage,
 } from "@/features/integration-messenger/components/messenger-pages"
 import { CoexistPopup } from "@/features/shared/coexist-popup"
 
 type SelectPageProps = {
-  pages: ConnectableFacebookPage[]
+  pages: PickerFacebookPage[]
   bmLookupFailed: boolean
   workspaceId: string
   referer: string

--- a/integrations/messenger/__tests__/generate-auth-url.test.ts
+++ b/integrations/messenger/__tests__/generate-auth-url.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "vitest"
+import { generateAuthUrl } from "../src/apis/auth"
+
+describe("generateAuthUrl", () => {
+  test("asks Facebook to rerequest previously declined permissions", () => {
+    const authUrl = generateAuthUrl({
+      clientId: "client-id",
+      redirectUrl: "https://example.com/callback",
+      stateParams: { workspaceId: "workspace-id" },
+    })
+
+    expect(new URL(authUrl).searchParams.get("auth_type")).toBe("rerequest")
+  })
+})

--- a/integrations/messenger/__tests__/get-user-pages.test.ts
+++ b/integrations/messenger/__tests__/get-user-pages.test.ts
@@ -38,18 +38,15 @@ const directPage = {
   tasks: adminTasks,
 }
 
-// The Business Manager lookup is disabled by default; these tests opt in to
-// keep the BM code path covered while it stays switched off in production.
-const getUserPagesWithBm = (token: string) =>
-  getUserPages(token, undefined, { includeBusinessManagerPages: true })
-
 describe("getUserPages", () => {
   beforeEach(() => {
     mockGet.mockReset()
   })
 
-  test("skips the Business Manager lookup by default", async () => {
-    mockGet.mockResolvedValueOnce({ data: [directPage] }) // /me/accounts
+  test("runs the Business Manager lookup", async () => {
+    mockGet
+      .mockResolvedValueOnce({ data: [directPage] }) // /me/accounts
+      .mockResolvedValueOnce({ data: [] }) // /me/businesses
 
     const result = await getUserPages("user-token")
 
@@ -57,8 +54,12 @@ describe("getUserPages", () => {
       pages: [{ ...directPage, isConnectable: true }],
       bmLookupFailed: false,
     })
-    expect(mockGet).toHaveBeenCalledTimes(1)
+    expect(mockGet).toHaveBeenCalledTimes(2)
     expect(mockGet).toHaveBeenCalledWith("v23.0/me/accounts", expect.anything())
+    expect(mockGet).toHaveBeenCalledWith(
+      "v23.0/me/businesses",
+      expect.anything(),
+    )
   })
 
   test("no businesses - returns /me/accounts pages with connectability", async () => {
@@ -66,7 +67,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [directPage] }) // /me/accounts
       .mockResolvedValueOnce({ data: [] }) // /me/businesses
 
-    const result = await getUserPagesWithBm("user-token")
+    const result = await getUserPages("user-token")
 
     expect(result).toEqual({
       pages: [{ ...directPage, isConnectable: true }],
@@ -93,7 +94,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [ownedPage] }) // owned_pages
       .mockResolvedValueOnce({ data: [clientPage] }) // client_pages
 
-    const result = await getUserPagesWithBm("user-token")
+    const result = await getUserPages("user-token")
 
     expect(result.bmLookupFailed).toBe(false)
     expect(result.pages).toEqual(
@@ -119,7 +120,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [bmDuplicate] }) // owned_pages
       .mockResolvedValueOnce({ data: [] }) // client_pages
 
-    const result = await getUserPagesWithBm("user-token")
+    const result = await getUserPages("user-token")
 
     expect(result.bmLookupFailed).toBe(false)
     expect(result.pages).toEqual([{ ...directPage, isConnectable: true }])
@@ -134,7 +135,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [pageWithoutToken] }) // owned_pages
       .mockResolvedValueOnce({ data: [] }) // client_pages
 
-    const result = await getUserPagesWithBm("user-token")
+    const result = await getUserPages("user-token")
 
     expect(result).toEqual({
       pages: [{ ...pageWithoutToken, isConnectable: false }],
@@ -147,7 +148,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [directPage] }) // /me/accounts
       .mockRejectedValueOnce(new Error("business_management not granted")) // /me/businesses
 
-    const result = await getUserPagesWithBm("user-token")
+    const result = await getUserPages("user-token")
 
     expect(result).toEqual({
       pages: [{ ...directPage, isConnectable: true }],
@@ -200,7 +201,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [ownedPage2] }) // owned_pages page 2
       .mockResolvedValueOnce({ data: [] }) // client_pages
 
-    const result = await getUserPagesWithBm("user-token")
+    const result = await getUserPages("user-token")
 
     expect(result.bmLookupFailed).toBe(false)
     expect(result.pages).toEqual(
@@ -251,7 +252,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [bmPageWithToken, bmPageWithoutToken] }) // owned_pages
       .mockResolvedValueOnce({ data: [] }) // client_pages
 
-    const result = await getUserPagesWithBm("user-token")
+    const result = await getUserPages("user-token")
 
     expect(result.pages).toEqual([
       { ...directPage, isConnectable: true },
@@ -275,7 +276,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [] }) // owned_pages
       .mockResolvedValueOnce({ data: [] }) // client_pages
 
-    await getUserPagesWithBm("user-token")
+    await getUserPages("user-token")
 
     for (const call of mockGet.mock.calls) {
       expect(call[1]?.searchParams).toEqual(
@@ -304,7 +305,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [recoveredPage] }) // biz2 owned_pages
       .mockResolvedValueOnce({ data: [] }) // biz2 client_pages
 
-    const result = await getUserPagesWithBm("user-token")
+    const result = await getUserPages("user-token")
 
     expect(result).toEqual({
       pages: [{ ...recoveredPage, isConnectable: true }],
@@ -325,7 +326,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [ownedPage] }) // owned_pages
       .mockRejectedValueOnce(new Error("client pages unavailable")) // client_pages
 
-    const result = await getUserPagesWithBm("user-token")
+    const result = await getUserPages("user-token")
 
     expect(result).toEqual({
       pages: [{ ...ownedPage, isConnectable: true }],
@@ -340,7 +341,7 @@ describe("getUserPages", () => {
       .mockRejectedValueOnce(new Error("owned pages unavailable")) // owned_pages
       .mockRejectedValueOnce(new Error("client pages unavailable")) // client_pages
 
-    const result = await getUserPagesWithBm("user-token")
+    const result = await getUserPages("user-token")
 
     expect(result).toEqual({
       pages: [{ ...directPage, isConnectable: true }],

--- a/integrations/messenger/__tests__/get-user-pages.test.ts
+++ b/integrations/messenger/__tests__/get-user-pages.test.ts
@@ -38,9 +38,27 @@ const directPage = {
   tasks: adminTasks,
 }
 
+// The Business Manager lookup is disabled by default; these tests opt in to
+// keep the BM code path covered while it stays switched off in production.
+const getUserPagesWithBm = (token: string) =>
+  getUserPages(token, undefined, { includeBusinessManagerPages: true })
+
 describe("getUserPages", () => {
   beforeEach(() => {
     mockGet.mockReset()
+  })
+
+  test("skips the Business Manager lookup by default", async () => {
+    mockGet.mockResolvedValueOnce({ data: [directPage] }) // /me/accounts
+
+    const result = await getUserPages("user-token")
+
+    expect(result).toEqual({
+      pages: [{ ...directPage, isConnectable: true }],
+      bmLookupFailed: false,
+    })
+    expect(mockGet).toHaveBeenCalledTimes(1)
+    expect(mockGet).toHaveBeenCalledWith("v23.0/me/accounts", expect.anything())
   })
 
   test("no businesses - returns /me/accounts pages with connectability", async () => {
@@ -48,7 +66,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [directPage] }) // /me/accounts
       .mockResolvedValueOnce({ data: [] }) // /me/businesses
 
-    const result = await getUserPages("user-token")
+    const result = await getUserPagesWithBm("user-token")
 
     expect(result).toEqual({
       pages: [{ ...directPage, isConnectable: true }],
@@ -75,7 +93,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [ownedPage] }) // owned_pages
       .mockResolvedValueOnce({ data: [clientPage] }) // client_pages
 
-    const result = await getUserPages("user-token")
+    const result = await getUserPagesWithBm("user-token")
 
     expect(result.bmLookupFailed).toBe(false)
     expect(result.pages).toEqual(
@@ -101,7 +119,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [bmDuplicate] }) // owned_pages
       .mockResolvedValueOnce({ data: [] }) // client_pages
 
-    const result = await getUserPages("user-token")
+    const result = await getUserPagesWithBm("user-token")
 
     expect(result.bmLookupFailed).toBe(false)
     expect(result.pages).toEqual([{ ...directPage, isConnectable: true }])
@@ -116,7 +134,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [pageWithoutToken] }) // owned_pages
       .mockResolvedValueOnce({ data: [] }) // client_pages
 
-    const result = await getUserPages("user-token")
+    const result = await getUserPagesWithBm("user-token")
 
     expect(result).toEqual({
       pages: [{ ...pageWithoutToken, isConnectable: false }],
@@ -129,7 +147,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [directPage] }) // /me/accounts
       .mockRejectedValueOnce(new Error("business_management not granted")) // /me/businesses
 
-    const result = await getUserPages("user-token")
+    const result = await getUserPagesWithBm("user-token")
 
     expect(result).toEqual({
       pages: [{ ...directPage, isConnectable: true }],
@@ -182,7 +200,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [ownedPage2] }) // owned_pages page 2
       .mockResolvedValueOnce({ data: [] }) // client_pages
 
-    const result = await getUserPages("user-token")
+    const result = await getUserPagesWithBm("user-token")
 
     expect(result.bmLookupFailed).toBe(false)
     expect(result.pages).toEqual(
@@ -233,7 +251,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [bmPageWithToken, bmPageWithoutToken] }) // owned_pages
       .mockResolvedValueOnce({ data: [] }) // client_pages
 
-    const result = await getUserPages("user-token")
+    const result = await getUserPagesWithBm("user-token")
 
     expect(result.pages).toEqual([
       { ...directPage, isConnectable: true },
@@ -257,7 +275,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [] }) // owned_pages
       .mockResolvedValueOnce({ data: [] }) // client_pages
 
-    await getUserPages("user-token")
+    await getUserPagesWithBm("user-token")
 
     for (const call of mockGet.mock.calls) {
       expect(call[1]?.searchParams).toEqual(
@@ -286,7 +304,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [recoveredPage] }) // biz2 owned_pages
       .mockResolvedValueOnce({ data: [] }) // biz2 client_pages
 
-    const result = await getUserPages("user-token")
+    const result = await getUserPagesWithBm("user-token")
 
     expect(result).toEqual({
       pages: [{ ...recoveredPage, isConnectable: true }],
@@ -307,7 +325,7 @@ describe("getUserPages", () => {
       .mockResolvedValueOnce({ data: [ownedPage] }) // owned_pages
       .mockRejectedValueOnce(new Error("client pages unavailable")) // client_pages
 
-    const result = await getUserPages("user-token")
+    const result = await getUserPagesWithBm("user-token")
 
     expect(result).toEqual({
       pages: [{ ...ownedPage, isConnectable: true }],
@@ -322,7 +340,7 @@ describe("getUserPages", () => {
       .mockRejectedValueOnce(new Error("owned pages unavailable")) // owned_pages
       .mockRejectedValueOnce(new Error("client pages unavailable")) // client_pages
 
-    const result = await getUserPages("user-token")
+    const result = await getUserPagesWithBm("user-token")
 
     expect(result).toEqual({
       pages: [{ ...directPage, isConnectable: true }],

--- a/integrations/messenger/__tests__/get-user-pages.test.ts
+++ b/integrations/messenger/__tests__/get-user-pages.test.ts
@@ -14,19 +14,28 @@ vi.mock("../src/lib/http-client", () => ({
 }))
 
 vi.mock("../src/lib/logger", () => ({
-  logger: { warn: vi.fn(), error: vi.fn() },
+  logger: { warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }))
 
-// Dynamic imports ensure vi.mock is fully applied before loading these modules
+// Dynamic imports ensure vi.mock is fully applied before loading these modules.
 const { getUserPages } = await import("../src/apis/auth")
 const { facebookGraphClient } = await import("../src/lib/http-client")
 
 const mockGet = facebookGraphClient.get as MockInstance
 
+const adminTasks = [
+  "ADVERTISE",
+  "ANALYZE",
+  "CREATE_CONTENT",
+  "MANAGE",
+  "MODERATE",
+]
+
 const directPage = {
   id: "page-direct",
   name: "Direct Page",
   access_token: "direct-token",
+  tasks: adminTasks,
 }
 
 describe("getUserPages", () => {
@@ -34,14 +43,17 @@ describe("getUserPages", () => {
     mockGet.mockReset()
   })
 
-  test("no businesses — returns /me/accounts data unchanged", async () => {
+  test("no businesses - returns /me/accounts pages with connectability", async () => {
     mockGet
       .mockResolvedValueOnce({ data: [directPage] }) // /me/accounts
       .mockResolvedValueOnce({ data: [] }) // /me/businesses
 
     const result = await getUserPages("user-token")
 
-    expect(result).toEqual([directPage])
+    expect(result).toEqual({
+      pages: [{ ...directPage, isConnectable: true }],
+      bmLookupFailed: false,
+    })
     expect(mockGet).toHaveBeenCalledTimes(2)
   })
 
@@ -65,10 +77,15 @@ describe("getUserPages", () => {
 
     const result = await getUserPages("user-token")
 
-    expect(result).toEqual(
-      expect.arrayContaining([directPage, ownedPage, clientPage]),
+    expect(result.bmLookupFailed).toBe(false)
+    expect(result.pages).toEqual(
+      expect.arrayContaining([
+        { ...directPage, isConnectable: true },
+        { ...ownedPage, isConnectable: true },
+        { ...clientPage, isConnectable: true },
+      ]),
     )
-    expect(result).toHaveLength(3)
+    expect(result.pages).toHaveLength(3)
   })
 
   test("page id colliding with /me/accounts keeps the direct-accounts record", async () => {
@@ -86,11 +103,11 @@ describe("getUserPages", () => {
 
     const result = await getUserPages("user-token")
 
-    expect(result).toHaveLength(1)
-    expect(result[0]).toEqual(directPage)
+    expect(result.bmLookupFailed).toBe(false)
+    expect(result.pages).toEqual([{ ...directPage, isConnectable: true }])
   })
 
-  test("BM page missing access_token is excluded", async () => {
+  test("BM page missing access_token is returned as non-connectable", async () => {
     const pageWithoutToken = { id: "page-no-token", name: "No Token Page" }
 
     mockGet
@@ -101,20 +118,32 @@ describe("getUserPages", () => {
 
     const result = await getUserPages("user-token")
 
-    expect(result).toEqual([])
+    expect(result).toEqual({
+      pages: [{ ...pageWithoutToken, isConnectable: false }],
+      bmLookupFailed: false,
+    })
   })
 
-  test("BM fetch failure falls back silently to direct pages only", async () => {
+  test("BM lookup failure returns direct pages and exposes the failure flag", async () => {
     mockGet
       .mockResolvedValueOnce({ data: [directPage] }) // /me/accounts
       .mockRejectedValueOnce(new Error("business_management not granted")) // /me/businesses
 
     const result = await getUserPages("user-token")
 
-    expect(result).toEqual([directPage])
+    expect(result).toEqual({
+      pages: [{ ...directPage, isConnectable: true }],
+      bmLookupFailed: true,
+    })
   })
 
-  test("paginates /me/businesses and owned_pages until cursors are exhausted", async () => {
+  test("paginates /me/accounts, /me/businesses, and owned_pages", async () => {
+    const directPage2 = {
+      id: "page-direct-2",
+      name: "Direct Page 2",
+      access_token: "direct-token-2",
+      tasks: adminTasks,
+    }
     const ownedPage1 = {
       id: "page-owned-1",
       name: "Owned 1",
@@ -127,7 +156,14 @@ describe("getUserPages", () => {
     }
 
     mockGet
-      .mockResolvedValueOnce({ data: [] }) // /me/accounts
+      .mockResolvedValueOnce({
+        data: [directPage],
+        paging: {
+          cursors: { after: "direct-cursor" },
+          next: "https://graph.facebook.com/v23.0/me/accounts?after=direct-cursor",
+        },
+      }) // /me/accounts page 1
+      .mockResolvedValueOnce({ data: [directPage2] }) // /me/accounts page 2
       .mockResolvedValueOnce({
         data: [{ id: "biz1", name: "Biz 1" }],
         paging: {
@@ -135,7 +171,7 @@ describe("getUserPages", () => {
           next: "https://graph.facebook.com/v23.0/me/businesses?after=biz-cursor",
         },
       }) // /me/businesses page 1
-      .mockResolvedValueOnce({ data: [] }) // /me/businesses page 2 (no more)
+      .mockResolvedValueOnce({ data: [] }) // /me/businesses page 2
       .mockResolvedValueOnce({
         data: [ownedPage1],
         paging: {
@@ -148,8 +184,149 @@ describe("getUserPages", () => {
 
     const result = await getUserPages("user-token")
 
-    expect(result).toEqual(expect.arrayContaining([ownedPage1, ownedPage2]))
-    expect(result).toHaveLength(2)
-    expect(mockGet).toHaveBeenCalledTimes(6)
+    expect(result.bmLookupFailed).toBe(false)
+    expect(result.pages).toEqual(
+      expect.arrayContaining([
+        { ...directPage, isConnectable: true },
+        { ...directPage2, isConnectable: true },
+        { ...ownedPage1, isConnectable: true },
+        { ...ownedPage2, isConnectable: true },
+      ]),
+    )
+    expect(result.pages).toHaveLength(4)
+    expect(mockGet).toHaveBeenCalledTimes(7)
+  })
+
+  test("classifies direct and BM-only pages and sorts connectable pages first", async () => {
+    const missingTaskPage = {
+      id: "page-missing-task",
+      name: "Missing Task",
+      access_token: "missing-task-token",
+      tasks: adminTasks.filter((task) => task !== "MODERATE"),
+    }
+    const emptyTasksPage = {
+      id: "page-empty-tasks",
+      name: "Empty Tasks",
+      access_token: "empty-tasks-token",
+      tasks: [],
+    }
+    const missingTasksPage = {
+      id: "page-missing-tasks",
+      name: "Missing Tasks",
+      access_token: "missing-tasks-token",
+    }
+    const bmPageWithToken = {
+      id: "page-bm-token",
+      name: "BM Token",
+      access_token: "bm-token",
+    }
+    const bmPageWithoutToken = {
+      id: "page-bm-no-token",
+      name: "BM No Token",
+    }
+
+    mockGet
+      .mockResolvedValueOnce({
+        data: [missingTaskPage, directPage, emptyTasksPage, missingTasksPage],
+      }) // /me/accounts
+      .mockResolvedValueOnce({ data: [{ id: "biz1", name: "Biz 1" }] }) // /me/businesses
+      .mockResolvedValueOnce({ data: [bmPageWithToken, bmPageWithoutToken] }) // owned_pages
+      .mockResolvedValueOnce({ data: [] }) // client_pages
+
+    const result = await getUserPages("user-token")
+
+    expect(result.pages).toEqual([
+      { ...directPage, isConnectable: true },
+      { ...bmPageWithToken, isConnectable: true },
+      { ...missingTaskPage, isConnectable: false },
+      { ...emptyTasksPage, isConnectable: false },
+      { ...missingTasksPage, isConnectable: false },
+      { ...bmPageWithoutToken, isConnectable: false },
+    ])
+    expect(mockGet).toHaveBeenCalledWith("v23.0/biz1/owned_pages", {
+      searchParams: expect.objectContaining({
+        fields: "id,name,access_token,category",
+      }),
+    })
+  })
+
+  test("passes limit=100 on every Graph page request", async () => {
+    mockGet
+      .mockResolvedValueOnce({ data: [directPage] }) // /me/accounts
+      .mockResolvedValueOnce({ data: [{ id: "biz1", name: "Biz 1" }] }) // /me/businesses
+      .mockResolvedValueOnce({ data: [] }) // owned_pages
+      .mockResolvedValueOnce({ data: [] }) // client_pages
+
+    await getUserPages("user-token")
+
+    for (const call of mockGet.mock.calls) {
+      expect(call[1]?.searchParams).toEqual(
+        expect.objectContaining({ limit: "100" }),
+      )
+    }
+  })
+
+  test("one business failure does not fail the whole BM lookup", async () => {
+    const recoveredPage = {
+      id: "page-recovered",
+      name: "Recovered Page",
+      access_token: "recovered-token",
+    }
+
+    mockGet
+      .mockResolvedValueOnce({ data: [] }) // /me/accounts
+      .mockResolvedValueOnce({
+        data: [
+          { id: "biz1", name: "Biz 1" },
+          { id: "biz2", name: "Biz 2" },
+        ],
+      }) // /me/businesses
+      .mockRejectedValueOnce(new Error("owned pages unavailable")) // biz1 owned_pages
+      .mockResolvedValueOnce({ data: [] }) // biz1 client_pages
+      .mockResolvedValueOnce({ data: [recoveredPage] }) // biz2 owned_pages
+      .mockResolvedValueOnce({ data: [] }) // biz2 client_pages
+
+    const result = await getUserPages("user-token")
+
+    expect(result).toEqual({
+      pages: [{ ...recoveredPage, isConnectable: true }],
+      bmLookupFailed: false,
+    })
+  })
+
+  test("one BM edge failure still returns pages from the successful edge", async () => {
+    const ownedPage = {
+      id: "page-owned-recovered",
+      name: "Owned Recovered",
+      access_token: "owned-recovered-token",
+    }
+
+    mockGet
+      .mockResolvedValueOnce({ data: [] }) // /me/accounts
+      .mockResolvedValueOnce({ data: [{ id: "biz1", name: "Biz 1" }] }) // /me/businesses
+      .mockResolvedValueOnce({ data: [ownedPage] }) // owned_pages
+      .mockRejectedValueOnce(new Error("client pages unavailable")) // client_pages
+
+    const result = await getUserPages("user-token")
+
+    expect(result).toEqual({
+      pages: [{ ...ownedPage, isConnectable: true }],
+      bmLookupFailed: false,
+    })
+  })
+
+  test("all BM page edge failures surface the BM lookup warning flag", async () => {
+    mockGet
+      .mockResolvedValueOnce({ data: [directPage] }) // /me/accounts
+      .mockResolvedValueOnce({ data: [{ id: "biz1", name: "Biz 1" }] }) // /me/businesses
+      .mockRejectedValueOnce(new Error("owned pages unavailable")) // owned_pages
+      .mockRejectedValueOnce(new Error("client pages unavailable")) // client_pages
+
+    const result = await getUserPages("user-token")
+
+    expect(result).toEqual({
+      pages: [{ ...directPage, isConnectable: true }],
+      bmLookupFailed: true,
+    })
   })
 })

--- a/integrations/messenger/src/apis/auth.ts
+++ b/integrations/messenger/src/apis/auth.ts
@@ -16,14 +16,6 @@ type SourcedFacebookPage = {
 const MAX_PAGES = 20
 const GRAPH_PAGE_LIMIT = 100
 const BUSINESS_PAGE_BATCH_SIZE = 5
-/**
- * Business Manager owned/client pages lookup is disabled by default:
- * a fully paginated /me/accounts already lists every page the user can
- * actually connect (pages reachable only through a BM role come back
- * without an access_token, so they could not be connected anyway).
- * Kept behind this switch so it can be re-enabled without a rewrite.
- */
-const INCLUDE_BUSINESS_MANAGER_PAGES = false
 const ADMIN_PAGE_TASKS = [
   "ADVERTISE",
   "ANALYZE",
@@ -240,10 +232,7 @@ export function exchangeCodeForToken(
 export async function getUserPages(
   userAccessToken: string,
   version: string = DEFAULT_API_VERSION,
-  options: { includeBusinessManagerPages?: boolean } = {},
 ): Promise<{ pages: ConnectableFacebookPage[]; bmLookupFailed: boolean }> {
-  const includeBusinessManagerPages =
-    options.includeBusinessManagerPages ?? INCLUDE_BUSINESS_MANAGER_PAGES
   const directPagesEndpoint = `${version}/me/accounts`
   const directPages = await rescue(directPagesEndpoint, () =>
     fetchAllPages<FacebookPage>(
@@ -253,9 +242,10 @@ export async function getUserPages(
     ),
   )
 
-  const businessPagesResult = includeBusinessManagerPages
-    ? await getBusinessManagedPages(userAccessToken, version)
-    : { pages: [] as FacebookPage[], failed: false }
+  const businessPagesResult = await getBusinessManagedPages(
+    userAccessToken,
+    version,
+  )
 
   const merged = new Map<string, SourcedFacebookPage>()
   for (const page of directPages) {
@@ -275,12 +265,10 @@ export async function getUserPages(
   const nonConnectable = pages.filter((page) => !page.isConnectable).length
 
   logger.debug({ nonConnectable }, "Classified Messenger pages")
-  if (includeBusinessManagerPages) {
-    if (businessPagesResult.failed) {
-      logger.debug("Business Manager page lookup failed")
-    } else if (businessPagesResult.pages.length === 0) {
-      logger.debug("No Business Manager pages found")
-    }
+  if (businessPagesResult.failed) {
+    logger.debug("Business Manager page lookup failed")
+  } else if (businessPagesResult.pages.length === 0) {
+    logger.debug("No Business Manager pages found")
   }
 
   return { pages, bmLookupFailed: businessPagesResult.failed }

--- a/integrations/messenger/src/apis/auth.ts
+++ b/integrations/messenger/src/apis/auth.ts
@@ -1,45 +1,45 @@
+import { fetchAllCursorPages } from "@chatbotx.io/utils"
 import { DEFAULT_API_VERSION } from "../constants"
 import { rescue } from "../exception"
 import { facebookGraphClient } from "../lib/http-client"
 import { logger } from "../lib/logger"
-import type { FacebookPage } from "../schema"
+import type { ConnectableFacebookPage, FacebookPage } from "../schema"
 
 type FacebookBusiness = { id: string; name: string }
+type FacebookPageSource = "direct" | "business"
+type BusinessPagesResult = { pages: FacebookPage[]; hadFailure: boolean }
+type SourcedFacebookPage = {
+  page: FacebookPage
+  source: FacebookPageSource
+}
 
 const MAX_PAGES = 20
+const GRAPH_PAGE_LIMIT = 100
+const BUSINESS_PAGE_BATCH_SIZE = 5
+const ADMIN_PAGE_TASKS = [
+  "ADVERTISE",
+  "ANALYZE",
+  "CREATE_CONTENT",
+  "MANAGE",
+  "MODERATE",
+]
 
-/**
- * Exhausts a Graph API cursor-paginated edge, following `paging.next` /
- * `paging.cursors.after` until pages run out or MAX_PAGES is hit.
- */
-async function fetchAllPages<T>(
+function fetchAllPages<T>(
   endpoint: string,
   fields: string,
   accessToken: string,
 ): Promise<T[]> {
-  const results: T[] = []
-  let cursor: string | undefined
-  let pageCount = 0
-
-  while (pageCount < MAX_PAGES) {
-    const res: {
-      data: T[]
-      paging?: { cursors?: { after?: string }; next?: string }
-    } = await facebookGraphClient.get(endpoint, {
-      searchParams: {
-        fields,
-        access_token: accessToken,
-        ...(cursor ? { after: cursor } : {}),
-      },
-    })
-    results.push(...res.data)
-    pageCount++
-    cursor = res.paging?.next ? res.paging.cursors?.after : undefined
-    if (!cursor) {
-      break
-    }
-  }
-  return results
+  return fetchAllCursorPages({
+    endpoint,
+    fields,
+    accessToken,
+    // Arrow wrapper keeps `this` bound to the client instance; passing the
+    // method reference directly detaches it and crashes at call time.
+    get: (pageEndpoint, options) =>
+      facebookGraphClient.get(pageEndpoint, options),
+    limit: GRAPH_PAGE_LIMIT,
+    maxPages: MAX_PAGES,
+  })
 }
 
 function getUserBusinesses(
@@ -57,21 +57,37 @@ async function getBusinessPages(
   businessId: string,
   userAccessToken: string,
   version: string,
-): Promise<FacebookPage[]> {
-  const fields = "id,name,access_token,category,tasks"
-  const [owned, client] = await Promise.all([
-    fetchAllPages<FacebookPage>(
-      `${version}/${businessId}/owned_pages`,
-      fields,
-      userAccessToken,
-    ),
-    fetchAllPages<FacebookPage>(
-      `${version}/${businessId}/client_pages`,
-      fields,
-      userAccessToken,
-    ),
-  ])
-  return [...owned, ...client]
+): Promise<BusinessPagesResult> {
+  const fields = "id,name,access_token,category"
+  const edges = [
+    { name: "owned_pages", endpoint: `${version}/${businessId}/owned_pages` },
+    { name: "client_pages", endpoint: `${version}/${businessId}/client_pages` },
+  ] as const
+  const edgeResults = await Promise.all(
+    edges.map(async (edge) => {
+      try {
+        return {
+          pages: await fetchAllPages<FacebookPage>(
+            edge.endpoint,
+            fields,
+            userAccessToken,
+          ),
+          failed: false,
+        }
+      } catch (error) {
+        logger.warn(
+          error,
+          `Failed to fetch BM ${edge.name} for business ${businessId}`,
+        )
+        return { pages: [], failed: true }
+      }
+    }),
+  )
+
+  return {
+    pages: edgeResults.flatMap((result) => result.pages),
+    hadFailure: edgeResults.some((result) => result.failed),
+  }
 }
 
 /**
@@ -83,30 +99,71 @@ async function getBusinessPages(
 async function getBusinessManagedPages(
   userAccessToken: string,
   version: string,
-): Promise<FacebookPage[]> {
+): Promise<{ pages: FacebookPage[]; failed: boolean }> {
   try {
     const businesses = await getUserBusinesses(userAccessToken, version)
-    const pagesPerBusiness = await Promise.all(
-      businesses.map((business) =>
-        getBusinessPages(business.id, userAccessToken, version).catch(
-          (error) => {
-            logger.warn(
-              error,
-              `Failed to fetch BM pages for business ${business.id}`,
-            )
-            return []
-          },
+    const pagesPerBusiness: BusinessPagesResult[] = []
+
+    for (
+      let index = 0;
+      index < businesses.length;
+      index += BUSINESS_PAGE_BATCH_SIZE
+    ) {
+      const batch = businesses.slice(index, index + BUSINESS_PAGE_BATCH_SIZE)
+      const batchPages = await Promise.all(
+        batch.map((business) =>
+          getBusinessPages(business.id, userAccessToken, version),
         ),
-      ),
-    )
-    return pagesPerBusiness.flat()
+      )
+      pagesPerBusiness.push(...batchPages)
+    }
+
+    const pages = pagesPerBusiness.flatMap((result) => result.pages)
+    const hadFailure = pagesPerBusiness.some((result) => result.hadFailure)
+
+    return { pages, failed: hadFailure && pages.length === 0 }
   } catch (error) {
     logger.warn(
       error,
       "Failed to fetch Business Manager pages, falling back to direct accounts",
     )
-    return []
+    return { pages: [], failed: true }
   }
+}
+
+function hasAllAdminTasks(tasks?: string[]): boolean {
+  if (!tasks?.length) {
+    return false
+  }
+
+  return ADMIN_PAGE_TASKS.every((task) => tasks.includes(task))
+}
+
+function classifyConnectable(
+  page: FacebookPage,
+  source: FacebookPageSource,
+): ConnectableFacebookPage {
+  const hasAccessToken = Boolean(page.access_token)
+
+  return {
+    ...page,
+    isConnectable:
+      source === "direct"
+        ? hasAccessToken && hasAllAdminTasks(page.tasks)
+        : hasAccessToken,
+  }
+}
+
+function sortConnectableFirst(
+  pages: ConnectableFacebookPage[],
+): ConnectableFacebookPage[] {
+  return [...pages].sort((current, next) => {
+    if (current.isConnectable === next.isConnectable) {
+      return 0
+    }
+
+    return current.isConnectable ? -1 : 1
+  })
 }
 
 const FACEBOOK_OAUTH_BASE = "https://www.facebook.com"
@@ -138,6 +195,7 @@ export function generateAuthUrl({
   stateParams?: Record<string, unknown>
 }): string {
   const params = new URLSearchParams({
+    auth_type: "rerequest",
     client_id: clientId,
     redirect_uri: redirectUrl,
     scope: MESSENGER_SCOPES.join(","),
@@ -174,31 +232,44 @@ export function exchangeCodeForToken(
 export async function getUserPages(
   userAccessToken: string,
   version: string = DEFAULT_API_VERSION,
-): Promise<FacebookPage[]> {
+): Promise<{ pages: ConnectableFacebookPage[]; bmLookupFailed: boolean }> {
   const directPagesEndpoint = `${version}/me/accounts`
-  const directPages = await rescue(directPagesEndpoint, async () => {
-    const res: { data: FacebookPage[] } = await facebookGraphClient.get(
+  const directPages = await rescue(directPagesEndpoint, () =>
+    fetchAllPages<FacebookPage>(
       directPagesEndpoint,
-      {
-        searchParams: {
-          fields: "id,name,access_token,category,tasks",
-          access_token: userAccessToken,
-        },
-      },
-    )
-    return res.data
-  })
+      "id,name,access_token,category,tasks",
+      userAccessToken,
+    ),
+  )
 
-  const businessPages = await getBusinessManagedPages(userAccessToken, version)
+  const businessPagesResult = await getBusinessManagedPages(
+    userAccessToken,
+    version,
+  )
 
-  const merged = new Map<string, FacebookPage>()
+  const merged = new Map<string, SourcedFacebookPage>()
   for (const page of directPages) {
-    merged.set(page.id, page)
+    merged.set(page.id, { page, source: "direct" })
   }
-  for (const page of businessPages) {
-    if (page.access_token && !merged.has(page.id)) {
-      merged.set(page.id, page)
+  for (const page of businessPagesResult.pages) {
+    if (!merged.has(page.id)) {
+      merged.set(page.id, { page, source: "business" })
     }
   }
-  return Array.from(merged.values())
+
+  const pages = sortConnectableFirst(
+    Array.from(merged.values()).map(({ page, source }) =>
+      classifyConnectable(page, source),
+    ),
+  )
+  const nonConnectable = pages.filter((page) => !page.isConnectable).length
+
+  logger.debug({ nonConnectable }, "Classified Messenger pages")
+  if (businessPagesResult.failed) {
+    logger.debug("Business Manager page lookup failed")
+  } else if (businessPagesResult.pages.length === 0) {
+    logger.debug("No Business Manager pages found")
+  }
+
+  return { pages, bmLookupFailed: businessPagesResult.failed }
 }

--- a/integrations/messenger/src/apis/auth.ts
+++ b/integrations/messenger/src/apis/auth.ts
@@ -16,6 +16,14 @@ type SourcedFacebookPage = {
 const MAX_PAGES = 20
 const GRAPH_PAGE_LIMIT = 100
 const BUSINESS_PAGE_BATCH_SIZE = 5
+/**
+ * Business Manager owned/client pages lookup is disabled by default:
+ * a fully paginated /me/accounts already lists every page the user can
+ * actually connect (pages reachable only through a BM role come back
+ * without an access_token, so they could not be connected anyway).
+ * Kept behind this switch so it can be re-enabled without a rewrite.
+ */
+const INCLUDE_BUSINESS_MANAGER_PAGES = false
 const ADMIN_PAGE_TASKS = [
   "ADVERTISE",
   "ANALYZE",
@@ -232,7 +240,10 @@ export function exchangeCodeForToken(
 export async function getUserPages(
   userAccessToken: string,
   version: string = DEFAULT_API_VERSION,
+  options: { includeBusinessManagerPages?: boolean } = {},
 ): Promise<{ pages: ConnectableFacebookPage[]; bmLookupFailed: boolean }> {
+  const includeBusinessManagerPages =
+    options.includeBusinessManagerPages ?? INCLUDE_BUSINESS_MANAGER_PAGES
   const directPagesEndpoint = `${version}/me/accounts`
   const directPages = await rescue(directPagesEndpoint, () =>
     fetchAllPages<FacebookPage>(
@@ -242,10 +253,9 @@ export async function getUserPages(
     ),
   )
 
-  const businessPagesResult = await getBusinessManagedPages(
-    userAccessToken,
-    version,
-  )
+  const businessPagesResult = includeBusinessManagerPages
+    ? await getBusinessManagedPages(userAccessToken, version)
+    : { pages: [] as FacebookPage[], failed: false }
 
   const merged = new Map<string, SourcedFacebookPage>()
   for (const page of directPages) {
@@ -265,10 +275,12 @@ export async function getUserPages(
   const nonConnectable = pages.filter((page) => !page.isConnectable).length
 
   logger.debug({ nonConnectable }, "Classified Messenger pages")
-  if (businessPagesResult.failed) {
-    logger.debug("Business Manager page lookup failed")
-  } else if (businessPagesResult.pages.length === 0) {
-    logger.debug("No Business Manager pages found")
+  if (includeBusinessManagerPages) {
+    if (businessPagesResult.failed) {
+      logger.debug("Business Manager page lookup failed")
+    } else if (businessPagesResult.pages.length === 0) {
+      logger.debug("No Business Manager pages found")
+    }
   }
 
   return { pages, bmLookupFailed: businessPagesResult.failed }

--- a/integrations/messenger/src/schema.ts
+++ b/integrations/messenger/src/schema.ts
@@ -420,7 +420,7 @@ export type FacebookUserProfile = z.infer<typeof facebookUserProfileSchema>
 export const facebookPageSchema = z.object({
   id: z.string(),
   name: z.string(),
-  access_token: z.string(),
+  access_token: z.string().optional(),
   category: z.string().optional(),
   category_list: z
     .array(
@@ -433,6 +433,7 @@ export const facebookPageSchema = z.object({
   tasks: z.array(z.string()).optional(),
 })
 export type FacebookPage = z.infer<typeof facebookPageSchema>
+export type ConnectableFacebookPage = FacebookPage & { isConnectable: boolean }
 
 // Webhook verification schemas
 export const webhookVerificationRequestSchema = z.object({

--- a/packages/business/src/integration-messenger/service.ts
+++ b/packages/business/src/integration-messenger/service.ts
@@ -1,5 +1,6 @@
 import { db, findOrFail } from "@chatbotx.io/database/client"
 import { integrationMessengerModel } from "@chatbotx.io/database/schema"
+import { inArray } from "drizzle-orm"
 
 export function findMessengerIntegrationByInboxId(inboxId: string) {
   return findOrFail({ table: integrationMessengerModel, where: { inboxId } })
@@ -9,4 +10,24 @@ export function findMessengerIntegrationsByWorkspaceId(workspaceId: string) {
   return db.query.integrationMessengerModel.findMany({
     where: { workspaceId },
   })
+}
+
+/**
+ * Page ids from the given list that already have a Messenger integration.
+ * `IntegrationMessenger.pageId` is unique platform-wide, so a match means the
+ * page cannot be connected again anywhere.
+ */
+export async function findConnectedMessengerPageIds(
+  pageIds: string[],
+): Promise<string[]> {
+  if (pageIds.length === 0) {
+    return []
+  }
+
+  const rows = await db
+    .select({ pageId: integrationMessengerModel.pageId })
+    .from(integrationMessengerModel)
+    .where(inArray(integrationMessengerModel.pageId, pageIds))
+
+  return rows.map((row) => row.pageId)
 }

--- a/packages/ui/src/components/form/radio-group-field.tsx
+++ b/packages/ui/src/components/form/radio-group-field.tsx
@@ -1,5 +1,6 @@
 import type { RadioGroupProps } from "@radix-ui/react-radio-group"
 import type { FieldPath, FieldValues } from "react-hook-form"
+import { cn } from "../../lib/utils"
 import { Label } from "../ui/label"
 import { RadioGroup, RadioGroupItem } from "../ui/radio-group"
 import { FormFieldWrapper } from "./field-wrapper"
@@ -13,6 +14,8 @@ type RadioGroupFieldProps<T extends FieldValues> = RadioGroupProps & {
   options: {
     value: string
     label: string
+    description?: string
+    disabled?: boolean
   }[]
 }
 
@@ -44,15 +47,37 @@ export function RadioGroupField<T extends FieldValues>({
           onValueChange={field.onChange}
         >
           {options.map((option) => (
-            <div className="flex items-center space-x-2" key={option.value}>
+            <div className="flex items-start space-x-2" key={option.value}>
               <RadioGroupItem
+                aria-describedby={
+                  option.description
+                    ? `${name}${option.value}-description`
+                    : undefined
+                }
+                disabled={option.disabled}
                 id={name + option.value}
                 key={option.value}
                 value={option.value}
               />
-              <Label className="font-normal" htmlFor={name + option.value}>
-                {option.label}
-              </Label>
+              <div className="grid gap-1">
+                <Label
+                  className={cn(
+                    "font-normal",
+                    option.disabled && "text-muted-foreground",
+                  )}
+                  htmlFor={name + option.value}
+                >
+                  {option.label}
+                </Label>
+                {option.description && (
+                  <p
+                    className="text-muted-foreground text-xs leading-snug"
+                    id={`${name}${option.value}-description`}
+                  >
+                    {option.description}
+                  </p>
+                )}
+              </div>
             </div>
           ))}
         </RadioGroup>

--- a/packages/utils/__tests__/graph-pagination.test.ts
+++ b/packages/utils/__tests__/graph-pagination.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test, vi } from "vitest"
+import { fetchAllCursorPages } from "../src/graph-pagination"
+
+describe("fetchAllCursorPages", () => {
+  test("follows cursor pages and sends the configured limit", async () => {
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: [{ id: "first" }],
+        paging: {
+          cursors: { after: "next-cursor" },
+          next: "https://graph.example/page?after=next-cursor",
+        },
+      })
+      .mockResolvedValueOnce({ data: [{ id: "second" }] })
+
+    const result = await fetchAllCursorPages({
+      endpoint: "v23.0/me/accounts",
+      fields: "id,name",
+      accessToken: "token",
+      get,
+      limit: 50,
+    })
+
+    expect(result).toEqual([{ id: "first" }, { id: "second" }])
+    expect(get).toHaveBeenNthCalledWith(1, "v23.0/me/accounts", {
+      searchParams: {
+        fields: "id,name",
+        access_token: "token",
+        limit: "50",
+      },
+    })
+    expect(get).toHaveBeenNthCalledWith(2, "v23.0/me/accounts", {
+      searchParams: {
+        fields: "id,name",
+        access_token: "token",
+        limit: "50",
+        after: "next-cursor",
+      },
+    })
+  })
+
+  test("stops at maxPages even when Graph keeps returning cursors", async () => {
+    const get = vi.fn().mockResolvedValue({
+      data: [{ id: "page" }],
+      paging: {
+        cursors: { after: "cursor" },
+        next: "https://graph.example/page?after=cursor",
+      },
+    })
+
+    const result = await fetchAllCursorPages({
+      endpoint: "v23.0/me/accounts",
+      fields: "id",
+      accessToken: "token",
+      get,
+      maxPages: 2,
+    })
+
+    expect(result).toEqual([{ id: "page" }, { id: "page" }])
+    expect(get).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/utils/src/graph-pagination.ts
+++ b/packages/utils/src/graph-pagination.ts
@@ -1,0 +1,57 @@
+export type CursorPaginatedResponse<T> = {
+  data: T[]
+  paging?: {
+    cursors?: {
+      after?: string
+    }
+    next?: string
+  }
+}
+
+type CursorPageGetter<T> = (
+  endpoint: string,
+  options: { searchParams: Record<string, string> },
+) => Promise<CursorPaginatedResponse<T>>
+
+export async function fetchAllCursorPages<T>({
+  endpoint,
+  fields,
+  accessToken,
+  get,
+  limit = 100,
+  maxPages = 20,
+}: {
+  endpoint: string
+  fields: string
+  accessToken: string
+  get: CursorPageGetter<T>
+  limit?: number
+  maxPages?: number
+}): Promise<T[]> {
+  const results: T[] = []
+  let cursor: string | undefined
+  let pageCount = 0
+
+  while (pageCount < maxPages) {
+    const searchParams: Record<string, string> = {
+      fields,
+      access_token: accessToken,
+      limit: String(limit),
+    }
+
+    if (cursor) {
+      searchParams.after = cursor
+    }
+
+    const response = await get(endpoint, { searchParams })
+    results.push(...response.data)
+    pageCount++
+
+    cursor = response.paging?.next ? response.paging.cursors?.after : undefined
+    if (!cursor) {
+      break
+    }
+  }
+
+  return results
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./encode"
+export * from "./graph-pagination"
 export * from "./id"
 export * from "./request"
 export * from "./storage"


### PR DESCRIPTION
## Summary

Some people connecting a Messenger fanpage could not find their page in the list — especially pages managed through a Business Manager or accounts with many pages. This blocked them from running broadcasts.

With this update:

- The page list is complete — every page the person manages shows up, including Business Manager pages.
- Pages that cannot be selected (already connected, or missing admin permission) are still shown, greyed out, with a short note explaining why.
- Clear messages guide the person to reconnect and grant access when something is missing, instead of a silent or empty screen.
- Small polish: the list scrolls properly with a visible scrollbar, and taking a long time on this screen no longer breaks the flow.

Available in English and Vietnamese.

## Test plan

- [x] Automated tests, type checks, and lint all pass
- [ ] Connect with an account that has many pages and Business Manager pages — the list shows all of them
- [ ] Already-connected pages and pages without admin permission appear greyed out with a note
- [ ] With no pages at all, the screen explains what to do next