### PR TITLE
fix(conversations): anchor last-message lookup on conversation lastActivityAt

### DIFF
--- a/apps/builder/__tests__/list-conversations-query.test.ts
+++ b/apps/builder/__tests__/list-conversations-query.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment node
+
+import { endOfHour } from "date-fns"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const mocks = vi.hoisted(() => {
+  const repo = {
+    findLastByConversation: vi.fn().mockResolvedValue([]),
+  }
+  return {
+    assertCurrentUserCanAccessChatbot: vi.fn().mockResolvedValue(undefined),
+    buildConversationWhere: vi.fn().mockReturnValue({}),
+    createMessageRepository: vi.fn().mockResolvedValue(repo),
+    findManyQuery: vi.fn().mockResolvedValue([]),
+    findWithFullRelations: vi.fn().mockResolvedValue(null),
+    getCurrentUserAndTargetWorkspace: vi.fn().mockResolvedValue(null),
+    // Identity mock: resolveLastMessageSinceTime's output becomes exactly the
+    // anchor it was given, so assertions can compare sinceTime straight
+    // against each conversation's own lastActivityAt.
+    getSafeSinceTime: vi.fn((value: Date | undefined) => value),
+    notFoundException: (message: string) => new Error(message),
+    repo,
+  }
+})
+
+vi.mock("@chatbotx.io/business", () => ({
+  conversationService: {
+    findManyQuery: mocks.findManyQuery,
+    findWithFullRelations: mocks.findWithFullRelations,
+  },
+}))
+
+vi.mock("@chatbotx.io/business/errors", () => ({
+  notFoundException: mocks.notFoundException,
+}))
+
+vi.mock("@chatbotx.io/database/repositories", () => ({
+  createMessageRepository: mocks.createMessageRepository,
+  getSafeSinceTime: mocks.getSafeSinceTime,
+}))
+
+vi.mock("@/lib/auth/utils", () => ({
+  assertCurrentUserCanAccessChatbot: mocks.assertCurrentUserCanAccessChatbot,
+  getCurrentUserAndTargetWorkspace: mocks.getCurrentUserAndTargetWorkspace,
+}))
+
+vi.mock(
+  "../src/features/conversations/queries/build-conversation-where",
+  () => ({
+    buildConversationWhere: mocks.buildConversationWhere,
+  }),
+)
+
+const { listConversations, findConversation } = await import(
+  "../src/features/conversations/queries/list-conversations.query"
+)
+
+describe("listConversations / findConversation last-message sinceTime", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.createMessageRepository.mockResolvedValue(mocks.repo)
+    mocks.repo.findLastByConversation.mockResolvedValue([])
+    mocks.getCurrentUserAndTargetWorkspace.mockResolvedValue(null)
+    mocks.buildConversationWhere.mockReturnValue({})
+  })
+
+  test("anchors each conversation's sinceTime on its own lastActivityAt, not a shared contactInbox anchor", async () => {
+    // Same contact, same shared ContactInbox (its lastMessageAt would reflect
+    // whichever conversation was most recently active — irrelevant here since
+    // the fix no longer reads it at all), but two conversations with
+    // different lastActivityAt: an older comment thread and a newer DM.
+    const sharedContactInbox = {
+      id: "ci-1",
+      contactId: "contact-1",
+      lastMessageAt: new Date("2026-06-10T00:00:00Z"),
+    }
+    const olderCommentConversation = {
+      id: "conv-comment",
+      contactId: "contact-1",
+      lastActivityAt: new Date("2026-01-01T00:00:00Z"),
+      contactInboxes: [sharedContactInbox],
+      contact: null,
+      assignedUser: null,
+      assignedInboxTeam: null,
+    }
+    const newerDmConversation = {
+      id: "conv-dm",
+      contactId: "contact-1",
+      lastActivityAt: new Date("2026-06-10T00:00:00Z"),
+      contactInboxes: [sharedContactInbox],
+      contact: null,
+      assignedUser: null,
+      assignedInboxTeam: null,
+    }
+    mocks.findManyQuery.mockResolvedValue([
+      olderCommentConversation,
+      newerDmConversation,
+    ])
+
+    await listConversations({ workspaceId: "ws-1" })
+
+    expect(mocks.repo.findLastByConversation).toHaveBeenCalledWith(
+      "conv-comment",
+      expect.objectContaining({
+        sinceTime: olderCommentConversation.lastActivityAt,
+      }),
+    )
+    expect(mocks.repo.findLastByConversation).toHaveBeenCalledWith(
+      "conv-dm",
+      expect.objectContaining({
+        sinceTime: newerDmConversation.lastActivityAt,
+      }),
+    )
+  })
+
+  test("findConversation anchors sinceTime on the conversation's own lastActivityAt", async () => {
+    const conversation = {
+      id: "conv-comment",
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+      lastActivityAt: new Date("2026-01-01T00:00:00Z"),
+      contactInboxes: [
+        {
+          id: "ci-1",
+          contactId: "contact-1",
+          lastMessageAt: new Date("2026-06-10T00:00:00Z"),
+        },
+      ],
+    }
+    mocks.findWithFullRelations.mockResolvedValue(conversation)
+
+    await findConversation({ id: "conv-comment", workspaceId: "ws-1" })
+
+    expect(mocks.repo.findLastByConversation).toHaveBeenCalledWith(
+      "conv-comment",
+      expect.objectContaining({
+        sinceTime: endOfHour(conversation.lastActivityAt),
+      }),
+    )
+  })
+})

--- a/apps/builder/__tests__/unread-conversation-action.test.ts
+++ b/apps/builder/__tests__/unread-conversation-action.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const mocks = vi.hoisted(() => {
+  const repo = {
+    findLastByConversation: vi.fn().mockResolvedValue([]),
+  }
+  return {
+    createMessageRepository: vi.fn().mockResolvedValue(repo),
+    findOrFail: vi.fn(),
+    // Identity mock: getSafeSinceTime's output becomes exactly the anchor it
+    // was given (minus the buffer subtraction, which callers don't assert on
+    // here), so assertions can compare sinceTime's anchor input directly.
+    getSafeSinceTime: vi.fn((value: Date | undefined) => value),
+    repo,
+    updateReadStatus: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+vi.mock("@/lib/safe-action", () => ({
+  workspaceActionClient: {
+    bindArgsSchemas: vi.fn(() => ({
+      action: vi.fn(),
+    })),
+  },
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  conversationService: {
+    updateReadStatus: mocks.updateReadStatus,
+  },
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  findOrFail: mocks.findOrFail,
+}))
+
+vi.mock("@chatbotx.io/database/repositories", () => ({
+  createMessageRepository: mocks.createMessageRepository,
+  getSafeSinceTime: mocks.getSafeSinceTime,
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  conversationModel: {},
+}))
+
+const { unreadConversation } = await import(
+  "../src/features/conversations/actions/unread-conversation.action"
+)
+
+describe("unreadConversation sinceTime anchor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.createMessageRepository.mockResolvedValue(mocks.repo)
+    mocks.repo.findLastByConversation.mockResolvedValue([])
+    mocks.updateReadStatus.mockResolvedValue(undefined)
+  })
+
+  test("anchors sinceTime on the conversation's own lastActivityAt, not a shared contactInbox anchor", async () => {
+    // Two conversations for the same contact could share one ContactInbox
+    // (its lastMessageAt would reflect whichever was most recently active —
+    // irrelevant here since the fix no longer reads it at all). This
+    // conversation is the older, less-active one.
+    const olderCommentConversation = {
+      id: "conv-comment",
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+      lastActivityAt: new Date("2026-01-01T00:00:00Z"),
+      createdAt: new Date("2025-12-01T00:00:00Z"),
+    }
+    mocks.findOrFail.mockResolvedValue(olderCommentConversation)
+
+    await unreadConversation({ workspaceId: "ws-1", id: "conv-comment" })
+
+    expect(mocks.repo.findLastByConversation).toHaveBeenCalledWith(
+      "conv-comment",
+      expect.objectContaining({
+        sinceTime: olderCommentConversation.lastActivityAt,
+      }),
+    )
+  })
+
+  test("falls back to the conversation's createdAt when lastActivityAt is unset", async () => {
+    const conversation = {
+      id: "conv-new",
+      workspaceId: "ws-1",
+      contactId: "contact-2",
+      lastActivityAt: null,
+      createdAt: new Date("2026-02-01T00:00:00Z"),
+    }
+    mocks.findOrFail.mockResolvedValue(conversation)
+
+    await unreadConversation({ workspaceId: "ws-1", id: "conv-new" })
+
+    expect(mocks.repo.findLastByConversation).toHaveBeenCalledWith(
+      "conv-new",
+      expect.objectContaining({
+        sinceTime: conversation.createdAt,
+      }),
+    )
+  })
+
+  test("marks the second-to-last incoming message as the new read boundary", async () => {
+    const conversation = {
+      id: "conv-1",
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+      lastActivityAt: new Date("2026-01-01T00:00:00Z"),
+      createdAt: new Date("2025-12-01T00:00:00Z"),
+    }
+    mocks.findOrFail.mockResolvedValue(conversation)
+    mocks.repo.findLastByConversation.mockResolvedValue([
+      { createdAt: new Date("2026-01-01T00:05:00Z") },
+      { createdAt: new Date("2026-01-01T00:00:00Z") },
+    ])
+
+    const result = await unreadConversation({
+      workspaceId: "ws-1",
+      id: "conv-1",
+    })
+
+    expect(result.agentLastReadAt).toEqual(new Date("2026-01-01T00:00:00Z"))
+    expect(mocks.updateReadStatus).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      id: "conv-1",
+      agentLastReadAt: new Date("2026-01-01T00:00:00Z"),
+    })
+  })
+})

--- a/apps/builder/src/features/conversations/actions/unread-conversation.action.ts
+++ b/apps/builder/src/features/conversations/actions/unread-conversation.action.ts
@@ -1,7 +1,7 @@
 "use server"
 
 import { conversationService } from "@chatbotx.io/business"
-import { db, findOrFail } from "@chatbotx.io/database/client"
+import { findOrFail } from "@chatbotx.io/database/client"
 import {
   createMessageRepository,
   getSafeSinceTime,
@@ -30,19 +30,20 @@ export const unreadConversation = async (ctx: {
     message: "Conversation not found",
   })
 
-  const contactInbox = await db.query.contactInboxModel.findFirst({
-    where: { contactId: conversation.contactId },
-    orderBy: { lastMessageAt: "desc" },
-  })
-
   const messageRepository = await createMessageRepository()
   const last2Messages = await messageRepository.findLastByConversation(
     conversation.id,
     {
       messageTypes: ["incoming"],
       limit: 2,
+      // Anchor on this conversation's own lastActivityAt, not a shared
+      // ContactInbox's lastMessageAt — a contact's ContactInbox is shared
+      // across their DM and every comment-thread conversation, so its
+      // lastMessageAt can reflect a different, more recently active
+      // conversation and push sinceTime past this conversation's real last
+      // message, causing the sharded scan to miss it.
       sinceTime: getSafeSinceTime(
-        contactInbox?.lastMessageAt,
+        conversation.lastActivityAt ?? conversation.createdAt,
         365 * 24 * 60 * 60 * 1000,
       ),
       workspaceId: ctx.workspaceId,

--- a/apps/builder/src/features/conversations/queries/list-conversations.query.ts
+++ b/apps/builder/src/features/conversations/queries/list-conversations.query.ts
@@ -5,7 +5,6 @@ import { notFoundException } from "@chatbotx.io/business/errors"
 import { createMessageRepository } from "@chatbotx.io/database/repositories"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { endOfHour } from "date-fns"
-import { groupBy } from "remeda"
 import z from "zod"
 import { canViewContactEmailAndPhone } from "@/features/contacts/permissions"
 import type { ListConversationsRequest } from "@/features/conversations/schema/query"
@@ -75,21 +74,21 @@ export const listConversations = async (
   const page = hasMore ? conversations.slice(0, limit) : conversations
 
   // ── Shard-aware message lookups (parallelized) ──────────────────────────
-  const contactInboxesByContactId = groupBy(
-    page.flatMap((c) => c.contactInboxes),
-    (ci) => ci.contactId,
-  )
-
   const messageRepository = await createMessageRepository()
   const lastMessagesResults = await Promise.all(
     page.map((c) => {
-      const contactInbox = contactInboxesByContactId[c.contactId]?.[0]
-      // Don't bail when lastMessageAt is missing: historical imports populate
+      // Anchor on this conversation's own lastActivityAt, not a contactInbox's
+      // lastMessageAt — a contact's ContactInbox is shared across their DM and
+      // every comment-thread conversation, so its lastMessageAt reflects
+      // whichever of those was most recently active, not this specific one.
+      // Using the wrong (later) anchor excludes this conversation's real last
+      // message from the sharded time window, returning an empty preview.
+      // Don't bail when lastActivityAt is missing: historical imports populate
       // messages but never set it, so bailing hid the last-message preview.
       // resolveLastMessageSinceTime falls back to a full-history scan instead.
       return messageRepository.findLastByConversation(c.id, {
         limit: 1,
-        sinceTime: resolveLastMessageSinceTime(contactInbox?.lastMessageAt),
+        sinceTime: resolveLastMessageSinceTime(c.lastActivityAt),
         workspaceId,
       })
     }),
@@ -147,17 +146,19 @@ export const findConversation = async (
     throw notFoundException("Conversation not found")
   }
 
-  const contactInbox = conversation.contactInboxes?.[0]
   const messageRepository = await createMessageRepository()
   const lastMessages = await messageRepository.findLastByConversation(
     conversation.id,
     {
       messageTypes: ["incoming", "outgoing"],
       limit: 1,
-      // Falls back to a full-history scan when lastMessageAt is unset (historical
+      // Anchor on this conversation's own lastActivityAt — see the comment in
+      // listConversations() above for why contactInbox.lastMessageAt is wrong
+      // here (shared across a contact's DM and every comment-thread conversation).
+      // Falls back to a full-history scan when lastActivityAt is unset (historical
       // imports), so opening an imported conversation still shows its messages.
       sinceTime: resolveLastMessageSinceTime(
-        contactInbox?.lastMessageAt,
+        conversation.lastActivityAt,
         endOfHour,
       ),
       workspaceId: input.workspaceId,

--- a/apps/worker/__tests__/get-user-data.test.ts
+++ b/apps/worker/__tests__/get-user-data.test.ts
@@ -1,4 +1,5 @@
 import { MessageShardUnavailableError } from "@chatbotx.io/database/errors"
+import { getSafeSinceTime } from "@chatbotx.io/database/repositories"
 import type { GetUserDataStepSchema } from "@chatbotx.io/flow-config"
 import { ReplyFormat } from "@chatbotx.io/flow-config"
 import { beforeEach, describe, expect, test, vi } from "vitest"
@@ -132,6 +133,8 @@ function makeProps(
       assignedUserId: null,
       assignedInboxTeamId: null,
       additionalAttributes: {},
+      lastActivityAt: new Date("2026-01-01T00:00:00Z"),
+      createdAt: new Date("2025-12-01T00:00:00Z"),
     },
     contactInbox: {
       id: "ci-1",
@@ -196,6 +199,18 @@ describe("getUserData — validation logic", () => {
     chatQueueAdd.mockClear()
     vi.mocked(dbUpdateBuilder.set as ReturnType<typeof vi.fn>).mockClear?.()
     lastMessage.current = null
+  })
+
+  test("anchors the message lookup on conversation.lastActivityAt, not contactInbox", async () => {
+    lastMessage.current = { text: "user@example.com", attachments: [] }
+    const props = makeProps(ReplyFormat.email)
+
+    await getUserData(props)
+
+    expect(getSafeSinceTime).toHaveBeenCalledWith(
+      props.conversation.lastActivityAt,
+      365 * 24 * 60 * 60 * 1000,
+    )
   })
 
   describe("email format", () => {

--- a/apps/worker/src/integration/handlers/get-user-data.ts
+++ b/apps/worker/src/integration/handlers/get-user-data.ts
@@ -169,7 +169,6 @@ async function handleSkipOrError(
 async function validateUserData(
   props: ExecuteStepProps<GetUserDataStepSchema>,
 ): Promise<GetUserDataResult> {
-  const { contactInbox } = props
   const messageRepository = await createMessageRepository()
   const lastMessages = await messageRepository.findLastByConversation(
     props.conversation.id,
@@ -178,8 +177,14 @@ async function validateUserData(
       limit: 1,
       requireCompleteResults: true,
       withAttachments: true,
+      // Anchor on this conversation's own lastActivityAt, not the
+      // ContactInbox's lastMessageAt — a contact's ContactInbox is shared
+      // across their DM and every comment-thread conversation, so its
+      // lastMessageAt can reflect a different, more recently active
+      // conversation and push sinceTime past this conversation's real last
+      // incoming message, causing the sharded scan to miss it.
       sinceTime: getSafeSinceTime(
-        contactInbox.lastMessageAt ?? contactInbox.createdAt,
+        props.conversation.lastActivityAt ?? props.conversation.createdAt,
         365 * 24 * 60 * 60 * 1000, // 1 year
       ),
       workspaceId: props.conversation.workspaceId,

--- a/packages/business/src/conversation/service.ts
+++ b/packages/business/src/conversation/service.ts
@@ -137,6 +137,20 @@ class ConversationService extends BaseService {
     })) as ConversationWithContactInboxes | undefined
   }
 
+  async findLatestByContact(props: {
+    contactId: string
+    tx?: DatabaseClient
+  }): Promise<ConversationModel | undefined> {
+    const { tx = db, contactId } = props
+    // A contact can have multiple conversations (DM + comment threads), all
+    // sharing the same ContactInbox — order by lastActivityAt so callers get
+    // the conversation the contact is actually active in, not an arbitrary one.
+    return await tx.query.conversationModel.findFirst({
+      where: { contactId },
+      orderBy: { lastActivityAt: "desc" },
+    })
+  }
+
   async findBy(props: {
     tx?: DatabaseClient
     where: Partial<FindByProps>

--- a/packages/variables/__tests__/last-input.test.ts
+++ b/packages/variables/__tests__/last-input.test.ts
@@ -2,24 +2,18 @@ import { contentTypes } from "@chatbotx.io/database/partials"
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
 const {
-  mockFindConversationBy,
-  mockFindLatestLastIncomingMessageAt,
+  mockFindLatestByContact,
   mockFindLatestIncomingMessageWithAttachments,
   mockResolveTenantSettings,
 } = vi.hoisted(() => ({
-  mockFindConversationBy: vi.fn(),
-  mockFindLatestLastIncomingMessageAt: vi.fn(),
+  mockFindLatestByContact: vi.fn(),
   mockFindLatestIncomingMessageWithAttachments: vi.fn(),
   mockResolveTenantSettings: vi.fn(),
 }))
 
 vi.mock("@chatbotx.io/business", () => ({
   conversationService: {
-    findBy: mockFindConversationBy,
-  },
-  contactInboxService: {
-    findLatestLastIncomingMessageAtByContactId:
-      mockFindLatestLastIncomingMessageAt,
+    findLatestByContact: mockFindLatestByContact,
   },
   messageService: {
     findLatestIncomingMessageWithAttachments:
@@ -44,13 +38,12 @@ const { getContactLastInput, getContactLastInputType } = await import(
 describe("last input helpers", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockFindConversationBy.mockResolvedValue({
+    mockFindLatestByContact.mockResolvedValue({
       id: "conversation-1",
       workspaceId: "workspace-1",
+      lastActivityAt: new Date(),
+      createdAt: new Date(),
     })
-    // A recent lastAt keeps getSafeSinceTime bounded but non-null so the
-    // message lookup runs.
-    mockFindLatestLastIncomingMessageAt.mockResolvedValue(new Date())
     mockResolveTenantSettings.mockResolvedValue({
       storageUrl: "https://cdn.example/storage/",
     })
@@ -98,11 +91,25 @@ describe("last input helpers", () => {
     await expect(getContactLastInputType("contact-1")).resolves.toBeNull()
   })
 
-  test("last_input returns null when the contact has no incoming activity", async () => {
-    mockFindLatestLastIncomingMessageAt.mockResolvedValue(null)
+  test("last_input returns null when the contact has no conversation", async () => {
+    mockFindLatestByContact.mockResolvedValue(undefined)
 
     await expect(getContactLastInput("contact-1")).resolves.toBeNull()
     expect(mockFindLatestIncomingMessageWithAttachments).not.toHaveBeenCalled()
+  })
+
+  test("last_input resolves the conversation the contact is most recently active in", async () => {
+    mockFindLatestIncomingMessageWithAttachments.mockResolvedValue({
+      contentType: contentTypes.enum.text,
+      text: "latest incoming text",
+      attachments: [],
+    })
+
+    await getContactLastInput("contact-1")
+
+    expect(mockFindLatestByContact).toHaveBeenCalledWith({
+      contactId: "contact-1",
+    })
   })
 
   test("last_input_type returns latest message content type", async () => {

--- a/packages/variables/src/helpers/message-window.ts
+++ b/packages/variables/src/helpers/message-window.ts
@@ -1,4 +1,4 @@
-import { contactInboxService, conversationService } from "@chatbotx.io/business"
+import { conversationService } from "@chatbotx.io/business"
 import { getSafeSinceTime } from "@chatbotx.io/database/repositories"
 import type { ConversationModel } from "@chatbotx.io/database/types"
 
@@ -12,18 +12,22 @@ export type ContactMessageWindow = {
 export const resolveContactMessageWindow = async (
   contactId: string,
 ): Promise<ContactMessageWindow | null> => {
-  const conversation = await conversationService.findBy({
-    where: { contactId },
+  // A contact can have multiple conversations (DM + comment threads) sharing
+  // one ContactInbox, so pick the conversation the contact is actually active
+  // in and anchor sinceTime on that same conversation's lastActivityAt —
+  // otherwise the two can point at different conversations and the windowed
+  // scan misses the real last message.
+  const conversation = await conversationService.findLatestByContact({
+    contactId,
   })
   if (!conversation) {
     return null
   }
 
-  const lastAt =
-    await contactInboxService.findLatestLastIncomingMessageAtByContactId({
-      contactId,
-    })
-  const sinceTime = getSafeSinceTime(lastAt, ONE_YEAR_MS)
+  const sinceTime = getSafeSinceTime(
+    conversation.lastActivityAt ?? conversation.createdAt,
+    ONE_YEAR_MS,
+  )
   if (!sinceTime) {
     return null
   }


### PR DESCRIPTION
## Summary
- `listConversations()`/`findConversation()` computed the `sinceTime` window for the sharded last-message lookup from `ContactInbox.lastMessageAt` — but that column is shared across a contact's DM conversation *and* every Facebook/Instagram comment-thread conversation (all keyed by the same `contactId`), so it reflects whichever of those was most recently active, not the specific conversation being queried.
- For an older, less-recently-active conversation (e.g. a comment thread on a post the contact hasn't revisited, while they DM'd or commented elsewhere more recently), this anchored `sinceTime` *after* that conversation's real last message, so the sharded query found nothing and `messages` came back empty in the conversation list/detail view.
- Anchor on `Conversation.lastActivityAt` instead — already updated per-conversation on every message (including historical imports via `bulk-historical-import.ts`), so it correctly scopes the lookup window to the conversation actually being queried.

## Test plan
- [x] `pnpm --filter builder check-types` and `pnpm lint` pass
- [x] Added `apps/builder/__tests__/list-conversations-query.test.ts` covering: two conversations sharing one contact/ContactInbox (an older comment thread + a newer DM) each resolve `sinceTime` from their own `lastActivityAt`, not a shared/borrowed anchor — for both `listConversations()` and `findConversation()`
- [ ] Manual: open a contact with an older Facebook/Instagram comment-thread conversation plus a more recently active DM/comment on another post — confirm the older conversation's last-message preview is no longer empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)