### PR TITLE
feat(conversations): show comment vs DM icon in conversation list

### DIFF
--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -1345,6 +1345,12 @@
     "channel": {
       "label": "Channel"
     },
+    "comment": {
+      "label": "Comment"
+    },
+    "directMessage": {
+      "label": "Direct Message"
+    },
     "updatedAt": {
       "label": "Updated At"
     },

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -1328,6 +1328,12 @@
     "channel": {
       "label": "Kênh"
     },
+    "comment": {
+      "label": "Bình luận"
+    },
+    "directMessage": {
+      "label": "Tin nhắn trực tiếp"
+    },
     "updatedAt": {
       "label": "Cập nhật lúc"
     },

--- a/apps/builder/src/features/conversations/conversation-item.tsx
+++ b/apps/builder/src/features/conversations/conversation-item.tsx
@@ -14,7 +14,13 @@ import {
 } from "@chatbotx.io/ui/components/ui/tooltip"
 import { cn } from "@chatbotx.io/ui/lib/utils"
 import { formatDistanceToNowStrict, isAfter } from "date-fns"
-import { StarIcon, UsersRoundIcon } from "lucide-react"
+import {
+  MailIcon,
+  MessageCircleMoreIcon,
+  StarIcon,
+  UsersRoundIcon,
+} from "lucide-react"
+import { useTranslations } from "next-intl"
 import { useAction } from "next-safe-action/hooks"
 import { useEffect, useMemo } from "react"
 import { toast } from "sonner"
@@ -64,10 +70,12 @@ export default function ConversationItem({
   conversation,
   onSelect,
 }: ConversationItemProps) {
+  const t = useTranslations()
   const { activeConversationId, readConversation } = useChatStore(
     (state) => state,
   )
   const isActive = conversation.id === activeConversationId
+  const isComment = conversation.messages?.[0]?.type === "comment"
   const avatarUrl = useAvatarUrl(conversation.contact)
 
   const contactAvatar = useMemo(
@@ -153,8 +161,26 @@ export default function ConversationItem({
         </div>
 
         <div className="flex-1 overflow-hidden">
-          <div className="truncate text-left font-medium dark:text-gray-200">
-            {conversation.contact?.fullName}
+          <div className="flex items-center justify-between gap-1">
+            <span className="truncate text-left font-medium dark:text-gray-200">
+              {conversation.contact?.fullName}
+            </span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  {isComment ? (
+                    <MessageCircleMoreIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                  ) : (
+                    <MailIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                  )}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent align="center" side="top">
+                {isComment
+                  ? t("fields.comment.label")
+                  : t("fields.directMessage.label")}
+              </TooltipContent>
+            </Tooltip>
           </div>
           <div
             className={cn(


### PR DESCRIPTION
## Summary
- The conversation list item only showed the channel icon (SiMessenger, SiInstagram...) with no way to tell a Facebook/Instagram comment-thread conversation apart from a regular DM at a glance.
- Add a small icon next to the contact name in `conversation-item.tsx` — `MessageCircleMoreIcon` for a comment-thread conversation, `MailIcon` for a DM — derived from the last message's `type`, with a tooltip ("Comment" / "Direct Message").
- Added the `fields.comment` / `fields.directMessage` translation keys to both `en.json` and `vi.json`.

Depends on #737 for the last-message preview itself being populated reliably (this PR only fixes the icon, based on whatever `messages[0].type` the list query returns).

## Test plan
- [x] `pnpm --filter builder check-types` and `pnpm lint` pass
- [ ] Manual: open the conversation list, confirm a comment-thread conversation shows the message-circle icon with "Comment" tooltip, and a DM conversation shows the mail icon with "Direct Message" tooltip
- [ ] Manual: switch language to Vietnamese, confirm tooltips read "Bình luận" / "Tin nhắn trực tiếp"

🤖 Generated with [Claude Code](https://claude.com/claude-code)