### PR TITLE
feat(broadcasts): preview receivers and view full broadcast details

### DIFF
--- a/apps/builder/__tests__/count-contact-inboxes.test.ts
+++ b/apps/builder/__tests__/count-contact-inboxes.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest"
 const mocks = vi.hoisted(() => ({
   assertCurrentUserCanAccessChatbot: vi.fn(),
   countAudience: vi.fn(),
+  listAudiencePreview: vi.fn(),
 }))
 
 vi.mock("@/lib/auth/utils", () => ({
@@ -13,10 +14,11 @@ vi.mock("@/lib/auth/utils", () => ({
 vi.mock("@chatbotx.io/business", () => ({
   broadcastService: {
     countAudience: mocks.countAudience,
+    listAudiencePreview: mocks.listAudiencePreview,
   },
 }))
 
-const { countContactInboxes } = await import(
+const { countContactInboxes, listAudienceInboxesPreview } = await import(
   "../src/features/contacts/queries/list-contact-inboxes.queries"
 )
 
@@ -24,6 +26,8 @@ beforeEach(() => {
   mocks.assertCurrentUserCanAccessChatbot.mockResolvedValue(undefined)
   mocks.countAudience.mockReset()
   mocks.countAudience.mockResolvedValue(12)
+  mocks.listAudiencePreview.mockReset()
+  mocks.listAudiencePreview.mockResolvedValue([])
 })
 
 describe("countContactInboxes", () => {
@@ -57,6 +61,95 @@ describe("countContactInboxes", () => {
       integrationMessengerId: "messenger-1",
       contactFilter,
       subaction: "messengerActiveContacts",
+      restrictToAssignedUserId: undefined,
+    })
+  })
+
+  test("forwards assigned-contact scope to broadcast audience counting", async () => {
+    await countContactInboxes(
+      {
+        workspaceId: "ws-1",
+        channels: ["messenger"],
+      },
+      {
+        canViewEmailAndPhone: false,
+        restrictToAssignedUserId: "user-1",
+      },
+    )
+
+    expect(mocks.countAudience).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      channels: ["messenger"],
+      integrationWhatsappId: undefined,
+      integrationMessengerId: undefined,
+      contactFilter: undefined,
+      subaction: undefined,
+      restrictToAssignedUserId: "user-1",
+    })
+  })
+
+  test("forwards assigned-contact scope to audience preview listing", async () => {
+    const result = await listAudienceInboxesPreview(
+      {
+        workspaceId: "ws-1",
+        channels: ["messenger"],
+        page: 2,
+        perPage: 10,
+      },
+      {
+        canViewEmailAndPhone: false,
+        restrictToAssignedUserId: "user-1",
+      },
+    )
+
+    expect(result).toEqual({ data: [] })
+    expect(mocks.listAudiencePreview).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      channels: ["messenger"],
+      integrationWhatsappId: undefined,
+      integrationMessengerId: undefined,
+      contactFilter: undefined,
+      subaction: undefined,
+      page: 2,
+      perPage: 10,
+      restrictToAssignedUserId: "user-1",
+    })
+  })
+
+  test("maps audience preview contact creation time to the stats dialog timestamp", async () => {
+    mocks.listAudiencePreview.mockResolvedValue([
+      {
+        contactId: "contact-1",
+        contactInboxId: "contact-inbox-1",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        fullName: "Ada Lovelace",
+        avatar: null,
+        createdAt: new Date("2026-01-01T10:00:00.000Z"),
+        channel: "messenger",
+        conversationId: "conversation-1",
+      },
+    ])
+
+    const result = await listAudienceInboxesPreview({
+      workspaceId: "ws-1",
+      channels: ["messenger"],
+    })
+
+    expect(result).toEqual({
+      data: [
+        {
+          contactId: "contact-1",
+          contactInboxId: "contact-inbox-1",
+          firstName: "Ada",
+          lastName: "Lovelace",
+          fullName: "Ada Lovelace",
+          avatar: null,
+          occurredAt: "2026-01-01T10:00:00.000Z",
+          channel: "messenger",
+          conversationId: "conversation-1",
+        },
+      ],
     })
   })
 })

--- a/apps/builder/__tests__/format-error-content.test.ts
+++ b/apps/builder/__tests__/format-error-content.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest"
+import { formatErrorContent } from "@/features/common/lib/format-error-content"
+
+describe("formatErrorContent", () => {
+  test("returns the message from a JSON error payload", () => {
+    expect(
+      formatErrorContent(JSON.stringify({ message: "Rate limited" })),
+    ).toBe("Rate limited")
+  })
+
+  test("returns raw JSON when message is missing", () => {
+    const raw = JSON.stringify({ code: "BAD_REQUEST" })
+
+    expect(formatErrorContent(raw)).toBe(raw)
+  })
+
+  test("returns raw JSON when message is empty", () => {
+    const raw = JSON.stringify({ message: "   " })
+
+    expect(formatErrorContent(raw)).toBe(raw)
+  })
+
+  test("returns raw content when the payload is not JSON", () => {
+    expect(formatErrorContent("plain failure")).toBe("plain failure")
+  })
+})

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -312,7 +312,8 @@
       "tagAllDialogDescription": "Tags will be added to all selected contacts.",
       "tagDialogDescription": "Tags will be added to {count} contact(s).",
       "tagQueued": "Tagging {count} contacts in the background.",
-      "loadingMore": "Loading more..."
+      "loadingMore": "Loading more...",
+      "receivers": "Receivers"
     },
     "messengerList": {
       "title": "Messenger List",
@@ -339,6 +340,7 @@
       "description": "Send a flow to all contacts."
     },
     "receiversCount": "Receivers: {count}",
+    "receiversLoading": "Receivers: Loading...",
     "whatsappTemplateMessage": {
       "title": "Template Message",
       "description": "Send WhatsApp template message to your contacts"
@@ -360,11 +362,24 @@
         "title": "Template",
         "description": "Send a template to your contacts"
       }
+    },
+    "detail": {
+      "title": "Broadcast detail",
+      "subaction": "Subaction",
+      "audienceFilter": "Audience filter",
+      "noAudienceFilter": "No audience filter",
+      "template": "Template",
+      "noTemplate": "No template",
+      "integration": "Integration"
     }
   },
   "condition": {
     "yes": "Yes",
     "no": "No",
+    "operator": {
+      "and": "All conditions",
+      "or": "Any condition"
+    },
     "fields": {
       "locale": "Language",
       "language": "Language",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -312,7 +312,8 @@
       "tagAllDialogDescription": "Thẻ sẽ được gắn cho tất cả liên hệ đã chọn.",
       "tagDialogDescription": "Thẻ sẽ được gắn cho {count} liên hệ.",
       "tagQueued": "Đang gắn thẻ cho {count} liên hệ trong nền.",
-      "loadingMore": "Đang tải thêm..."
+      "loadingMore": "Đang tải thêm...",
+      "receivers": "Người nhận"
     },
     "messengerList": {
       "title": "Danh sách Messenger",
@@ -339,6 +340,7 @@
       "description": "Gửi luồng đến tất cả liên hệ."
     },
     "receiversCount": "Người nhận: {count}",
+    "receiversLoading": "Người nhận: Đang tải...",
     "whatsappTemplateMessage": {
       "title": "Tin nhắn mẫu WhatsApp",
       "description": "Gửi tin nhắn mẫu WhatsApp đến các liên hệ của bạn"
@@ -360,11 +362,24 @@
         "title": "Template",
         "description": "Gửi template đến các liên hệ của bạn"
       }
+    },
+    "detail": {
+      "title": "Chi tiết phát sóng",
+      "subaction": "Hành động con",
+      "audienceFilter": "Bộ lọc người nhận",
+      "noAudienceFilter": "Không có bộ lọc người nhận",
+      "template": "Template",
+      "noTemplate": "Không có template",
+      "integration": "Tích hợp"
     }
   },
   "condition": {
     "yes": "Có",
     "no": "Không",
+    "operator": {
+      "and": "Tất cả điều kiện",
+      "or": "Bất kỳ điều kiện nào"
+    },
     "fields": {
       "locale": "Ngôn ngữ",
       "language": "Ngôn ngữ",

--- a/apps/builder/src/features/broadcasts/api/private.ts
+++ b/apps/builder/src/features/broadcasts/api/private.ts
@@ -34,6 +34,37 @@ const getBatchBroadcastStatsResponse = z.record(
   getBroadcastStatsResponse,
 )
 
+const getBroadcastTemplateDetailRequest = z.object({
+  workspaceId: z.string(),
+  broadcastId: z.string(),
+})
+
+const broadcastTemplateDetailResponse = z
+  .discriminatedUnion("channel", [
+    z.object({
+      channel: z.literal("whatsapp"),
+      id: z.string(),
+      name: z.string(),
+      language: z.string(),
+      category: z.string(),
+      status: z.string(),
+      components: z.unknown(),
+      integrationName: z.string().nullable(),
+    }),
+    z.object({
+      channel: z.literal("messenger"),
+      id: z.string(),
+      name: z.string(),
+      language: z.string(),
+      category: z.string(),
+      status: z.string(),
+      parameterFormat: z.string(),
+      components: z.unknown(),
+      integrationName: z.string().nullable(),
+    }),
+  ])
+  .nullable()
+
 export const broadcastPrivateAPIs = {
   privateListBroadcastOptionsAPI: authorizedAPI
     .route({
@@ -65,6 +96,20 @@ export const broadcastPrivateAPIs = {
           workspaceId: input.workspaceId,
           broadcastIds: input.broadcastIds,
         }),
+    ),
+
+  privateGetBroadcastTemplateDetailAPI: authorizedAPI
+    .route({
+      method: "GET",
+      path: "/workspaces/{workspaceId}/broadcasts/{broadcastId}/template-detail",
+      summary: "Get broadcast template detail",
+      tags: ["Broadcasts"],
+    })
+    .input(getBroadcastTemplateDetailRequest)
+    .output(broadcastTemplateDetailResponse)
+    .use(workspaceAuthorizedMidddleware, (input) => input.workspaceId)
+    .handler(
+      async ({ input }) => await broadcastService.getTemplateDetail(input),
     ),
 
   privateListBroadcastContactsAPI: authorizedAPI

--- a/apps/builder/src/features/broadcasts/broadcast-detail-dialog.tsx
+++ b/apps/builder/src/features/broadcasts/broadcast-detail-dialog.tsx
@@ -1,0 +1,291 @@
+"use client"
+
+import type { BroadcastTemplateDetail } from "@chatbotx.io/business"
+import {
+  broadcastSubactions,
+  channelTypes,
+} from "@chatbotx.io/database/partials"
+import type {
+  MessengerTemplateComponent,
+  MessengerTemplateParams,
+  TemplateComponent,
+  WaTemplateParams,
+} from "@chatbotx.io/flow-config"
+import { Badge } from "@chatbotx.io/ui/components/ui/badge"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@chatbotx.io/ui/components/ui/dialog"
+import { Skeleton } from "@chatbotx.io/ui/components/ui/skeleton"
+import { format } from "date-fns"
+import { useTranslations } from "next-intl"
+import { type ReactNode, useEffect, useMemo, useState } from "react"
+import { ContactFilterSummary } from "@/features/contact-filter/components/contact-filter-summary"
+import { contactFilterCriteriaSchema } from "@/features/contact-filter/schemas"
+import { InboxIcon } from "@/features/inboxes/components/inbox-icon"
+import { MessengerTemplatePreview } from "@/features/integration-messenger/message-templates/components/template-preview"
+import { TemplatePreview } from "@/features/integration-whatsapp/message-templates/components/template-preview"
+import { useWorkspaceId } from "@/hooks/routing"
+import { client } from "@/lib/orpc/orpc"
+import type { BroadcastResourceWithRelations } from "./schemas/resource"
+
+type BroadcastDetailDialogProps = {
+  broadcast: BroadcastResourceWithRelations | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function BroadcastDetailDialog({
+  broadcast,
+  open,
+  onOpenChange,
+}: BroadcastDetailDialogProps) {
+  const t = useTranslations()
+  const workspaceId = useWorkspaceId()
+  const [templateDetail, setTemplateDetail] =
+    useState<BroadcastTemplateDetail | null>(null)
+  const [loadingTemplateDetail, setLoadingTemplateDetail] = useState(false)
+
+  useEffect(() => {
+    if (!(open && broadcast?.templateId)) {
+      setTemplateDetail(null)
+      setLoadingTemplateDetail(false)
+      return
+    }
+
+    let isActive = true
+    setLoadingTemplateDetail(true)
+
+    client.broadcastAPIs
+      .privateGetBroadcastTemplateDetailAPI({
+        workspaceId,
+        broadcastId: broadcast.id,
+      })
+      .then((detail) => {
+        if (isActive) {
+          setTemplateDetail(detail)
+        }
+      })
+      .catch(() => {
+        if (isActive) {
+          setTemplateDetail(null)
+        }
+      })
+      .finally(() => {
+        if (isActive) {
+          setLoadingTemplateDetail(false)
+        }
+      })
+
+    return () => {
+      isActive = false
+    }
+  }, [broadcast?.id, broadcast?.templateId, open, workspaceId])
+
+  const contactFilter = useMemo(() => {
+    const parsed = contactFilterCriteriaSchema.safeParse(
+      broadcast?.contactFilter,
+    )
+    return parsed.success ? parsed.data : null
+  }, [broadcast?.contactFilter])
+
+  if (!broadcast) {
+    return (
+      <Dialog onOpenChange={onOpenChange} open={open}>
+        <DialogContent />
+      </Dialog>
+    )
+  }
+
+  const channel = channelTypes.safeParse(broadcast.channel)
+  const channelValue = channel.success
+    ? channel.data
+    : channelTypes.enum.omnichannel
+  const subaction = broadcastSubactions.safeParse(broadcast.subaction)
+  const templateData = broadcast.templateData as
+    | WaTemplateParams
+    | MessengerTemplateParams
+    | null
+    | undefined
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="max-h-screen overflow-y-auto sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>{t("broadcasts.detail.title")}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          <div className="grid gap-3 text-sm sm:grid-cols-2">
+            <DetailField
+              label={t("fields.name.label")}
+              value={broadcast.name}
+            />
+            <DetailField
+              label={t("fields.channel.label")}
+              value={
+                <InboxIcon
+                  channel={channelValue}
+                  label={t(`fields.${channelValue}.label`)}
+                  size="small"
+                />
+              }
+            />
+            <DetailField
+              label={t("broadcasts.detail.subaction")}
+              value={
+                subaction.success
+                  ? t(`broadcasts.${subaction.data}.title`)
+                  : broadcast.subaction
+              }
+            />
+            <DetailField
+              label={t("fields.status.label")}
+              value={
+                <Badge
+                  variant={
+                    broadcast.status === "scheduled" ? "outline" : "default"
+                  }
+                >
+                  {t(`broadcasts.status.${broadcast.status}`)}
+                </Badge>
+              }
+            />
+            <DetailField
+              label={t("fields.schedule.label")}
+              value={t(`fields.schedule.${broadcast.schedulesType}`)}
+            />
+            <DetailField
+              label={t("fields.scheduledAt.label")}
+              value={format(
+                new Date(broadcast.schedulesAt),
+                "yyyy/MM/dd HH:mm",
+              )}
+            />
+            <DetailField
+              label={t("fields.estimatedContacts.label")}
+              value={broadcast.contactCount?.toLocaleString() ?? "-"}
+            />
+            <DetailField
+              label={t("fields.flowId.label")}
+              value={broadcast.flow?.name ?? broadcast.flowId ?? "-"}
+            />
+          </div>
+
+          <section className="space-y-2">
+            <h3 className="font-medium text-sm">
+              {t("broadcasts.detail.audienceFilter")}
+            </h3>
+            <ContactFilterSummary contactFilter={contactFilter} />
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="font-medium text-sm">
+              {t("broadcasts.detail.template")}
+            </h3>
+            <TemplateSection
+              loading={loadingTemplateDetail}
+              templateData={templateData}
+              templateDetail={templateDetail}
+            />
+          </section>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function DetailField({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div>
+      <div className="text-muted-foreground">{label}</div>
+      <div className="font-medium">{value}</div>
+    </div>
+  )
+}
+
+function TemplateSection({
+  loading,
+  templateDetail,
+  templateData,
+}: {
+  loading: boolean
+  templateDetail: BroadcastTemplateDetail | null
+  templateData: WaTemplateParams | MessengerTemplateParams | null | undefined
+}) {
+  const t = useTranslations()
+
+  if (loading) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-40" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    )
+  }
+
+  if (!templateDetail) {
+    return (
+      <div className="text-muted-foreground text-sm">
+        {t("broadcasts.detail.noTemplate")}
+      </div>
+    )
+  }
+
+  const components = Array.isArray(templateDetail.components)
+    ? templateDetail.components
+    : []
+
+  return (
+    <div className="space-y-3">
+      <div className="grid gap-3 text-sm sm:grid-cols-2">
+        <DetailField
+          label={t("fields.name.label")}
+          value={`${templateDetail.name} (${templateDetail.language})`}
+        />
+        <DetailField
+          label={t("fields.category.label")}
+          value={templateDetail.category}
+        />
+        <DetailField
+          label={t("fields.status.label")}
+          value={templateDetail.status}
+        />
+        <DetailField
+          label={t("broadcasts.detail.integration")}
+          value={templateDetail.integrationName ?? "-"}
+        />
+      </div>
+
+      {templateDetail.channel === "whatsapp" ? (
+        <TemplatePreview
+          bodyParams={
+            (templateData as WaTemplateParams | undefined)?.body ?? []
+          }
+          buttonParams={
+            (templateData as WaTemplateParams | undefined)?.button ?? []
+          }
+          components={components as TemplateComponent[]}
+          headerParams={
+            (templateData as WaTemplateParams | undefined)?.header ?? []
+          }
+        />
+      ) : (
+        <MessengerTemplatePreview
+          bodyParams={
+            (templateData as MessengerTemplateParams | undefined)?.body ?? []
+          }
+          buttonParams={
+            (templateData as MessengerTemplateParams | undefined)?.button ?? []
+          }
+          components={components as MessengerTemplateComponent[]}
+          headerParams={
+            (templateData as MessengerTemplateParams | undefined)?.header ?? []
+          }
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/builder/src/features/broadcasts/broadcasts-table.tsx
+++ b/apps/builder/src/features/broadcasts/broadcasts-table.tsx
@@ -21,6 +21,7 @@ import type { DataTableRowAction } from "@chatbotx.io/ui/types/data-table"
 import type { ColumnDef } from "@tanstack/react-table"
 import { format } from "date-fns"
 import {
+  EyeIcon,
   Loader2Icon,
   MoreHorizontalIcon,
   PencilIcon,
@@ -33,6 +34,7 @@ import { useTranslations } from "next-intl"
 import React, { useMemo, useState } from "react"
 import type { listBroadcasts } from "@/features/broadcasts/queries"
 import { useWorkspaceId } from "@/hooks/routing"
+import { BroadcastDetailDialog } from "./broadcast-detail-dialog"
 import { BroadcastStatsCell } from "./components/broadcast-stats-cell"
 import { BroadcastStatsStoreProvider } from "./provider/broadcast-stats-store-context"
 import { RenameBroadcastDialog } from "./rename-broadcast-dialog"
@@ -277,6 +279,12 @@ export function BroadcastsTable({ promises }: BroadcastsTableProps) {
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem
+                onClick={() => setRowAction({ row, variant: "view" })}
+              >
+                <EyeIcon className="mr-2" />
+                {t("actions.view")}
+              </DropdownMenuItem>
+              <DropdownMenuItem
                 onClick={() => setRowAction({ row, variant: "rename" })}
               >
                 <PencilIcon className="mr-2" />
@@ -345,6 +353,16 @@ export function BroadcastsTable({ promises }: BroadcastsTableProps) {
         broadcast={rowAction?.row.original || null}
         onOpenChange={() => setRowAction(null)}
         open={rowAction?.variant === "resend"}
+      />
+
+      <BroadcastDetailDialog
+        broadcast={rowAction?.row.original ?? null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRowAction(null)
+          }
+        }}
+        open={rowAction?.variant === "view"}
       />
     </BroadcastStatsStoreProvider>
   )

--- a/apps/builder/src/features/broadcasts/components/broadcast-audience-preview-dialog.tsx
+++ b/apps/builder/src/features/broadcasts/components/broadcast-audience-preview-dialog.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import type {
+  BroadcastSubaction,
+  ChannelType,
+} from "@chatbotx.io/database/partials"
+import { useTranslations } from "next-intl"
+import { memo, useCallback } from "react"
+import {
+  type StatsContactRow,
+  StatsContactsDialog,
+} from "@/features/common/components/stats-contacts-dialog"
+import type { ContactFilterRequest } from "@/features/contacts/schemas/query"
+import { client } from "@/lib/orpc/orpc"
+
+type BroadcastAudiencePreviewDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  workspaceId: string
+  total: number
+  channel: ChannelType
+  subaction: BroadcastSubaction
+  integrationWhatsappId?: string | null
+  integrationMessengerId?: string | null
+  contactFilter?: ContactFilterRequest["contactFilter"] | null
+}
+
+export const BroadcastAudiencePreviewDialog = memo(
+  function BroadcastAudiencePreviewDialog({
+    open,
+    onOpenChange,
+    workspaceId,
+    total,
+    channel,
+    subaction,
+    integrationWhatsappId,
+    integrationMessengerId,
+    contactFilter,
+  }: BroadcastAudiencePreviewDialogProps) {
+    const t = useTranslations()
+
+    const fetchPage = useCallback(
+      async (page: number, perPage: number): Promise<StatsContactRow[]> => {
+        const result =
+          await client.contactsAPIs.listContactInboxesAudiencePreviewAuthenticatedAPI(
+            {
+              workspaceId,
+              page,
+              perPage,
+              channels: [channel],
+              integrationWhatsappId: integrationWhatsappId ?? undefined,
+              integrationMessengerId: integrationMessengerId ?? undefined,
+              contactFilter: contactFilter ?? undefined,
+              subaction,
+            },
+          )
+
+        return result.data
+      },
+      [
+        channel,
+        contactFilter,
+        integrationMessengerId,
+        integrationWhatsappId,
+        subaction,
+        workspaceId,
+      ],
+    )
+
+    return (
+      <StatsContactsDialog
+        fetchPage={fetchPage}
+        i18nNamespace="broadcasts"
+        onOpenChange={onOpenChange}
+        open={open}
+        title={t("broadcasts.stats.receivers")}
+        total={total}
+        workspaceId={workspaceId}
+      />
+    )
+  },
+)

--- a/apps/builder/src/features/broadcasts/components/broadcast-confirm-dialog.tsx
+++ b/apps/builder/src/features/broadcasts/components/broadcast-confirm-dialog.tsx
@@ -4,11 +4,11 @@ import { Button } from "@chatbotx.io/ui/components/ui/button"
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
+  DialogTitle,
 } from "@chatbotx.io/ui/components/ui/dialog"
-import { Loader2Icon } from "lucide-react"
+import { Loader2Icon, UsersIcon } from "lucide-react"
 import { useTranslations } from "next-intl"
 
 export function BroadcastConfirmDialog({
@@ -16,11 +16,15 @@ export function BroadcastConfirmDialog({
   onOpenChange,
   count,
   isSubmitting,
+  isReceiversCountLoading,
+  onPreviewReceivers,
 }: {
   open: boolean
   onOpenChange: (val: boolean) => void
   count: number
   isSubmitting: boolean
+  isReceiversCountLoading: boolean
+  onPreviewReceivers: () => void
 }) {
   const t = useTranslations()
 
@@ -28,12 +32,33 @@ export function BroadcastConfirmDialog({
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogDescription className="py-2">
-            {t("broadcasts.receiversCount", {
-              count: count || 0,
-            })}
-          </DialogDescription>
+          <DialogTitle>{t("actions.confirm")}</DialogTitle>
         </DialogHeader>
+
+        <div className="py-2">
+          <Button
+            className="h-auto px-0 text-muted-foreground text-sm"
+            disabled={isReceiversCountLoading || !count}
+            onClick={onPreviewReceivers}
+            type="button"
+            variant="link"
+          >
+            {isReceiversCountLoading ? (
+              <>
+                <Loader2Icon className="size-4 animate-spin" />
+                {t("broadcasts.receiversLoading")}
+              </>
+            ) : (
+              <>
+                <UsersIcon className="size-4" />
+                {t("broadcasts.receiversCount", {
+                  count: count || 0,
+                })}
+              </>
+            )}
+          </Button>
+        </div>
+
         <DialogFooter className="border-t pt-4">
           <div className="flex w-full items-center justify-between gap-2">
             <Button
@@ -43,7 +68,11 @@ export function BroadcastConfirmDialog({
             >
               {t("actions.cancel")}
             </Button>
-            <Button disabled={isSubmitting} form="broadcast-form" type="submit">
+            <Button
+              disabled={isSubmitting || isReceiversCountLoading}
+              form="broadcast-form"
+              type="submit"
+            >
               {isSubmitting && <Loader2Icon className="animate-spin" />}
               {t("actions.confirm")}
             </Button>

--- a/apps/builder/src/features/broadcasts/components/broadcast-contacts-dialog.tsx
+++ b/apps/builder/src/features/broadcasts/components/broadcast-contacts-dialog.tsx
@@ -108,6 +108,7 @@ export const BroadcastContactsDialog = memo(function BroadcastContactsDialog({
       onManualTag={onManualTag}
       onOpenChange={onOpenChange}
       open={open}
+      showErrors={eventType === "message:failed"}
       title={t(`broadcasts.stats.${eventTypeToLabel[eventType]}`)}
       total={total}
       workspaceId={workspaceId}

--- a/apps/builder/src/features/broadcasts/create-broadcast-form.tsx
+++ b/apps/builder/src/features/broadcasts/create-broadcast-form.tsx
@@ -37,10 +37,11 @@ import { add } from "date-fns"
 import { Loader2Icon, XIcon } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useFormContext, useWatch } from "react-hook-form"
 import { toast } from "sonner"
 import { createBroadcastAction } from "@/features/broadcasts/actions/create-broadcast.action"
+import { BroadcastAudiencePreviewDialog } from "@/features/broadcasts/components/broadcast-audience-preview-dialog"
 import { BroadcastConfirmDialog } from "@/features/broadcasts/components/broadcast-confirm-dialog"
 import { createBroadcastRequest } from "@/features/broadcasts/schemas/action"
 import { useWorkspaceId } from "@/hooks/routing"
@@ -467,9 +468,15 @@ type CreateBroadcastChooseFlowProps = {
 function CreateBroadcastChooseFlow(props: CreateBroadcastChooseFlowProps) {
   const t = useTranslations()
   const router = useRouter()
-  const { contactInboxesCount: count, getContactInboxesCount } =
-    useContactStore((state) => state)
-  const fetchReceiversCount = useDebouncedCallback(getContactInboxesCount, 300)
+  const {
+    contactInboxesCount: count,
+    getContactInboxesCount,
+    loadingInboxesCount,
+  } = useContactStore((state) => state)
+  const [audiencePreviewOpen, setAudiencePreviewOpen] = useState(false)
+  const latestReceiversCountQueryKeyRef = useRef<string | null>(null)
+  const [completedReceiversCountQueryKey, setCompletedReceiversCountQueryKey] =
+    useState<string | null>(null)
 
   const workspaceId = useWorkspaceId()
 
@@ -518,6 +525,46 @@ function CreateBroadcastChooseFlow(props: CreateBroadcastChooseFlowProps) {
   const watchedMessengerTemplateData = watchedTemplateData as
     | MessengerTemplateParams
     | undefined
+
+  const receiversCountParams = useMemo(
+    () => ({
+      contactFilter: watchedContactFilter,
+      channel: props.channel,
+      integrationWhatsappId: watchedIntegrationWhatsappId,
+      integrationMessengerId: watchedIntegrationMessengerId,
+      subaction: props.subaction,
+    }),
+    [
+      watchedContactFilter,
+      props.channel,
+      props.subaction,
+      watchedIntegrationWhatsappId,
+      watchedIntegrationMessengerId,
+    ],
+  )
+
+  const receiversCountQueryKey = useMemo(
+    () => JSON.stringify(receiversCountParams),
+    [receiversCountParams],
+  )
+
+  const fetchReceiversCount = useDebouncedCallback(
+    async (
+      params: typeof receiversCountParams,
+      queryKey: string,
+    ): Promise<void> => {
+      await getContactInboxesCount(params)
+
+      if (latestReceiversCountQueryKeyRef.current === queryKey) {
+        setCompletedReceiversCountQueryKey(queryKey)
+      }
+    },
+    300,
+  )
+
+  const isReceiversCountLoading =
+    loadingInboxesCount ||
+    completedReceiversCountQueryKey !== receiversCountQueryKey
 
   const [selectedTemplate, setSelectedTemplate] =
     useState<MessageTemplateWithComponents | null>(null)
@@ -619,21 +666,10 @@ function CreateBroadcastChooseFlow(props: CreateBroadcastChooseFlowProps) {
   }, [watchedIntegrationWhatsappId, setIntegrationWhatsappId, setValue])
 
   useEffect(() => {
-    fetchReceiversCount({
-      contactFilter: watchedContactFilter,
-      channel: props.channel,
-      integrationWhatsappId: watchedIntegrationWhatsappId,
-      integrationMessengerId: watchedIntegrationMessengerId,
-      subaction: props.subaction,
-    })
-  }, [
-    watchedContactFilter,
-    props.channel,
-    props.subaction,
-    watchedIntegrationWhatsappId,
-    watchedIntegrationMessengerId,
-    fetchReceiversCount,
-  ])
+    latestReceiversCountQueryKeyRef.current = receiversCountQueryKey
+    setCompletedReceiversCountQueryKey(null)
+    fetchReceiversCount(receiversCountParams, receiversCountQueryKey)
+  }, [fetchReceiversCount, receiversCountParams, receiversCountQueryKey])
 
   useEffect(() => {
     if (watchedTemplateId && whatsappTemplates.length > 0) {
@@ -898,11 +934,24 @@ function CreateBroadcastChooseFlow(props: CreateBroadcastChooseFlowProps) {
       </Card>
 
       <div className="flex items-center justify-between">
-        <div className="flex-1 text-gray-500 text-sm">
-          {t("broadcasts.receiversCount", {
-            count: count || 0,
-          })}
-        </div>
+        <Button
+          className="h-auto px-0 text-gray-500 text-sm"
+          disabled={isReceiversCountLoading || !count}
+          onClick={() => setAudiencePreviewOpen(true)}
+          type="button"
+          variant="link"
+        >
+          {isReceiversCountLoading ? (
+            <span className="inline-flex items-center gap-1.5">
+              <Loader2Icon className="size-3 animate-spin" />
+              {t("broadcasts.receiversLoading")}
+            </span>
+          ) : (
+            t("broadcasts.receiversCount", {
+              count: count || 0,
+            })
+          )}
+        </Button>
         <div className="flex justify-end gap-2">
           <Button onClick={handleCancel} type="button" variant="outline">
             {t("actions.cancel")}
@@ -919,9 +968,22 @@ function CreateBroadcastChooseFlow(props: CreateBroadcastChooseFlowProps) {
 
           <BroadcastConfirmDialog
             count={count || 0}
+            isReceiversCountLoading={isReceiversCountLoading}
             isSubmitting={formState.isSubmitting}
             onOpenChange={setConfirmOpen}
+            onPreviewReceivers={() => setAudiencePreviewOpen(true)}
             open={confirmOpen}
+          />
+          <BroadcastAudiencePreviewDialog
+            channel={props.channel}
+            contactFilter={watchedContactFilter}
+            integrationMessengerId={watchedIntegrationMessengerId}
+            integrationWhatsappId={watchedIntegrationWhatsappId}
+            onOpenChange={setAudiencePreviewOpen}
+            open={audiencePreviewOpen}
+            subaction={props.subaction}
+            total={count || 0}
+            workspaceId={workspaceId}
           />
         </div>
       </div>

--- a/apps/builder/src/features/broadcasts/queries/index.ts
+++ b/apps/builder/src/features/broadcasts/queries/index.ts
@@ -30,6 +30,14 @@ export async function listBroadcasts(
   const [data, total] = await Promise.all([
     db.query.broadcastModel.findMany({
       where,
+      with: {
+        flow: {
+          columns: {
+            id: true,
+            name: true,
+          },
+        },
+      },
       ...pagination,
       orderBy,
     }),

--- a/apps/builder/src/features/broadcasts/schemas/resource.ts
+++ b/apps/builder/src/features/broadcasts/schemas/resource.ts
@@ -8,7 +8,7 @@ export const broadcastResource = createSelectSchema(broadcastModel)
 export type BroadcastResource = BroadcastModel
 
 export type BroadcastResourceWithRelations = BroadcastResource & {
-  flow?: FlowModel
+  flow?: Pick<FlowModel, "id" | "name"> | null
   contactsCount?: number
 }
 

--- a/apps/builder/src/features/common/components/stats-contacts-dialog.tsx
+++ b/apps/builder/src/features/common/components/stats-contacts-dialog.tsx
@@ -40,6 +40,7 @@ import {
   type StatsSelection,
   useStatsSelection,
 } from "../hooks/use-stats-selection"
+import { formatErrorContent } from "../lib/format-error-content"
 
 const perPage = 20
 const scrollThreshold = 200
@@ -58,9 +59,9 @@ export type StatsContactRow = {
   fullName: string | null
   avatar: string | null
   channel: ChannelType
-  conversationId: string
-  errorContent: string | null
-  occurredAt: string
+  conversationId: string | null
+  errorContent?: string | null
+  occurredAt?: string | null
 }
 
 type StatsContactsDialogProps = {
@@ -70,18 +71,24 @@ type StatsContactsDialogProps = {
   title: string
   total: number
   i18nNamespace: "broadcasts" | "sequences"
+  showErrors?: boolean
   fetchPage: (page: number, perPage: number) => Promise<StatsContactRow[]>
-  onManualTag: (contactIds: string[], tags: string[]) => Promise<void>
-  onBulkTag: (excludedContactIds: string[], tags: string[]) => Promise<void>
+  onManualTag?: (contactIds: string[], tags: string[]) => Promise<void>
+  onBulkTag?: (excludedContactIds: string[], tags: string[]) => Promise<void>
 }
 
 export const StatsContactsDialog = memo(function StatsContactsDialog(
   props: StatsContactsDialogProps,
 ) {
-  return (
+  const canTag = Boolean(props.onManualTag && props.onBulkTag)
+  const dialog = <StatsContactsDialogInner {...props} />
+
+  return canTag ? (
     <TagStoreProvider workspaceId={props.workspaceId}>
-      <StatsContactsDialogInner {...props} />
+      {dialog}
     </TagStoreProvider>
+  ) : (
+    dialog
   )
 })
 
@@ -92,6 +99,7 @@ const StatsContactsDialogInner = memo(function StatsContactsDialogInner({
   title,
   total,
   i18nNamespace,
+  showErrors = false,
   fetchPage,
   onManualTag,
   onBulkTag,
@@ -106,6 +114,7 @@ const StatsContactsDialogInner = memo(function StatsContactsDialogInner({
   const [tagDialogOpen, setTagDialogOpen] = useState(false)
   const loadInFlightRef = useRef(false)
   const selectionState = useStatsSelection(total)
+  const canTag = Boolean(onManualTag && onBulkTag)
   const hasSelectedAll =
     selectionState.selection.mode === "all" &&
     selectionState.selection.excludedIds.size === 0
@@ -211,31 +220,33 @@ const StatsContactsDialogInner = memo(function StatsContactsDialogInner({
           </DialogTitle>
         </DialogHeader>
 
-        <div className="flex items-center justify-between gap-3 border-y py-2">
-          <div className="flex min-w-0 items-center gap-2">
-            <Checkbox
-              aria-label={t("actions.selectAll")}
-              checked={selectionState.headerState}
-              onCheckedChange={selectionState.toggleHeader}
-            />
-            <span className="truncate text-muted-foreground text-sm">
-              {hasSelectedAll
-                ? t(`${i18nNamespace}.stats.selectedAll`)
-                : t(`${i18nNamespace}.stats.selectedCount`, {
-                    count: selectionState.selectedCount,
-                  })}
-            </span>
+        {canTag && (
+          <div className="flex items-center justify-between gap-3 border-y py-2">
+            <div className="flex min-w-0 items-center gap-2">
+              <Checkbox
+                aria-label={t("actions.selectAll")}
+                checked={selectionState.headerState}
+                onCheckedChange={selectionState.toggleHeader}
+              />
+              <span className="truncate text-muted-foreground text-sm">
+                {hasSelectedAll
+                  ? t(`${i18nNamespace}.stats.selectedAll`)
+                  : t(`${i18nNamespace}.stats.selectedCount`, {
+                      count: selectionState.selectedCount,
+                    })}
+              </span>
+            </div>
+            <Button
+              disabled={selectionState.selectedCount === 0}
+              onClick={() => setTagDialogOpen(true)}
+              size="sm"
+              type="button"
+            >
+              <TagIcon className="size-4" />
+              {t("actions.addTag")}
+            </Button>
           </div>
-          <Button
-            disabled={selectionState.selectedCount === 0}
-            onClick={() => setTagDialogOpen(true)}
-            size="sm"
-            type="button"
-          >
-            <TagIcon className="size-4" />
-            {t("actions.addTag")}
-          </Button>
-        </div>
+        )}
 
         <div ref={scrollRootRef} style={{ height: "min(520px, 60vh)" }}>
           <ScrollArea className="h-full">
@@ -257,12 +268,14 @@ const StatsContactsDialogInner = memo(function StatsContactsDialogInner({
               <div className="space-y-2 pr-4">
                 {contacts.map((contact) => (
                   <SelectableContactItem
+                    canTag={canTag}
                     contact={contact}
                     isSelected={selectionState.isSelected(contact.contactId)}
                     key={contact.contactId}
                     onToggle={() =>
                       selectionState.toggleContact(contact.contactId)
                     }
+                    showErrors={showErrors}
                     workspaceId={workspaceId}
                   />
                 ))}
@@ -276,15 +289,17 @@ const StatsContactsDialogInner = memo(function StatsContactsDialogInner({
           </ScrollArea>
         </div>
 
-        <StatsTagDialog
-          i18nNamespace={i18nNamespace}
-          onBulkTag={onBulkTag}
-          onManualTag={onManualTag}
-          onOpenChange={setTagDialogOpen}
-          open={tagDialogOpen}
-          selectedCount={selectionState.selectedCount}
-          selection={selectionState.selection}
-        />
+        {canTag && onManualTag && onBulkTag && (
+          <StatsTagDialog
+            i18nNamespace={i18nNamespace}
+            onBulkTag={onBulkTag}
+            onManualTag={onManualTag}
+            onOpenChange={setTagDialogOpen}
+            open={tagDialogOpen}
+            selectedCount={selectionState.selectedCount}
+            selection={selectionState.selection}
+          />
+        )}
       </DialogContent>
     </Dialog>
   )
@@ -405,11 +420,15 @@ const SelectableContactItem = memo(function SelectableContactItem({
   workspaceId,
   contact,
   isSelected,
+  canTag,
+  showErrors,
   onToggle,
 }: {
   workspaceId: string
   contact: StatsContactRow
   isSelected: boolean
+  canTag: boolean
+  showErrors: boolean
   onToggle: () => void
 }) {
   const avatarUrl = useAvatarUrl({
@@ -420,11 +439,13 @@ const SelectableContactItem = memo(function SelectableContactItem({
 
   return (
     <div className="flex items-center gap-3 rounded-lg p-0 transition-colors hover:bg-muted/50">
-      <Checkbox
-        aria-label={contact.fullName ?? contact.contactId}
-        checked={isSelected}
-        onCheckedChange={onToggle}
-      />
+      {canTag && (
+        <Checkbox
+          aria-label={contact.fullName ?? contact.contactId}
+          checked={isSelected}
+          onCheckedChange={onToggle}
+        />
+      )}
 
       <Avatar className="size-8 shrink-0">
         <AvatarImage src={avatarUrl} />
@@ -435,15 +456,21 @@ const SelectableContactItem = memo(function SelectableContactItem({
 
       <div className="w-32 shrink space-y-1">
         <div className="flex items-center gap-1.5">
-          <Link
-            className="max-w-[200px] truncate text-blue-500"
-            href={`/space/${workspaceId}/inbox?conversationId=${contact.conversationId}`}
-            target="_blank"
-          >
+          {contact.conversationId ? (
+            <Link
+              className="max-w-[200px] truncate text-blue-500"
+              href={`/space/${workspaceId}/inbox?conversationId=${contact.conversationId}`}
+              target="_blank"
+            >
+              <span className="truncate font-medium text-sm leading-tight">
+                {contact.fullName}
+              </span>
+            </Link>
+          ) : (
             <span className="truncate font-medium text-sm leading-tight">
               {contact.fullName}
             </span>
-          </Link>
+          )}
           <InboxIcon
             channel={contact.channel || ""}
             showLabel={false}
@@ -457,13 +484,13 @@ const SelectableContactItem = memo(function SelectableContactItem({
         )}
       </div>
 
-      <div className="flex min-w-0 flex-1 items-center">
-        {contact.errorContent && (
+      <div className="flex min-w-0 flex-1 items-center justify-center self-center">
+        {showErrors && contact.errorContent && (
           <div
             className="space-y-0 whitespace-pre-wrap text-left text-destructive text-xs"
             style={{ overflowWrap: "anywhere" }}
           >
-            {contact.errorContent}
+            {formatErrorContent(contact.errorContent)}
           </div>
         )}
       </div>

--- a/apps/builder/src/features/common/lib/format-error-content.ts
+++ b/apps/builder/src/features/common/lib/format-error-content.ts
@@ -1,0 +1,18 @@
+export function formatErrorContent(errorContent: string): string {
+  try {
+    const parsed: unknown = JSON.parse(errorContent)
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "message" in parsed &&
+      typeof parsed.message === "string" &&
+      parsed.message.trim()
+    ) {
+      return parsed.message
+    }
+  } catch {
+    return errorContent
+  }
+
+  return errorContent
+}

--- a/apps/builder/src/features/contact-filter/components/contact-filter-summary.tsx
+++ b/apps/builder/src/features/contact-filter/components/contact-filter-summary.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+import type { ContactFilterCriteria } from "../schemas"
+import {
+  formatConditionValueDisplay,
+  getConditionOptions,
+  getFieldConfigs,
+} from "./contact-filter-config"
+
+type ContactFilterSummaryProps = {
+  contactFilter?: ContactFilterCriteria | null
+}
+
+export function ContactFilterSummary({
+  contactFilter,
+}: ContactFilterSummaryProps) {
+  const t = useTranslations()
+
+  if (!contactFilter || contactFilter.conditions.length === 0) {
+    return (
+      <div className="text-muted-foreground text-sm">
+        {t("broadcasts.detail.noAudienceFilter")}
+      </div>
+    )
+  }
+
+  const configs = getFieldConfigs({
+    t,
+    tagOptions: [],
+    inboxOptions: [],
+    customFields: [],
+    flowVersionOptions: [],
+    broadcastOptions: [],
+    sequenceOptions: [],
+    reflinkOptions: [],
+    assigneeOptions: [],
+  })
+  const operatorLabelByValue = new Map(
+    getConditionOptions(t).map((option) => [option.value, option.label]),
+  )
+  const operatorLabel =
+    contactFilter.operator === "and"
+      ? t("condition.operator.and")
+      : t("condition.operator.or")
+  const conditionKeyCounts = new Map<string, number>()
+
+  return (
+    <div className="space-y-2">
+      <div className="text-muted-foreground text-xs uppercase">
+        {operatorLabel}
+      </div>
+      <div className="space-y-2">
+        {contactFilter.conditions.map((condition) => {
+          const isCustomField = condition.field === "customField"
+          const fieldConfig = configs.find((config) =>
+            isCustomField && "customFieldId" in condition
+              ? String(config.customFieldId) === String(condition.customFieldId)
+              : config.name === condition.field,
+          )
+          const fieldLabel =
+            fieldConfig?.label ??
+            (isCustomField
+              ? t("fields.customField.label")
+              : t(`condition.fields.${condition.field}`))
+          const conditionOperator =
+            operatorLabelByValue.get(condition.operator) ?? condition.operator
+          const valueDisplay = formatConditionValueDisplay(
+            "value" in condition ? condition.value : undefined,
+            fieldConfig?.options,
+          )
+          const conditionKey = [
+            condition.field,
+            "customFieldId" in condition ? condition.customFieldId : "",
+            condition.operator,
+            valueDisplay,
+          ].join(":")
+          const conditionKeyCount = conditionKeyCounts.get(conditionKey) ?? 0
+          conditionKeyCounts.set(conditionKey, conditionKeyCount + 1)
+
+          return (
+            <div
+              className="rounded-md border bg-background px-3 py-2 text-sm"
+              key={
+                conditionKeyCount === 0
+                  ? conditionKey
+                  : `${conditionKey}:${conditionKeyCount}`
+              }
+            >
+              <span className="font-medium">{fieldLabel}</span>{" "}
+              <span className="italic">{conditionOperator}</span>{" "}
+              {valueDisplay && <span>{valueDisplay}</span>}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/builder/src/features/contacts/api/authenticated.ts
+++ b/apps/builder/src/features/contacts/api/authenticated.ts
@@ -12,7 +12,10 @@ import { requireContactPermissionScope } from "../permissions"
 import { getContact } from "../queries/get-contact.query"
 import { getExportFile } from "../queries/get-export-file.query"
 import { listContactCustomFields } from "../queries/list-contact-fields.query"
-import { countContactInboxes } from "../queries/list-contact-inboxes.queries"
+import {
+  countContactInboxes,
+  listAudienceInboxesPreview,
+} from "../queries/list-contact-inboxes.queries"
 import { listContactTags } from "../queries/list-contact-tags.query"
 import { countContacts, listContacts } from "../queries/list-contacts.queries"
 import {
@@ -36,6 +39,8 @@ import {
 import {
   getContactRequest,
   getContactResponse,
+  listContactInboxesAudiencePreviewRequest,
+  listContactInboxesAudiencePreviewResponse,
   listContactsRequest,
   listContactsResponse,
 } from "../schemas/query"
@@ -109,8 +114,23 @@ export const contactsAuthenticatedAPI = {
     .use(workspaceAuthorizedMidddleware, (input) => input.workspaceId)
     .output(z.object({ total: z.number() }))
     .handler(async ({ input }) => {
-      await requireContactPermissionScope(input.workspaceId)
-      return await countContactInboxes(input)
+      const accessScope = await requireContactPermissionScope(input.workspaceId)
+      return await countContactInboxes(input, accessScope)
+    }),
+
+  listContactInboxesAudiencePreviewAuthenticatedAPI: authorizedAPI
+    .route({
+      method: "POST",
+      path: "/workspaces/{workspaceId}/contacts/inboxes/audience-preview",
+      summary: "List audience contact inboxes preview",
+      tags: ["Contacts"],
+    })
+    .input(listContactInboxesAudiencePreviewRequest)
+    .use(workspaceAuthorizedMidddleware, (input) => input.workspaceId)
+    .output(listContactInboxesAudiencePreviewResponse)
+    .handler(async ({ input }) => {
+      const accessScope = await requireContactPermissionScope(input.workspaceId)
+      return await listAudienceInboxesPreview(input, accessScope)
     }),
 
   createContactAuthenticatedAPI: authorizedAPI

--- a/apps/builder/src/features/contacts/queries/list-contact-inboxes.queries.ts
+++ b/apps/builder/src/features/contacts/queries/list-contact-inboxes.queries.ts
@@ -1,9 +1,14 @@
 import { broadcastService } from "@chatbotx.io/business"
 import { assertCurrentUserCanAccessChatbot } from "@/lib/auth/utils"
-import type { ListContactsRequest } from "../schemas/query"
+import type { ContactPermissionScope } from "../permissions"
+import type {
+  ListContactInboxesAudiencePreviewRequest,
+  ListContactsRequest,
+} from "../schemas/query"
 
 export async function countContactInboxes(
   input: ListContactsRequest,
+  accessScope?: ContactPermissionScope,
 ): Promise<{ total: number }> {
   await assertCurrentUserCanAccessChatbot(input.workspaceId)
 
@@ -14,7 +19,34 @@ export async function countContactInboxes(
     integrationMessengerId: input.integrationMessengerId,
     contactFilter: input.contactFilter,
     subaction: input.subaction,
+    restrictToAssignedUserId: accessScope?.restrictToAssignedUserId,
   })
 
   return { total }
+}
+
+export async function listAudienceInboxesPreview(
+  input: ListContactInboxesAudiencePreviewRequest,
+  accessScope?: ContactPermissionScope,
+) {
+  await assertCurrentUserCanAccessChatbot(input.workspaceId)
+
+  const data = await broadcastService.listAudiencePreview({
+    workspaceId: input.workspaceId,
+    channels: input.channels,
+    integrationWhatsappId: input.integrationWhatsappId,
+    integrationMessengerId: input.integrationMessengerId,
+    contactFilter: input.contactFilter,
+    subaction: input.subaction,
+    page: input.page ?? 1,
+    perPage: input.perPage ?? 20,
+    restrictToAssignedUserId: accessScope?.restrictToAssignedUserId,
+  })
+
+  return {
+    data: data.map(({ createdAt, ...row }) => ({
+      ...row,
+      occurredAt: createdAt.toISOString(),
+    })),
+  }
 }

--- a/apps/builder/src/features/contacts/schemas/query.ts
+++ b/apps/builder/src/features/contacts/schemas/query.ts
@@ -61,6 +61,30 @@ export const listContactsRequest = basePaginationRequest.extend({
 })
 export type ListContactsRequest = z.infer<typeof listContactsRequest>
 
+export const listContactInboxesAudiencePreviewRequest =
+  listContactsRequest.extend({
+    perPage: z.coerce.number().int().min(1).max(50).nullish(),
+  })
+export type ListContactInboxesAudiencePreviewRequest = z.infer<
+  typeof listContactInboxesAudiencePreviewRequest
+>
+
+export const audiencePreviewContactResource = z.object({
+  contactId: z.string(),
+  contactInboxId: z.string(),
+  firstName: z.string().nullable(),
+  lastName: z.string().nullable(),
+  fullName: z.string().nullable(),
+  avatar: z.string().nullable(),
+  occurredAt: z.string().nullable(),
+  channel: channelTypes,
+  conversationId: z.string().nullable(),
+})
+
+export const listContactInboxesAudiencePreviewResponse = z.object({
+  data: z.array(audiencePreviewContactResource),
+})
+
 export const contactResponse = contactResource.and(
   z.object({
     contactCustomFields: z.array(contactCustomFieldResource).optional(),

--- a/apps/builder/src/features/sequences/components/sequence-step-contacts-dialog.tsx
+++ b/apps/builder/src/features/sequences/components/sequence-step-contacts-dialog.tsx
@@ -111,6 +111,7 @@ export const SequenceStepContactsDialog = memo(
         onManualTag={onManualTag}
         onOpenChange={onOpenChange}
         open={open}
+        showErrors={eventType === "message:failed"}
         title={t(`sequences.stats.${eventTypeToLabel[eventType]}`)}
         total={total}
         workspaceId={workspaceId}

--- a/packages/business/src/broadcast/__tests__/broadcast.service.test.ts
+++ b/packages/business/src/broadcast/__tests__/broadcast.service.test.ts
@@ -3,7 +3,12 @@ import { beforeEach, describe, expect, test, vi } from "vitest"
 const mocks = vi.hoisted(() => ({
   resolveBroadcastInboxIds: vi.fn(),
   count: vi.fn(),
+  findBroadcast: vi.fn(),
+  selectRows: [] as Record<string, unknown>[],
+  selectInnerJoin: vi.fn(),
+  selectLeftJoin: vi.fn(),
   selectLimit: vi.fn(),
+  selectOffset: vi.fn(),
   selectOrderBy: vi.fn(),
   selectWhere: vi.fn(),
   chunkById: vi.fn(),
@@ -35,41 +40,112 @@ vi.mock("@chatbotx.io/database/schema", () => ({
     id: "ContactInbox.id",
     inboxId: "ContactInbox.inboxId",
     contactId: "ContactInbox.contactId",
+    channel: "ContactInbox.channel",
+  },
+  contactModel: {
+    id: "Contact.id",
+    firstName: "Contact.firstName",
+    lastName: "Contact.lastName",
+    fullName: "Contact.fullName",
+    avatar: "Contact.avatar",
+    createdAt: "Contact.createdAt",
+    workspaceId: "Contact.workspaceId",
+  },
+  conversationModel: {
+    id: "Conversation.id",
+    contactId: "Conversation.contactId",
+    sourceId: "Conversation.sourceId",
+    workspaceId: "Conversation.workspaceId",
+    assignedUserId: "Conversation.assignedUserId",
+  },
+  integrationMessengerModel: {
+    id: "IntegrationMessenger.id",
+    name: "IntegrationMessenger.name",
+    workspaceId: "IntegrationMessenger.workspaceId",
+  },
+  integrationWhatsappModel: {
+    id: "IntegrationWhatsapp.id",
+    name: "IntegrationWhatsapp.name",
+    workspaceId: "IntegrationWhatsapp.workspaceId",
+  },
+  messengerMessageTemplateModel: {
+    id: "MessengerMessageTemplate.id",
+    name: "MessengerMessageTemplate.name",
+    language: "MessengerMessageTemplate.language",
+    category: "MessengerMessageTemplate.category",
+    status: "MessengerMessageTemplate.status",
+    parameterFormat: "MessengerMessageTemplate.parameterFormat",
+    components: "MessengerMessageTemplate.components",
+    integrationMessengerId: "MessengerMessageTemplate.integrationMessengerId",
+  },
+  whatsappMessageTemplateModel: {
+    id: "WhatsappMessageTemplate.id",
+    name: "WhatsappMessageTemplate.name",
+    language: "WhatsappMessageTemplate.language",
+    category: "WhatsappMessageTemplate.category",
+    status: "WhatsappMessageTemplate.status",
+    components: "WhatsappMessageTemplate.components",
+    integrationWhatsappId: "WhatsappMessageTemplate.integrationWhatsappId",
   },
 }))
 
 vi.mock("@chatbotx.io/database/client", () => ({
   db: {
     $count: mocks.count,
-    select: () => ({
-      from: () => ({
+    query: {
+      broadcastModel: {
+        findFirst: mocks.findBroadcast,
+      },
+    },
+    select: (selection?: Record<string, unknown>) => {
+      const isAudiencePreview = Boolean(selection?.contactId)
+      const isCountSelect = Boolean(selection?.count)
+      const builder = {
+        from: () => builder,
+        innerJoin: (...args: unknown[]) => {
+          mocks.selectInnerJoin(args)
+          return builder
+        },
+        leftJoin: (...args: unknown[]) => {
+          mocks.selectLeftJoin(args)
+          return builder
+        },
         where: (where: unknown) => {
           mocks.selectWhere(where)
-          return {
-            orderBy: (orderBy: unknown) => {
-              mocks.selectOrderBy(orderBy)
-              return {
-                limit: (limit: number) => {
-                  mocks.selectLimit(limit)
-                  return Promise.resolve([])
-                },
-              }
-            },
-            limit: (limit: number) => {
-              mocks.selectLimit(limit)
-              return Promise.resolve([])
-            },
+          if (isCountSelect) {
+            return Promise.resolve(mocks.selectRows)
           }
+          return builder
         },
-      }),
-    }),
+        orderBy: (orderBy: unknown) => {
+          mocks.selectOrderBy(orderBy)
+          return builder
+        },
+        limit: (limit: number) => {
+          mocks.selectLimit(limit)
+          if (isAudiencePreview) {
+            return {
+              offset: (offset: number) => {
+                mocks.selectOffset(offset)
+                return Promise.resolve(mocks.selectRows)
+              },
+            }
+          }
+          return Promise.resolve(mocks.selectRows)
+        },
+      }
+
+      return builder
+    },
   },
   and: (...args: unknown[]) => ({ __and: args }),
   asc: (value: unknown) => ({ __asc: value }),
+  count: () => "count()",
   desc: (value: unknown) => ({ __desc: value }),
   eq: (left: unknown, right: unknown) => ({ __eq: [left, right] }),
   gt: (left: unknown, right: unknown) => ({ __gt: [left, right] }),
   inArray: (left: unknown, right: unknown) => ({ __inArray: [left, right] }),
+  isNull: (value: unknown) => ({ __isNull: value }),
 }))
 
 vi.mock("@chatbotx.io/database/queries", () => ({
@@ -97,7 +173,12 @@ const contactFilter = {
 beforeEach(() => {
   mocks.resolveBroadcastInboxIds.mockReset()
   mocks.count.mockReset()
+  mocks.findBroadcast.mockReset()
+  mocks.selectRows = []
+  mocks.selectInnerJoin.mockReset()
+  mocks.selectLeftJoin.mockReset()
   mocks.selectLimit.mockReset()
+  mocks.selectOffset.mockReset()
   mocks.selectOrderBy.mockReset()
   mocks.selectWhere.mockReset()
   mocks.chunkById.mockReset()
@@ -202,6 +283,239 @@ describe("broadcastService.countAudience", () => {
       channels: ["messenger"],
       integrationWhatsappId: undefined,
       integrationMessengerId: "messenger-1",
+    })
+  })
+
+  test("counts only assigned DM conversations for restricted contact scope", async () => {
+    mocks.resolveBroadcastInboxIds.mockResolvedValue(["inbox-1"])
+    mocks.selectRows = [{ count: 2 }]
+
+    const total = await broadcastService.countAudience({
+      workspaceId: "ws-1",
+      channels: ["messenger"],
+      restrictToAssignedUserId: "user-1",
+    })
+
+    expect(total).toBe(2)
+    expect(mocks.count).not.toHaveBeenCalled()
+    expect(mocks.selectInnerJoin).toHaveBeenCalledWith([
+      expect.anything(),
+      {
+        __and: [
+          { __eq: ["Conversation.contactId", "ContactInbox.contactId"] },
+          { __isNull: "Conversation.sourceId" },
+        ],
+      },
+    ])
+    expect(mocks.selectWhere).toHaveBeenCalledWith(
+      expect.objectContaining({
+        __and: expect.arrayContaining([
+          expect.objectContaining({
+            __and: expect.arrayContaining([
+              { __inArray: ["ContactInbox.inboxId", ["inbox-1"]] },
+            ]),
+          }),
+          {
+            __and: [
+              { __eq: ["Conversation.workspaceId", "ws-1"] },
+              { __eq: ["Conversation.assignedUserId", "user-1"] },
+            ],
+          },
+        ]),
+      }),
+    )
+  })
+})
+
+describe("broadcastService.listAudiencePreview", () => {
+  test("returns an empty preview without querying when no inboxes resolve", async () => {
+    mocks.resolveBroadcastInboxIds.mockResolvedValue([])
+
+    const rows = await broadcastService.listAudiencePreview({
+      workspaceId: "ws-1",
+      channels: ["messenger"],
+    })
+
+    expect(rows).toEqual([])
+    expect(mocks.selectWhere).not.toHaveBeenCalled()
+  })
+
+  test("joins contacts and the bounded DM conversation for a paginated preview", async () => {
+    mocks.resolveBroadcastInboxIds.mockResolvedValue(["inbox-1"])
+    mocks.selectRows = [
+      {
+        contactId: "contact-1",
+        contactInboxId: "contact-inbox-1",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        fullName: "Ada Lovelace",
+        avatar: null,
+        createdAt: new Date("2026-01-01T10:00:00.000Z"),
+        channel: "messenger",
+        conversationId: "conversation-1",
+      },
+    ]
+
+    const rows = await broadcastService.listAudiencePreview({
+      workspaceId: "ws-1",
+      channels: ["messenger"],
+      contactFilter,
+      page: 3,
+      perPage: 10,
+    })
+
+    expect(rows).toEqual(mocks.selectRows)
+    expect(mocks.selectLeftJoin).toHaveBeenCalledWith([
+      expect.anything(),
+      {
+        __and: [
+          {
+            __eq: ["Conversation.contactId", "ContactInbox.contactId"],
+          },
+          { __isNull: "Conversation.sourceId" },
+        ],
+      },
+    ])
+    expect(mocks.selectWhere).toHaveBeenCalledWith(
+      expect.objectContaining({
+        __and: expect.arrayContaining([
+          expect.objectContaining({
+            __and: expect.arrayContaining([
+              { __inArray: ["ContactInbox.inboxId", ["inbox-1"]] },
+              { RAW: "contact-filter" },
+            ]),
+          }),
+          { __eq: ["Contact.workspaceId", "ws-1"] },
+        ]),
+      }),
+    )
+    expect(mocks.selectOrderBy).toHaveBeenCalledWith({
+      __asc: "ContactInbox.id",
+    })
+    expect(mocks.selectLimit).toHaveBeenCalledWith(10)
+    expect(mocks.selectOffset).toHaveBeenCalledWith(20)
+  })
+
+  test("caps preview page size at fifty rows", async () => {
+    mocks.resolveBroadcastInboxIds.mockResolvedValue(["inbox-1"])
+
+    await broadcastService.listAudiencePreview({
+      workspaceId: "ws-1",
+      channels: ["messenger"],
+      page: 1,
+      perPage: 500,
+    })
+
+    expect(mocks.selectLimit).toHaveBeenCalledWith(50)
+  })
+
+  test("filters preview rows to assigned DM conversations for restricted contact scope", async () => {
+    mocks.resolveBroadcastInboxIds.mockResolvedValue(["inbox-1"])
+
+    await broadcastService.listAudiencePreview({
+      workspaceId: "ws-1",
+      channels: ["messenger"],
+      restrictToAssignedUserId: "user-1",
+    })
+
+    expect(mocks.selectWhere).toHaveBeenCalledWith(
+      expect.objectContaining({
+        __and: expect.arrayContaining([
+          { __eq: ["Contact.workspaceId", "ws-1"] },
+          {
+            __and: [
+              { __eq: ["Conversation.workspaceId", "ws-1"] },
+              { __eq: ["Conversation.assignedUserId", "user-1"] },
+            ],
+          },
+        ]),
+      }),
+    )
+  })
+})
+
+describe("broadcastService.getTemplateDetail", () => {
+  test("returns null when the broadcast has no template", async () => {
+    mocks.findBroadcast.mockResolvedValue({
+      templateId: null,
+      channel: "whatsapp",
+    })
+
+    const detail = await broadcastService.getTemplateDetail({
+      workspaceId: "ws-1",
+      broadcastId: "broadcast-1",
+    })
+
+    expect(detail).toBeNull()
+    expect(mocks.selectWhere).not.toHaveBeenCalled()
+  })
+
+  test("loads a whatsapp template scoped through its integration workspace", async () => {
+    mocks.findBroadcast.mockResolvedValue({
+      templateId: "template-1",
+      channel: "whatsapp",
+    })
+    mocks.selectRows = [
+      {
+        id: "template-1",
+        name: "Order update",
+        language: "en",
+        category: "UTILITY",
+        status: "APPROVED",
+        components: [],
+        integrationName: "WhatsApp Main",
+      },
+    ]
+
+    const detail = await broadcastService.getTemplateDetail({
+      workspaceId: "ws-1",
+      broadcastId: "broadcast-1",
+    })
+
+    expect(detail).toEqual({
+      ...mocks.selectRows[0],
+      channel: "whatsapp",
+    })
+    expect(mocks.selectWhere).toHaveBeenCalledWith({
+      __and: [
+        { __eq: ["WhatsappMessageTemplate.id", "template-1"] },
+        { __eq: ["IntegrationWhatsapp.workspaceId", "ws-1"] },
+      ],
+    })
+  })
+
+  test("loads a messenger template with its integration name", async () => {
+    mocks.findBroadcast.mockResolvedValue({
+      templateId: "template-2",
+      channel: "messenger",
+    })
+    mocks.selectRows = [
+      {
+        id: "template-2",
+        name: "Promo",
+        language: "en",
+        category: "MARKETING",
+        status: "APPROVED",
+        parameterFormat: "POSITIONAL",
+        components: [],
+        integrationName: "Messenger Page",
+      },
+    ]
+
+    const detail = await broadcastService.getTemplateDetail({
+      workspaceId: "ws-1",
+      broadcastId: "broadcast-1",
+    })
+
+    expect(detail).toEqual({
+      ...mocks.selectRows[0],
+      channel: "messenger",
+    })
+    expect(mocks.selectWhere).toHaveBeenCalledWith({
+      __and: [
+        { __eq: ["MessengerMessageTemplate.id", "template-2"] },
+        { __eq: ["IntegrationMessenger.workspaceId", "ws-1"] },
+      ],
     })
   })
 })

--- a/packages/business/src/broadcast/schema.ts
+++ b/packages/business/src/broadcast/schema.ts
@@ -11,4 +11,36 @@ export type BroadcastAudienceInput = {
   integrationMessengerId?: string | null
   contactFilter?: ContactFilterCriteriaInput | null
   subaction?: BroadcastSubaction | null
+  restrictToAssignedUserId?: string
 }
+
+export type BroadcastAudiencePreviewRow = {
+  contactId: string
+  contactInboxId: string
+  firstName: string | null
+  lastName: string | null
+  fullName: string | null
+  avatar: string | null
+  createdAt: Date
+  channel: ChannelType
+  conversationId: string | null
+}
+
+type BroadcastBaseTemplateDetail = {
+  id: string
+  name: string
+  language: string
+  category: string
+  status: string
+  components: unknown
+  integrationName: string | null
+}
+
+export type BroadcastTemplateDetail =
+  | (BroadcastBaseTemplateDetail & {
+      channel: "whatsapp"
+    })
+  | (BroadcastBaseTemplateDetail & {
+      channel: "messenger"
+      parameterFormat: string
+    })

--- a/packages/business/src/broadcast/service.ts
+++ b/packages/business/src/broadcast/service.ts
@@ -1,11 +1,13 @@
 import {
   and,
   asc,
+  count,
   db,
   desc,
   eq,
   gt,
   inArray,
+  isNull,
   type SQL,
 } from "@chatbotx.io/database/client"
 import {
@@ -16,14 +18,29 @@ import {
   buildContactInboxContactFilterSQL,
   contactInboxInteractedWithin24hSQL,
 } from "@chatbotx.io/database/queries"
-import { broadcastModel, contactInboxModel } from "@chatbotx.io/database/schema"
+import {
+  broadcastModel,
+  contactInboxModel,
+  contactModel,
+  conversationModel,
+  integrationMessengerModel,
+  integrationWhatsappModel,
+  messengerMessageTemplateModel,
+  whatsappMessageTemplateModel,
+} from "@chatbotx.io/database/schema"
 import { chunkById } from "@chatbotx.io/database/utils"
 import { BaseService } from "../base.service"
 import { inboxService } from "../inbox/service"
-import type { BroadcastAudienceInput } from "./schema"
+import type {
+  BroadcastAudienceInput,
+  BroadcastAudiencePreviewRow,
+  BroadcastTemplateDetail,
+} from "./schema"
 
 const DEFAULT_CHUNK_SIZE = 1000
 const OPTION_LIST_LIMIT = 500
+const DEFAULT_PREVIEW_PER_PAGE = 20
+const MAX_PREVIEW_PER_PAGE = 50
 
 type ContactInboxRow = typeof contactInboxModel.$inferSelect
 type SelectOptionRow = { id: string; name: string }
@@ -77,16 +94,181 @@ class BroadcastService extends BaseService {
     })
   }
 
+  private buildDmConversationJoin(): SQL | undefined {
+    return and(
+      eq(conversationModel.contactId, contactInboxModel.contactId),
+      isNull(conversationModel.sourceId),
+    )
+  }
+
+  private buildAssignedConversationWhere(
+    input: BroadcastAudienceInput,
+  ): SQL | undefined {
+    return input.restrictToAssignedUserId
+      ? and(
+          eq(conversationModel.workspaceId, input.workspaceId),
+          eq(conversationModel.assignedUserId, input.restrictToAssignedUserId),
+        )
+      : undefined
+  }
+
   async countAudience(input: BroadcastAudienceInput): Promise<number> {
     const inboxIds = await this.resolveInboxIds(input)
     if (inboxIds.length === 0) {
       return 0
     }
 
+    if (input.restrictToAssignedUserId) {
+      const [result] = await db
+        .select({ count: count() })
+        .from(contactInboxModel)
+        .innerJoin(conversationModel, this.buildDmConversationJoin())
+        .where(
+          and(
+            this.buildAudienceWhere(inboxIds, input),
+            this.buildAssignedConversationWhere(input),
+          ),
+        )
+
+      return result?.count ?? 0
+    }
+
     return db.$count(
       contactInboxModel,
       this.buildAudienceWhere(inboxIds, input),
     )
+  }
+
+  async listAudiencePreview(
+    input: BroadcastAudienceInput & {
+      page?: number | null
+      perPage?: number | null
+    },
+  ): Promise<BroadcastAudiencePreviewRow[]> {
+    const inboxIds = await this.resolveInboxIds(input)
+    if (inboxIds.length === 0) {
+      return []
+    }
+
+    const page = Math.max(1, input.page ?? 1)
+    const perPage = Math.min(
+      MAX_PREVIEW_PER_PAGE,
+      Math.max(1, input.perPage ?? DEFAULT_PREVIEW_PER_PAGE),
+    )
+
+    const rows = await db
+      .select({
+        contactId: contactModel.id,
+        contactInboxId: contactInboxModel.id,
+        firstName: contactModel.firstName,
+        lastName: contactModel.lastName,
+        fullName: contactModel.fullName,
+        avatar: contactModel.avatar,
+        createdAt: contactModel.createdAt,
+        channel: contactInboxModel.channel,
+        conversationId: conversationModel.id,
+      })
+      .from(contactInboxModel)
+      .innerJoin(contactModel, eq(contactModel.id, contactInboxModel.contactId))
+      .leftJoin(conversationModel, this.buildDmConversationJoin())
+      .where(
+        and(
+          this.buildAudienceWhere(inboxIds, input),
+          eq(contactModel.workspaceId, input.workspaceId),
+          this.buildAssignedConversationWhere(input),
+        ),
+      )
+      .orderBy(asc(contactInboxModel.id))
+      .limit(perPage)
+      .offset((page - 1) * perPage)
+
+    return rows.map((row) => ({
+      ...row,
+      channel: row.channel as ChannelType,
+    }))
+  }
+
+  async getTemplateDetail(input: {
+    workspaceId: string
+    broadcastId: string
+  }): Promise<BroadcastTemplateDetail | null> {
+    const broadcast = await db.query.broadcastModel.findFirst({
+      where: {
+        id: input.broadcastId,
+        workspaceId: input.workspaceId,
+      },
+      columns: {
+        templateId: true,
+        channel: true,
+      },
+    })
+
+    if (!broadcast?.templateId) {
+      return null
+    }
+
+    if (broadcast.channel === "whatsapp") {
+      const [template] = await db
+        .select({
+          id: whatsappMessageTemplateModel.id,
+          name: whatsappMessageTemplateModel.name,
+          language: whatsappMessageTemplateModel.language,
+          category: whatsappMessageTemplateModel.category,
+          status: whatsappMessageTemplateModel.status,
+          components: whatsappMessageTemplateModel.components,
+          integrationName: integrationWhatsappModel.name,
+        })
+        .from(whatsappMessageTemplateModel)
+        .innerJoin(
+          integrationWhatsappModel,
+          eq(
+            integrationWhatsappModel.id,
+            whatsappMessageTemplateModel.integrationWhatsappId,
+          ),
+        )
+        .where(
+          and(
+            eq(whatsappMessageTemplateModel.id, broadcast.templateId),
+            eq(integrationWhatsappModel.workspaceId, input.workspaceId),
+          ),
+        )
+        .limit(1)
+
+      return template ? { ...template, channel: "whatsapp" } : null
+    }
+
+    if (broadcast.channel === "messenger") {
+      const [template] = await db
+        .select({
+          id: messengerMessageTemplateModel.id,
+          name: messengerMessageTemplateModel.name,
+          language: messengerMessageTemplateModel.language,
+          category: messengerMessageTemplateModel.category,
+          status: messengerMessageTemplateModel.status,
+          parameterFormat: messengerMessageTemplateModel.parameterFormat,
+          components: messengerMessageTemplateModel.components,
+          integrationName: integrationMessengerModel.name,
+        })
+        .from(messengerMessageTemplateModel)
+        .innerJoin(
+          integrationMessengerModel,
+          eq(
+            integrationMessengerModel.id,
+            messengerMessageTemplateModel.integrationMessengerId,
+          ),
+        )
+        .where(
+          and(
+            eq(messengerMessageTemplateModel.id, broadcast.templateId),
+            eq(integrationMessengerModel.workspaceId, input.workspaceId),
+          ),
+        )
+        .limit(1)
+
+      return template ? { ...template, channel: "messenger" } : null
+    }
+
+    return null
   }
 
   async forEachAudienceChunk(

--- a/packages/database/src/relations/broadcast.ts
+++ b/packages/database/src/relations/broadcast.ts
@@ -14,6 +14,10 @@ export const broadcastRelations = defineRelationsPart(schema, (r) => ({
       ),
       to: r.contactModel.id.through(r.contactsOnBroadcastsModel.contactId),
     }),
+    flow: r.one.flowModel({
+      from: r.broadcastModel.flowId,
+      to: r.flowModel.id,
+    }),
     integrationWhatsapp: r.one.integrationWhatsappModel({
       from: r.broadcastModel.integrationWhatsappId,
       to: r.integrationWhatsappModel.id,

--- a/packages/ui/src/types/data-table.ts
+++ b/packages/ui/src/types/data-table.ts
@@ -44,7 +44,16 @@ export interface ExtendedColumnFilter<TData> extends FilterItemSchema {
 
 export interface DataTableRowAction<TData> {
   row: Row<TData>
-  variant: "update" | "delete" | "duplicate" | "rename" | "resend" | "enable" | "move" | "copyUrl"
+  variant:
+    | "update"
+    | "delete"
+    | "duplicate"
+    | "rename"
+    | "resend"
+    | "view"
+    | "enable"
+    | "move"
+    | "copyUrl"
 }
 
 export type { ColumnDef } from "@tanstack/react-table"


### PR DESCRIPTION
## Summary

When preparing a broadcast, it was hard to know exactly who would receive it, and once a broadcast was created there was no way to look back at how it was set up. Error lists were also cluttered with raw data that was hard to read.

This update makes broadcasts easier to trust and review:

- **See who will receive your broadcast** — while creating a broadcast, the receivers number is now clickable and opens a list of everyone who matches your audience, so you can double-check before sending.
- **Review any broadcast at a glance** — a new "View" option in the broadcast list shows the full setup of a broadcast: its audience, message content, and schedule.
- **Clearer error messages** — when a message fails, the failed list now shows a short, readable reason. Other lists (sent, delivered, seen, clicked) no longer show error text at all.

## Test plan

- [x] All checks pass (lint, types, tests for the affected areas)
- [ ] Create a broadcast, click the receivers number, and confirm the list matches the chosen audience
- [ ] Confirm the receivers list is view-only (no tagging or selection)
- [ ] Open "View" from the broadcast list and confirm the audience, message, and schedule are shown correctly
- [ ] Click "Failed" on a finished broadcast and confirm a readable reason is shown; other counters show no error text
- [ ] Confirm rename and resend still work as before