### PR TITLE
fix(analytics): count monthly active contacts for every outgoing message

### DIFF
--- a/apps/builder/__tests__/messenger-select-page.test.tsx
+++ b/apps/builder/__tests__/messenger-select-page.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment node
+
+import type { ConnectableFacebookPage } from "@chatbotx.io/integration-messenger/schema"
+import { isValidElement } from "react"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+  mockCookies,
+  mockDecryptAuth,
+  mockFindConnectedMessengerPageIds,
+  mockGetUserPages,
+  mockRedirect,
+  mockSelectPage,
+} = vi.hoisted(() => ({
+  mockCookies: vi.fn(),
+  mockDecryptAuth: vi.fn(),
+  mockFindConnectedMessengerPageIds: vi.fn(),
+  mockGetUserPages: vi.fn(),
+  mockRedirect: vi.fn((path: string) => {
+    throw new Error(`redirect:${path}`)
+  }),
+  mockSelectPage: vi.fn(() => null),
+}))
+
+vi.mock("next/headers", () => ({
+  cookies: mockCookies,
+}))
+
+vi.mock("next/navigation", () => ({
+  redirect: mockRedirect,
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  findConnectedMessengerPageIds: mockFindConnectedMessengerPageIds,
+}))
+
+vi.mock("@chatbotx.io/integration-messenger", () => ({
+  getUserPages: mockGetUserPages,
+}))
+
+vi.mock("@/lib/facebook-pending-auth", () => ({
+  decryptAuth: mockDecryptAuth,
+  FB_MESSENGER_PENDING_AUTH_COOKIE: "fb_messenger_pending_auth",
+}))
+
+vi.mock("@/features/integration-messenger/components/select-account", () => ({
+  SelectPage: mockSelectPage,
+}))
+
+const { default: MessengerSelectPage } = await import(
+  "../src/app/(no-sidebar)/channels/messenger/select/page"
+)
+
+type SelectPageElementProps = {
+  pages: Array<{
+    id: string
+    isAlreadyConnected: boolean
+  }>
+}
+
+const connectablePage: ConnectableFacebookPage = {
+  id: "page-connectable",
+  name: "Connectable Page",
+  access_token: "page-token",
+  isConnectable: true,
+}
+
+const connectedWithoutPermissionPage: ConnectableFacebookPage = {
+  id: "page-connected",
+  name: "Connected Page",
+  isConnectable: false,
+}
+
+const unavailablePage: ConnectableFacebookPage = {
+  id: "page-unavailable",
+  name: "Unavailable Page",
+  isConnectable: false,
+}
+
+describe("MessengerSelectPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCookies.mockResolvedValue({
+      get: vi.fn(() => ({ value: "encrypted-auth" })),
+    })
+    mockDecryptAuth.mockResolvedValue({
+      userToken: "user-token",
+      version: "v23.0",
+      referer: "/channels/create",
+      workspaceId: "ws-1",
+    })
+    mockGetUserPages.mockResolvedValue({
+      pages: [unavailablePage, connectedWithoutPermissionPage, connectablePage],
+      bmLookupFailed: false,
+    })
+    mockFindConnectedMessengerPageIds.mockResolvedValue(["page-connected"])
+  })
+
+  test("passes only connectable or already-connected pages to the picker", async () => {
+    const element = await MessengerSelectPage()
+
+    expect(isValidElement<SelectPageElementProps>(element)).toBe(true)
+    if (!isValidElement<SelectPageElementProps>(element)) {
+      throw new Error("MessengerSelectPage did not return a valid element")
+    }
+
+    expect(element.props.pages).toEqual([
+      expect.objectContaining({
+        id: "page-connectable",
+        isAlreadyConnected: false,
+      }),
+      expect.objectContaining({
+        id: "page-connected",
+        isAlreadyConnected: true,
+      }),
+    ])
+  })
+
+  test("redirects to channel creation when pending auth is missing", async () => {
+    mockCookies.mockResolvedValue({
+      get: vi.fn(() => undefined),
+    })
+    mockDecryptAuth.mockResolvedValue(null)
+
+    await expect(MessengerSelectPage()).rejects.toThrow(
+      "redirect:/channels/create",
+    )
+  })
+})

--- a/apps/builder/src/app/(no-sidebar)/channels/messenger/select/page.tsx
+++ b/apps/builder/src/app/(no-sidebar)/channels/messenger/select/page.tsx
@@ -13,14 +13,15 @@ import {
 export const dynamic = "force-dynamic"
 
 /**
- * Picker ordering (mirrors v1): selectable pages first, then pages already
- * connected elsewhere, then pages the user lacks admin permission on.
+ * Picker ordering: selectable pages first, then pages already connected
+ * elsewhere. Unconnected pages without connect permission are hidden.
  */
 function rankPickerPage(page: PickerFacebookPage): number {
-  if (page.isAlreadyConnected) {
-    return 1
-  }
-  return page.isConnectable ? 0 : 2
+  return page.isAlreadyConnected ? 1 : 0
+}
+
+function shouldShowPickerPage(page: PickerFacebookPage): boolean {
+  return page.isConnectable || page.isAlreadyConnected
 }
 
 export default async function MessengerSelectPage() {
@@ -45,6 +46,7 @@ export default async function MessengerSelectPage() {
       ...page,
       isAlreadyConnected: connectedPageIds.has(page.id),
     }))
+    .filter(shouldShowPickerPage)
     .sort((current, next) => rankPickerPage(current) - rankPickerPage(next))
 
   return (

--- a/apps/worker/__tests__/moosend-handler.test.ts
+++ b/apps/worker/__tests__/moosend-handler.test.ts
@@ -39,6 +39,11 @@ vi.mock("@chatbotx.io/redis", () => ({
   cacheConnections: {
     useExisting: vi.fn(async () => ({ eval: state.eval, set: state.set })),
   },
+  distributedLock: {
+    runExclusive: vi.fn(
+      async ({ fn }: { fn: () => Promise<void> }) => await fn(),
+    ),
+  },
 }))
 
 vi.mock("../src/integration/handlers/contact-field-map", () => ({
@@ -59,11 +64,9 @@ vi.mock("../src/lib/logger", () => ({
   logger: { error: state.errorLog },
 }))
 
-const {
-  addOrUpdateMoosendContact,
-  buildMoosendContactLockKey,
-  MoosendLockError,
-} = await import("../src/integration/handlers/moosend-handler")
+const { addOrUpdateMoosendContact, buildMoosendContactLockKey } = await import(
+  "../src/integration/handlers/moosend-handler"
+)
 const { acquireMoosendSubscribePermit } = await import(
   "../src/integration/handlers/moosend-rate-limit"
 )
@@ -133,7 +136,7 @@ describe("addOrUpdateMoosendContact", () => {
   })
 
   test("does not retry provider failures and keeps logs secret/PII-safe", async () => {
-    state.runAction.mockRejectedValueOnce(new MoosendLockError())
+    state.runAction.mockRejectedValueOnce(new Error("provider failed"))
     await expect(
       addOrUpdateMoosendContact(createProps()),
     ).resolves.toMatchObject({ status: "error" })

--- a/apps/worker/__tests__/send-messenger-template-create.test.ts
+++ b/apps/worker/__tests__/send-messenger-template-create.test.ts
@@ -380,4 +380,22 @@ describe("processMessengerTemplate", () => {
 
     expect(mockSendFlowStep).toHaveBeenCalledTimes(1)
   })
+
+  test("template-not-found failure emits message:failed with inboxId in context", async () => {
+    mockValidateTemplate.mockResolvedValueOnce(null)
+
+    await expect(
+      sendMessengerTemplateMessage(broadcastTemplateJobData),
+    ).rejects.toThrow("Messenger template not found")
+
+    expect(mockEmit).toHaveBeenCalledWith(
+      "message:failed",
+      expect.objectContaining({
+        context: expect.objectContaining({
+          contactInboxId: "ci-1",
+          inboxId: "inbox-1",
+        }),
+      }),
+    )
+  })
 })

--- a/apps/worker/__tests__/send-messenger-template.test.ts
+++ b/apps/worker/__tests__/send-messenger-template.test.ts
@@ -111,11 +111,13 @@ const { sendFlowStepToChannel } = await import(
 const { validateMessengerTemplate, replaceMessengerTemplateVariables } =
   await import("../src/integration/handlers/messenger-template-handler")
 const { db } = await import("@chatbotx.io/database/client")
+const { emit } = await import("@chatbotx.io/event-bus")
 
 const mockSendFlowStep = sendFlowStepToChannel as MockInstance
 const mockValidate = validateMessengerTemplate as MockInstance
 const mockReplace = replaceMessengerTemplateVariables as MockInstance
 const mockDbUpdate = db.update as MockInstance
+const mockEmit = emit as MockInstance
 
 const CONVERSATION = {
   id: "conv-1",
@@ -169,6 +171,26 @@ describe("processMessengerTemplate — sourceId persistence", () => {
     expect(mockDbUpdate).toHaveBeenCalled()
     const setCall = mockDbUpdate.mock.results[0].value.set
     expect(setCall).toHaveBeenCalledWith({ sourceId: PROVIDER_ID })
+  })
+
+  test("emits message:sent with inboxId for MAC tracking", async () => {
+    mockSendFlowStep.mockResolvedValueOnce({ messageIds: ["mid.ABC123"] })
+
+    await processMessengerTemplate({
+      conversation: CONVERSATION as never,
+      contactInbox: CONTACT_INBOX as never,
+      template: TEMPLATE,
+    })
+
+    expect(mockEmit).toHaveBeenCalledWith(
+      "message:sent",
+      expect.objectContaining({
+        context: expect.objectContaining({
+          contactInboxId: "ci-1",
+          inboxId: "inbox-1",
+        }),
+      }),
+    )
   })
 
   test("does NOT persist sourceId when providerMessageId is undefined", async () => {

--- a/apps/worker/__tests__/send-whatsapp-template.test.ts
+++ b/apps/worker/__tests__/send-whatsapp-template.test.ts
@@ -442,4 +442,22 @@ describe("processWhatsappTemplate", () => {
 
     expect(mockSendFlowStep).toHaveBeenCalledTimes(1)
   })
+
+  test("template-not-found failure emits message:failed with inboxId in context", async () => {
+    mockValidateTemplate.mockResolvedValueOnce(null)
+
+    await expect(
+      sendWhatsappTemplateMessage(broadcastTemplateJobData),
+    ).rejects.toThrow("WhatsApp template not found")
+
+    expect(mockEmit).toHaveBeenCalledWith(
+      "message:failed",
+      expect.objectContaining({
+        context: expect.objectContaining({
+          contactInboxId: "ci-1",
+          inboxId: "inbox-1",
+        }),
+      }),
+    )
+  })
 })

--- a/apps/worker/__tests__/sendgrid-handler.test.ts
+++ b/apps/worker/__tests__/sendgrid-handler.test.ts
@@ -9,6 +9,22 @@ const runAction = vi.fn(async () => ({ job_id: "job-secret" }))
 const errorLog = vi.fn()
 const infoLog = vi.fn()
 
+function makeSendGridActionResult(action: string) {
+  if (action === "checkImportJob") {
+    return {
+      status: "completed",
+      results: {
+        requested_count: 1,
+        created_count: 1,
+        updated_count: 0,
+        errored_count: 0,
+      },
+    }
+  }
+
+  return { job_id: "job-secret" }
+}
+
 vi.mock("@chatbotx.io/business", () => ({
   buildContext: vi.fn(async ({ integration }: { integration: unknown }) => ({
     auth: state.auth,
@@ -67,7 +83,9 @@ beforeEach(() => {
     company: " Analytical Engines ",
   }
   vi.clearAllMocks()
-  runAction.mockResolvedValue({ job_id: "job-secret" })
+  runAction.mockImplementation(async (action: string) =>
+    makeSendGridActionResult(action),
+  )
 })
 
 describe("addSendGridContact", () => {
@@ -76,7 +94,6 @@ describe("addSendGridContact", () => {
       status: "success",
       result: null,
     })
-    expect(runAction).toHaveBeenCalledTimes(1)
     expect(runAction).toHaveBeenCalledWith("addOrUpdateContact", {
       ctx: expect.any(Object),
       props: {
@@ -86,11 +103,15 @@ describe("addSendGridContact", () => {
             email: "person@example.com",
             first_name: "Ada",
             last_name: "Lovelace",
-            phone_number_id: "phone-value",
+            phone_number: "phone-value",
             custom_fields: { "field-1": "Analytical Engines" },
           },
         ],
       },
+    })
+    expect(runAction).toHaveBeenCalledWith("checkImportJob", {
+      ctx: expect.any(Object),
+      props: { jobId: "job-secret" },
     })
     const logs = JSON.stringify(infoLog.mock.calls)
     expect(logs).not.toContain("job-secret")
@@ -109,7 +130,7 @@ describe("addSendGridContact", () => {
     expect(sentProps).not.toHaveProperty("list_ids")
   })
 
-  test("omits phone_number_id when phoneField is absent", async () => {
+  test("omits phone_number when phoneField is absent", async () => {
     const props = createProps()
     props.step.phoneField = undefined
     await addSendGridContact(props)
@@ -117,17 +138,17 @@ describe("addSendGridContact", () => {
       string,
       { props: { contacts: Record<string, unknown>[] } },
     ]
-    expect(sentProps.contacts[0]).not.toHaveProperty("phone_number_id")
+    expect(sentProps.contacts[0]).not.toHaveProperty("phone_number")
   })
 
-  test("omits phone_number_id when phone field value is blank", async () => {
+  test("omits phone_number when phone field value is blank", async () => {
     state.fields.phone = "   "
     await addSendGridContact(createProps())
     const [, { props: sentProps }] = runAction.mock.calls[0] as [
       string,
       { props: { contacts: Record<string, unknown>[] } },
     ]
-    expect(sentProps.contacts[0]).not.toHaveProperty("phone_number_id")
+    expect(sentProps.contacts[0]).not.toHaveProperty("phone_number")
   })
 
   test("omits custom_fields when all mapping values are blank", async () => {

--- a/apps/worker/src/chat/handlers/send-messenger-template.ts
+++ b/apps/worker/src/chat/handlers/send-messenger-template.ts
@@ -117,6 +117,7 @@ export async function processMessengerTemplate(
       conversationId: conversation.id,
       channel: contactInbox.channel,
       contactInboxId: contactInbox.id,
+      inboxId: contactInbox.inboxId,
     },
     action: {
       flowId: flow?.id || "",
@@ -309,6 +310,7 @@ export async function sendMessengerTemplateMessage(
       conversationId: conversation.id,
       channel: contactInbox.channel,
       contactInboxId: contactInbox.id,
+      inboxId: contactInbox.inboxId,
     },
     action: {
       flowId: "",

--- a/apps/worker/src/chat/handlers/send-whatsapp-template.ts
+++ b/apps/worker/src/chat/handlers/send-whatsapp-template.ts
@@ -281,6 +281,7 @@ export async function sendWhatsappTemplateMessage(
       conversationId: conversation.id,
       channel: contactInbox.channel,
       contactInboxId: contactInbox.id,
+      inboxId: contactInbox.inboxId,
     },
     action: {
       flowId: "",

--- a/packages/analytics/__tests__/mac-tracking.service.test.ts
+++ b/packages/analytics/__tests__/mac-tracking.service.test.ts
@@ -10,6 +10,7 @@ const macRepository = {
   upsertMonthlyPresence: vi.fn(async () => [] as unknown[]),
   upsertHourlyPresence: vi.fn(async () => undefined),
   addWorkspaceMacCount: vi.fn(async () => [] as unknown[]),
+  getInboxIdsByContactInboxIds: vi.fn(async () => new Map<string, string>()),
 }
 vi.mock("../src/repositories/postgres/mac.repository", () => ({
   macRepository,
@@ -138,6 +139,9 @@ beforeEach(() => {
   macRepository.upsertMonthlyPresence.mockResolvedValue([])
   macRepository.upsertHourlyPresence.mockResolvedValue(undefined)
   macRepository.addWorkspaceMacCount.mockResolvedValue([])
+  macRepository.getInboxIdsByContactInboxIds.mockResolvedValue(
+    new Map<string, string>(),
+  )
   macRepository.ensureWorkspaceMac.mockImplementation(
     (
       entries: { workspaceId: string; periodStart: Date; periodEnd: Date }[],
@@ -206,6 +210,169 @@ describe("MacTrackingService — payload filtering", () => {
     ])
 
     expect(bloomFilter.addMany).not.toHaveBeenCalled()
+    expect(macRepository.upsertHourlyPresence).not.toHaveBeenCalled()
+  })
+})
+
+describe("MacTrackingService — inboxId guard and fallback", () => {
+  test("trackMessageOut resolves a missing inboxId via repository fallback", async () => {
+    seedQuotaContext()
+    macRepository.getInboxIdsByContactInboxIds.mockResolvedValue(
+      new Map([["ci-1", "ib-resolved"]]),
+    )
+
+    await newService().trackMessageOut([
+      makeOutPayload({
+        context: {
+          workspaceId: WORKSPACE_ID,
+          contactId: "c-1",
+          contactInboxId: "ci-1",
+          channel: "messenger",
+        },
+      }),
+    ])
+
+    expect(macRepository.getInboxIdsByContactInboxIds).toHaveBeenCalledWith([
+      "ci-1",
+    ])
+    expect(macRepository.upsertMonthlyPresence).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          contactInboxId: "ci-1",
+          inboxId: "ib-resolved",
+        }),
+      ],
+      expect.anything(),
+    )
+  })
+
+  test("trackMessageOut drops (with warn) events whose inboxId cannot be resolved", async () => {
+    seedQuotaContext()
+    macRepository.getInboxIdsByContactInboxIds.mockResolvedValue(new Map())
+
+    await newService().trackMessageOut([
+      makeOutPayload({
+        context: {
+          workspaceId: WORKSPACE_ID,
+          contactId: "c-1",
+          contactInboxId: "ci-orphan",
+          channel: "messenger",
+        },
+      }),
+    ])
+
+    expect(macRepository.upsertMonthlyPresence).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ contactInboxIds: ["ci-orphan"] }),
+      expect.stringContaining("unresolvable inboxId"),
+    )
+  })
+
+  test("trackMessageOut skips the database lookup when every payload carries inboxId", async () => {
+    seedQuotaContext()
+
+    await newService().trackMessageOut([makeOutPayload()])
+
+    expect(macRepository.getInboxIdsByContactInboxIds).not.toHaveBeenCalled()
+    expect(macRepository.upsertMonthlyPresence).toHaveBeenCalledWith(
+      [expect.objectContaining({ inboxId: "ib-1" })],
+      expect.anything(),
+    )
+  })
+
+  test("trackMessageOut keeps valid events when a sibling event is dropped", async () => {
+    seedQuotaContext()
+    macRepository.getInboxIdsByContactInboxIds.mockResolvedValue(new Map())
+
+    await newService().trackMessageOut([
+      makeOutPayload(),
+      makeOutPayload({
+        context: {
+          workspaceId: WORKSPACE_ID,
+          contactId: "c-2",
+          contactInboxId: "ci-orphan",
+          channel: "messenger",
+        },
+        action: { messageId: "m-2" },
+      }),
+    ])
+
+    expect(macRepository.upsertMonthlyPresence).toHaveBeenCalledWith(
+      [expect.objectContaining({ contactInboxId: "ci-1", inboxId: "ib-1" })],
+      expect.anything(),
+    )
+  })
+
+  test("trackMessageOut deduplicates fallback lookups per contactInboxId", async () => {
+    seedQuotaContext()
+    macRepository.getInboxIdsByContactInboxIds.mockResolvedValue(
+      new Map([["ci-1", "ib-resolved"]]),
+    )
+
+    await newService().trackMessageOut([
+      makeOutPayload({
+        context: {
+          workspaceId: WORKSPACE_ID,
+          contactId: "c-1",
+          contactInboxId: "ci-1",
+          channel: "messenger",
+        },
+      }),
+      makeOutPayload({
+        context: {
+          workspaceId: WORKSPACE_ID,
+          contactId: "c-1",
+          contactInboxId: "ci-1",
+          channel: "messenger",
+        },
+        action: { messageId: "m-2" },
+      }),
+    ])
+
+    expect(macRepository.getInboxIdsByContactInboxIds).toHaveBeenCalledTimes(1)
+    expect(macRepository.getInboxIdsByContactInboxIds).toHaveBeenCalledWith([
+      "ci-1",
+    ])
+  })
+
+  test("trackMessageOutHourly resolves a missing inboxId via repository fallback", async () => {
+    macRepository.getInboxIdsByContactInboxIds.mockResolvedValue(
+      new Map([["ci-1", "ib-resolved"]]),
+    )
+
+    await newService().trackMessageOutHourly([
+      makeOutPayload({
+        context: {
+          workspaceId: WORKSPACE_ID,
+          contactId: "c-1",
+          contactInboxId: "ci-1",
+          channel: "messenger",
+        },
+      }),
+    ])
+
+    expect(macRepository.upsertHourlyPresence).toHaveBeenCalledWith([
+      expect.objectContaining({
+        contactInboxId: "ci-1",
+        inboxId: "ib-resolved",
+      }),
+    ])
+  })
+
+  test("trackMessageOutHourly drops events whose inboxId cannot be resolved", async () => {
+    macRepository.getInboxIdsByContactInboxIds.mockResolvedValue(new Map())
+
+    await newService().trackMessageOutHourly([
+      makeOutPayload({
+        context: {
+          workspaceId: WORKSPACE_ID,
+          contactId: "c-1",
+          contactInboxId: "ci-orphan",
+          channel: "messenger",
+        },
+      }),
+    ])
+
     expect(macRepository.upsertHourlyPresence).not.toHaveBeenCalled()
   })
 })

--- a/packages/analytics/__tests__/mac.repository.test.ts
+++ b/packages/analytics/__tests__/mac.repository.test.ts
@@ -58,6 +58,7 @@ const and = vi.fn((...args: unknown[]) => args)
 const eq = vi.fn((...args: unknown[]) => ({ op: "eq", args }))
 const gte = vi.fn((...args: unknown[]) => ({ op: "gte", args }))
 const gt = vi.fn((...args: unknown[]) => ({ op: "gt", args }))
+const inArray = vi.fn((...args: unknown[]) => ({ op: "inArray", args }))
 const lte = vi.fn((...args: unknown[]) => ({ op: "lte", args }))
 
 vi.mock("@chatbotx.io/database/client", () => ({
@@ -75,6 +76,7 @@ vi.mock("@chatbotx.io/database/client", () => ({
   eq,
   gt,
   gte,
+  inArray,
   lt: (...args: unknown[]) => args,
   lte,
 }))
@@ -97,6 +99,10 @@ vi.mock("@chatbotx.io/database/schema", () => ({
     hourBucket: "cah.hourBucket",
     inboxId: "cah.inboxId",
     workspaceId: "cah.workspaceId",
+  },
+  contactInboxModel: {
+    id: "ci.id",
+    inboxId: "ci.inboxId",
   },
   workspaceModel: { id: "ws.id", ownerId: "ws.ownerId" },
 }))
@@ -156,6 +162,7 @@ beforeEach(() => {
   eq.mockClear()
   gte.mockClear()
   gt.mockClear()
+  inArray.mockClear()
   lte.mockClear()
 })
 
@@ -317,6 +324,41 @@ describe("MacRepository — upsertHourlyPresence", () => {
       ?.value as QueryChain
     expect(chain.values).toHaveBeenCalledWith(rows)
     expect(chain.onConflictDoNothing).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("MacRepository — getInboxIdsByContactInboxIds", () => {
+  test("returns empty map without querying when input is empty", async () => {
+    const repo = new MacRepository()
+
+    const result = await repo.getInboxIdsByContactInboxIds([])
+
+    expect(result.size).toBe(0)
+    expect(dbSelect).not.toHaveBeenCalled()
+  })
+
+  test("maps each contactInboxId to its inboxId from fetched rows", async () => {
+    const repo = new MacRepository()
+    queueResult([
+      { contactInboxId: "ci-1", inboxId: "ib-1" },
+      { contactInboxId: "ci-2", inboxId: "ib-2" },
+    ])
+
+    const result = await repo.getInboxIdsByContactInboxIds(["ci-1", "ci-2"])
+
+    expect(result.get("ci-1")).toBe("ib-1")
+    expect(result.get("ci-2")).toBe("ib-2")
+    expect(result.size).toBe(2)
+  })
+
+  test("omits contactInboxIds the database did not return", async () => {
+    const repo = new MacRepository()
+    queueResult([{ contactInboxId: "ci-1", inboxId: "ib-1" }])
+
+    const result = await repo.getInboxIdsByContactInboxIds(["ci-1", "ci-gone"])
+
+    expect(result.get("ci-1")).toBe("ib-1")
+    expect(result.has("ci-gone")).toBe(false)
   })
 })
 

--- a/packages/analytics/src/repositories/postgres/mac.repository.ts
+++ b/packages/analytics/src/repositories/postgres/mac.repository.ts
@@ -8,6 +8,7 @@ import {
   eq,
   gt,
   gte,
+  inArray,
   lte,
   sql,
 } from "@chatbotx.io/database/client"
@@ -15,6 +16,7 @@ import type { MacEventType } from "@chatbotx.io/database/partials"
 import {
   contactActiveHourlyModel,
   contactActiveMonthlyModel,
+  contactInboxModel,
   workspaceMacModel,
   workspaceModel,
 } from "@chatbotx.io/database/schema"
@@ -170,6 +172,29 @@ export class MacRepository {
       .insert(contactActiveHourlyModel)
       .values(rows)
       .onConflictDoNothing()
+  }
+
+  /**
+   * Batch-resolve `ContactInbox.inboxId` for MAC events published before
+   * message-sent producers stamped `inboxId` in their event context.
+   */
+  async getInboxIdsByContactInboxIds(
+    contactInboxIds: string[],
+    client: DatabaseClient = db,
+  ): Promise<Map<string, string>> {
+    if (contactInboxIds.length === 0) {
+      return new Map()
+    }
+
+    const rows = await client
+      .select({
+        contactInboxId: contactInboxModel.id,
+        inboxId: contactInboxModel.inboxId,
+      })
+      .from(contactInboxModel)
+      .where(inArray(contactInboxModel.id, contactInboxIds))
+
+    return new Map(rows.map((row) => [row.contactInboxId, row.inboxId]))
   }
 
   async addWorkspaceMacCount(

--- a/packages/analytics/src/services/mac-tracking.service.ts
+++ b/packages/analytics/src/services/mac-tracking.service.ts
@@ -63,6 +63,11 @@ type QuotaContextCacheValue = {
 }
 
 type DraftRow = Omit<PreparedRow, "workspaceMacId">
+type ResolvedOutPayload = {
+  payload: MacMessageOutPayload
+  contactInboxId: string
+  inboxId: string
+}
 
 function quotaContextCacheKey(workspaceId: string): string {
   return `mac:ctx:ws:${workspaceId}`
@@ -84,27 +89,95 @@ export class MacTrackingService {
     this.bloomFilterInstance = filter
   }
 
-  async trackMessageOut(payloads: MacMessageOutPayload[]): Promise<void> {
-    if (payloads.length === 0) {
-      return
+  /**
+   * Resolve missing outbound `inboxId` values from ContactInbox so legacy
+   * message:sent events already queued in Redis are recovered instead of
+   * dropped or written with an undefined NOT NULL column.
+   */
+  private async resolveInboxIds(
+    contexts: { contactInboxId?: string; inboxId?: string }[],
+  ): Promise<Map<string, string>> {
+    const inboxIdByContactInbox = new Map<string, string>()
+    const missing = new Set<string>()
+
+    for (const { contactInboxId, inboxId } of contexts) {
+      if (!contactInboxId) {
+        continue
+      }
+      if (inboxId) {
+        inboxIdByContactInbox.set(contactInboxId, inboxId)
+      } else {
+        missing.add(contactInboxId)
+      }
     }
-    const validPayloads = payloads.filter((p) => p.context.contactInboxId)
-    if (validPayloads.length === 0) {
+
+    for (const contactInboxId of inboxIdByContactInbox.keys()) {
+      missing.delete(contactInboxId)
+    }
+    if (missing.size === 0) {
+      return inboxIdByContactInbox
+    }
+
+    const fetched = await macRepository.getInboxIdsByContactInboxIds(
+      Array.from(missing),
+    )
+    for (const [contactInboxId, inboxId] of fetched) {
+      inboxIdByContactInbox.set(contactInboxId, inboxId)
+      missing.delete(contactInboxId)
+    }
+
+    if (missing.size > 0) {
+      logger.warn(
+        { contactInboxIds: Array.from(missing) },
+        "[MacTrackingService] dropped events with unresolvable inboxId",
+      )
+    }
+
+    return inboxIdByContactInbox
+  }
+
+  private async resolveOutPayloads(
+    payloads: MacMessageOutPayload[],
+  ): Promise<ResolvedOutPayload[]> {
+    if (payloads.length === 0) {
+      return []
+    }
+
+    const inboxIdByContactInbox = await this.resolveInboxIds(
+      payloads.map((payload) => payload.context),
+    )
+
+    const resolved: ResolvedOutPayload[] = []
+    for (const payload of payloads) {
+      const { contactInboxId } = payload.context
+      const inboxId = contactInboxId
+        ? inboxIdByContactInbox.get(contactInboxId)
+        : undefined
+      if (contactInboxId && inboxId) {
+        resolved.push({ payload, contactInboxId, inboxId })
+      }
+    }
+
+    return resolved
+  }
+
+  async trackMessageOut(payloads: MacMessageOutPayload[]): Promise<void> {
+    const resolved = await this.resolveOutPayloads(payloads)
+    if (resolved.length === 0) {
       return
     }
 
-    const events: MacInputEvent[] = []
-    for (const payload of validPayloads) {
-      events.push({
+    const events: MacInputEvent[] = resolved.map(
+      ({ payload, contactInboxId, inboxId }) => ({
         workspaceId: payload.context.workspaceId,
         contactId: payload.context.contactId,
-        contactInboxId: payload.context.contactInboxId as string,
-        inboxId: payload.context.inboxId as string,
+        contactInboxId,
+        inboxId,
         eventType: "message_out",
         occurredAt: coerceOccurredAt(payload.occurredAt),
         sourceId: payload.action.sourceId ?? payload.action.messageId,
-      })
-    }
+      }),
+    )
     await this.track(events)
   }
 
@@ -118,8 +191,8 @@ export class MacTrackingService {
       events.push({
         workspaceId: payload.workspaceId,
         contactId: payload.contactId,
-        contactInboxId: payload.contactInboxId as string,
-        inboxId: payload.inboxId as string,
+        contactInboxId: payload.contactInboxId,
+        inboxId: payload.inboxId,
         eventType: "message_in",
         occurredAt: coerceOccurredAt(payload.occurredAt),
         sourceId: payload.sourceId ?? undefined,
@@ -130,18 +203,23 @@ export class MacTrackingService {
 
   async trackMessageOutHourly(payloads: MacMessageOutPayload[]): Promise<void> {
     try {
-      const rows = payloads
-        .filter((payload) => payload.context.contactInboxId)
-        .map((payload) => {
-          const occurredAt = coerceOccurredAt(payload.occurredAt)
-          return {
-            workspaceId: payload.context.workspaceId,
-            contactId: payload.context.contactId,
-            contactInboxId: payload.context.contactInboxId as string,
-            inboxId: payload.context.inboxId as string,
-            hourBucket: truncateHourInTimezone(occurredAt, DEFAULT_TIMEZONE),
-          }
-        })
+      const resolved = await this.resolveOutPayloads(payloads)
+      if (resolved.length === 0) {
+        return
+      }
+
+      const rows: HourlyPresenceRow[] = resolved.map(
+        ({ payload, contactInboxId, inboxId }) => ({
+          workspaceId: payload.context.workspaceId,
+          contactId: payload.context.contactId,
+          contactInboxId,
+          inboxId,
+          hourBucket: truncateHourInTimezone(
+            coerceOccurredAt(payload.occurredAt),
+            DEFAULT_TIMEZONE,
+          ),
+        }),
+      )
 
       await this.recordHourlyPresence(rows)
     } catch (error) {
@@ -159,8 +237,8 @@ export class MacTrackingService {
         return {
           workspaceId: payload.workspaceId,
           contactId: payload.contactId,
-          contactInboxId: payload.contactInboxId as string,
-          inboxId: payload.inboxId as string,
+          contactInboxId: payload.contactInboxId,
+          inboxId: payload.inboxId,
           hourBucket: truncateHourInTimezone(occurredAt, DEFAULT_TIMEZONE),
         }
       })

--- a/packages/flow-config/src/event/schema.ts
+++ b/packages/flow-config/src/event/schema.ts
@@ -19,6 +19,7 @@ export const eventContextSchema = z.object({
   conversationId: z.string(),
   channel: z.string(),
   contactInboxId: z.string().optional(),
+  inboxId: z.string().optional(),
   sequenceStepId: z.string().optional(),
 })
 


### PR DESCRIPTION
## Summary

Some outgoing messages — in particular template messages sent through broadcasts and flows — were not being counted toward a workspace's monthly active contacts. In production this also produced a steady stream of failed background jobs, because the counting step received incomplete information and could not save its records.

With this change, every outgoing message carries the information the counter needs, and messages that were already waiting in the queue with incomplete details are recovered and counted instead of being lost. Monthly active contact numbers — which billing and usage limits rely on — now stay accurate.

This also includes a small improvement to the fanpage picker: when connecting a Facebook page, pages the user has no permission to connect are no longer shown, so the list only contains pages that can actually be selected.

- Outgoing template messages are now always counted toward monthly active contacts
- Messages queued before this update are recovered and counted instead of failing
- The background errors seen in production logs for the monthly counting job are resolved
- The fanpage picker only shows pages the user can connect or has already connected

## Test plan

- [x] New tests covering outgoing messages with and without complete details, including recovery of older queued messages
- [x] New tests for the fanpage picker showing only connectable or already-connected pages
- [x] Analytics suite passes (139 tests), related worker suites pass (37 tests), picker page test passes
- [x] `pnpm lint` and `check-types` for `analytics`, `worker`, `builder`, `flow-config` all pass
- [ ] Manual check: send a broadcast and confirm the monthly active contact count increases without errors in the worker logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)