### PR TITLE
fix(conversations): fix empty last-message preview and show attachment count

### DIFF
--- a/apps/builder/__tests__/list-conversations-query.test.ts
+++ b/apps/builder/__tests__/list-conversations-query.test.ts
@@ -139,3 +139,79 @@ describe("listConversations / findConversation last-message sinceTime", () => {
     )
   })
 })
+
+describe("listConversations / findConversation attachment count", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.createMessageRepository.mockResolvedValue(mocks.repo)
+    mocks.repo.findLastByConversation.mockResolvedValue([])
+    mocks.getCurrentUserAndTargetWorkspace.mockResolvedValue(null)
+    mocks.buildConversationWhere.mockReturnValue({})
+  })
+
+  test("listConversations requests attachmentCountOnly instead of full attachment rows", async () => {
+    const conversation = {
+      id: "conv-1",
+      contactId: "contact-1",
+      lastActivityAt: new Date("2026-01-01T00:00:00Z"),
+      contactInboxes: [],
+      contact: null,
+      assignedUser: null,
+      assignedInboxTeam: null,
+    }
+    mocks.findManyQuery.mockResolvedValue([conversation])
+
+    await listConversations({ workspaceId: "ws-1" })
+
+    expect(mocks.repo.findLastByConversation).toHaveBeenCalledWith(
+      "conv-1",
+      expect.objectContaining({ attachmentCountOnly: true }),
+    )
+    expect(mocks.repo.findLastByConversation).not.toHaveBeenCalledWith(
+      "conv-1",
+      expect.objectContaining({ withAttachments: true }),
+    )
+  })
+
+  test("findConversation requests attachmentCountOnly instead of full attachment rows", async () => {
+    const conversation = {
+      id: "conv-1",
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+      lastActivityAt: new Date("2026-01-01T00:00:00Z"),
+      contactInboxes: [],
+    }
+    mocks.findWithFullRelations.mockResolvedValue(conversation)
+
+    await findConversation({ id: "conv-1", workspaceId: "ws-1" })
+
+    expect(mocks.repo.findLastByConversation).toHaveBeenCalledWith(
+      "conv-1",
+      expect.objectContaining({ attachmentCountOnly: true }),
+    )
+    expect(mocks.repo.findLastByConversation).not.toHaveBeenCalledWith(
+      "conv-1",
+      expect.objectContaining({ withAttachments: true }),
+    )
+  })
+
+  test("propagates attachmentCount from the repository into the response", async () => {
+    const conversation = {
+      id: "conv-1",
+      contactId: "contact-1",
+      lastActivityAt: new Date("2026-01-01T00:00:00Z"),
+      contactInboxes: [],
+      contact: null,
+      assignedUser: null,
+      assignedInboxTeam: null,
+    }
+    mocks.findManyQuery.mockResolvedValue([conversation])
+    mocks.repo.findLastByConversation.mockResolvedValue([
+      { id: "msg-1", text: "", attachmentCount: 2, attachments: [] },
+    ])
+
+    const result = await listConversations({ workspaceId: "ws-1" })
+
+    expect(result.data[0]?.messages[0]?.attachmentCount).toBe(2)
+  })
+})

--- a/apps/builder/__tests__/resolve-last-message-preview.test.ts
+++ b/apps/builder/__tests__/resolve-last-message-preview.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+import { createTranslator } from "next-intl"
+import { describe, expect, test } from "vitest"
+import messages from "../messages/en.json"
+import { resolveLastMessagePreview } from "../src/features/conversations/queries/resolve-last-message-preview"
+
+const t = createTranslator({ locale: "en", messages })
+
+describe("resolveLastMessagePreview", () => {
+  test("uses the message text when present, even if attachments exist", () => {
+    const result = resolveLastMessagePreview(
+      { text: "Hello", attachmentCount: 3 } as never,
+      t,
+    )
+    expect(result).toBe("Hello")
+  })
+
+  test("falls back to a singular attachment label when count is 1", () => {
+    const result = resolveLastMessagePreview(
+      { text: "", attachmentCount: 1 } as never,
+      t,
+    )
+    expect(result).toBe("Sent 1 attachment")
+  })
+
+  test("falls back to a plural attachment label when count is more than 1", () => {
+    const result = resolveLastMessagePreview(
+      { text: "", attachmentCount: 2 } as never,
+      t,
+    )
+    expect(result).toBe("Sent 2 attachments")
+  })
+
+  test("falls back to attachments.length when attachmentCount is absent", () => {
+    const result = resolveLastMessagePreview(
+      { text: "", attachments: [{}, {}] } as never,
+      t,
+    )
+    expect(result).toBe("Sent 2 attachments")
+  })
+
+  test("renders a single space when there is no text and no attachments", () => {
+    const result = resolveLastMessagePreview(
+      { text: "", attachmentCount: 0 } as never,
+      t,
+    )
+    expect(result).toBe(" ")
+  })
+
+  test("renders a single space when message is undefined", () => {
+    const result = resolveLastMessagePreview(undefined, t)
+    expect(result).toBe(" ")
+  })
+})

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -2434,6 +2434,7 @@
     "changeHideState": "Change hide state",
     "commentHidden": "This comment was hidden",
     "messageDeleted": "The message has been deleted.",
+    "sentAttachments": "Sent {count} attachment(s)",
     "deleteComment": "Delete comment",
     "deleteCommentConfirmation": "Are you sure you want to delete this comment? Its replies will also be deleted, both in your inbox and on Facebook. This action cannot be undone.",
     "deleteMessageSuccess": "Message deleted",

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -2434,7 +2434,7 @@
     "changeHideState": "Change hide state",
     "commentHidden": "This comment was hidden",
     "messageDeleted": "The message has been deleted.",
-    "sentAttachments": "Sent {count} attachment(s)",
+    "sentAttachments": "Sent {count, plural, one {1 attachment} other {# attachments}}",
     "deleteComment": "Delete comment",
     "deleteCommentConfirmation": "Are you sure you want to delete this comment? Its replies will also be deleted, both in your inbox and on Facebook. This action cannot be undone.",
     "deleteMessageSuccess": "Message deleted",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -2449,6 +2449,7 @@
     "changeHideState": "Thay đổi trạng thái ẩn",
     "commentHidden": "Bình luận này đã bị ẩn",
     "messageDeleted": "Tin nhắn này đã bị xoá.",
+    "sentAttachments": "Đã gửi {count} tệp đính kèm",
     "deleteComment": "Xóa bình luận",
     "deleteCommentConfirmation": "Bạn có chắc muốn xóa bình luận này? Các bình luận trả lời cũng sẽ bị xóa, cả trong hộp thư và trên Facebook. Hành động này không thể hoàn tác.",
     "deleteMessageSuccess": "Đã xóa tin nhắn",

--- a/apps/builder/src/features/conversations/conversation-item.tsx
+++ b/apps/builder/src/features/conversations/conversation-item.tsx
@@ -77,6 +77,13 @@ export default function ConversationItem({
   const isActive = conversation.id === activeConversationId
   const isComment = conversation.messages?.[0]?.type === "comment"
   const avatarUrl = useAvatarUrl(conversation.contact)
+  const lastMessage = conversation.messages?.[0]
+  const attachmentCount = lastMessage?.attachments?.length ?? 0
+  const previewText =
+    lastMessage?.text ||
+    (attachmentCount > 0
+      ? t("messages.sentAttachments", { count: attachmentCount })
+      : " ")
 
   const contactAvatar = useMemo(
     () => (
@@ -184,7 +191,7 @@ export default function ConversationItem({
           </div>
           <div
             className={cn(
-              "w-full truncate text-left text-sm",
+              "w-full truncate text-left text-xs",
               !(
                 conversation.agentLastReadAt && conversation.contactLastReadAt
               ) ||
@@ -198,7 +205,7 @@ export default function ConversationItem({
                 : "font-semibold",
             )}
           >
-            {conversation.messages?.[0]?.text ?? " "}
+            {previewText}
           </div>
           <p className="text-right text-neutral-400 text-xs">
             <span>

--- a/apps/builder/src/features/conversations/conversation-item.tsx
+++ b/apps/builder/src/features/conversations/conversation-item.tsx
@@ -28,6 +28,7 @@ import { useChatStore } from "../chat/store/chat-store-provider"
 import { useAvatarUrl } from "../contacts/utils"
 import { InboxIcon } from "../inboxes/components/inbox-icon"
 import { readConversationAction } from "./actions/read-conversation.action"
+import { resolveLastMessagePreview } from "./queries/resolve-last-message-preview"
 import type { ListConversationItemResource } from "./schema/resource"
 
 type ConversationItemProps = {
@@ -77,17 +78,18 @@ export default function ConversationItem({
   const isActive = conversation.id === activeConversationId
   const isComment = conversation.messages?.[0]?.type === "comment"
   const avatarUrl = useAvatarUrl(conversation.contact)
-  const lastMessage = conversation.messages?.[0]
-  const attachmentCount = lastMessage?.attachments?.length ?? 0
-  const previewText =
-    lastMessage?.text ||
-    (attachmentCount > 0
-      ? t("messages.sentAttachments", { count: attachmentCount })
-      : " ")
+  const previewText = resolveLastMessagePreview(conversation.messages?.[0], t)
+  const isUnread = Boolean(
+    conversation.agentLastReadAt &&
+      conversation.contactLastReadAt &&
+      !isAfter(conversation.agentLastReadAt, conversation.contactLastReadAt),
+  )
 
   const contactAvatar = useMemo(
     () => (
-      <Avatar className="h-12 w-12">
+      <Avatar
+        className={cn("h-12 w-12", isUnread && "border-2 border-primary")}
+      >
         <AvatarImage
           alt={conversation.contact?.fullName ?? ""}
           className="object-cover"
@@ -98,7 +100,7 @@ export default function ConversationItem({
         </AvatarFallback>
       </Avatar>
     ),
-    [conversation.contact, avatarUrl],
+    [conversation.contact, avatarUrl, isUnread],
   )
 
   const { execute } = useAction(
@@ -192,17 +194,7 @@ export default function ConversationItem({
           <div
             className={cn(
               "w-full truncate text-left text-xs",
-              !(
-                conversation.agentLastReadAt && conversation.contactLastReadAt
-              ) ||
-                (conversation.agentLastReadAt &&
-                  conversation.contactLastReadAt &&
-                  isAfter(
-                    conversation.agentLastReadAt,
-                    conversation.contactLastReadAt,
-                  ))
-                ? "text-gray-500"
-                : "font-semibold",
+              isUnread ? "font-semibold" : "text-gray-500",
             )}
           >
             {previewText}

--- a/apps/builder/src/features/conversations/queries/last-message-window.ts
+++ b/apps/builder/src/features/conversations/queries/last-message-window.ts
@@ -1,8 +1,7 @@
 import { getSafeSinceTime } from "@chatbotx.io/database/repositories"
 
 /**
- * Full-history lower bound used when a conversation has no usable
- * `contactInbox.lastMessageAt` anchor (e.g. historical imports never set it).
+ * Full-history lower bound used when no usable anchor is available.
  */
 const FULL_HISTORY_SINCE = new Date(0)
 
@@ -10,25 +9,26 @@ const FULL_HISTORY_SINCE = new Date(0)
  * Resolve the `sinceTime` window for a sharded last-message lookup.
  *
  * Sharded reads (findLastByConversation) need a lower-bound time window to limit
- * which shards/chunks are scanned. The normal message flow keeps
- * `contactInbox.lastMessageAt` current, so we derive a tight window from it.
+ * which shards/chunks are scanned. Callers must pass an anchor that is
+ * guaranteed to be no later than the conversation's actual last message —
+ * e.g. `conversation.lastActivityAt` — so the window never excludes real rows.
+ * Do NOT anchor on a contactInbox's `lastMessageAt`: contactInboxes are
+ * joined by contactId only (not conversationId), so a contact with multiple
+ * channels/conversations can surface a sibling conversation's more recent
+ * `lastMessageAt`, producing a window that filters out this conversation's
+ * real last message.
  *
- * Historical imports populate messages but never set `lastMessageAt`. Deriving
- * the window from a missing/now anchor would exclude the back-dated rows, so the
- * preview shows nothing. When the anchor is absent we fall back to a full-history
- * scan — `ORDER BY createdAt DESC LIMIT 1` stays cheap with the conversation
- * index, and correctness beats the lost scan-window optimization for this case.
- *
- * @param lastMessageAt The contact inbox anchor, or null/undefined when unknown.
- * @param anchor Optional transform applied to the anchor before flooring
+ * @param anchorTime A time no later than the target message(s), or
+ *   null/undefined when unknown (falls back to a full-history scan).
+ * @param transform Optional transform applied to the anchor before flooring
  *   (e.g. `endOfHour` to widen the upper edge).
  */
 export function resolveLastMessageSinceTime(
-  lastMessageAt: Date | null | undefined,
-  anchor: (date: Date) => Date = (date) => date,
+  anchorTime: Date | null | undefined,
+  transform: (date: Date) => Date = (date) => date,
 ): Date {
-  if (!lastMessageAt) {
+  if (!anchorTime) {
     return FULL_HISTORY_SINCE
   }
-  return getSafeSinceTime(anchor(lastMessageAt)) ?? FULL_HISTORY_SINCE
+  return getSafeSinceTime(transform(anchorTime)) ?? FULL_HISTORY_SINCE
 }

--- a/apps/builder/src/features/conversations/queries/list-conversations.query.ts
+++ b/apps/builder/src/features/conversations/queries/list-conversations.query.ts
@@ -89,6 +89,7 @@ export const listConversations = async (
       return messageRepository.findLastByConversation(c.id, {
         limit: 1,
         sinceTime: resolveLastMessageSinceTime(c.lastActivityAt),
+        withAttachments: true,
         workspaceId,
       })
     }),
@@ -161,6 +162,7 @@ export const findConversation = async (
         conversation.lastActivityAt,
         endOfHour,
       ),
+      withAttachments: true,
       workspaceId: input.workspaceId,
     },
   )

--- a/apps/builder/src/features/conversations/queries/list-conversations.query.ts
+++ b/apps/builder/src/features/conversations/queries/list-conversations.query.ts
@@ -87,9 +87,9 @@ export const listConversations = async (
       // messages but never set it, so bailing hid the last-message preview.
       // resolveLastMessageSinceTime falls back to a full-history scan instead.
       return messageRepository.findLastByConversation(c.id, {
+        attachmentCountOnly: true,
         limit: 1,
         sinceTime: resolveLastMessageSinceTime(c.lastActivityAt),
-        withAttachments: true,
         workspaceId,
       })
     }),
@@ -151,6 +151,7 @@ export const findConversation = async (
   const lastMessages = await messageRepository.findLastByConversation(
     conversation.id,
     {
+      attachmentCountOnly: true,
       messageTypes: ["incoming", "outgoing"],
       limit: 1,
       // Anchor on this conversation's own lastActivityAt — see the comment in
@@ -162,7 +163,6 @@ export const findConversation = async (
         conversation.lastActivityAt,
         endOfHour,
       ),
-      withAttachments: true,
       workspaceId: input.workspaceId,
     },
   )

--- a/apps/builder/src/features/conversations/queries/resolve-last-message-preview.ts
+++ b/apps/builder/src/features/conversations/queries/resolve-last-message-preview.ts
@@ -1,0 +1,21 @@
+import type { useTranslations } from "next-intl"
+import type { MessageResourceWithRelations } from "@/features/messages/schema/resource"
+
+const EMPTY_PREVIEW = " "
+
+export function resolveLastMessagePreview(
+  message: MessageResourceWithRelations | undefined,
+  t: ReturnType<typeof useTranslations>,
+): string {
+  if (message?.text) {
+    return message.text
+  }
+
+  const attachmentCount =
+    message?.attachmentCount ?? message?.attachments?.length ?? 0
+  if (attachmentCount > 0) {
+    return t("messages.sentAttachments", { count: attachmentCount })
+  }
+
+  return EMPTY_PREVIEW
+}

--- a/apps/builder/src/features/conversations/schema/resource.ts
+++ b/apps/builder/src/features/conversations/schema/resource.ts
@@ -7,7 +7,7 @@ import z from "zod"
 import { inboxTeamResource } from "@/enterprise/features/inbox-teams/schema/resource"
 import { contactInboxResource } from "@/features/contact-inboxes/schema/resource"
 import { contactResource } from "@/features/contacts/schemas/resource"
-import { messageResource } from "@/features/messages/schema/resource"
+import { messageResourceWithRelations } from "@/features/messages/schema/resource"
 import { userResource } from "@/features/users/schemas/resource"
 
 export const conversationResource = createSelectSchema(conversationModel, {
@@ -20,7 +20,7 @@ export type ConversationResource = z.infer<typeof conversationResource>
 export const listConversationsItemResource = conversationResource.and(
   z.object({
     contactInboxes: z.array(contactInboxResource),
-    messages: z.array(messageResource),
+    messages: z.array(messageResourceWithRelations),
     contact: contactResource.nullable(),
     assignedUser: userResource.nullable(),
     assignedInboxTeam: inboxTeamResource.nullable(),

--- a/apps/builder/src/features/messages/schema/resource.ts
+++ b/apps/builder/src/features/messages/schema/resource.ts
@@ -19,6 +19,7 @@ export type MessageResource = z.infer<typeof messageResource>
 
 export const messageResourceWithRelations = messageResource.and(
   z.object({
+    attachmentCount: z.number().optional(),
     attachments: z.array(attachmentResource).optional(),
     user: userResource.optional(),
     contact: contactResource.optional(),

--- a/packages/database/src/repositories/message/message-repository.ts
+++ b/packages/database/src/repositories/message/message-repository.ts
@@ -42,6 +42,7 @@ export interface CreateAttachmentInput {
 export type BulkCreateAttachmentInput = CreateAttachmentInput & { id: string }
 
 export interface MessageWithAttachments extends MessageModel {
+  attachmentCount?: number
   attachments: AttachmentModel[]
 }
 
@@ -70,6 +71,7 @@ export interface ListMessagesQuery {
 }
 
 export interface FindLastByConversationOptions {
+  attachmentCountOnly?: boolean
   limit?: number
   messageTypes?: ("incoming" | "outgoing" | "activity")[]
   requireCompleteResults?: boolean

--- a/packages/database/src/sharding/message/repository/sharded-message-repository.ts
+++ b/packages/database/src/sharding/message/repository/sharded-message-repository.ts
@@ -247,6 +247,20 @@ export class ShardedMessageRepository implements IMessageRepository {
     )
   }
 
+  private mapMessagesToWithAttachmentCounts(
+    messages: MessageModel[],
+    attachmentCountByMessageId: Record<string, number>,
+  ): MessageWithAttachments[] {
+    return messages.map(
+      (message) =>
+        ({
+          ...message,
+          attachmentCount: attachmentCountByMessageId[message.id] ?? 0,
+          attachments: [],
+        }) as MessageWithAttachments,
+    )
+  }
+
   private async queryAttachmentsForMessages(
     db: MessageShardDatabaseClient,
     messageIds: string[],
@@ -276,6 +290,64 @@ export class ShardedMessageRepository implements IMessageRepository {
       .where(inArray(attachmentModel.messageId, messageIds))
 
     return attachments as AttachmentModel[]
+  }
+
+  private groupAttachmentCountsByMessageId(
+    rows: { messageId: string; count: number }[],
+  ): Record<string, number> {
+    return rows.reduce(
+      (acc, row) => {
+        acc[row.messageId] = Number(row.count)
+        return acc
+      },
+      {} as Record<string, number>,
+    )
+  }
+
+  private async fetchAttachmentCounts(
+    shardClient: MessageShardDatabaseClient,
+    messages: { id: string; createdAt: Date }[],
+  ): Promise<Record<string, number>> {
+    const messageIds = messages.map((m) => m.id)
+    const messageCreatedAts = messages.map((m) => m.createdAt)
+    const rows = await this.queryAttachmentCountsForMessages(
+      shardClient,
+      messageIds,
+      messageCreatedAts,
+    )
+    return this.groupAttachmentCountsByMessageId(rows)
+  }
+
+  private async queryAttachmentCountsForMessages(
+    db: MessageShardDatabaseClient,
+    messageIds: string[],
+    messageCreatedAts?: Date[],
+  ): Promise<{ messageId: string; count: number }[]> {
+    if (messageIds.length === 0) {
+      return []
+    }
+
+    const countColumn = sql<number>`count(*)`.as("count")
+
+    if (messageCreatedAts && messageCreatedAts.length === messageIds.length) {
+      const perMessageConditions = messageIds.map((id, i) =>
+        and(
+          eq(attachmentModel.messageId, id),
+          eq(attachmentModel.messageCreatedAt, messageCreatedAts[i]),
+        ),
+      )
+      return await db
+        .select({ messageId: attachmentModel.messageId, count: countColumn })
+        .from(attachmentModel)
+        .where(or(...perMessageConditions))
+        .groupBy(attachmentModel.messageId)
+    }
+
+    return await db
+      .select({ messageId: attachmentModel.messageId, count: countColumn })
+      .from(attachmentModel)
+      .where(inArray(attachmentModel.messageId, messageIds))
+      .groupBy(attachmentModel.messageId)
   }
 
   create(message: CreateMessageInput): Promise<MessageModel> {
@@ -1688,17 +1760,27 @@ export class ShardedMessageRepository implements IMessageRepository {
                 return []
               }
 
-              let attachmentsByMessageId: Record<string, AttachmentModel[]> = {}
               if (options?.withAttachments) {
-                attachmentsByMessageId = await this.fetchAndGroupAttachments(
-                  shardClient,
-                  messages,
+                const attachmentsByMessageId =
+                  await this.fetchAndGroupAttachments(shardClient, messages)
+                return this.mapMessagesToWithAttachments(
+                  messages as MessageModel[],
+                  attachmentsByMessageId,
+                )
+              }
+
+              if (options?.attachmentCountOnly) {
+                const attachmentCountByMessageId =
+                  await this.fetchAttachmentCounts(shardClient, messages)
+                return this.mapMessagesToWithAttachmentCounts(
+                  messages as MessageModel[],
+                  attachmentCountByMessageId,
                 )
               }
 
               return this.mapMessagesToWithAttachments(
                 messages as MessageModel[],
-                attachmentsByMessageId,
+                {},
               )
             },
           )


### PR DESCRIPTION
## Summary
- Show a "Sent N attachment(s)" fallback in the conversation list preview when the last message has no text but has attachments — previously the preview rendered blank.
- Fetch only an attachment **count** for last-message previews (`attachmentCountOnly`) instead of loading full attachment rows, keeping the per-conversation lookup cheap.
- Refactor the unread check in `ConversationItem` into a single `isUnread` flag (behavior-preserving) and highlight unread conversations with a ring on the avatar; preview text size changed from `text-sm` to `text-xs`.

> Note: the earlier "empty last-message preview" root cause (anchoring `sinceTime` on a shared `contactInbox.lastMessageAt`) is already fixed on `main` by anchoring on `conversation.lastActivityAt`; this PR builds the attachment-preview support on top of it and generalizes the docs of `resolveLastMessageSinceTime` accordingly.

## Changes
- `packages/database/src/sharding/message/repository/sharded-message-repository.ts`: new `attachmentCountOnly` handling in `findLastByConversation` — counts attachments per message (grouped by `messageId`, with `(messageId, messageCreatedAt)` conditions for partition pruning, mirroring `queryAttachmentsForMessages`).
- `packages/database/src/repositories/message/message-repository.ts`: add `attachmentCountOnly` to `FindLastByConversationOptions` and optional `attachmentCount` to `MessageWithAttachments`.
- `apps/builder/src/features/messages/schema/resource.ts`: `messageResourceWithRelations` now carries optional `attachmentCount`.
- `apps/builder/src/features/conversations/schema/resource.ts`: conversation list items use `messageResourceWithRelations` so `attachmentCount`/`attachments` survive oRPC output validation (also covers `findConversationResponse`).
- `apps/builder/src/features/conversations/queries/list-conversations.query.ts`: pass `attachmentCountOnly: true` in both `listConversations` and `findConversation`.
- `apps/builder/src/features/conversations/queries/resolve-last-message-preview.ts`: new preview helper — message text → `attachmentCount` → `attachments.length` (realtime payloads carry full attachments) → blank.
- `apps/builder/src/features/conversations/conversation-item.tsx`: use the preview helper; extract `isUnread`; unread avatar ring; preview `text-sm` → `text-xs`.
- `apps/builder/src/features/conversations/queries/last-message-window.ts`: doc/param-naming cleanup for `resolveLastMessageSinceTime` (no behavior change).
- `apps/builder/messages/en.json`, `apps/builder/messages/vi.json`: new `messages.sentAttachments` key (ICU plural in en).
- Tests: `apps/builder/__tests__/list-conversations-query.test.ts` (query passes `attachmentCountOnly`, propagates `attachmentCount`), `apps/builder/__tests__/resolve-last-message-preview.test.ts` (text priority, singular/plural, `attachments.length` fallback, empty states).

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [x] `vitest` — new suites for the list query flag and the preview helper
- [ ] Manual: send an attachment-only message (no text) and confirm the list shows "Sent 1 attachment" / "Đã gửi 1 tệp đính kèm", including via realtime update without reloading
- [ ] Manual: confirm unread conversations show the avatar ring and bold preview