### PR TITLE
fix(builder): show numbers in the app language and fix a page load error

### DIFF
--- a/apps/builder/__tests__/usage-number-formatting.test.tsx
+++ b/apps/builder/__tests__/usage-number-formatting.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment node
+
+import { NextIntlClientProvider } from "next-intl"
+import type { ReactNode } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, test } from "vitest"
+import { UsageBars } from "@/components/usage-bars"
+import { UsageRing } from "@/components/usage-ring"
+import type { QuotaMetricKey } from "@/lib/quota-metrics"
+
+const LABELS: Record<QuotaMetricKey, string> = {
+  contacts: "Contacts",
+  mac: "Monthly active contacts",
+  workspaces: "Workspaces",
+  channels: "Channels",
+  teamMembers: "Team members",
+}
+
+// renderToStaticMarkup mirrors what the server emits during SSR, so these
+// assertions prove the output depends on the next-intl locale rather than the
+// runtime's default locale — the invariant that prevents React #418
+// hydration text mismatches.
+const renderWithLocale = (locale: string, node: ReactNode) =>
+  renderToStaticMarkup(
+    <NextIntlClientProvider locale={locale} onError={() => undefined}>
+      {node}
+    </NextIntlClientProvider>,
+  )
+
+describe("usage number formatting", () => {
+  test("UsageRing formats numbers with the vi app locale", () => {
+    const html = renderWithLocale(
+      "vi",
+      <UsageRing label="MAC" limit={10_000} used={1234} />,
+    )
+
+    expect(html).toContain("1.234")
+    expect(html).toContain("10.000")
+  })
+
+  test("UsageRing formats numbers with the en app locale", () => {
+    const html = renderWithLocale(
+      "en",
+      <UsageRing label="MAC" limit={10_000} used={1234} />,
+    )
+
+    expect(html).toContain("1,234")
+    expect(html).toContain("10,000")
+  })
+
+  test("UsageBars formats numbers with the app locale", () => {
+    const metrics = [{ key: "mac" as const, used: 5678, limit: 100_000 }]
+
+    const viHtml = renderWithLocale(
+      "vi",
+      <UsageBars labels={LABELS} metrics={metrics} />,
+    )
+    expect(viHtml).toContain("5.678")
+    expect(viHtml).toContain("100.000")
+
+    const enHtml = renderWithLocale(
+      "en",
+      <UsageBars labels={LABELS} metrics={metrics} />,
+    )
+    expect(enHtml).toContain("5,678")
+    expect(enHtml).toContain("100,000")
+  })
+})

--- a/apps/builder/src/components/usage-bars.tsx
+++ b/apps/builder/src/components/usage-bars.tsx
@@ -1,5 +1,6 @@
 import { Progress } from "@chatbotx.io/ui/components/ui/progress"
 import { cn } from "@chatbotx.io/ui/lib/utils"
+import { useFormatter } from "next-intl"
 import {
   type QuotaMetric,
   type QuotaMetricKey,
@@ -9,9 +10,10 @@ import {
 export type { QuotaMetric, QuotaMetricKey } from "@/lib/quota-metrics"
 
 /**
- * Presentational quota usage bars. Pure (no hooks/context) so it can render in
- * both the client sidebar (`NavUsage`) and the server-rendered account rail.
- * Labels are resolved by the caller to keep this component context-free.
+ * Presentational quota usage bars. Renders in both the client sidebar
+ * (`NavUsage`) and the server-rendered account rail; numbers are formatted
+ * via next-intl so server and client produce identical text. Labels are
+ * resolved by the caller.
  */
 export function UsageBars({
   metrics,
@@ -22,6 +24,7 @@ export function UsageBars({
   labels: Record<QuotaMetricKey, string>
   className?: string
 }) {
+  const formatter = useFormatter()
   return (
     <div className={cn("flex flex-col gap-3", className)}>
       {metrics.map((metric) => {
@@ -38,7 +41,8 @@ export function UsageBars({
                   isOverLimit && "font-medium text-destructive",
                 )}
               >
-                {metric.used.toLocaleString()} / {metric.limit.toLocaleString()}
+                {formatter.number(metric.used)} /{" "}
+                {formatter.number(metric.limit)}
               </span>
             </div>
             <Progress

--- a/apps/builder/src/components/usage-ring.tsx
+++ b/apps/builder/src/components/usage-ring.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@chatbotx.io/ui/lib/utils"
+import { useFormatter } from "next-intl"
 import { quotaUsageState } from "@/lib/quota-metrics"
 
 const SIZE = 44
@@ -8,9 +9,10 @@ const CIRCUMFERENCE = 2 * Math.PI * RADIUS
 
 /**
  * Presentational circular usage ring (ManyChat-style) for the sidebar footer.
- * Pure (no hooks/context) like {@link UsageBars} so the caller owns label and
- * value resolution. The ring fills clockwise from the top; the track turns
- * destructive once usage reaches the limit.
+ * Like {@link UsageBars} the caller owns label resolution; numbers are
+ * formatted via next-intl so server and client render the same text (works in
+ * both RSC and client trees). The ring fills clockwise from the top; the
+ * track turns destructive once usage reaches the limit.
  */
 export function UsageRing({
   used,
@@ -23,6 +25,7 @@ export function UsageRing({
   label: string
   className?: string
 }) {
+  const formatter = useFormatter()
   const { pct, isOverLimit } = quotaUsageState(used, limit)
   const dashOffset = CIRCUMFERENCE - (pct / 100) * CIRCUMFERENCE
 
@@ -68,7 +71,7 @@ export function UsageRing({
             isOverLimit && "text-destructive",
           )}
         >
-          {used.toLocaleString()} / {limit.toLocaleString()}
+          {formatter.number(used)} / {formatter.number(limit)}
         </span>
       </div>
     </div>

--- a/apps/builder/src/features/broadcasts/broadcast-detail-dialog.tsx
+++ b/apps/builder/src/features/broadcasts/broadcast-detail-dialog.tsx
@@ -20,7 +20,7 @@ import {
 } from "@chatbotx.io/ui/components/ui/dialog"
 import { Skeleton } from "@chatbotx.io/ui/components/ui/skeleton"
 import { format } from "date-fns"
-import { useTranslations } from "next-intl"
+import { useFormatter, useTranslations } from "next-intl"
 import { type ReactNode, useEffect, useMemo, useState } from "react"
 import { ContactFilterSummary } from "@/features/contact-filter/components/contact-filter-summary"
 import { contactFilterCriteriaSchema } from "@/features/contact-filter/schemas"
@@ -43,6 +43,7 @@ export function BroadcastDetailDialog({
   onOpenChange,
 }: BroadcastDetailDialogProps) {
   const t = useTranslations()
+  const formatter = useFormatter()
   const workspaceId = useWorkspaceId()
   const [templateDetail, setTemplateDetail] =
     useState<BroadcastTemplateDetail | null>(null)
@@ -166,7 +167,11 @@ export function BroadcastDetailDialog({
             />
             <DetailField
               label={t("fields.estimatedContacts.label")}
-              value={broadcast.contactCount?.toLocaleString() ?? "-"}
+              value={
+                broadcast.contactCount == null
+                  ? "-"
+                  : formatter.number(broadcast.contactCount)
+              }
             />
             <DetailField
               label={t("fields.flowId.label")}

--- a/apps/builder/src/features/broadcasts/components/broadcast-stats-cell.tsx
+++ b/apps/builder/src/features/broadcasts/components/broadcast-stats-cell.tsx
@@ -3,6 +3,7 @@
 import type { GetBroadcastStatsResponse } from "@chatbotx.io/analytics/schemas"
 import { Skeleton } from "@chatbotx.io/ui/components/ui/skeleton"
 import { useParams } from "next/navigation"
+import { useFormatter } from "next-intl"
 import { memo, useCallback, useState } from "react"
 import { useBroadcastStatsStore } from "../provider/broadcast-stats-store-context"
 import { BroadcastContactsDialog } from "./broadcast-contacts-dialog"
@@ -17,6 +18,7 @@ export const BroadcastStatsCell = memo(function BroadcastStatsCell({
   field,
 }: Props) {
   const { workspaceId } = useParams<{ workspaceId: string }>()
+  const formatter = useFormatter()
   const [dialogOpen, setDialogOpen] = useState(false)
 
   const stats = useBroadcastStatsStore((state) => state.stats[broadcastId])
@@ -61,7 +63,7 @@ export const BroadcastStatsCell = memo(function BroadcastStatsCell({
         onClick={handleClick}
         type="button"
       >
-        {value ? value.toLocaleString() : "----"}
+        {value ? formatter.number(value) : "----"}
         {percentage && (
           <span className="ml-1 text-muted-foreground">({percentage}%)</span>
         )}

--- a/apps/builder/src/features/common/components/stats-contacts-dialog.tsx
+++ b/apps/builder/src/features/common/components/stats-contacts-dialog.tsx
@@ -24,7 +24,7 @@ import { Skeleton } from "@chatbotx.io/ui/components/ui/skeleton"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { Loader2Icon, TagIcon } from "lucide-react"
 import Link from "next/link"
-import { useTranslations } from "next-intl"
+import { useFormatter, useTranslations } from "next-intl"
 import { memo, useCallback, useEffect, useRef, useState } from "react"
 import { useForm } from "react-hook-form"
 import { toast } from "sonner"
@@ -105,6 +105,7 @@ const StatsContactsDialogInner = memo(function StatsContactsDialogInner({
   onBulkTag,
 }: StatsContactsDialogProps) {
   const t = useTranslations()
+  const formatter = useFormatter()
   const scrollRootRef = useRef<HTMLDivElement>(null)
   const [contacts, setContacts] = useState<StatsContactRow[]>([])
   const [page, setPage] = useState(1)
@@ -216,7 +217,7 @@ const StatsContactsDialogInner = memo(function StatsContactsDialogInner({
       <DialogContent className="flex max-h-screen flex-col sm:max-w-2xl">
         <DialogHeader className="mb-2">
           <DialogTitle>
-            {title} ({total.toLocaleString()})
+            {title} ({formatter.number(total)})
           </DialogTitle>
         </DialogHeader>
 

--- a/apps/builder/src/features/contacts/contacts-table.tsx
+++ b/apps/builder/src/features/contacts/contacts-table.tsx
@@ -20,7 +20,7 @@ import type { Column, ColumnDef } from "@tanstack/react-table"
 import { format, formatDistanceToNow } from "date-fns"
 import Link from "next/link"
 import { useSearchParams } from "next/navigation"
-import { useTranslations } from "next-intl"
+import { useFormatter, useTranslations } from "next-intl"
 import { use, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   type ContactFilterCriteria,
@@ -129,6 +129,7 @@ export function ContactsTable({
   promises,
 }: ContactsTableProps) {
   const t = useTranslations()
+  const formatter = useFormatter()
   const searchParams = useSearchParams()
   const searchParamsKey = searchParams.toString()
   const [
@@ -239,7 +240,7 @@ export function ContactsTable({
     }),
     [keyword, isOptimisticContactFilterActive, optimisticContactFilter],
   )
-  const totalCountDisplay = tableTotalCount.toLocaleString()
+  const totalCountDisplay = formatter.number(tableTotalCount)
   const totalCountLabel = tableTotalCountCapped
     ? t("contacts.countCapped", { count: totalCountDisplay })
     : t("contacts.countExact", { count: totalCountDisplay })

--- a/apps/builder/src/features/sequences/components/sequence-step-stats.tsx
+++ b/apps/builder/src/features/sequences/components/sequence-step-stats.tsx
@@ -8,6 +8,7 @@ import type {
 import { Skeleton } from "@chatbotx.io/ui/components/ui/skeleton"
 import ky from "ky"
 import { useParams } from "next/navigation"
+import { useFormatter } from "next-intl"
 import { memo, useEffect, useState } from "react"
 import { SequenceStepContactsDialog } from "./sequence-step-contacts-dialog"
 
@@ -21,6 +22,7 @@ export const SequenceStepStats = memo(function SequenceStepStats({
   stepId,
 }: Props) {
   const { workspaceId } = useParams<{ workspaceId: string }>()
+  const formatter = useFormatter()
   const [stats, setStats] = useState<GetSequenceStepStatsResponse | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -73,7 +75,7 @@ export const SequenceStepStats = memo(function SequenceStepStats({
   }, [workspaceId, sequenceId, stepId])
 
   const formatValue = (value: number) =>
-    stats === null ? "----" : value.toLocaleString()
+    stats === null ? "----" : formatter.number(value)
 
   const handleStatClick = (eventType: SequenceStepEventType, total: number) => {
     if (total > 0 && stepId) {


### PR DESCRIPTION
## What this fixes

- Numbers across the app (usage in the sidebar, contact counts, broadcast and sequence stats) now always follow the language selected in the app, on every page.
- Fixes a React error (#418) that appeared in the browser console on production every time a page loaded. The page still worked, but it made loading slightly slower and caused a small flicker.

## Why it happened

Numbers were formatted using the server's language on the server and the browser's language on the client, so the two sides could disagree (for example `1,234` vs `1.234`). Now both sides use the language configured in the app, so they always match.

## Test plan

- [x] New test verifying numbers render as `1.234` for Vietnamese and `1,234` for English on the server-rendered output
- [x] `pnpm lint` and `pnpm --filter builder check-types` pass
- [ ] After deploy, confirm the console error no longer appears on production