### PR TITLE
feat(auth): add reseller SMTP routing and account credentials email template

### DIFF
--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -3455,6 +3455,10 @@
       "magicLink": {
         "title": "Magic Link Sign-in Email",
         "description": "Sent when a user requests a magic link to sign in"
+      },
+      "accountCredentials": {
+        "title": "Sub-account Credentials Email",
+        "description": "Sent when a reseller provisions a new sub-account"
       }
     },
     "fields": {

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -3479,6 +3479,10 @@
       "magicLink": {
         "title": "Email Magic Link Đăng Nhập",
         "description": "Gửi khi người dùng yêu cầu magic link để đăng nhập"
+      },
+      "accountCredentials": {
+        "title": "Email Thông Tin Đăng Nhập Tài Khoản Con",
+        "description": "Gửi khi reseller tạo một tài khoản con mới"
       }
     },
     "fields": {

--- a/apps/builder/src/app/admin/(enterprise)/(non-cloud)/email-templates/[type]/page.tsx
+++ b/apps/builder/src/app/admin/(enterprise)/(non-cloud)/email-templates/[type]/page.tsx
@@ -1,6 +1,8 @@
 import { tenantService } from "@chatbotx.io/business"
 import { ROOT_TENANT_ID } from "@chatbotx.io/database/schema"
 import {
+  DEFAULT_ACCOUNT_CREDENTIALS_SUBJECT,
+  DEFAULT_ACCOUNT_CREDENTIALS_TEMPLATE,
   DEFAULT_FORGOT_PASSWORD_SUBJECT,
   DEFAULT_FORGOT_PASSWORD_TEMPLATE,
   DEFAULT_MAGIC_LINK_SUBJECT,
@@ -8,6 +10,9 @@ import {
   DEFAULT_SIGNUP_SUBJECT,
   DEFAULT_SIGNUP_TEMPLATE,
 } from "@chatbotx.io/mail"
+import { Button } from "@chatbotx.io/ui/components/ui/button"
+import { ArrowLeftIcon } from "lucide-react"
+import Link from "next/link"
 import { notFound } from "next/navigation"
 import { getTranslations } from "next-intl/server"
 import {
@@ -29,6 +34,7 @@ type TemplateConfig = {
     | "signupEmailTemplate"
     | "forgotPasswordEmailTemplate"
     | "magicLinkEmailTemplate"
+    | "accountCredentialsEmailTemplate"
   defaultSubject: string
   defaultBody: string
 }
@@ -59,6 +65,21 @@ const TEMPLATE_CONFIG: Record<EmailTemplateType, TemplateConfig> = {
     defaultSubject: DEFAULT_MAGIC_LINK_SUBJECT,
     defaultBody: DEFAULT_MAGIC_LINK_TEMPLATE,
   },
+  accountCredentials: {
+    titleKey: "platformEmailTemplates.sections.accountCredentials.title",
+    descriptionKey:
+      "platformEmailTemplates.sections.accountCredentials.description",
+    variables: [
+      "{{userName}}",
+      "{{loginEmail}}",
+      "{{initialPassword}}",
+      "{{signInUrl}}",
+      "{{brandName}}",
+    ],
+    settingKey: "accountCredentialsEmailTemplate",
+    defaultSubject: DEFAULT_ACCOUNT_CREDENTIALS_SUBJECT,
+    defaultBody: DEFAULT_ACCOUNT_CREDENTIALS_TEMPLATE,
+  },
 }
 
 export default async function AdminEmailTemplateEditPage({
@@ -85,9 +106,17 @@ export default async function AdminEmailTemplateEditPage({
 
   return (
     <div className="space-y-4">
-      <h3 className="font-bold text-lg sm:text-xl">
-        {t(config.titleKey as Parameters<typeof t>[0])}
-      </h3>
+      <div className="flex items-center gap-3">
+        <Button asChild size="icon" variant="outline">
+          <Link href="/admin/email-templates">
+            <ArrowLeftIcon className="size-4" />
+            <span className="sr-only">{t("actions.back")}</span>
+          </Link>
+        </Button>
+        <h3 className="font-bold text-lg sm:text-xl">
+          {t(config.titleKey as Parameters<typeof t>[0])}
+        </h3>
+      </div>
 
       <PlatformEmailTemplateEditor
         description={t(config.descriptionKey as Parameters<typeof t>[0])}

--- a/apps/builder/src/app/manage/(enterprise)/email-templates/[type]/page.tsx
+++ b/apps/builder/src/app/manage/(enterprise)/email-templates/[type]/page.tsx
@@ -1,5 +1,7 @@
 import { tenantService } from "@chatbotx.io/business"
 import {
+  DEFAULT_ACCOUNT_CREDENTIALS_SUBJECT,
+  DEFAULT_ACCOUNT_CREDENTIALS_TEMPLATE,
   DEFAULT_FORGOT_PASSWORD_SUBJECT,
   DEFAULT_FORGOT_PASSWORD_TEMPLATE,
   DEFAULT_MAGIC_LINK_SUBJECT,
@@ -7,6 +9,9 @@ import {
   DEFAULT_SIGNUP_SUBJECT,
   DEFAULT_SIGNUP_TEMPLATE,
 } from "@chatbotx.io/mail"
+import { Button } from "@chatbotx.io/ui/components/ui/button"
+import { ArrowLeftIcon } from "lucide-react"
+import Link from "next/link"
 import { notFound } from "next/navigation"
 import { getTranslations } from "next-intl/server"
 import {
@@ -29,6 +34,7 @@ type TemplateConfig = {
     | "signupEmailTemplate"
     | "forgotPasswordEmailTemplate"
     | "magicLinkEmailTemplate"
+    | "accountCredentialsEmailTemplate"
   defaultSubject: string
   defaultBody: string
 }
@@ -58,6 +64,21 @@ const TEMPLATE_CONFIG: Record<EmailTemplateType, TemplateConfig> = {
     settingKey: "magicLinkEmailTemplate",
     defaultSubject: DEFAULT_MAGIC_LINK_SUBJECT,
     defaultBody: DEFAULT_MAGIC_LINK_TEMPLATE,
+  },
+  accountCredentials: {
+    titleKey: "platformEmailTemplates.sections.accountCredentials.title",
+    descriptionKey:
+      "platformEmailTemplates.sections.accountCredentials.description",
+    variables: [
+      "{{userName}}",
+      "{{loginEmail}}",
+      "{{initialPassword}}",
+      "{{signInUrl}}",
+      "{{brandName}}",
+    ],
+    settingKey: "accountCredentialsEmailTemplate",
+    defaultSubject: DEFAULT_ACCOUNT_CREDENTIALS_SUBJECT,
+    defaultBody: DEFAULT_ACCOUNT_CREDENTIALS_TEMPLATE,
   },
 }
 
@@ -91,9 +112,17 @@ export default async function ManageEmailTemplateEditPage({
 
   return (
     <div className="space-y-4">
-      <h3 className="font-bold text-lg sm:text-xl">
-        {t(config.titleKey as Parameters<typeof t>[0])}
-      </h3>
+      <div className="flex items-center gap-3">
+        <Button asChild size="icon" variant="outline">
+          <Link href="/manage/email-templates">
+            <ArrowLeftIcon className="size-4" />
+            <span className="sr-only">{t("actions.back")}</span>
+          </Link>
+        </Button>
+        <h3 className="font-bold text-lg sm:text-xl">
+          {t(config.titleKey as Parameters<typeof t>[0])}
+        </h3>
+      </div>
 
       <PlatformEmailTemplateEditor
         description={t(config.descriptionKey as Parameters<typeof t>[0])}

--- a/apps/builder/src/enterprise/features/platform-email-templates/email-template.schema.ts
+++ b/apps/builder/src/enterprise/features/platform-email-templates/email-template.schema.ts
@@ -4,6 +4,7 @@ export const emailTemplateTypes = [
   "signup",
   "forgotPassword",
   "magicLink",
+  "accountCredentials",
 ] as const
 export type EmailTemplateType = (typeof emailTemplateTypes)[number]
 

--- a/apps/builder/src/enterprise/features/platform-email-templates/platform-email-templates-settings.tsx
+++ b/apps/builder/src/enterprise/features/platform-email-templates/platform-email-templates-settings.tsx
@@ -19,6 +19,7 @@ type TemplateConfig = {
     | "signupEmailTemplate"
     | "forgotPasswordEmailTemplate"
     | "magicLinkEmailTemplate"
+    | "accountCredentialsEmailTemplate"
   >
   type: string
   titleKey:
@@ -26,11 +27,13 @@ type TemplateConfig = {
     | "platformEmailTemplates.sections.invitation.title"
     | "platformEmailTemplates.sections.forgotPassword.title"
     | "platformEmailTemplates.sections.magicLink.title"
+    | "platformEmailTemplates.sections.accountCredentials.title"
   descriptionKey:
     | "platformEmailTemplates.sections.signup.description"
     | "platformEmailTemplates.sections.invitation.description"
     | "platformEmailTemplates.sections.forgotPassword.description"
     | "platformEmailTemplates.sections.magicLink.description"
+    | "platformEmailTemplates.sections.accountCredentials.description"
 }
 
 const TEMPLATES: TemplateConfig[] = [
@@ -52,6 +55,13 @@ const TEMPLATES: TemplateConfig[] = [
     type: "magicLink",
     titleKey: "platformEmailTemplates.sections.magicLink.title",
     descriptionKey: "platformEmailTemplates.sections.magicLink.description",
+  },
+  {
+    settingKey: "accountCredentialsEmailTemplate",
+    type: "accountCredentials",
+    titleKey: "platformEmailTemplates.sections.accountCredentials.title",
+    descriptionKey:
+      "platformEmailTemplates.sections.accountCredentials.description",
   },
 ]
 

--- a/apps/builder/src/enterprise/features/platform-email-templates/update-email-template.action.ts
+++ b/apps/builder/src/enterprise/features/platform-email-templates/update-email-template.action.ts
@@ -20,11 +20,13 @@ const templateKeyMap: Record<
     | "signupEmailTemplate"
     | "forgotPasswordEmailTemplate"
     | "magicLinkEmailTemplate"
+    | "accountCredentialsEmailTemplate"
   >
 > = {
   signup: "signupEmailTemplate",
   forgotPassword: "forgotPasswordEmailTemplate",
   magicLink: "magicLinkEmailTemplate",
+  accountCredentials: "accountCredentialsEmailTemplate",
 }
 
 const toTemplateUpdate = (input: UpdateEmailTemplateSchema) => {

--- a/packages/auth/__tests__/provisioning.test.ts
+++ b/packages/auth/__tests__/provisioning.test.ts
@@ -94,6 +94,10 @@ beforeEach(() => {
     name: "Reseller Co",
     logoLightUrl: "https://reseller.test/logo.svg",
     appUrl: "https://app.reseller.test",
+    accountCredentialsEmailTemplate: {
+      subject: "Welcome to {{brandName}}",
+      body: "<mjml>custom credentials</mjml>",
+    },
   })
 })
 
@@ -155,6 +159,10 @@ describe("provisionResellerAccount", () => {
         initialPassword: "TempPass123456AB",
         brandName: "Reseller Co",
         signInUrl: "https://app.reseller.test/auth/sign-in",
+        customTemplate: {
+          subject: "Welcome to {{brandName}}",
+          body: "<mjml>custom credentials</mjml>",
+        },
       }),
       expect.objectContaining({
         host: "smtp.reseller.test",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@chatbotx.io/business": "workspace:*",
     "@chatbotx.io/database": "workspace:*",
+    "@chatbotx.io/logger": "workspace:*",
     "@chatbotx.io/mail": "workspace:*",
     "@chatbotx.io/sdk": "workspace:*",
     "@chatbotx.io/utils": "workspace:*",

--- a/packages/auth/src/logger.ts
+++ b/packages/auth/src/logger.ts
@@ -1,0 +1,3 @@
+import { getChildLogger } from "@chatbotx.io/logger"
+
+export const logger = getChildLogger("Auth")

--- a/packages/auth/src/provisioning.ts
+++ b/packages/auth/src/provisioning.ts
@@ -110,6 +110,7 @@ export async function provisionResellerAccount(
       brandLogoUrl: settings.logoLightUrl,
       brandUrl: settings.appUrl,
       subject: DEFAULT_ACCOUNT_CREDENTIALS_SUBJECT,
+      customTemplate: settings.accountCredentialsEmailTemplate,
       userName: name,
       loginEmail: email,
       initialPassword,

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -1,5 +1,6 @@
 import {
   customDomainService,
+  platformCredentialService,
   resolveTenantSettingsByDomain,
 } from "@chatbotx.io/business"
 import { db } from "@chatbotx.io/database/client"
@@ -17,6 +18,7 @@ import {
   sendResetPassword,
   sendSignUpVerification,
 } from "@chatbotx.io/mail"
+import type { SmtpTransportOptions } from "@chatbotx.io/mail/transport"
 import { createId, getPublicOriginFromRequest } from "@chatbotx.io/utils"
 import { APIError, betterAuth } from "better-auth"
 import { drizzleAdapter } from "better-auth/adapters/drizzle"
@@ -24,6 +26,7 @@ import { nextCookies } from "better-auth/next-js"
 import { anonymous, magicLink, oneTimeToken } from "better-auth/plugins"
 import { PHASE_PRODUCTION_BUILD } from "next/constants"
 import { env, getBrokerUrl } from "./keys"
+import { logger } from "./logger"
 import {
   getTenantId,
   isStrictTenantScope,
@@ -33,6 +36,49 @@ import {
 const getTenantSettings = async (request: Request) => {
   const domain = request.headers.get("x-domain") ?? ""
   return await resolveTenantSettingsByDomain(domain)
+}
+
+type SmtpResolution =
+  | { kind: "default" }
+  | {
+      kind: "transport"
+      transport: SmtpTransportOptions & {
+        fromEmail: string
+        fromName?: string
+      }
+    }
+  | { kind: "blocked" }
+
+const resolveSmtpForTenant = async (): Promise<SmtpResolution> => {
+  const tenantId = getTenantId()
+  const ownerId = await resolveTenantOwnerId(tenantId)
+  if (!ownerId) {
+    return { kind: "default" }
+  }
+
+  const smtp = await platformCredentialService.findDecryptedForUser({
+    userId: ownerId,
+    type: "smtp",
+  })
+  if (!smtp) {
+    logger.warn(
+      { tenantId, ownerId },
+      "Reseller has no SMTP credential configured; skipping auth email send",
+    )
+    return { kind: "blocked" }
+  }
+
+  return {
+    kind: "transport",
+    transport: {
+      host: smtp.config.host,
+      port: smtp.config.port,
+      username: smtp.config.username,
+      password: smtp.config.password,
+      fromEmail: smtp.config.fromEmail,
+      fromName: smtp.config.fromName,
+    },
+  }
 }
 
 type AdapterFactory = ReturnType<typeof drizzleAdapter>
@@ -355,10 +401,15 @@ export function createAuth(config: AuthConfig) {
           })
         }
 
-        const [originUrl, platformInfo] = await Promise.all([
+        const [originUrl, platformInfo, smtpResolution] = await Promise.all([
           getPublicOriginFromRequest(request as unknown as Request),
           getTenantSettings(request),
+          resolveSmtpForTenant(),
         ])
+
+        if (smtpResolution.kind === "blocked") {
+          return
+        }
 
         const resetPasswordUrl = new URL(url)
         resetPasswordUrl.hostname = new URL(originUrl).hostname
@@ -369,7 +420,7 @@ export function createAuth(config: AuthConfig) {
           forgotPasswordEmailTemplate,
         } = platformInfo
 
-        await sendResetPassword(user.email, {
+        const props = {
           brandName,
           brandLogoUrl: logoLightUrl,
           brandUrl: new URL("/", originUrl).toString(),
@@ -377,7 +428,12 @@ export function createAuth(config: AuthConfig) {
           userName: user.name ?? user.email,
           resetPasswordUrl: resetPasswordUrl.toString(),
           customTemplate: forgotPasswordEmailTemplate,
-        })
+        }
+        if (smtpResolution.kind === "transport") {
+          await sendResetPassword(user.email, props, smtpResolution.transport)
+        } else {
+          await sendResetPassword(user.email, props)
+        }
       },
     },
     emailVerification: {
@@ -388,10 +444,15 @@ export function createAuth(config: AuthConfig) {
           })
         }
 
-        const [originUrl, platformInfo] = await Promise.all([
+        const [originUrl, platformInfo, smtpResolution] = await Promise.all([
           getPublicOriginFromRequest(request as unknown as Request),
           getTenantSettings(request),
+          resolveSmtpForTenant(),
         ])
+
+        if (smtpResolution.kind === "blocked") {
+          return
+        }
 
         const verificationUrl = new URL(url)
         verificationUrl.hostname = new URL(originUrl).hostname
@@ -402,7 +463,7 @@ export function createAuth(config: AuthConfig) {
           signupEmailTemplate,
         } = platformInfo
 
-        await sendSignUpVerification(user.email, {
+        const props = {
           brandName,
           brandLogoUrl: logoLightUrl,
           brandUrl: new URL("/", originUrl).toString(),
@@ -410,7 +471,16 @@ export function createAuth(config: AuthConfig) {
           userName: user.name ?? user.email,
           verificationUrl: verificationUrl.toString(),
           customTemplate: signupEmailTemplate,
-        })
+        }
+        if (smtpResolution.kind === "transport") {
+          await sendSignUpVerification(
+            user.email,
+            props,
+            smtpResolution.transport,
+          )
+        } else {
+          await sendSignUpVerification(user.email, props)
+        }
       },
     },
     plugins: [
@@ -422,10 +492,15 @@ export function createAuth(config: AuthConfig) {
             })
           }
 
-          const [originUrl, platformInfo] = await Promise.all([
+          const [originUrl, platformInfo, smtpResolution] = await Promise.all([
             getPublicOriginFromRequest(request as unknown as Request),
             getTenantSettings(request as unknown as Request),
+            resolveSmtpForTenant(),
           ])
+
+          if (smtpResolution.kind === "blocked") {
+            return
+          }
 
           const magicUrl = new URL(url)
           magicUrl.hostname = new URL(originUrl).hostname
@@ -461,7 +536,7 @@ export function createAuth(config: AuthConfig) {
             })
           }
 
-          await sendMagicLink(email, {
+          const props = {
             brandName,
             brandLogoUrl: logoLightUrl,
             brandUrl: new URL("/", originUrl).toString(),
@@ -469,7 +544,12 @@ export function createAuth(config: AuthConfig) {
             userName: user.name ?? email,
             magicUrl: magicUrl.toString(),
             customTemplate: magicLinkEmailTemplate,
-          })
+          }
+          if (smtpResolution.kind === "transport") {
+            await sendMagicLink(email, props, smtpResolution.transport)
+          } else {
+            await sendMagicLink(email, props)
+          }
         },
       }),
       oneTimeToken(),

--- a/packages/business/src/platform/settings.ts
+++ b/packages/business/src/platform/settings.ts
@@ -32,6 +32,7 @@ export type TenantSettings = {
   signupEmailTemplate: EmailTemplate | null
   forgotPasswordEmailTemplate: EmailTemplate | null
   magicLinkEmailTemplate: EmailTemplate | null
+  accountCredentialsEmailTemplate: EmailTemplate | null
   helpItems: TenantHelpItemModel[]
 }
 
@@ -58,6 +59,7 @@ const buildDefaults = (helpItems: TenantHelpItemModel[]): TenantSettings => {
     signupEmailTemplate: null,
     forgotPasswordEmailTemplate: null,
     magicLinkEmailTemplate: null,
+    accountCredentialsEmailTemplate: null,
     helpItems,
   }
 }
@@ -122,6 +124,7 @@ const applyTenantSetting = (
     signupEmailTemplate: setting.signupEmailTemplate,
     forgotPasswordEmailTemplate: setting.forgotPasswordEmailTemplate,
     magicLinkEmailTemplate: setting.magicLinkEmailTemplate,
+    accountCredentialsEmailTemplate: setting.accountCredentialsEmailTemplate,
     helpItems,
   }
 }

--- a/packages/database/drizzle/20260711143539_add_webhook_execution_table/snapshot.json
+++ b/packages/database/drizzle/20260711143539_add_webhook_execution_table/snapshot.json
@@ -2,7 +2,7 @@
   "version": "8",
   "dialect": "postgres",
   "id": "f5930f13-9a54-4d16-907c-0cf8e2a8fa8a",
-  "prevIds": ["729023c3-068e-494a-ba73-963576883a68"],
+  "prevIds": ["655697bf-15a9-45b4-9be7-fe98ff9f0a0d"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],

--- a/packages/database/drizzle/20260714001355_add_broadcast_integration_messenger_id/snapshot.json
+++ b/packages/database/drizzle/20260714001355_add_broadcast_integration_messenger_id/snapshot.json
@@ -1,8 +1,8 @@
 {
   "version": "8",
   "dialect": "postgres",
-  "id": "43dbfa0b-5c41-4380-9103-04cea417022b",
-  "prevIds": ["54d5310f-03ec-4c42-9e6a-8bb868b55d46"],
+  "id": "2e8c9ec0-59e9-4135-a158-ac6d6e606144",
+  "prevIds": ["43dbfa0b-5c41-4380-9103-04cea417022b"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],
@@ -8416,6 +8416,19 @@
       "generated": null,
       "identity": null,
       "name": "periodEnd",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "UserQuota"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "channelsTornDownAt",
       "entityType": "columns",
       "schema": "public",
       "table": "UserQuota"
@@ -17199,6 +17212,19 @@
       "table": "Workspace"
     },
     {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scheduledDeletionAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Workspace"
+    },
+    {
       "type": "bigint",
       "typeSchema": null,
       "notNull": true,
@@ -19916,6 +19942,27 @@
       "entityType": "indexes",
       "schema": "public",
       "table": "TenantHelpItem"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "channelsTornDownAt",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "UserQuota_channelsTornDownAt_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "UserQuota"
     },
     {
       "nameExplicit": true,
@@ -23525,6 +23572,27 @@
       "method": "btree",
       "concurrently": false,
       "name": "Workspace_tenantId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "Workspace"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "scheduledDeletionAt",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "Workspace_scheduledDeletionAt_idx",
       "entityType": "indexes",
       "schema": "public",
       "table": "Workspace"

--- a/packages/database/drizzle/20260714082320_add_account_credentials_email_template/migration.sql
+++ b/packages/database/drizzle/20260714082320_add_account_credentials_email_template/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Tenant" ADD COLUMN "accountCredentialsEmailTemplate" jsonb;

--- a/packages/database/drizzle/20260714082320_add_account_credentials_email_template/snapshot.json
+++ b/packages/database/drizzle/20260714082320_add_account_credentials_email_template/snapshot.json
@@ -1,8 +1,8 @@
 {
   "version": "8",
   "dialect": "postgres",
-  "id": "b7994885-807e-4aeb-b987-9c8eda2539ca",
-  "prevIds": ["729023c3-068e-494a-ba73-963576883a68"],
+  "id": "7cdd16f4-ac5f-4dd4-8d48-b60257ef74ee",
+  "prevIds": ["2e8c9ec0-59e9-4135-a158-ac6d6e606144"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],
@@ -252,6 +252,12 @@
     {
       "values": ["refLink", "qrCode"],
       "name": "ReflinkType",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": ["me"],
+      "name": "SystemFieldType",
       "entityType": "enums",
       "schema": "public"
     },
@@ -695,6 +701,12 @@
     },
     {
       "isRlsEnabled": false,
+      "name": "IntegrationFacebookAds",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
       "name": "IntegrationGemini",
       "entityType": "tables",
       "schema": "public"
@@ -750,6 +762,12 @@
     {
       "isRlsEnabled": false,
       "name": "IntegrationOpenai",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "IntegrationOpenaiCompatible",
       "entityType": "tables",
       "schema": "public"
     },
@@ -899,6 +917,12 @@
     },
     {
       "isRlsEnabled": false,
+      "name": "SystemField",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
       "name": "Tag",
       "entityType": "tables",
       "schema": "public"
@@ -948,6 +972,12 @@
     {
       "isRlsEnabled": false,
       "name": "Webhook",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "WebhookExecution",
       "entityType": "tables",
       "schema": "public"
     },
@@ -4960,6 +4990,19 @@
       "default": null,
       "generated": null,
       "identity": null,
+      "name": "integrationMessengerId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Broadcast"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
       "name": "templateId",
       "entityType": "columns",
       "schema": "public",
@@ -6068,6 +6111,19 @@
       "default": null,
       "generated": null,
       "identity": null,
+      "name": "language",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ContactInbox"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
       "name": "personaId",
       "entityType": "columns",
       "schema": "public",
@@ -6094,6 +6150,19 @@
       "default": null,
       "generated": null,
       "identity": null,
+      "name": "firstInteractionAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ContactInbox"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
       "name": "lastMessageAt",
       "entityType": "columns",
       "schema": "public",
@@ -6108,6 +6177,123 @@
       "generated": null,
       "identity": null,
       "name": "lastIncomingMessageAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ContactInbox"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "lastOutboundMessageAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ContactInbox"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "referral",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ContactInbox"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "lastCommentMessageId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ContactInbox"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "lastCommentMessageAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ContactInbox"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "consecutiveFailedReply",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ContactInbox"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "lastInputFailure",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ContactInbox"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "lastErrorLog",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ContactInbox"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "lastBtnTitle",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ContactInbox"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "webchatParentUrl",
       "entityType": "columns",
       "schema": "public",
       "table": "ContactInbox"
@@ -7000,6 +7186,32 @@
       "table": "Conversation"
     },
     {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "lastStep",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Conversation"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "currentStep",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Conversation"
+    },
+    {
       "type": "timestamp(6) with time zone",
       "typeSchema": null,
       "notNull": false,
@@ -7819,6 +8031,19 @@
       "table": "Tenant"
     },
     {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "accountCredentialsEmailTemplate",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Tenant"
+    },
+    {
       "type": "bigint",
       "typeSchema": null,
       "notNull": true,
@@ -8204,6 +8429,19 @@
       "generated": null,
       "identity": null,
       "name": "periodEnd",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "UserQuota"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "channelsTornDownAt",
       "entityType": "columns",
       "schema": "public",
       "table": "UserQuota"
@@ -10611,6 +10849,110 @@
       "name": "id",
       "entityType": "columns",
       "schema": "public",
+      "table": "IntegrationFacebookAds"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationFacebookAds"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationFacebookAds"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspaceId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationFacebookAds"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "integrationId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationFacebookAds"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "auth",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationFacebookAds"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tokenExpiresAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationFacebookAds"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'active'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationFacebookAds"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
       "table": "IntegrationGemini"
     },
     {
@@ -11782,6 +12124,162 @@
       "entityType": "columns",
       "schema": "public",
       "table": "IntegrationOpenai"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationOpenaiCompatible"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationOpenaiCompatible"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationOpenaiCompatible"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "auth",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationOpenaiCompatible"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "autoReply",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationOpenaiCompatible"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "baseURL",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationOpenaiCompatible"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "defaultModel",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationOpenaiCompatible"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationOpenaiCompatible"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "integrationId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationOpenaiCompatible"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationOpenaiCompatible"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "preset",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationOpenaiCompatible"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspaceId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationOpenaiCompatible"
     },
     {
       "type": "bigint",
@@ -15125,6 +15623,71 @@
       "name": "id",
       "entityType": "columns",
       "schema": "public",
+      "table": "SystemField"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "SystemField"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "SystemField"
+    },
+    {
+      "type": "SystemFieldType",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "SystemField"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "SystemField"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
       "table": "Tag"
     },
     {
@@ -16023,6 +16586,97 @@
       "entityType": "columns",
       "schema": "public",
       "table": "Webhook"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "WebhookExecution"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "WebhookExecution"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "WebhookExecution"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "executedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "WebhookExecution"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "webhookId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "WebhookExecution"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "contactId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "WebhookExecution"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspaceId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "WebhookExecution"
     },
     {
       "type": "bigint",
@@ -18356,6 +19010,130 @@
       "nameExplicit": true,
       "columns": [
         {
+          "value": "workspaceId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "createdAt",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "idx_contact_workspace_created_at",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "Contact"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "firstName",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": {
+            "name": "gin_trgm_ops",
+            "default": false
+          }
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "gin",
+      "concurrently": false,
+      "name": "Contact_firstName_trgm_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "Contact"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "lastName",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": {
+            "name": "gin_trgm_ops",
+            "default": false
+          }
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "gin",
+      "concurrently": false,
+      "name": "Contact_lastName_trgm_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "Contact"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": {
+            "name": "gin_trgm_ops",
+            "default": false
+          }
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "gin",
+      "concurrently": false,
+      "name": "Contact_email_trgm_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "Contact"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "phoneNumber",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": {
+            "name": "gin_trgm_ops",
+            "default": false
+          }
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "gin",
+      "concurrently": false,
+      "name": "Contact_phoneNumber_trgm_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "Contact"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
           "value": "contactId",
           "isExpression": false,
           "asc": true,
@@ -18376,6 +19154,34 @@
       "method": "btree",
       "concurrently": false,
       "name": "ContactCustomField_contactId_customFieldId_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "ContactCustomField"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "customFieldId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ContactCustomField_customFieldId_id_idx",
       "entityType": "indexes",
       "schema": "public",
       "table": "ContactCustomField"
@@ -18432,6 +19238,34 @@
       "method": "btree",
       "concurrently": false,
       "name": "ContactInbox_contactId_lastIncomingMessageAt_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "ContactInbox"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "contactId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "lastOutboundMessageAt",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ContactInbox_contactId_lastOutboundMessageAt_idx",
       "entityType": "indexes",
       "schema": "public",
       "table": "ContactInbox"
@@ -19121,6 +19955,27 @@
       "entityType": "indexes",
       "schema": "public",
       "table": "TenantHelpItem"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "channelsTornDownAt",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "UserQuota_channelsTornDownAt_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "UserQuota"
     },
     {
       "nameExplicit": true,
@@ -19833,6 +20688,48 @@
       "nameExplicit": true,
       "columns": [
         {
+          "value": "integrationId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "IntegrationFacebookAds_integrationId_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "IntegrationFacebookAds"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspaceId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "IntegrationFacebookAds_workspaceId_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "IntegrationFacebookAds"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
           "value": "workspaceId",
           "isExpression": false,
           "asc": true,
@@ -20302,6 +21199,76 @@
           "opclass": null
         }
       ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "IntegrationOpenaiCompatible_workspaceId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "IntegrationOpenaiCompatible"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "integrationId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "IntegrationOpenaiCompatible_integrationId_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "IntegrationOpenaiCompatible"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspaceId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "preset",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"preset\" <> 'custom'",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "IntegrationOpenaiCompatible_workspaceId_preset_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "IntegrationOpenaiCompatible"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspaceId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
       "isUnique": true,
       "where": null,
       "with": "",
@@ -20392,6 +21359,27 @@
       "method": "btree",
       "concurrently": false,
       "name": "IntegrationSmtp_workspaceId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "IntegrationSmtp"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "inboxId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "IntegrationSmtp_inboxId_key",
       "entityType": "indexes",
       "schema": "public",
       "table": "IntegrationSmtp"
@@ -21163,6 +22151,27 @@
       "nameExplicit": true,
       "columns": [
         {
+          "value": "contactId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "RefLinkStat_contactId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "RefLinkStat"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
           "value": "workspaceId",
           "isExpression": false,
           "asc": true,
@@ -21463,6 +22472,48 @@
       "method": "btree",
       "concurrently": false,
       "name": "SequenceDispatch_enrollmentId_workspaceId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "SequenceDispatch"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspaceId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "sequenceId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "stepId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "SequenceDispatch_workspace_sequence_step_id_idx",
       "entityType": "indexes",
       "schema": "public",
       "table": "SequenceDispatch"
@@ -22346,6 +23397,55 @@
       "nameExplicit": true,
       "columns": [
         {
+          "value": "webhookId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "contactId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "WebhookExecution_webhookId_contactId_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "WebhookExecution"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspaceId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "WebhookExecution_workspaceId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "WebhookExecution"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
           "value": "phoneNumberId",
           "isExpression": false,
           "asc": true,
@@ -23104,6 +24204,19 @@
       "onUpdate": "CASCADE",
       "onDelete": "SET NULL",
       "name": "Broadcast_integrationWhatsappId_IntegrationWhatsapp_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "Broadcast"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["integrationMessengerId"],
+      "schemaTo": "public",
+      "tableTo": "IntegrationMessenger",
+      "columnsTo": ["id"],
+      "onUpdate": "CASCADE",
+      "onDelete": "SET NULL",
+      "name": "Broadcast_integrationMessengerId_IntegrationMessenger_id_fkey",
       "entityType": "fks",
       "schema": "public",
       "table": "Broadcast"
@@ -24091,6 +25204,32 @@
       "columnsTo": ["id"],
       "onUpdate": "CASCADE",
       "onDelete": "CASCADE",
+      "name": "IntegrationFacebookAds_workspaceId_Workspace_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "IntegrationFacebookAds"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["integrationId"],
+      "schemaTo": "public",
+      "tableTo": "Integration",
+      "columnsTo": ["id"],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "IntegrationFacebookAds_integrationId_Integration_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "IntegrationFacebookAds"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["workspaceId"],
+      "schemaTo": "public",
+      "tableTo": "Workspace",
+      "columnsTo": ["id"],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
       "name": "IntegrationGemini_workspaceId_Workspace_id_fkey",
       "entityType": "fks",
       "schema": "public",
@@ -24394,6 +25533,32 @@
       "entityType": "fks",
       "schema": "public",
       "table": "IntegrationOpenai"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["integrationId"],
+      "schemaTo": "public",
+      "tableTo": "Integration",
+      "columnsTo": ["id"],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "IntegrationOpenaiCompatible_integrationId_Integration_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "IntegrationOpenaiCompatible"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["workspaceId"],
+      "schemaTo": "public",
+      "tableTo": "Workspace",
+      "columnsTo": ["id"],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "IntegrationOpenaiCompatible_workspaceId_Workspace_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "IntegrationOpenaiCompatible"
     },
     {
       "nameExplicit": false,
@@ -25255,6 +26420,45 @@
     },
     {
       "nameExplicit": false,
+      "columns": ["webhookId"],
+      "schemaTo": "public",
+      "tableTo": "Webhook",
+      "columnsTo": ["id"],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "WebhookExecution_webhookId_Webhook_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "WebhookExecution"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["contactId"],
+      "schemaTo": "public",
+      "tableTo": "Contact",
+      "columnsTo": ["id"],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "WebhookExecution_contactId_Contact_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "WebhookExecution"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["workspaceId"],
+      "schemaTo": "public",
+      "tableTo": "Workspace",
+      "columnsTo": ["id"],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "WebhookExecution_workspaceId_Workspace_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "WebhookExecution"
+    },
+    {
+      "nameExplicit": false,
       "columns": ["integrationWhatsappId"],
       "schemaTo": "public",
       "tableTo": "IntegrationWhatsapp",
@@ -25959,6 +27163,14 @@
     {
       "columns": ["id"],
       "nameExplicit": false,
+      "name": "IntegrationFacebookAds_pkey",
+      "schema": "public",
+      "table": "IntegrationFacebookAds",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
       "name": "IntegrationGemini_pkey",
       "schema": "public",
       "table": "IntegrationGemini",
@@ -26034,6 +27246,14 @@
       "name": "IntegrationOpenai_pkey",
       "schema": "public",
       "table": "IntegrationOpenai",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "IntegrationOpenaiCompatible_pkey",
+      "schema": "public",
+      "table": "IntegrationOpenaiCompatible",
       "entityType": "pks"
     },
     {
@@ -26199,6 +27419,14 @@
     {
       "columns": ["id"],
       "nameExplicit": false,
+      "name": "SystemField_pkey",
+      "schema": "public",
+      "table": "SystemField",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
       "name": "Tag_pkey",
       "schema": "public",
       "table": "Tag",
@@ -26258,6 +27486,14 @@
       "name": "Webhook_pkey",
       "schema": "public",
       "table": "Webhook",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "WebhookExecution_pkey",
+      "schema": "public",
+      "table": "WebhookExecution",
       "entityType": "pks"
     },
     {

--- a/packages/database/src/schema/enterprise/tenant.ts
+++ b/packages/database/src/schema/enterprise/tenant.ts
@@ -53,6 +53,10 @@ export const tenantModel = pgTable(
       subject?: string
       body?: string
     }>(),
+    accountCredentialsEmailTemplate: jsonb().$type<{
+      subject?: string
+      body?: string
+    }>(),
   },
   (table) => [uniqueIndex("Tenant_ownerId_key").on(table.ownerId)],
 )

--- a/packages/mail/src/emails/default-templates.ts
+++ b/packages/mail/src/emails/default-templates.ts
@@ -1,4 +1,8 @@
 import { buildSystemEmail } from "./base-template"
+import {
+  buildAccountCredentialsMjml,
+  DEFAULT_ACCOUNT_CREDENTIALS_SUBJECT,
+} from "./sign-up-credentials"
 
 function buildDefaultMjml(subject: string, bodyMjml: string): string {
   return buildSystemEmail(
@@ -106,4 +110,17 @@ export const MAGIC_LINK_BODY_MJML = `<mj-section padding="0 0 16px 0">
 export const DEFAULT_MAGIC_LINK_TEMPLATE = buildDefaultMjml(
   DEFAULT_MAGIC_LINK_SUBJECT,
   MAGIC_LINK_BODY_MJML,
+)
+
+export const DEFAULT_ACCOUNT_CREDENTIALS_TEMPLATE = buildAccountCredentialsMjml(
+  {
+    brandName: "{{brandName}}",
+    brandLogoUrl: "{{brandLogoUrl}}",
+    brandUrl: "{{brandUrl}}",
+    subject: DEFAULT_ACCOUNT_CREDENTIALS_SUBJECT,
+    userName: "{{userName}}",
+    loginEmail: "{{loginEmail}}",
+    initialPassword: "{{initialPassword}}",
+    signInUrl: "{{signInUrl}}",
+  },
 )

--- a/packages/mail/src/index.ts
+++ b/packages/mail/src/index.ts
@@ -22,6 +22,7 @@ import { createSmtpTransporter, type SmtpTransportOptions } from "./transport"
 
 export type EmailTemplate = { subject?: string; body?: string }
 export {
+  DEFAULT_ACCOUNT_CREDENTIALS_TEMPLATE,
   DEFAULT_FORGOT_PASSWORD_SUBJECT,
   DEFAULT_FORGOT_PASSWORD_TEMPLATE,
   DEFAULT_MAGIC_LINK_SUBJECT,
@@ -123,6 +124,7 @@ async function sendEmailWithTemplate(
 export const sendMagicLink = async (
   email: string,
   props: SignInMagicLinkProps & { customTemplate?: EmailTemplate | null },
+  transport?: SmtpTransportOptions & { fromEmail: string; fromName?: string },
 ) => {
   const { customTemplate, ...templateProps } = props
   await sendEmailWithTemplate(
@@ -137,12 +139,14 @@ export const sendMagicLink = async (
       brandLogoUrl: templateProps.brandLogoUrl,
       brandUrl: templateProps.brandUrl,
     },
+    transport ? { from: formatFrom(transport), transport } : undefined,
   )
 }
 
 export const sendSignUpVerification = async (
   email: string,
   props: SignUpVerificationProps & { customTemplate?: EmailTemplate | null },
+  transport?: SmtpTransportOptions & { fromEmail: string; fromName?: string },
 ) => {
   const { customTemplate, ...templateProps } = props
   await sendEmailWithTemplate(
@@ -157,12 +161,14 @@ export const sendSignUpVerification = async (
       brandLogoUrl: templateProps.brandLogoUrl,
       brandUrl: templateProps.brandUrl,
     },
+    transport ? { from: formatFrom(transport), transport } : undefined,
   )
 }
 
 export const sendResetPassword = async (
   email: string,
   props: ResetPasswordProps & { customTemplate?: EmailTemplate | null },
+  transport?: SmtpTransportOptions & { fromEmail: string; fromName?: string },
 ) => {
   const { customTemplate, ...templateProps } = props
   await sendEmailWithTemplate(
@@ -177,6 +183,7 @@ export const sendResetPassword = async (
       brandLogoUrl: templateProps.brandLogoUrl,
       brandUrl: templateProps.brandUrl,
     },
+    transport ? { from: formatFrom(transport), transport } : undefined,
   )
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1807,6 +1807,9 @@ importers:
       '@chatbotx.io/database':
         specifier: workspace:*
         version: link:../database
+      '@chatbotx.io/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@chatbotx.io/mail':
         specifier: workspace:*
         version: link:../mail


### PR DESCRIPTION
## Summary
- Auth emails (reset password, signup verification, magic link) now resolve the reseller tenant's own SMTP credential and send through it instead of the platform default SMTP; the send is skipped when no SMTP credential is configured for that tenant.
- Adds a new `accountCredentials` email template type so resellers can customize the email sent when provisioning a sub-account, alongside the existing signup/forgotPassword/magicLink templates.
- Adds a `packages/database` migration for the new `accountCredentialsEmailTemplate` column on `Tenant`, and a dedicated logger for `packages/auth`.

## Changes
- `packages/auth/src/server.ts` — resolves reseller SMTP transport via `platformCredentialService`, wires it into `sendResetPassword`/`sendSignUpVerification`/`sendMagicLink`, blocks sending when unconfigured.
- `packages/auth/src/provisioning.ts`, `packages/mail/src/index.ts`, `packages/mail/src/emails/default-templates.ts` — account credentials email template + optional transport override plumbing.
- `packages/business/src/platform/settings.ts`, `packages/database/src/schema/enterprise/tenant.ts` — new `accountCredentialsEmailTemplate` field on tenant settings.
- `apps/builder/src/enterprise/features/platform-email-templates/*` — new template type in the platform email templates settings UI and update action.
- `apps/builder/messages/{en,vi}.json` — translations for the new template section.
- `packages/database/drizzle/20260714082320_add_account_credentials_email_template/*` — new migration.
- `packages/auth/src/logger.ts` (new) — child logger for the auth package.

## Test plan
- [x] `pnpm lint`
- [x] typecheck (all packages, via lefthook pre-commit)
- [ ] manual verification: reseller with SMTP configured receives auth emails from their own SMTP; reseller without SMTP configured has auth email sends skipped without error
- [ ] manual verification: platform email templates settings UI shows and saves the new "Sub-account Credentials Email" section