### PR TITLE
fix(google-sheets): remove unused google drive scope

### DIFF
--- a/integrations/google-sheets/src/client.ts
+++ b/integrations/google-sheets/src/client.ts
@@ -28,10 +28,7 @@ export function generateAuthUrl(props: GoogleSheetsConfig): string {
   return getClient(props).generateAuthUrl({
     access_type: "offline",
     prompt: "consent",
-    scope: [
-      "https://www.googleapis.com/auth/drive.readonly",
-      "https://www.googleapis.com/auth/spreadsheets",
-    ],
+    scope: ["https://www.googleapis.com/auth/spreadsheets"],
     state: btoa(JSON.stringify(props.stateParams)),
   })
 }


### PR DESCRIPTION
## Summary
- Remove the unused Google Drive readonly scope from the Google Sheets OAuth flow.
- The integration only uses the Google Sheets API, so the `spreadsheets` scope is enough.

## Test plan
- [x] `pnpm --filter @chatbotx.io/integration-google-sheets check-types`
- [x] `pnpm lint`
- [ ] Reconnect Google Sheets and verify the consent screen no longer asks for Drive access