### PR TITLE
fix(builder): make sequence step cards responsive instead of overflowing on narrow widths

### DIFF
--- a/apps/builder/src/features/sequences/components/sequence-step-card.tsx
+++ b/apps/builder/src/features/sequences/components/sequence-step-card.tsx
@@ -103,9 +103,9 @@ export function SequenceStepCard({
         <Card className="py-2 shadow-none">
           <CardContent>
             {/* Main row */}
-            <div className="flex items-center gap-4">
+            <div className="flex flex-wrap items-center gap-4">
               {/* Column 1: Switch + Label + Flow Selector */}
-              <div className="flex min-w-[320px] flex-1 items-center gap-2">
+              <div className="order-1 flex min-w-55 flex-1 items-center gap-2">
                 <Switch
                   checked={isActive}
                   className="cursor-pointer"
@@ -135,21 +135,25 @@ export function SequenceStepCard({
               </div>
 
               {/* Column 2: Delay Selector */}
-              <DelaySelector
-                delayUnit={delayUnit}
-                delayValue={delayValue}
-                isSaving={isSaving}
-                onDelayUnitChange={handleDelayUnitChange}
-                onDelayValueChange={handleDelayValueChange}
-                onSpecificDateTimeChange={handleSpecificDateTimeChange}
-                specificDateTime={specificDateTime}
-              />
+              <div className="@6xl:order-2 order-3">
+                <DelaySelector
+                  delayUnit={delayUnit}
+                  delayValue={delayValue}
+                  isSaving={isSaving}
+                  onDelayUnitChange={handleDelayUnitChange}
+                  onDelayValueChange={handleDelayValueChange}
+                  onSpecificDateTimeChange={handleSpecificDateTimeChange}
+                  specificDateTime={specificDateTime}
+                />
+              </div>
 
               {/* Column 3: Stats */}
-              <SequenceStepStats sequenceId={sequenceId} stepId={step?.id} />
+              <div className="@6xl:order-3 order-4 @6xl:w-auto w-full min-w-0">
+                <SequenceStepStats sequenceId={sequenceId} stepId={step?.id} />
+              </div>
 
               {/* Column 4: Actions */}
-              <div className="flex items-center gap-1">
+              <div className="@6xl:order-4 order-2 @6xl:ml-0 ml-auto flex items-center gap-1">
                 <Button
                   className="h-8 w-8 hover:bg-muted hover:text-primary"
                   onClick={() =>

--- a/apps/builder/src/features/sequences/components/sequence-step-stats.tsx
+++ b/apps/builder/src/features/sequences/components/sequence-step-stats.tsx
@@ -6,9 +6,10 @@ import type {
   SequenceStepEventType,
 } from "@chatbotx.io/analytics/schemas"
 import { Skeleton } from "@chatbotx.io/ui/components/ui/skeleton"
+import { cn } from "@chatbotx.io/ui/lib/utils"
 import ky from "ky"
 import { useParams } from "next/navigation"
-import { useFormatter } from "next-intl"
+import { useFormatter, useTranslations } from "next-intl"
 import { memo, useEffect, useState } from "react"
 import { SequenceStepContactsDialog } from "./sequence-step-contacts-dialog"
 
@@ -22,6 +23,7 @@ export const SequenceStepStats = memo(function SequenceStepStats({
   stepId,
 }: Props) {
   const { workspaceId } = useParams<{ workspaceId: string }>()
+  const t = useTranslations()
   const formatter = useFormatter()
   const [stats, setStats] = useState<GetSequenceStepStatsResponse | null>(null)
   const [isLoading, setIsLoading] = useState(true)
@@ -95,7 +97,7 @@ export const SequenceStepStats = memo(function SequenceStepStats({
 
   if (isLoading) {
     return (
-      <div className="flex w-[400px] items-center justify-between gap-4">
+      <div className="flex @6xl:w-100 w-full items-center justify-between gap-4">
         <Skeleton className="h-4 w-12" />
         <Skeleton className="h-4 w-12" />
         <Skeleton className="h-4 w-12" />
@@ -110,92 +112,74 @@ export const SequenceStepStats = memo(function SequenceStepStats({
   const clicked = stats?.["flow:clicked"] ?? 0
   const failed = stats?.["message:failed"] ?? 0
 
+  const statItems: Array<{
+    eventType: SequenceStepEventType
+    label: string
+    value: number
+    percentage: string | null
+  }> = [
+    {
+      eventType: "message:sent",
+      label: t("sequences.stats.sent"),
+      value: sent,
+      percentage: null,
+    },
+    {
+      eventType: "message:delivered",
+      label: t("sequences.stats.delivered"),
+      value: delivered,
+      percentage: getPercentage(delivered, sent),
+    },
+    {
+      eventType: "message:seen",
+      label: t("sequences.stats.seen"),
+      value: seen,
+      percentage: getPercentage(seen, delivered),
+    },
+    {
+      eventType: "flow:clicked",
+      label: t("sequences.stats.clicked"),
+      value: clicked,
+      percentage: getPercentage(clicked, delivered),
+    },
+    {
+      eventType: "message:failed",
+      label: t("sequences.stats.failed"),
+      value: failed,
+      percentage: getPercentage(failed, sent),
+    },
+  ]
+
   return (
     <>
       <div
-        className="flex w-[400px] items-center justify-between gap-4 text-xs"
+        className="flex @6xl:w-100 w-full items-center justify-between gap-4 text-xs"
         title={error ?? undefined}
       >
-        <button
-          className={
-            sent === 0
-              ? "w-12 text-center tabular-nums transition-colors disabled:cursor-default disabled:hover:text-current"
-              : "w-12 cursor-pointer text-center tabular-nums transition-colors hover:text-primary disabled:cursor-default disabled:hover:text-current"
-          }
-          disabled={sent === 0}
-          onClick={() => handleStatClick("message:sent", sent)}
-          type="button"
-        >
-          {formatValue(sent)}
-        </button>
-        <button
-          className={
-            delivered === 0
-              ? "w-12 text-center tabular-nums transition-colors disabled:cursor-default disabled:hover:text-current"
-              : "w-12 cursor-pointer text-center tabular-nums transition-colors hover:text-primary disabled:cursor-default disabled:hover:text-current"
-          }
-          disabled={delivered === 0}
-          onClick={() => handleStatClick("message:delivered", delivered)}
-          type="button"
-        >
-          {formatValue(delivered)}
-          {getPercentage(delivered, sent) && (
-            <span className="ml-0.5 text-muted-foreground">
-              ({getPercentage(delivered, sent)}%)
+        {statItems.map((statItem) => (
+          <button
+            className={cn(
+              "flex @6xl:w-12 flex-col items-center text-center tabular-nums transition-colors disabled:cursor-default disabled:hover:text-current",
+              statItem.value > 0 && "cursor-pointer hover:text-primary",
+            )}
+            disabled={statItem.value === 0}
+            key={statItem.eventType}
+            onClick={() => handleStatClick(statItem.eventType, statItem.value)}
+            type="button"
+          >
+            <span className="@6xl:hidden text-muted-foreground">
+              {statItem.label}
             </span>
-          )}
-        </button>
-        <button
-          className={
-            seen === 0
-              ? "w-12 text-center tabular-nums transition-colors disabled:cursor-default disabled:hover:text-current"
-              : "w-12 cursor-pointer text-center tabular-nums transition-colors hover:text-primary disabled:cursor-default disabled:hover:text-current"
-          }
-          disabled={seen === 0}
-          onClick={() => handleStatClick("message:seen", seen)}
-          type="button"
-        >
-          {formatValue(seen)}
-          {getPercentage(seen, delivered) && (
-            <span className="ml-0.5 text-muted-foreground">
-              ({getPercentage(seen, delivered)}%)
+            <span>
+              {formatValue(statItem.value)}
+              {statItem.percentage && (
+                <span className="ml-0.5 text-muted-foreground">
+                  ({statItem.percentage}%)
+                </span>
+              )}
             </span>
-          )}
-        </button>
-        <button
-          className={
-            clicked === 0
-              ? "w-12 text-center tabular-nums transition-colors disabled:cursor-default disabled:hover:text-current"
-              : "w-12 cursor-pointer text-center tabular-nums transition-colors hover:text-primary disabled:cursor-default disabled:hover:text-current"
-          }
-          disabled={clicked === 0}
-          onClick={() => handleStatClick("flow:clicked", clicked)}
-          type="button"
-        >
-          {formatValue(clicked)}
-          {getPercentage(clicked, delivered) && (
-            <span className="ml-0.5 text-muted-foreground">
-              ({getPercentage(clicked, delivered)}%)
-            </span>
-          )}
-        </button>
-        <button
-          className={
-            failed === 0
-              ? "w-12 text-center tabular-nums transition-colors disabled:cursor-default disabled:hover:text-current"
-              : "w-12 cursor-pointer text-center tabular-nums transition-colors hover:text-primary disabled:cursor-default disabled:hover:text-current"
-          }
-          disabled={failed === 0}
-          onClick={() => handleStatClick("message:failed", failed)}
-          type="button"
-        >
-          {formatValue(failed)}
-          {getPercentage(failed, sent) && (
-            <span className="ml-0.5 text-muted-foreground">
-              ({getPercentage(failed, sent)}%)
-            </span>
-          )}
-        </button>
+          </button>
+        ))}
       </div>
 
       {stepId && (

--- a/apps/builder/src/features/sequences/sequence-editor.tsx
+++ b/apps/builder/src/features/sequences/sequence-editor.tsx
@@ -79,7 +79,7 @@ export function SequenceEditor({ sequence, workspaceId }: SequenceEditorProps) {
 
   return (
     <FlowStoreProvider autoInitialize={true} workspaceId={workspaceId}>
-      <div className="mx- container py-1">
+      <div className="@container container mx-auto w-full">
         <Breadcrumb className="mb-4">
           <BreadcrumbList>
             <BreadcrumbItem>
@@ -105,10 +105,10 @@ export function SequenceEditor({ sequence, workspaceId }: SequenceEditorProps) {
                 <div className="grid">
                   <div className="space-y-4 pl-4">
                     <div className="flex flex-col gap-6 rounded-xl py-2 text-card-foreground shadow-none">
-                      <div className="flex items-center gap-4 px-6 pl-4 text-muted-foreground text-xs">
-                        <div className="min-w-[320px] flex-1" />
-                        <div className="w-[280px]" />
-                        <div className="ml-2 flex w-[400px] items-center justify-between gap-4 text-xs">
+                      <div className="@6xl:flex hidden items-center gap-4 px-6 pl-4 text-muted-foreground text-xs">
+                        <div className="min-w-55 flex-1" />
+                        <div className="w-70" />
+                        <div className="ml-2 flex w-100 items-center justify-between gap-4 text-xs">
                           <span className="w-12 text-center">
                             {t("sequences.stats.sent")}
                           </span>
@@ -125,7 +125,7 @@ export function SequenceEditor({ sequence, workspaceId }: SequenceEditorProps) {
                             {t("sequences.stats.failed")}
                           </span>
                         </div>
-                        <div className="w-[68px]" />
+                        <div className="w-17" />
                       </div>
                     </div>
                   </div>

--- a/packages/ui/src/components/form/combobox-field.tsx
+++ b/packages/ui/src/components/form/combobox-field.tsx
@@ -131,7 +131,9 @@ export function ComboboxField<T extends FieldValues>({
                 role="combobox"
                 variant="outline"
               >
-                {selectedLabel || placeholder || "Please select..."}
+                <span className="truncate">
+                  {selectedLabel || placeholder || "Please select..."}
+                </span>
                 <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
               </Button>
             </PopoverTrigger>


### PR DESCRIPTION
## Summary
- Sequence step cards used fixed column widths (~1100px total) in a non-wrapping flex row, so on narrow bodies (small window or open sidebar) the card was clipped and required horizontal scrolling to see the stats and action buttons.
- Layout now reflows with Tailwind v4 container queries: below the `@6xl` container width the main row wraps (flow selector + actions, then delay selector, then full-width stats); at `@6xl` and above the original single-row layout with the shared column header is preserved.

## Changes
- `apps/builder/src/features/sequences/components/sequence-step-card.tsx` — main row wraps with responsive `order-*` classes per column.
- `apps/builder/src/features/sequences/components/sequence-step-stats.tsx` — stats span full width with per-stat labels when the shared header is hidden; the five duplicated stat buttons are refactored into a mapped `statItems` array reusing existing `sequences.stats.*` translation keys.
- `apps/builder/src/features/sequences/sequence-editor.tsx` — outer wrapper becomes the `@container` (also fixes the broken `mx-` class with `mx-auto` so the editor centers); the column header row only renders at `@6xl`.
- `packages/ui/src/components/form/combobox-field.tsx` — trigger label wrapped in a `truncate` span so long option names shrink with an ellipsis instead of blowing out flex layouts.

## Test plan
- [x] pnpm lint (remaining errors are pre-existing generated files)
- [x] pnpm --filter builder check-types
- [x] pnpm --filter @chatbotx.io/ui check-types
- [ ] manual verification: resize the sequence editor (narrow window / open sidebar) and confirm cards wrap with labeled stats instead of horizontal scroll; confirm wide layout still aligns with the header row