### PR TITLE
feat(builder): restrict flow step menu to supported steps for tiktok channel

### DIFF
--- a/apps/builder/src/features/flows/react-flow/nodes/send-message/__tests__/menu.test.ts
+++ b/apps/builder/src/features/flows/react-flow/nodes/send-message/__tests__/menu.test.ts
@@ -105,6 +105,21 @@ describe("sendMessageEditorMenus — template message consolidation", () => {
     expect(labels).not.toContain(messengerInbox.name)
   })
 
+  it("shows only the 5 allowed steps when channel is tiktok", () => {
+    const items = sendMessageEditorMenus(
+      t,
+      buildMenuData(channelTypes.enum.tiktok),
+    )
+
+    expect(items.map((item) => item.label)).toEqual([
+      "flows.actions.sendText",
+      "flows.actions.sendImage",
+      "flows.actions.getUserData",
+      "flows.actions.typing",
+      "flows.actions.actions",
+    ])
+  })
+
   it("shows only Messenger inboxes when channel is messenger", () => {
     const items = sendMessageEditorMenus(
       t,

--- a/apps/builder/src/features/flows/react-flow/nodes/send-message/menu.tsx
+++ b/apps/builder/src/features/flows/react-flow/nodes/send-message/menu.tsx
@@ -156,9 +156,18 @@ const MESSENGER_MENU_ORDER = [
   "actions",
 ] as const
 
+const TIKTOK_MENU_ORDER = [
+  "sendText",
+  "sendImage",
+  "getUserData",
+  "typing",
+  "actions",
+] as const
+
 const MENU_ORDER_BY_CHANNEL: Record<string, readonly string[]> = {
   [channelTypes.enum.whatsapp]: WHATSAPP_MENU_ORDER,
   [channelTypes.enum.messenger]: MESSENGER_MENU_ORDER,
+  [channelTypes.enum.tiktok]: TIKTOK_MENU_ORDER,
 }
 
 export const sendMessageEditorMenus = (


### PR DESCRIPTION
## Summary
- TikTok previously fell through to the default step menu, so the flow builder offered steps the channel does not support (Send Card, Send Carousel, Send Video, Send GIF, Send File).
- When the Choose Channel step selects TikTok, the Send Message add-step menu now shows only: Send Text, Send Image, Get User Data, Typing, Actions.

## Changes
- `apps/builder/src/features/flows/react-flow/nodes/send-message/menu.tsx` — add `TIKTOK_MENU_ORDER` and register it in `MENU_ORDER_BY_CHANNEL`, following the existing WhatsApp/Messenger pattern.
- `apps/builder/src/features/flows/react-flow/nodes/send-message/__tests__/menu.test.ts` — test asserting the exact 5-item menu for the tiktok channel.

## Test plan
- [x] `vitest run` on `send-message/__tests__/menu.test.ts` — 8/8 pass
- [x] `pnpm --filter builder check-types`
- [x] Biome lint on changed files
- [ ] Manual: Choose Channel → TikTok → verify Send Message menu shows only the 5 steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)