### PR TITLE
feat(contacts): add phone and email filters

### DIFF
--- a/apps/builder/__tests__/contact-filter-config.test.ts
+++ b/apps/builder/__tests__/contact-filter-config.test.ts
@@ -6,6 +6,7 @@ import {
   formFieldTypes,
   operatorTypes,
 } from "@chatbotx.io/database/partials"
+import type { SelectOption } from "@chatbotx.io/ui/components/form/select-field"
 import { describe, expect, test } from "vitest"
 import {
   convertCustomFieldTypeToConditionType,
@@ -184,10 +185,45 @@ describe("contact filter field config helpers", () => {
     expect(groupFor("unreplied")).toBe("analytics")
     expect(groupFor("unread")).toBe("analytics")
     expect(groupFor("existingContact")).toBe("contactInfo")
+    expect(groupFor("hasContactInfo")).toBe("contactInfo")
     expect(groupFor("phone")).toBe("sms")
     expect(groupFor("email")).toBe("email")
     expect(groupFor("emailWasVerified")).toBe("email")
     expect(groupFor("optedInForEmail")).toBe("email")
+  })
+
+  test("offers phone, email and phone+email as hasContactInfo options with presence operators only", () => {
+    const configs = getFieldConfigs({
+      t,
+      tagOptions: [],
+      inboxOptions: [],
+      flowVersionOptions: [],
+      customFields: [],
+    })
+    const infoOptions = configs.find(
+      (config) => config.name === "hasContactInfo",
+    )?.options
+
+    expect(infoOptions).toEqual([
+      { label: "fields.phone.label", value: "phone" },
+      { label: "fields.email.label", value: "email" },
+      { label: "fields.phoneAndEmail.label", value: "phoneAndEmail" },
+    ])
+
+    const infoConfig: FieldConfig = {
+      name: "hasContactInfo",
+      formField: formFieldTypes.enum.multiSelect,
+      group: "contactInfo",
+    }
+    const operators = getStaticFieldConditionOptions(
+      infoConfig,
+      conditionOptions,
+    )
+    expect(option(operators, operatorTypes.enum.in)?.disabled).toBeFalsy()
+    expect(option(operators, operatorTypes.enum.notIn)?.disabled).toBeFalsy()
+    expect(option(operators, operatorTypes.enum.isEmpty)?.disabled).toBeFalsy()
+    expect(option(operators, operatorTypes.enum.eq)?.disabled).toBe(true)
+    expect(option(operators, operatorTypes.enum.contains)?.disabled).toBe(true)
   })
 
   test("derives contact source options from the contact source taxonomy", () => {
@@ -386,6 +422,30 @@ describe("contact filter field config helpers", () => {
       { label: "Zulu", value: "tags" },
       { label: "Alpha", value: "lastSeen" },
     ])
+  })
+
+  test("hides existingContact from the picker but keeps its config for rendering", () => {
+    const configs = getFieldConfigs({
+      t,
+      tagOptions: [],
+      inboxOptions: [],
+      flowVersionOptions: [],
+      customFields: [],
+    })
+
+    const existingContactConfig = configs.find(
+      (config) => config.name === "existingContact",
+    )
+    expect(existingContactConfig).toBeDefined()
+    expect(existingContactConfig?.hidden).toBe(true)
+
+    const collectValues = (options: SelectOption[]): string[] =>
+      options.flatMap((option) =>
+        option.children ? collectValues(option.children) : [option.value],
+      )
+    const pickerValues = collectValues(getFieldOptions(configs, t))
+    expect(pickerValues).not.toContain("existingContact")
+    expect(pickerValues).toContain("hasContactInfo")
   })
 
   test("converts custom field types and formats values for display", () => {

--- a/apps/builder/__tests__/contact-filter-schema.test.ts
+++ b/apps/builder/__tests__/contact-filter-schema.test.ts
@@ -65,6 +65,54 @@ describe("staticFieldFilter", () => {
     ).toBe(true)
   })
 
+  test("accepts hasContactInfo presence operators and rejects the rest", () => {
+    expect(
+      staticFieldFilter("hasContactInfo").safeParse({
+        field: "hasContactInfo",
+        operator: operatorTypes.enum.in,
+        value: ["phone", "email"],
+      }).success,
+    ).toBe(true)
+
+    expect(
+      staticFieldFilter("hasContactInfo").safeParse({
+        field: "hasContactInfo",
+        operator: operatorTypes.enum.notIn,
+        value: ["email"],
+      }).success,
+    ).toBe(true)
+
+    expect(
+      staticFieldFilter("hasContactInfo").safeParse({
+        field: "hasContactInfo",
+        operator: operatorTypes.enum.in,
+        value: ["phoneAndEmail"],
+      }).success,
+    ).toBe(true)
+
+    expect(
+      staticFieldFilter("hasContactInfo").safeParse({
+        field: "hasContactInfo",
+        operator: operatorTypes.enum.isEmpty,
+      }).success,
+    ).toBe(true)
+
+    expect(
+      staticFieldFilter("hasContactInfo").safeParse({
+        field: "hasContactInfo",
+        operator: operatorTypes.enum.eq,
+        value: ["phone"],
+      }).success,
+    ).toBe(false)
+
+    expect(
+      staticFieldFilter("hasContactInfo").safeParse({
+        field: "hasContactInfo",
+        operator: operatorTypes.enum.in,
+      }).success,
+    ).toBe(false)
+  })
+
   test("rejects disabled operators and missing interval values", () => {
     expect(
       staticFieldFilter("tags").safeParse({

--- a/apps/builder/__tests__/contacts-permissions.test.ts
+++ b/apps/builder/__tests__/contacts-permissions.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 
 import { beforeEach, describe, expect, test, vi } from "vitest"
+import type { ContactFilterCriteria } from "@/features/contact-filter/schemas"
 
 const applyContactFilterSpy = vi.fn<
   (criteria: unknown) => Record<string, unknown>
@@ -41,6 +42,31 @@ vi.mock("@chatbotx.io/database/queries", () => ({
       ],
     }
   },
+  pruneEmailPhoneFilterConditions: (
+    contactFilter:
+      | { operator: "and" | "or"; conditions: unknown[] }
+      | undefined,
+    canViewEmailAndPhone: boolean,
+  ) =>
+    canViewEmailAndPhone || !contactFilter
+      ? contactFilter
+      : {
+          operator: contactFilter.operator,
+          conditions: contactFilter.conditions.filter((condition) => {
+            const field =
+              typeof condition === "object" && condition !== null
+                ? (condition as { field?: unknown }).field
+                : undefined
+            return ![
+              "email",
+              "phone",
+              "hasContactInfo",
+              "emailWasVerified",
+              "optedInForEmail",
+              "existingContact",
+            ].includes(String(field))
+          }),
+        },
 }))
 
 vi.mock("@chatbotx.io/database/schema", () => ({
@@ -138,7 +164,7 @@ describe("contact permission helpers", () => {
     ).toBeUndefined()
   })
 
-  test("strips email and phone fields when PII is denied", () => {
+  test("strips email and phone fields when emailAndPhone is denied", () => {
     expect(
       stripContactPIIFields(
         ["sys:firstName", "sys:email", "sys:phoneNumber", "tag:t1"],
@@ -205,7 +231,7 @@ describe("generateWhere contact permission scope", () => {
     applyContactFilterSpy.mockReturnValue({})
   })
 
-  test("removes email and phoneNumber keyword clauses when PII is denied", () => {
+  test("removes email and phoneNumber keyword clauses when emailAndPhone is denied", () => {
     const where = generateWhere(
       { workspaceId: "ws-1", keyword: "Example" },
       { canViewEmailAndPhone: false },
@@ -217,7 +243,7 @@ describe("generateWhere contact permission scope", () => {
     ])
   })
 
-  test("keeps email and phoneNumber keyword clauses when PII is allowed", () => {
+  test("keeps email and phoneNumber keyword clauses when emailAndPhone is allowed", () => {
     const where = generateWhere(
       { workspaceId: "ws-1", keyword: "Example" },
       { canViewEmailAndPhone: true },
@@ -256,6 +282,30 @@ describe("generateWhere contact permission scope", () => {
     expect(where.conversation).toEqual({
       botEnabled: false,
       assignedUserId: "user-1",
+    })
+  })
+
+  test("prunes email/phone contact-filter conditions before applying the filter", () => {
+    const contactFilter = {
+      operator: "and" as const,
+      conditions: [
+        { field: "email", operator: "eq", value: "ada@example.com" },
+        { field: "hasContactInfo", operator: "in", value: ["phone"] },
+        { field: "fullName", operator: "contains", value: "Ada" },
+      ],
+    } satisfies ContactFilterCriteria
+
+    generateWhere(
+      {
+        workspaceId: "ws-1",
+        contactFilter,
+      },
+      { canViewEmailAndPhone: false },
+    )
+
+    expect(applyContactFilterSpy).toHaveBeenCalledWith({
+      operator: "and",
+      conditions: [{ field: "fullName", operator: "contains", value: "Ada" }],
     })
   })
 })

--- a/apps/builder/__tests__/contacts-route-guards.test.ts
+++ b/apps/builder/__tests__/contacts-route-guards.test.ts
@@ -110,6 +110,7 @@ describe("contacts route guards", () => {
 
   test("allows assigned-only members to reach contacts and contacts import pages", async () => {
     mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
+      user: { id: "user-1" },
       targetWorkspaceMember: {
         permissions: {
           ...basePermissions,
@@ -139,6 +140,7 @@ describe("contacts route guards", () => {
 
   test("rejects members without full or assigned-only contact access on contacts routes", async () => {
     mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
+      user: { id: "user-1" },
       targetWorkspaceMember: {
         permissions: basePermissions,
       },

--- a/apps/builder/__tests__/count-contact-inboxes.test.ts
+++ b/apps/builder/__tests__/count-contact-inboxes.test.ts
@@ -60,6 +60,7 @@ describe("countContactInboxes", () => {
       integrationWhatsappId: "wa-1",
       integrationMessengerId: "messenger-1",
       contactFilter,
+      canViewEmailAndPhone: undefined,
       subaction: "messengerActiveContacts",
       restrictToAssignedUserId: undefined,
     })
@@ -83,6 +84,7 @@ describe("countContactInboxes", () => {
       integrationWhatsappId: undefined,
       integrationMessengerId: undefined,
       contactFilter: undefined,
+      canViewEmailAndPhone: false,
       subaction: undefined,
       restrictToAssignedUserId: "user-1",
     })
@@ -109,6 +111,7 @@ describe("countContactInboxes", () => {
       integrationWhatsappId: undefined,
       integrationMessengerId: undefined,
       contactFilter: undefined,
+      canViewEmailAndPhone: false,
       subaction: undefined,
       page: 2,
       perPage: 10,

--- a/apps/builder/__tests__/create-broadcast-action.test.ts
+++ b/apps/builder/__tests__/create-broadcast-action.test.ts
@@ -26,6 +26,17 @@ vi.mock("@/lib/safe-action", () => ({
   },
 }))
 
+vi.mock("@/lib/auth/utils", () => ({
+  getCurrentUserAndTargetWorkspace: vi.fn().mockResolvedValue({
+    targetWorkspaceMember: { permissions: ["emailAndPhone"] },
+  }),
+}))
+
+vi.mock("@chatbotx.io/database/queries/contact-filter/permission", () => ({
+  pruneEmailPhoneFilterConditions: (contactFilter: unknown) =>
+    contactFilter ?? undefined,
+}))
+
 vi.mock("@chatbotx.io/database/schema", () => ({
   broadcastModel: {},
 }))

--- a/apps/builder/__tests__/create-broadcast.action.test.ts
+++ b/apps/builder/__tests__/create-broadcast.action.test.ts
@@ -48,6 +48,17 @@ vi.mock("next-safe-action", () => ({
   returnValidationErrors: mockReturnValidationErrors,
 }))
 
+vi.mock("@/lib/auth/utils", () => ({
+  getCurrentUserAndTargetWorkspace: vi.fn().mockResolvedValue({
+    targetWorkspaceMember: { permissions: ["emailAndPhone"] },
+  }),
+}))
+
+vi.mock("@chatbotx.io/database/queries/contact-filter/permission", () => ({
+  pruneEmailPhoneFilterConditions: (contactFilter: unknown) =>
+    contactFilter ?? undefined,
+}))
+
 vi.mock("@chatbotx.io/database/client", () => ({
   db: {
     query: {

--- a/apps/builder/__tests__/resend-broadcast.action.test.ts
+++ b/apps/builder/__tests__/resend-broadcast.action.test.ts
@@ -47,6 +47,17 @@ vi.mock("@chatbotx.io/business/errors", () => ({
   ChatbotXException: MockChatbotXException,
 }))
 
+vi.mock("@/lib/auth/utils", () => ({
+  getCurrentUserAndTargetWorkspace: vi.fn().mockResolvedValue({
+    targetWorkspaceMember: { permissions: ["emailAndPhone"] },
+  }),
+}))
+
+vi.mock("@chatbotx.io/database/queries/contact-filter/permission", () => ({
+  pruneEmailPhoneFilterConditions: (contactFilter: unknown) =>
+    contactFilter ?? undefined,
+}))
+
 vi.mock("@chatbotx.io/database/client", () => ({
   db: {
     transaction: mockDbTransaction,

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -397,6 +397,7 @@
       "followUp": "Follow up",
       "isGuestUser": "Guest user",
       "existingContact": "Existing contact",
+      "hasContactInfo": "Phone and email",
       "currentChannel": "Channel",
       "inbox": "Inbox",
       "subjectToEuRules": "Subject to EU rules",
@@ -1847,6 +1848,9 @@
     "phone": {
       "label": "Phone"
     },
+    "phoneAndEmail": {
+      "label": "Phone and email"
+    },
     "timezoneName": {
       "label": "Timezone Name"
     },
@@ -3067,6 +3071,7 @@
       "tagRemoved": "Tag Removed",
       "dateTimeBasedTrigger": "DateTime Based Trigger",
       "customFieldValueChanged": "Custom Field Changed",
+      "contactInfoUpdated": "Phone or email updated",
       "conversationTransferredToHuman": "Conversation transferred to human",
       "conversationTransferredToBot": "Conversation transferred to bot",
       "newContact": "New Contact",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -397,6 +397,7 @@
       "followUp": "Theo dõi",
       "isGuestUser": "Người dùng khách",
       "existingContact": "Liên hệ hiện có",
+      "hasContactInfo": "Số điện thoại và Email",
       "currentChannel": "Kênh",
       "inbox": "Hộp thư",
       "subjectToEuRules": "Thuộc quy định EU",
@@ -1862,6 +1863,9 @@
     "phone": {
       "label": "Điện thoại"
     },
+    "phoneAndEmail": {
+      "label": "Số điện thoại và Email"
+    },
     "timezoneName": {
       "label": "Tên múi giờ"
     },
@@ -3061,6 +3065,7 @@
       "tagRemoved": "Thẻ bị xóa",
       "dateTimeBasedTrigger": "Trigger dựa trên ngày giờ",
       "customFieldValueChanged": "Trường tùy chỉnh thay đổi",
+      "contactInfoUpdated": "Số điện thoại hoặc Email được cập nhật",
       "conversationTransferredToHuman": "Cuộc trò chuyện được chuyển cho người",
       "conversationTransferredToBot": "Cuộc trò chuyện được chuyển cho bot",
       "newContact": "Liên hệ mới",

--- a/apps/builder/src/app/space/[workspaceId]/broadcasts/create/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/broadcasts/create/page.tsx
@@ -1,6 +1,7 @@
 import { getIdFromParams } from "@chatbotx.io/utils"
 import { notFound } from "next/navigation"
 import { CreateBroadcastForm } from "@/features/broadcasts/create-broadcast-form"
+import { canViewContactEmailAndPhone } from "@/features/contacts/permissions"
 import { ContactStoreProvider } from "@/features/contacts/provider/contact-store-context"
 import { CustomFieldStoreProvider } from "@/features/custom-fields/provider/custom-field-store-context"
 import { FlowStoreProvider } from "@/features/flows/provider/flow-store-context"
@@ -11,6 +12,7 @@ import { IntegrationStoreProvider } from "@/features/integration-whatsapp/provid
 import { SequenceStoreProvider } from "@/features/sequences/provider/sequence-store-context"
 import { TagStoreProvider } from "@/features/tags/provider/tag-store-context"
 import { UserStoreProvider } from "@/features/users/provider/user-store-context"
+import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
 
 export default async function CreateBroadcastPage({
   params,
@@ -21,6 +23,14 @@ export default async function CreateBroadcastPage({
   if (!workspaceId) {
     return notFound()
   }
+
+  const userAndWorkspace = await getCurrentUserAndTargetWorkspace(workspaceId)
+  if (!userAndWorkspace) {
+    return notFound()
+  }
+  const canViewEmailAndPhone = canViewContactEmailAndPhone(
+    userAndWorkspace.targetWorkspaceMember.permissions,
+  )
 
   const openaiCompatibleIntegrations = await listIntegrationOpenaiCompatible({
     workspaceId,
@@ -42,7 +52,10 @@ export default async function CreateBroadcastPage({
                       autoInitialize={false}
                       workspaceId={workspaceId}
                     >
-                      <CreateBroadcastForm workspaceId={workspaceId} />
+                      <CreateBroadcastForm
+                        canViewEmailAndPhone={canViewEmailAndPhone}
+                        workspaceId={workspaceId}
+                      />
                     </ContactStoreProvider>
                   </SequenceStoreProvider>
                 </UserStoreProvider>

--- a/apps/builder/src/app/space/[workspaceId]/contacts/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/contacts/page.tsx
@@ -6,6 +6,7 @@ import { Suspense } from "react"
 import { EMPTY_CONTACT_FILTER } from "@/features/contact-filter"
 import { ContactsTable } from "@/features/contacts/contacts-table"
 import { CreateContactDialog } from "@/features/contacts/create-contact-dialog"
+import { requireContactPermissionScope } from "@/features/contacts/permissions"
 import { listContactsRSC } from "@/features/contacts/queries/list-contacts.queries"
 import { listContactsRequest } from "@/features/contacts/schemas/query"
 import { CustomFieldStoreProvider } from "@/features/custom-fields/provider/custom-field-store-context"
@@ -25,6 +26,8 @@ export default async function ContactsPage(props: {
     return notFound()
   }
   await requireContactsAccess(workspaceId)
+  const contactPermissionScope =
+    await requireContactPermissionScope(workspaceId)
 
   const t = await getTranslations()
   const searchParams = await props.searchParams
@@ -55,6 +58,9 @@ export default async function ContactsPage(props: {
                 <InboxStoreProvider workspaceId={workspaceId}>
                   <SequenceStoreProvider workspaceId={workspaceId}>
                     <ContactsTable
+                      canViewEmailAndPhone={
+                        contactPermissionScope.canViewEmailAndPhone
+                      }
                       initialContactFilter={initialContactFilter}
                       promises={promises}
                       workspaceId={workspaceId}

--- a/apps/builder/src/app/space/[workspaceId]/inbox/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/inbox/page.tsx
@@ -3,6 +3,7 @@ import { cookies } from "next/headers"
 import { notFound } from "next/navigation"
 import { ChatLayout } from "@/features/chat/chat-layout"
 import { ChatStoreProvider } from "@/features/chat/store/chat-store-provider"
+import { canViewContactEmailAndPhone } from "@/features/contacts/permissions"
 import { CustomFieldStoreProvider } from "@/features/custom-fields/provider/custom-field-store-context"
 import { FlowStoreProvider } from "@/features/flows/provider/flow-store-context"
 import { InboxStoreProvider } from "@/features/inboxes/provider/inbox-store-context"
@@ -10,6 +11,7 @@ import { SavedReplyStoreProvider } from "@/features/saved-replies/provider/saved
 import { SequenceStoreProvider } from "@/features/sequences/provider/sequence-store-context"
 import { TagStoreProvider } from "@/features/tags/provider/tag-store-context"
 import { UserStoreProvider } from "@/features/users/provider/user-store-context"
+import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
 
 type InboxPageProps = {
   params: Promise<{ workspaceId: string }>
@@ -23,6 +25,13 @@ export default async function InboxPage({ params }: InboxPageProps) {
 
   const layout = (await cookies()).get("csm:layout:inbox")
   const savedLayout = layout ? JSON.parse(layout.value) : [25, 50, 25]
+  const userAndWorkspace = await getCurrentUserAndTargetWorkspace(workspaceId)
+  if (!userAndWorkspace) {
+    return notFound()
+  }
+  const canViewEmailAndPhone = canViewContactEmailAndPhone(
+    userAndWorkspace.targetWorkspaceMember.permissions,
+  )
 
   return (
     <div className="-m-6">
@@ -38,6 +47,7 @@ export default async function InboxPage({ params }: InboxPageProps) {
                   <SequenceStoreProvider workspaceId={workspaceId}>
                     <FlowStoreProvider workspaceId={workspaceId}>
                       <ChatLayout
+                        canViewEmailAndPhone={canViewEmailAndPhone}
                         layout={savedLayout}
                         workspaceId={workspaceId}
                       />

--- a/apps/builder/src/features/broadcasts/actions/create-broadcast.action.ts
+++ b/apps/builder/src/features/broadcasts/actions/create-broadcast.action.ts
@@ -1,10 +1,13 @@
 "use server"
 
 import { db } from "@chatbotx.io/database/client"
+import { pruneEmailPhoneFilterConditions } from "@chatbotx.io/database/queries/contact-filter/permission"
 import { broadcastModel } from "@chatbotx.io/database/schema"
 import { startOfMinute } from "date-fns"
 import { returnValidationErrors } from "next-safe-action"
 import { workspaceIdrequestParams } from "@/features/common/schemas"
+import { canViewContactEmailAndPhone } from "@/features/contacts/permissions"
+import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
 import { workspaceActionClient } from "@/lib/safe-action"
 import { createBroadcastRequest } from "../schemas/action"
 export const createBroadcastAction = workspaceActionClient
@@ -17,6 +20,12 @@ export const createBroadcastAction = workspaceActionClient
     } = props
 
     let broadcastName = "Broadcast"
+    const userAndWorkspace = await getCurrentUserAndTargetWorkspace(workspaceId)
+    const canViewEmailAndPhone = userAndWorkspace
+      ? canViewContactEmailAndPhone(
+          userAndWorkspace.targetWorkspaceMember.permissions,
+        )
+      : false
 
     // Never trust integration ids from the client: they scope the audience,
     // so a foreign id would let a broadcast target another workspace's pages.
@@ -118,11 +127,16 @@ export const createBroadcastAction = workspaceActionClient
     }
 
     const { buttons, ...insertValues } = parsedInput
+    const contactFilter = pruneEmailPhoneFilterConditions(
+      insertValues.contactFilter,
+      canViewEmailAndPhone,
+    )
 
     const [broadcast] = await db
       .insert(broadcastModel)
       .values({
         ...insertValues,
+        contactFilter,
         name: broadcastName,
         workspaceId,
         status: "scheduled",

--- a/apps/builder/src/features/broadcasts/actions/resend-broadcast.action.ts
+++ b/apps/builder/src/features/broadcasts/actions/resend-broadcast.action.ts
@@ -2,8 +2,12 @@
 
 import { ChatbotXException } from "@chatbotx.io/business/errors"
 import { db, findOrFail } from "@chatbotx.io/database/client"
+import { pruneEmailPhoneFilterConditions } from "@chatbotx.io/database/queries/contact-filter/permission"
 import { broadcastModel } from "@chatbotx.io/database/schema"
 import { createId, zodBigintAsString } from "@chatbotx.io/utils"
+import { contactFilterCriteriaSchema } from "@/features/contact-filter/schemas"
+import { canViewContactEmailAndPhone } from "@/features/contacts/permissions"
+import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
 import { workspaceActionClient } from "@/lib/safe-action"
 
 export const resendBroadcastAction = workspaceActionClient
@@ -30,6 +34,20 @@ export const resendBroadcast = async (ctx: {
   if (broadcast.status !== "sent") {
     throw new ChatbotXException("Broadcast is not sent")
   }
+  const userAndWorkspace = await getCurrentUserAndTargetWorkspace(
+    ctx.workspaceId,
+  )
+  const persistedContactFilter = contactFilterCriteriaSchema.safeParse(
+    broadcast.contactFilter,
+  )
+  const contactFilter = pruneEmailPhoneFilterConditions(
+    persistedContactFilter.success ? persistedContactFilter.data : undefined,
+    userAndWorkspace
+      ? canViewContactEmailAndPhone(
+          userAndWorkspace.targetWorkspaceMember.permissions,
+        )
+      : false,
+  )
 
   const newBroadcast = await db.transaction(async (tx) => {
     const newBroadcast = await tx
@@ -46,7 +64,7 @@ export const resendBroadcast = async (ctx: {
         status: "scheduled",
         schedulesType: "now",
         schedulesAt: new Date(),
-        contactFilter: broadcast.contactFilter,
+        contactFilter,
         name: `${broadcast.name} (Resend)`,
         id: createId(),
       })

--- a/apps/builder/src/features/broadcasts/create-broadcast-form.tsx
+++ b/apps/builder/src/features/broadcasts/create-broadcast-form.tsx
@@ -129,10 +129,14 @@ const getConfigs = (t: ReturnType<typeof useTranslations>) =>
   ] as BroadcastConfig[]
 
 type CreateBroadcastFormProps = {
+  canViewEmailAndPhone?: boolean
   workspaceId: string
 }
 
-export function CreateBroadcastForm({ workspaceId }: CreateBroadcastFormProps) {
+export function CreateBroadcastForm({
+  canViewEmailAndPhone = true,
+  workspaceId,
+}: CreateBroadcastFormProps) {
   const t = useTranslations()
   const router = useRouter()
 
@@ -233,6 +237,7 @@ export function CreateBroadcastForm({ workspaceId }: CreateBroadcastFormProps) {
 
           {watchedChannel && watchedSubAction && (
             <CreateBroadcastChooseFlow
+              canViewEmailAndPhone={canViewEmailAndPhone}
               channel={watchedChannel}
               subaction={watchedSubAction}
             />
@@ -461,6 +466,7 @@ function BroadcastFlowTypeSelector({
 }
 
 type CreateBroadcastChooseFlowProps = {
+  canViewEmailAndPhone: boolean
   channel: ChannelType
   subaction: BroadcastSubaction
 }
@@ -610,10 +616,11 @@ function CreateBroadcastChooseFlow(props: CreateBroadcastChooseFlowProps) {
   const excludeFields = useMemo(
     () =>
       getBroadcastExcludedFilterFields({
+        canViewEmailAndPhone: props.canViewEmailAndPhone,
         channel: props.channel,
         subaction: props.subaction,
       }),
-    [props.channel, props.subaction],
+    [props.canViewEmailAndPhone, props.channel, props.subaction],
   )
 
   const handleCancel = useCallback(() => {

--- a/apps/builder/src/features/broadcasts/lib/broadcast-filter-fields.ts
+++ b/apps/builder/src/features/broadcasts/lib/broadcast-filter-fields.ts
@@ -7,6 +7,7 @@ import {
   contactFilterFields,
   requiresRecentInteractionWindow,
 } from "@chatbotx.io/database/partials"
+import { EMAIL_PHONE_RESTRICTED_FILTER_FIELDS } from "@/features/contact-filter/lib/restricted-fields"
 
 const CHANNEL_SCOPED_EXCLUDED_FIELDS = [
   contactFilterFields.enum.currentChannel,
@@ -33,22 +34,31 @@ const isTemplateMessageSubaction = (
 
 export const getBroadcastExcludedFilterFields = ({
   channel,
+  canViewEmailAndPhone = true,
   subaction,
 }: {
   channel?: ChannelType | null
+  canViewEmailAndPhone?: boolean
   subaction?: BroadcastSubaction | null
 } = {}): ContactFilterField[] => {
+  const permissionExcludedFields = canViewEmailAndPhone
+    ? []
+    : [...EMAIL_PHONE_RESTRICTED_FILTER_FIELDS]
+
   if (!channel || channel === channelTypes.enum.omnichannel) {
-    return []
+    return permissionExcludedFields
   }
 
   if (isTemplateMessageSubaction(subaction)) {
-    return [...TEMPLATE_MESSAGE_EXCLUDED_FIELDS]
+    return [...TEMPLATE_MESSAGE_EXCLUDED_FIELDS, ...permissionExcludedFields]
   }
 
   if (requiresRecentInteractionWindow(subaction)) {
-    return [...RECENT_INTERACTION_WINDOW_EXCLUDED_FIELDS]
+    return [
+      ...RECENT_INTERACTION_WINDOW_EXCLUDED_FIELDS,
+      ...permissionExcludedFields,
+    ]
   }
 
-  return [...CHANNEL_SCOPED_EXCLUDED_FIELDS]
+  return [...CHANNEL_SCOPED_EXCLUDED_FIELDS, ...permissionExcludedFields]
 }

--- a/apps/builder/src/features/chat/chat-layout.tsx
+++ b/apps/builder/src/features/chat/chat-layout.tsx
@@ -32,13 +32,18 @@ import { ChatRealtime } from "./chat-realtime"
 import { useChatStore } from "./store/chat-store-provider"
 
 type ChatLayoutProps = {
+  canViewEmailAndPhone?: boolean
   workspaceId: string
   layout?: [number, number, number]
 }
 
 export const ChatLayout = (props: ChatLayoutProps) => {
   const t = useTranslations()
-  const { workspaceId, layout = [25, 50, 25] } = props
+  const {
+    canViewEmailAndPhone = true,
+    workspaceId,
+    layout = [25, 50, 25],
+  } = props
 
   const {
     conversations,
@@ -103,7 +108,10 @@ export const ChatLayout = (props: ChatLayoutProps) => {
         maxSize={"30%"}
         minSize={"20%"}
       >
-        <ConversationList workspaceId={workspaceId} />
+        <ConversationList
+          canViewEmailAndPhone={canViewEmailAndPhone}
+          workspaceId={workspaceId}
+        />
       </ResizablePanel>
 
       <ResizableHandle withHandle />

--- a/apps/builder/src/features/conditions/__tests__/editor.test.tsx
+++ b/apps/builder/src/features/conditions/__tests__/editor.test.tsx
@@ -1,5 +1,8 @@
 // @vitest-environment jsdom
-import { triggerEventTypes } from "@chatbotx.io/database/partials"
+import {
+  type TriggerEventType,
+  triggerEventTypes,
+} from "@chatbotx.io/database/partials"
 import { act } from "react"
 import { createRoot, type Root } from "react-dom/client"
 import { FormProvider, useForm } from "react-hook-form"
@@ -53,6 +56,10 @@ vi.mock("@/features/tags/provider/tag-hook", () => ({
   useTagSelectOptions: () => [],
 }))
 
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
 vi.mock("../custom-field-value-changed", () => ({
   CustomFieldValueChanged: () => null,
 }))
@@ -88,9 +95,11 @@ const render = (ui: React.ReactElement) => {
 
 function TestConditionEditor({
   defaultSourceId = "sequence-2",
+  type = triggerEventTypes.enum.subscribedToSequence,
   onSubmit,
 }: {
   defaultSourceId?: string
+  type?: TriggerEventType
   onSubmit?: (values: { conditions: { sourceId: string }[] }) => void
 }) {
   const form = useForm({
@@ -102,10 +111,7 @@ function TestConditionEditor({
   return (
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit((values) => onSubmit?.(values))}>
-        <ConditionEditor
-          parentName="conditions.0"
-          type={triggerEventTypes.enum.subscribedToSequence}
-        />
+        <ConditionEditor parentName="conditions.0" type={type} />
         <button type="submit">Save</button>
       </form>
     </FormProvider>
@@ -158,5 +164,29 @@ describe("ConditionEditor", () => {
         ) as HTMLSelectElement
       ).value,
     ).toBe("sequence-1")
+  })
+
+  test("offers phone and email source options for contact info updated conditions", () => {
+    render(
+      <TestConditionEditor
+        defaultSourceId="phone"
+        type={triggerEventTypes.enum.contactInfoUpdated}
+      />,
+    )
+
+    const select = container.querySelector(
+      'select[name="conditions.0.sourceId"]',
+    )
+    expect(select).toBeInstanceOf(HTMLSelectElement)
+    expect(
+      Array.from(select?.querySelectorAll("option") ?? []).map((option) => ({
+        label: option.textContent,
+        value: option.getAttribute("value"),
+      })),
+    ).toEqual([
+      { label: "fields.phone.label", value: "phone" },
+      { label: "fields.email.label", value: "email" },
+    ])
+    expect((select as HTMLSelectElement).value).toBe("phone")
   })
 })

--- a/apps/builder/src/features/conditions/editor.tsx
+++ b/apps/builder/src/features/conditions/editor.tsx
@@ -4,8 +4,10 @@ import {
 } from "@chatbotx.io/database/partials"
 import { InputField } from "@chatbotx.io/ui/components/form/input-field"
 import { SelectField } from "@chatbotx.io/ui/components/form/select-field"
+import { useTranslations } from "next-intl"
 import { useMemo } from "react"
 import { useFormContext } from "react-hook-form"
+import { getContactInfoTypeOptions } from "@/features/contact-filter/components/contact-filter-config"
 import { useSequenceOptions } from "@/features/sequences/provider/sequence-hook"
 import { useTagSelectOptions } from "@/features/tags/provider/tag-hook"
 import { CustomFieldValueChanged } from "./custom-field-value-changed"
@@ -18,7 +20,12 @@ export const ConditionEditor = ({
   parentName: string
   type: TriggerEventType
 }) => {
+  const t = useTranslations()
   const tagOptions = useTagSelectOptions()
+  const contactInfoTypeOptions = useMemo(
+    () => getContactInfoTypeOptions(t),
+    [t],
+  )
   const sequences = useSequenceOptions()
   const sequenceOptions = useMemo(
     () =>
@@ -37,6 +44,13 @@ export const ConditionEditor = ({
         <SelectField name={`${parentName}.sourceId`} options={tagOptions} />
       )
     }
+    case triggerEventTypes.enum.contactInfoUpdated:
+      return (
+        <SelectField
+          name={`${parentName}.sourceId`}
+          options={contactInfoTypeOptions}
+        />
+      )
     case triggerEventTypes.enum.subscribedToSequence:
     case triggerEventTypes.enum.unsubscribedFromSequence:
       return (

--- a/apps/builder/src/features/conditions/schemas/contact-info-updated.ts
+++ b/apps/builder/src/features/conditions/schemas/contact-info-updated.ts
@@ -1,0 +1,18 @@
+import {
+  contactInfoTypes,
+  triggerEventTypes,
+} from "@chatbotx.io/database/partials"
+import z from "zod"
+
+export const contactInfoUpdated = z.object({
+  id: z.string().optional(),
+  type: z.literal(triggerEventTypes.enum.contactInfoUpdated),
+  sourceId: contactInfoTypes,
+})
+export type ContactInfoUpdated = z.infer<typeof contactInfoUpdated>
+
+export const defaultFn = (): ContactInfoUpdated => ({
+  type: triggerEventTypes.enum.contactInfoUpdated,
+  sourceId: contactInfoTypes.enum.phone,
+})
+export type DefaultFn = typeof defaultFn

--- a/apps/builder/src/features/conditions/schemas/index.ts
+++ b/apps/builder/src/features/conditions/schemas/index.ts
@@ -1,3 +1,4 @@
+import { contactInfoUpdated } from "./contact-info-updated"
 import { customFieldValueChanged } from "./custom-field-value-changed"
 import { dateTimeBasedTrigger } from "./date-time-based-trigger"
 import {
@@ -21,6 +22,7 @@ export const allConditions = {
   tagApplied,
   tagRemoved,
   customFieldValueChanged,
+  contactInfoUpdated,
   dateTimeBasedTrigger,
   conversationTransferredToHuman,
   conversationTransferredToBot,

--- a/apps/builder/src/features/contact-filter/components/contact-filter-config.ts
+++ b/apps/builder/src/features/contact-filter/components/contact-filter-config.ts
@@ -5,6 +5,10 @@ import {
 } from "@chatbotx.io/business/contact-locale"
 import {
   type ContactFilterField,
+  type ContactInfoFilterValue,
+  type ContactInfoType,
+  contactInfoFilterValues,
+  contactInfoTypes,
   contactSources,
   type FormFieldType,
   formFieldTypes,
@@ -19,6 +23,7 @@ import {
 } from "@/features/workspaces/schema/types"
 import {
   CONTACT_FILTER_FIELD_DEFINITIONS,
+  type ContactFilterFieldDefinition,
   type ContactFilterOptionSource,
   type ContactFilterSchemaKind,
 } from "../schemas"
@@ -41,6 +46,8 @@ export type FieldConfig = {
   formField: FormFieldType
   group: ContactFilterFieldGroup
   options?: SelectOption[]
+  /** Retired field: still rendered/validated, but omitted from the picker. */
+  hidden?: boolean
 }
 
 /** Minimal workspace custom field shape needed to build a per-field filter config. */
@@ -138,6 +145,35 @@ const getContactSourceOptions = (t: (key: string) => string): SelectOption[] =>
     value: source,
   }))
 
+const CONTACT_INFO_TYPE_LABEL_KEYS = {
+  phone: "fields.phone.label",
+  email: "fields.email.label",
+} as const satisfies Record<ContactInfoType, string>
+
+/** Atomic phone/email options for the `contactInfoUpdated` trigger source. */
+export const getContactInfoTypeOptions = (
+  t: (key: string) => string,
+): SelectOption[] =>
+  contactInfoTypes.options.map((infoType) => ({
+    label: t(CONTACT_INFO_TYPE_LABEL_KEYS[infoType]),
+    value: infoType,
+  }))
+
+const CONTACT_INFO_FILTER_LABEL_KEYS = {
+  phone: "fields.phone.label",
+  email: "fields.email.label",
+  phoneAndEmail: "fields.phoneAndEmail.label",
+} as const satisfies Record<ContactInfoFilterValue, string>
+
+/** Phone / Email / Phone+Email options for the `hasContactInfo` filter. */
+export const getContactInfoFilterOptions = (
+  t: (key: string) => string,
+): SelectOption[] =>
+  contactInfoFilterValues.options.map((value) => ({
+    label: t(CONTACT_INFO_FILTER_LABEL_KEYS[value]),
+    value,
+  }))
+
 const getLocaleOptions = (t: (key: string) => string): SelectOption[] => {
   const localeOptions = [...languageOptions]
   const existingValues = new Set(localeOptions.map((option) => option.value))
@@ -177,6 +213,8 @@ const resolveContactFilterOptions = (
   switch (optionSource) {
     case "none":
       return
+    case "contactInfoFilterValues":
+      return getContactInfoFilterOptions(ctx.t)
     case "languages":
       return getLocaleOptions(ctx.t)
     case "timezones":
@@ -348,10 +386,11 @@ export const getFieldConfigs = ({
   const channelOptions = getChannelMultiSelectOptions(t)
 
   const staticConfigs: FieldConfig[] = CONTACT_FILTER_FIELD_DEFINITIONS.map(
-    (def) => ({
+    (def: ContactFilterFieldDefinition) => ({
       name: def.field,
       formField: schemaKindToFormField(def.schemaKind),
       group: getContactFilterFieldGroup(def.field),
+      hidden: def.hidden,
       options: resolveContactFilterOptions(def.optionSource, {
         t,
         channelOptions,
@@ -390,12 +429,16 @@ export const getFieldOptions = (
     value: config.name,
   })
 
-  const contactInfoOptions = configs
+  // Retired fields stay valid + rendered for existing conditions but are never
+  // offered for new ones.
+  const pickableConfigs = configs.filter((config) => !config.hidden)
+
+  const contactInfoOptions = pickableConfigs
     .filter((config) => config.group === "contactInfo")
     .map(toOption)
 
   const groupOptions = (group: GroupedContactFilterFieldGroup) => {
-    const children = configs
+    const children = pickableConfigs
       .filter((config) => config.group === group)
       .map(toOption)
 

--- a/apps/builder/src/features/contact-filter/components/static-field-filter-config.ts
+++ b/apps/builder/src/features/contact-filter/components/static-field-filter-config.ts
@@ -90,6 +90,17 @@ const relationSetRule = {
   singleInput: "field",
 } as const satisfies StaticFieldRule
 
+const PRESENCE_SET_OPERATORS = [
+  operatorTypes.enum.in,
+  operatorTypes.enum.notIn,
+  operatorTypes.enum.isEmpty,
+] as const satisfies readonly OperatorType[]
+
+const presenceSetRule = {
+  enabledOperators: PRESENCE_SET_OPERATORS,
+  singleInput: "field",
+} as const satisfies StaticFieldRule
+
 const booleanRule = {
   enabledOperators: BOOLEAN_OPERATORS,
   singleInput: "boolean",
@@ -189,6 +200,7 @@ const staticFieldRules: Record<string, StaticFieldRule> = {
   lastComment: textFreeRule,
   phone: textFreeRule,
   email: textFreeRule,
+  hasContactInfo: presenceSetRule,
   lastUserInput: textFreeRule,
 
   contactCreatedAt: dateRule,

--- a/apps/builder/src/features/contact-filter/index.ts
+++ b/apps/builder/src/features/contact-filter/index.ts
@@ -9,4 +9,5 @@ export {
   EMPTY_CONTACT_FILTER,
   useContactFilterQueryState,
 } from "./components/use-contact-filter-query-state"
+export { EMAIL_PHONE_RESTRICTED_FILTER_FIELDS } from "./lib/restricted-fields"
 export * from "./schemas"

--- a/apps/builder/src/features/contact-filter/lib/restricted-fields.ts
+++ b/apps/builder/src/features/contact-filter/lib/restricted-fields.ts
@@ -1,0 +1,11 @@
+import {
+  type ContactFilterField,
+  contactFilterFields,
+} from "@chatbotx.io/database/partials"
+import { EMAIL_PHONE_FILTER_FIELDS } from "@chatbotx.io/database/queries/contact-filter/permission"
+
+export const EMAIL_PHONE_RESTRICTED_FILTER_FIELDS = [
+  ...EMAIL_PHONE_FILTER_FIELDS,
+  contactFilterFields.enum.phoneWasVerified,
+  contactFilterFields.enum.optedInForSms,
+] as const satisfies readonly ContactFilterField[]

--- a/apps/builder/src/features/contact-filter/schemas/definitions.ts
+++ b/apps/builder/src/features/contact-filter/schemas/definitions.ts
@@ -20,6 +20,7 @@ export type ContactFilterSchemaKind =
  */
 export type ContactFilterOptionSource =
   | "none"
+  | "contactInfoFilterValues"
   | "languages"
   | "timezones"
   | "countries"
@@ -39,6 +40,12 @@ export type ContactFilterFieldDefinition = {
   field: ContactFilterField
   schemaKind: ContactFilterSchemaKind
   optionSource: ContactFilterOptionSource
+  /**
+   * Kept valid in the Zod schema and rendered for existing conditions, but
+   * hidden from the "add condition" picker. Use to retire a field from new use
+   * (e.g. superseded by another) without breaking saved filters/broadcasts.
+   */
+  hidden?: boolean
 }
 
 const conditionSchemaForDef = (def: ContactFilterFieldDefinition) =>
@@ -170,6 +177,11 @@ export const CONTACT_FILTER_FIELD_DEFINITIONS = [
     optionSource: "none",
   },
   {
+    field: contactFilterFields.enum.hasContactInfo,
+    schemaKind: "multiSelect",
+    optionSource: "contactInfoFilterValues",
+  },
+  {
     field: contactFilterFields.enum.tags,
     schemaKind: "multiSelect",
     optionSource: "tags",
@@ -228,6 +240,9 @@ export const CONTACT_FILTER_FIELD_DEFINITIONS = [
     field: contactFilterFields.enum.existingContact,
     schemaKind: "boolean",
     optionSource: "none",
+    // Superseded by `hasContactInfo`; hidden from the picker but still valid so
+    // existing filters/broadcasts keep resolving.
+    hidden: true,
   },
   {
     field: contactFilterFields.enum.consecutiveAiFailures,

--- a/apps/builder/src/features/contact-filter/schemas/static-field-filter.ts
+++ b/apps/builder/src/features/contact-filter/schemas/static-field-filter.ts
@@ -22,6 +22,12 @@ const SET_OPERATORS = [
   ...BASE_OPERATORS,
 ] as const satisfies readonly OperatorType[]
 
+const PRESENCE_SET_OPERATORS = [
+  operatorTypes.enum.in,
+  operatorTypes.enum.notIn,
+  operatorTypes.enum.isEmpty,
+] as const satisfies readonly OperatorType[]
+
 const BOOLEAN_OPERATORS = [
   operatorTypes.enum.eq,
   operatorTypes.enum.isEmpty,
@@ -102,6 +108,7 @@ const STATIC_OPERATOR_RULES: Record<string, readonly OperatorType[]> = {
   fullName: TEXT_FREE_OPERATORS,
   email: TEXT_FREE_OPERATORS,
   phone: TEXT_FREE_OPERATORS,
+  hasContactInfo: PRESENCE_SET_OPERATORS,
   timezone: BASE_OPERATORS,
 
   contactCreatedAt: DATE_OPERATORS,

--- a/apps/builder/src/features/contacts/actions/update-contact-field.action.ts
+++ b/apps/builder/src/features/contacts/actions/update-contact-field.action.ts
@@ -4,6 +4,7 @@ import {
   type ContactAccessScope,
   contactInboxService,
   contactService,
+  emitContactInfoChangeEvents,
   normalizeLanguage,
   normalizeStoredTimezone,
 } from "@chatbotx.io/business"
@@ -49,7 +50,7 @@ export const updateContactFields = async (
   },
   parsedInput: UpdateContactFieldRequest,
 ) => {
-  await contactService.findByIdOrFail({
+  const existingContact = await contactService.findByIdOrFail({
     workspaceId: ctx.workspaceId,
     id: ctx.id,
     accessScope: ctx.accessScope,
@@ -118,6 +119,11 @@ export const updateContactFields = async (
           })
       }
     }
+  })
+
+  await emitContactInfoChangeEvents(ctx.workspaceId, ctx.id, existingContact, {
+    phoneNumber: contactFields.phoneNumber ?? existingContact.phoneNumber,
+    email: contactFields.email ?? existingContact.email,
   })
 }
 

--- a/apps/builder/src/features/contacts/contacts-table.tsx
+++ b/apps/builder/src/features/contacts/contacts-table.tsx
@@ -29,6 +29,7 @@ import {
   EMPTY_CONTACT_FILTER,
   useContactFilterQueryState,
 } from "@/features/contact-filter"
+import { EMAIL_PHONE_RESTRICTED_FILTER_FIELDS } from "@/features/contact-filter/lib/restricted-fields"
 import { client } from "@/lib/orpc/orpc"
 import { InboxIcon } from "../inboxes/components/inbox-icon"
 import { getUserName } from "../users/schemas/resource"
@@ -118,12 +119,14 @@ function NameCell({
 }
 
 type ContactsTableProps = {
+  canViewEmailAndPhone?: boolean
   initialContactFilter?: ContactFilterCriteria
   workspaceId: string
   promises: Promise<[Awaited<ReturnType<typeof listContacts>>]>
 }
 
 export function ContactsTable({
+  canViewEmailAndPhone = true,
   initialContactFilter = EMPTY_CONTACT_FILTER,
   workspaceId,
   promises,
@@ -160,6 +163,11 @@ export function ContactsTable({
   )
   const isOptimisticContactFilterActive =
     optimisticContactFilter.conditions.length > 0
+  const excludedFilterFields = useMemo(
+    () =>
+      canViewEmailAndPhone ? [] : [...EMAIL_PHONE_RESTRICTED_FILTER_FIELDS],
+    [canViewEmailAndPhone],
+  )
 
   const keyword = useMemo(() => {
     const params = new URLSearchParams(searchParamsKey)
@@ -442,6 +450,7 @@ export function ContactsTable({
     >
       {showContactFilterPanel && (
         <ContactListFilterPanel
+          excludeFields={excludedFilterFields}
           filter={optimisticContactFilter}
           onFilterChange={handleContactFilterChange}
         />

--- a/apps/builder/src/features/contacts/queries/__tests__/list-contacts.queries.test.ts
+++ b/apps/builder/src/features/contacts/queries/__tests__/list-contacts.queries.test.ts
@@ -29,6 +29,31 @@ vi.mock("@chatbotx.io/database/queries", () => ({
       ],
     }
   },
+  pruneEmailPhoneFilterConditions: (
+    contactFilter:
+      | { operator: "and" | "or"; conditions: unknown[] }
+      | undefined,
+    canViewEmailAndPhone: boolean,
+  ) =>
+    canViewEmailAndPhone || !contactFilter
+      ? contactFilter
+      : {
+          operator: contactFilter.operator,
+          conditions: contactFilter.conditions.filter((condition) => {
+            const field =
+              typeof condition === "object" && condition !== null
+                ? (condition as { field?: unknown }).field
+                : undefined
+            return ![
+              "email",
+              "phone",
+              "hasContactInfo",
+              "emailWasVerified",
+              "optedInForEmail",
+              "existingContact",
+            ].includes(String(field))
+          }),
+        },
 }))
 vi.mock("@chatbotx.io/database/schema", () => ({
   contactModel: { createdAt: "createdAt", fullName: "fullName" },
@@ -81,7 +106,7 @@ describe("generateWhere", () => {
     expect(where.conversation).toEqual({ assignedUserId: "user-1" })
   })
 
-  test("drops email and phone keyword clauses when PII is denied", () => {
+  test("drops email and phone keyword clauses when emailAndPhone is denied", () => {
     const where = generateWhere(
       { ...baseInput, keyword: "Alice" },
       { canViewEmailAndPhone: false },
@@ -108,6 +133,27 @@ describe("generateWhere", () => {
     expect(where.conversation).toEqual({
       status: "open",
       assignedUserId: "user-1",
+    })
+  })
+
+  test("prunes email/phone contact-filter conditions when emailAndPhone is denied", () => {
+    const where = generateWhere(
+      {
+        ...baseInput,
+        contactFilter: {
+          operator: "and",
+          conditions: [
+            { field: "email", operator: "eq", value: "ada@example.com" },
+            { field: "fullName", operator: "contains", value: "Ada" },
+          ],
+        },
+      },
+      { canViewEmailAndPhone: false },
+    )
+
+    expect(where.__filter).toEqual({
+      operator: "and",
+      conditions: [{ field: "fullName", operator: "contains", value: "Ada" }],
     })
   })
 

--- a/apps/builder/src/features/contacts/queries/list-contact-inboxes.queries.ts
+++ b/apps/builder/src/features/contacts/queries/list-contact-inboxes.queries.ts
@@ -18,6 +18,7 @@ export async function countContactInboxes(
     integrationWhatsappId: input.integrationWhatsappId,
     integrationMessengerId: input.integrationMessengerId,
     contactFilter: input.contactFilter,
+    canViewEmailAndPhone: accessScope?.canViewEmailAndPhone,
     subaction: input.subaction,
     restrictToAssignedUserId: accessScope?.restrictToAssignedUserId,
   })
@@ -37,6 +38,7 @@ export async function listAudienceInboxesPreview(
     integrationWhatsappId: input.integrationWhatsappId,
     integrationMessengerId: input.integrationMessengerId,
     contactFilter: input.contactFilter,
+    canViewEmailAndPhone: accessScope?.canViewEmailAndPhone,
     subaction: input.subaction,
     page: input.page ?? 1,
     perPage: input.perPage ?? 20,

--- a/apps/builder/src/features/contacts/queries/list-contacts.queries.ts
+++ b/apps/builder/src/features/contacts/queries/list-contacts.queries.ts
@@ -7,6 +7,7 @@ import {
 import {
   applyContactFilter,
   buildSmartKeywordWhere,
+  pruneEmailPhoneFilterConditions,
 } from "@chatbotx.io/database/queries"
 import { contactModel } from "@chatbotx.io/database/schema"
 import {
@@ -234,13 +235,18 @@ export const generateWhere = (
     workspaceId: input.workspaceId,
   }
 
+  const contactFilter = pruneEmailPhoneFilterConditions(
+    input.contactFilter,
+    scope?.canViewEmailAndPhone !== false,
+  )
+
   const filters = [
     input.keyword
       ? buildSmartKeywordWhere(input.keyword, {
           includeEmailAndPhone: scope?.canViewEmailAndPhone !== false,
         })
       : undefined,
-    input.contactFilter ? applyContactFilter(input.contactFilter) : undefined,
+    contactFilter ? applyContactFilter(contactFilter) : undefined,
   ].filter((filter): filter is ContactWhere =>
     filter ? hasWhereParts(filter) : false,
   )

--- a/apps/builder/src/features/conversations/conversation-filter.tsx
+++ b/apps/builder/src/features/conversations/conversation-filter.tsx
@@ -23,10 +23,11 @@ import {
   UserLockIcon,
 } from "lucide-react"
 import { useTranslations } from "next-intl"
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import { useFormContext, useWatch } from "react-hook-form"
 import { useChatStore } from "../chat/store/chat-store-provider"
 import { ContactFilterDialog } from "../contact-filter"
+import { EMAIL_PHONE_RESTRICTED_FILTER_FIELDS } from "../contact-filter/lib/restricted-fields"
 import { useConfiguredInboxTypeOptions } from "../inboxes/provider/inbox-hook"
 import { useContactAssigneeOptions } from "../users/provider/user-hook"
 
@@ -35,7 +36,11 @@ import { useContactAssigneeOptions } from "../users/provider/user-hook"
 // chosen channel ("omnichannel" → all channels).
 const EXCLUDED_FILTER_FIELDS = [contactFilterFields.enum.currentChannel]
 
-export function ConversationFilter() {
+export function ConversationFilter({
+  canViewEmailAndPhone = true,
+}: {
+  canViewEmailAndPhone?: boolean
+}) {
   const t = useTranslations()
   const [open, setOpen] = useState(false)
   const { filters } = useChatStore((state) => state)
@@ -48,6 +53,13 @@ export function ConversationFilter() {
 
   const filterCount = filters.contactFilter?.conditions.length ?? 0
   const hasFilter = filterCount > 0
+  const excludedFilterFields = useMemo(
+    () =>
+      canViewEmailAndPhone
+        ? EXCLUDED_FILTER_FIELDS
+        : [...EXCLUDED_FILTER_FIELDS, ...EMAIL_PHONE_RESTRICTED_FILTER_FIELDS],
+    [canViewEmailAndPhone],
+  )
 
   const contactAssigneeOptions = useContactAssigneeOptions({
     includeAll: true,
@@ -122,7 +134,7 @@ export function ConversationFilter() {
 
           <ContactFilterDialog
             btnTitle={t("fields.contactFilter.moreOptions")}
-            excludeFields={EXCLUDED_FILTER_FIELDS}
+            excludeFields={excludedFilterFields}
             inboxChannel={watchedChannel}
             onSubmitted={(submitted) => {
               if (submitted.conditions.length > 0) {

--- a/apps/builder/src/features/conversations/conversation-list.tsx
+++ b/apps/builder/src/features/conversations/conversation-list.tsx
@@ -25,8 +25,10 @@ import { ConversationFilter } from "./conversation-filter"
 import ConversationItem from "./conversation-item"
 
 export default function ConversationList({
+  canViewEmailAndPhone = true,
   workspaceId,
 }: {
+  canViewEmailAndPhone?: boolean
   workspaceId: string
 }) {
   const t = useTranslations()
@@ -143,7 +145,7 @@ export default function ConversationList({
           />
 
           <TagStoreProvider workspaceId={workspaceId}>
-            <ConversationFilter />
+            <ConversationFilter canViewEmailAndPhone={canViewEmailAndPhone} />
           </TagStoreProvider>
         </div>
 

--- a/apps/builder/src/features/conversations/queries/__tests__/list-conversations.query.test.ts
+++ b/apps/builder/src/features/conversations/queries/__tests__/list-conversations.query.test.ts
@@ -1,5 +1,7 @@
 // @vitest-environment node
-import { describe, expect, test, vi } from "vitest"
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import type { ContactFilterCriteria } from "@/features/contact-filter/schemas"
 
 vi.mock("@chatbotx.io/business", () => ({
   conversationService: { findManyQuery: vi.fn() },
@@ -32,6 +34,31 @@ vi.mock("@chatbotx.io/database/queries", () => ({
       .filter((value) => value.startsWith("u_"))
       .map((value) => value.slice(2)),
   })),
+  pruneEmailPhoneFilterConditions: (
+    contactFilter:
+      | { operator: "and" | "or"; conditions: unknown[] }
+      | undefined,
+    canViewEmailAndPhone: boolean,
+  ) =>
+    canViewEmailAndPhone || !contactFilter
+      ? contactFilter
+      : {
+          operator: contactFilter.operator,
+          conditions: contactFilter.conditions.filter((condition) => {
+            const field =
+              typeof condition === "object" && condition !== null
+                ? (condition as { field?: unknown }).field
+                : undefined
+            return ![
+              "email",
+              "phone",
+              "hasContactInfo",
+              "emailWasVerified",
+              "optedInForEmail",
+              "existingContact",
+            ].includes(String(field))
+          }),
+        },
   UNASSIGNED_ASSIGNEE_VALUE: "unassigned",
 }))
 vi.mock("@chatbotx.io/database/repositories", () => ({
@@ -60,6 +87,10 @@ const baseInput = {
 }
 
 describe("buildConversationWhere channel filter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   test("does not restrict by contactInboxes when channel is the omnichannel sentinel", () => {
     const where = buildConversationWhere(
       "1",
@@ -121,6 +152,26 @@ describe("buildConversationWhere channel filter", () => {
         includeEmailAndPhone: false,
       },
     )
+  })
+
+  test("prunes email/phone contact-filter conditions when emailAndPhone is denied", () => {
+    const contactFilter = {
+      operator: "and" as const,
+      conditions: [
+        { field: "email", operator: "eq", value: "ada@example.com" },
+        { field: "hasContactInfo", operator: "in", value: ["phone"] },
+        { field: "fullName", operator: "contains", value: "Ada" },
+      ],
+    } satisfies ContactFilterCriteria
+
+    buildConversationWhere("1", { ...baseInput, contactFilter }, null, {
+      includeEmailAndPhone: false,
+    })
+
+    expect(vi.mocked(applyContactFilter)).toHaveBeenCalledWith({
+      operator: "and",
+      conditions: [{ field: "fullName", operator: "contains", value: "Ada" }],
+    })
   })
 
   test("defaults to including email/phone when no scope is provided", () => {

--- a/apps/builder/src/features/conversations/queries/build-conversation-where.ts
+++ b/apps/builder/src/features/conversations/queries/build-conversation-where.ts
@@ -4,6 +4,7 @@ import {
   applyContactFilter,
   buildSmartKeywordWhere,
   parseConversationAssigneeValues,
+  pruneEmailPhoneFilterConditions,
   UNASSIGNED_ASSIGNEE_VALUE,
 } from "@chatbotx.io/database/queries"
 import type { ListConversationsRequest } from "@/features/conversations/schema/query"
@@ -162,8 +163,12 @@ export function buildConversationWhere(
   }
 
   // ── contactFilter (complex filter builder) ───────────────────────────────
-  if (input.contactFilter) {
-    const contactFilterWhere = applyContactFilter(input.contactFilter)
+  const contactFilter = pruneEmailPhoneFilterConditions(
+    input.contactFilter,
+    options.includeEmailAndPhone !== false,
+  )
+  if (contactFilter) {
+    const contactFilterWhere = applyContactFilter(contactFilter)
     if (Object.keys(contactFilterWhere).length > 0) {
       addContactWhere(where, contactFilterWhere)
     }

--- a/apps/builder/src/features/triggers/add-condition.tsx
+++ b/apps/builder/src/features/triggers/add-condition.tsx
@@ -16,6 +16,7 @@ import {
 import { PlusIcon } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { useMemo } from "react"
+import { defaultFn as addContactInfoUpdatedCondition } from "../conditions/schemas/contact-info-updated"
 import { defaultFn as addCustomFieldValueChangedCondition } from "../conditions/schemas/custom-field-value-changed"
 import { defaultFn as addDateTimeBaseTriggerCondition } from "../conditions/schemas/date-time-based-trigger"
 import {
@@ -85,6 +86,11 @@ export function AddCondition({
             label: t("trigger.conditions.newContact"),
             value: triggerEventTypes.enum.newContact,
             defaultFn: createDefaultFn(triggerEventTypes.enum.newContact),
+          },
+          {
+            label: t("trigger.conditions.contactInfoUpdated"),
+            value: triggerEventTypes.enum.contactInfoUpdated,
+            defaultFn: addContactInfoUpdatedCondition,
           },
           {
             label: t("trigger.conditions.contactUnsubscribedFormBroadcast"),

--- a/apps/builder/src/features/triggers/base-editor.tsx
+++ b/apps/builder/src/features/triggers/base-editor.tsx
@@ -44,6 +44,8 @@ export const BaseEditor = ({
         return t("trigger.conditions.conversationTransferredToBot")
       case triggerEventTypes.enum.newContact:
         return t("trigger.conditions.newContact")
+      case triggerEventTypes.enum.contactInfoUpdated:
+        return t("trigger.conditions.contactInfoUpdated")
       case triggerEventTypes.enum.contactUnsubscribedFormBroadcast:
         return t("trigger.conditions.contactUnsubscribedFormBroadcast")
       case triggerEventTypes.enum.archived:

--- a/apps/builder/src/features/webhooks/add-condition.tsx
+++ b/apps/builder/src/features/webhooks/add-condition.tsx
@@ -16,6 +16,7 @@ import {
 import { PlusIcon } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { useMemo } from "react"
+import { defaultFn as addContactInfoUpdatedCondition } from "../conditions/schemas/contact-info-updated"
 import { defaultFn as addCustomFieldValueChangedCondition } from "../conditions/schemas/custom-field-value-changed"
 import { defaultFn as addDateTimeBaseTriggerCondition } from "../conditions/schemas/date-time-based-trigger"
 import {
@@ -85,6 +86,11 @@ export function AddCondition({
             label: t("trigger.conditions.newContact"),
             value: triggerEventTypes.enum.newContact,
             defaultFn: createDefaultFn(triggerEventTypes.enum.newContact),
+          },
+          {
+            label: t("trigger.conditions.contactInfoUpdated"),
+            value: triggerEventTypes.enum.contactInfoUpdated,
+            defaultFn: addContactInfoUpdatedCondition,
           },
           {
             label: t("trigger.conditions.contactUnsubscribedFormBroadcast"),

--- a/apps/builder/src/features/webhooks/base-editor.tsx
+++ b/apps/builder/src/features/webhooks/base-editor.tsx
@@ -44,6 +44,8 @@ export const BaseEditor = ({
         return t("trigger.conditions.conversationTransferredToBot")
       case triggerEventTypes.enum.newContact:
         return t("trigger.conditions.newContact")
+      case triggerEventTypes.enum.contactInfoUpdated:
+        return t("trigger.conditions.contactInfoUpdated")
       case triggerEventTypes.enum.contactUnsubscribedFormBroadcast:
         return t("trigger.conditions.contactUnsubscribedFormBroadcast")
       case triggerEventTypes.enum.archived:

--- a/apps/worker/__tests__/condition-evaluator.test.ts
+++ b/apps/worker/__tests__/condition-evaluator.test.ts
@@ -1,0 +1,94 @@
+import { triggerEventTypes } from "@chatbotx.io/database/partials"
+import type { WorkspaceModel } from "@chatbotx.io/database/types"
+import { describe, expect, test, vi } from "vitest"
+import type { ConditionEvaluationContext } from "../src/trigger/types"
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      contactCustomFieldModel: { findFirst: vi.fn() },
+      customFieldModel: { findFirst: vi.fn() },
+    },
+  },
+}))
+
+import { ConditionEvaluator } from "../src/trigger/services/condition-evaluator"
+
+const workspace = { timezone: "UTC" } as WorkspaceModel
+
+const buildContext = (
+  condition: Partial<ConditionEvaluationContext["condition"]>,
+  metadata: Record<string, unknown>,
+): ConditionEvaluationContext =>
+  ({
+    condition: {
+      sourceId: null,
+      operator: null,
+      value: null,
+      ...condition,
+    },
+    eventData: {
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+      eventType: condition.type,
+      eventData: metadata,
+      timestamp: new Date(),
+    },
+    workspaceId: "ws-1",
+    contactId: "contact-1",
+    workspace,
+  }) as ConditionEvaluationContext
+
+describe("ConditionEvaluator contactInfoUpdated", () => {
+  const evaluator = new ConditionEvaluator()
+
+  test("matches when the updated info type equals the condition sourceId", async () => {
+    await expect(
+      evaluator.evaluate(
+        buildContext(
+          {
+            type: triggerEventTypes.enum.contactInfoUpdated,
+            sourceId: "phone",
+          },
+          { infoType: "phone", newValue: "+84912345678" },
+        ),
+      ),
+    ).resolves.toBe(true)
+  })
+
+  test("does not match a different info type", async () => {
+    await expect(
+      evaluator.evaluate(
+        buildContext(
+          {
+            type: triggerEventTypes.enum.contactInfoUpdated,
+            sourceId: "email",
+          },
+          { infoType: "phone", newValue: "+84912345678" },
+        ),
+      ),
+    ).resolves.toBe(false)
+  })
+
+  test("does not match when the condition has no sourceId", async () => {
+    await expect(
+      evaluator.evaluate(
+        buildContext(
+          { type: triggerEventTypes.enum.contactInfoUpdated, sourceId: null },
+          { infoType: "phone", newValue: "+84912345678" },
+        ),
+      ),
+    ).resolves.toBe(false)
+  })
+
+  test("still matches tag conditions through the shared source-id check", async () => {
+    await expect(
+      evaluator.evaluate(
+        buildContext(
+          { type: triggerEventTypes.enum.tagApplied, sourceId: "tag-1" },
+          { tagId: "tag-1" },
+        ),
+      ),
+    ).resolves.toBe(true)
+  })
+})

--- a/apps/worker/__tests__/export-contacts-csv.test.ts
+++ b/apps/worker/__tests__/export-contacts-csv.test.ts
@@ -23,6 +23,7 @@ vi.mock("@chatbotx.io/database/partials", async () =>
 
 vi.mock("@chatbotx.io/database/queries", () => ({
   applyContactFilter: (criteria: unknown) => ({ __filter: criteria }),
+  pruneEmailPhoneFilterConditions: (criteria: unknown) => criteria,
 }))
 
 vi.mock("@chatbotx.io/database/schema", () => ({

--- a/apps/worker/__tests__/export-contacts-fields.test.ts
+++ b/apps/worker/__tests__/export-contacts-fields.test.ts
@@ -39,6 +39,7 @@ vi.mock("@chatbotx.io/database/partials", async () =>
 
 vi.mock("@chatbotx.io/database/queries", () => ({
   applyContactFilter: (criteria: unknown) => ({ __filter: criteria }),
+  pruneEmailPhoneFilterConditions: (criteria: unknown) => criteria,
 }))
 
 vi.mock("@chatbotx.io/database/schema", () => ({

--- a/apps/worker/__tests__/export-contacts-handler.test.ts
+++ b/apps/worker/__tests__/export-contacts-handler.test.ts
@@ -40,6 +40,7 @@ vi.mock("@chatbotx.io/database/partials", async () =>
 
 vi.mock("@chatbotx.io/database/queries", () => ({
   applyContactFilter: (criteria: unknown) => ({ __filter: criteria }),
+  pruneEmailPhoneFilterConditions: (criteria: unknown) => criteria,
 }))
 
 vi.mock("@chatbotx.io/database/schema", () => ({

--- a/apps/worker/__tests__/export-contacts-where.test.ts
+++ b/apps/worker/__tests__/export-contacts-where.test.ts
@@ -29,6 +29,31 @@ const applyContactFilterSpy = vi.fn((criteria: unknown) => ({
 
 vi.mock("@chatbotx.io/database/queries", () => ({
   applyContactFilter: (criteria: unknown) => applyContactFilterSpy(criteria),
+  pruneEmailPhoneFilterConditions: (
+    contactFilter:
+      | { operator: "and" | "or"; conditions: unknown[] }
+      | undefined,
+    canViewEmailAndPhone: boolean,
+  ) =>
+    canViewEmailAndPhone || !contactFilter
+      ? contactFilter
+      : {
+          operator: contactFilter.operator,
+          conditions: contactFilter.conditions.filter((condition) => {
+            const field =
+              typeof condition === "object" && condition !== null
+                ? (condition as { field?: unknown }).field
+                : undefined
+            return ![
+              "email",
+              "phone",
+              "hasContactInfo",
+              "emailWasVerified",
+              "optedInForEmail",
+              "existingContact",
+            ].includes(String(field))
+          }),
+        },
 }))
 
 vi.mock("@chatbotx.io/database/schema", () => ({
@@ -65,7 +90,7 @@ const buildData = (
     workspaceId: "ws-1",
     fileId: "file-1",
     fields: ["sys:email"],
-    // The real producer always sets this; PII export fails closed when omitted.
+    // The real producer always sets this; email/phone export fails closed when omitted.
     canExportEmailAndPhone: true,
     outputPath: "exports/ws-1/contacts.csv",
     outputFormat: "csv",
@@ -157,7 +182,7 @@ describe("buildBaseWhere", () => {
       expect(or[3]).toEqual({ phoneNumber: { ilike: "%hello%" } })
     })
 
-    test("OR array omits email and phoneNumber when PII export is denied", () => {
+    test("OR array omits email and phoneNumber when email/phone export is denied", () => {
       // Arrange
       const data = buildData({
         filter: { keyword: "hello" },
@@ -174,7 +199,7 @@ describe("buildBaseWhere", () => {
       ])
     })
 
-    test("OR array omits email and phoneNumber when PII flag is omitted (fails closed)", () => {
+    test("OR array omits email and phoneNumber when the email/phone flag is omitted (fails closed)", () => {
       // Arrange
       const data = buildData({
         filter: { keyword: "hello" },
@@ -230,6 +255,30 @@ describe("buildBaseWhere", () => {
       // Assert
       expect(applyContactFilterSpy).toHaveBeenCalledOnce()
       expect(applyContactFilterSpy).toHaveBeenCalledWith(criteria)
+    })
+
+    test("email/phone contact-filter conditions are dropped when email/phone export is denied", () => {
+      // Arrange
+      const criteria = {
+        operator: "and" as const,
+        conditions: [
+          { field: "email", operator: "eq", value: "ada@example.com" },
+          { field: "fullName", operator: "contains", value: "Ada" },
+        ],
+      }
+      const data = buildData({
+        canExportEmailAndPhone: false,
+        filter: { contactFilter: criteria },
+      })
+
+      // Act
+      buildBaseWhere(data)
+
+      // Assert
+      expect(applyContactFilterSpy).toHaveBeenCalledWith({
+        operator: "and",
+        conditions: [{ field: "fullName", operator: "contains", value: "Ada" }],
+      })
     })
 
     test("result of applyContactFilter is merged into where", () => {
@@ -379,7 +428,7 @@ describe("buildBaseWhere", () => {
 })
 
 describe("stripContactPIIFields", () => {
-  test("removes email and phoneNumber fields when PII export is denied", () => {
+  test("removes email and phoneNumber fields when email/phone export is denied", () => {
     expect(
       stripContactPIIFields(
         ["sys:firstName", "sys:email", "sys:phoneNumber", "tag:t1"],
@@ -388,7 +437,7 @@ describe("stripContactPIIFields", () => {
     ).toEqual(["sys:firstName", "tag:t1"])
   })
 
-  test("preserves fields when PII export is allowed", () => {
+  test("preserves fields when email/phone export is allowed", () => {
     expect(
       stripContactPIIFields(["sys:email", "sys:phoneNumber"], true),
     ).toEqual(["sys:email", "sys:phoneNumber"])

--- a/apps/worker/src/default/handlers/export-contacts.ts
+++ b/apps/worker/src/default/handlers/export-contacts.ts
@@ -1,7 +1,10 @@
 import type { PassThrough } from "node:stream"
 import { and, db, eq } from "@chatbotx.io/database/client"
 import { fileStatuses } from "@chatbotx.io/database/partials"
-import { applyContactFilter } from "@chatbotx.io/database/queries"
+import {
+  applyContactFilter,
+  pruneEmailPhoneFilterConditions,
+} from "@chatbotx.io/database/queries"
 import {
   type contactCustomFieldModel,
   fileModel,
@@ -146,8 +149,13 @@ export const buildBaseWhere = (data: ExportData): Record<string, unknown> => {
     ]
   }
 
-  if (data.filter.contactFilter) {
-    Object.assign(where, applyContactFilter(data.filter.contactFilter))
+  const contactFilter = pruneEmailPhoneFilterConditions(
+    data.filter.contactFilter,
+    data.canExportEmailAndPhone === true,
+  )
+
+  if (contactFilter) {
+    Object.assign(where, applyContactFilter(contactFilter))
   }
 
   addAssignedContactScope(where, data.restrictToAssignedUserId)

--- a/apps/worker/src/trigger/services/condition-evaluator.ts
+++ b/apps/worker/src/trigger/services/condition-evaluator.ts
@@ -14,10 +14,15 @@ export class ConditionEvaluator {
     switch (type) {
       case triggerEventTypes.enum.tagApplied:
       case triggerEventTypes.enum.tagRemoved:
-        return this.evaluateTagCondition(
-          type,
+        return this.evaluateSourceIdMatch(
           sourceId,
           eventData.eventData.tagId as string,
+        )
+
+      case triggerEventTypes.enum.contactInfoUpdated:
+        return this.evaluateSourceIdMatch(
+          sourceId,
+          eventData.eventData.infoType as string,
         )
 
       case triggerEventTypes.enum.customFieldValueChanged:
@@ -58,15 +63,15 @@ export class ConditionEvaluator {
     }
   }
 
-  private evaluateTagCondition(
-    _conditionType: string,
-    expectedTagId: string | null,
-    actualTagId: string,
+  /** Conditions pinned to a source (tag id, contact info type, …) match only that exact source. */
+  private evaluateSourceIdMatch(
+    expectedSourceId: string | null,
+    actualSourceId: string,
   ): boolean {
-    if (!expectedTagId) {
+    if (!expectedSourceId) {
       return false
     }
-    return expectedTagId === actualTagId
+    return expectedSourceId === actualSourceId
   }
 
   private async evaluateCustomFieldCondition(

--- a/apps/worker/src/webhook/services/webhook-executor.service.ts
+++ b/apps/worker/src/webhook/services/webhook-executor.service.ts
@@ -22,6 +22,7 @@ const EVENT_NAMES = {
   [triggerEventTypes.enum.tagApplied]: "tag_applied",
   [triggerEventTypes.enum.tagRemoved]: "tag_removed",
   [triggerEventTypes.enum.customFieldValueChanged]: "custom_field_changed",
+  [triggerEventTypes.enum.contactInfoUpdated]: "contact_info_updated",
   [triggerEventTypes.enum.conversationTransferredToHuman]:
     "conversation_transferred_to_human",
   [triggerEventTypes.enum.conversationTransferredToBot]:
@@ -114,6 +115,12 @@ const PAYLOAD_BUILDERS = {
   [triggerEventTypes.enum.tagApplied]: buildTagPayload,
   [triggerEventTypes.enum.tagRemoved]: buildTagPayload,
   [triggerEventTypes.enum.customFieldValueChanged]: buildCustomFieldPayload,
+  [triggerEventTypes.enum.contactInfoUpdated]: (basePayload, data) => ({
+    ...basePayload,
+    info_type: data.infoType as string,
+    old_value: (data.oldValue as string) || null,
+    new_value: data.newValue as string,
+  }),
   [triggerEventTypes.enum.conversationTransferredToHuman]: (
     basePayload,
     data,

--- a/packages/business/__tests__/contact-info-changes.test.ts
+++ b/packages/business/__tests__/contact-info-changes.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest"
+import { collectContactInfoChanges } from "../src/contact/contact-info-changes"
+
+describe("collectContactInfoChanges", () => {
+  test("reports a phone number that was just set", () => {
+    expect(
+      collectContactInfoChanges(
+        { phoneNumber: null, email: null },
+        { phoneNumber: "+84912345678", email: null },
+      ),
+    ).toEqual([{ infoType: "phone", oldValue: null, newValue: "+84912345678" }])
+  })
+
+  test("reports both fields when phone and email change together", () => {
+    expect(
+      collectContactInfoChanges(
+        { phoneNumber: "+84900000000", email: "old@example.com" },
+        { phoneNumber: "+84912345678", email: "new@example.com" },
+      ),
+    ).toEqual([
+      {
+        infoType: "phone",
+        oldValue: "+84900000000",
+        newValue: "+84912345678",
+      },
+      {
+        infoType: "email",
+        oldValue: "old@example.com",
+        newValue: "new@example.com",
+      },
+    ])
+  })
+
+  test("ignores unchanged values and whitespace-only differences", () => {
+    expect(
+      collectContactInfoChanges(
+        { phoneNumber: "+84912345678", email: "same@example.com" },
+        { phoneNumber: "+84912345678", email: " same@example.com " },
+      ),
+    ).toEqual([])
+  })
+
+  test("does not treat clearing a value as an update", () => {
+    expect(
+      collectContactInfoChanges(
+        { phoneNumber: "+84912345678", email: "old@example.com" },
+        { phoneNumber: null, email: "" },
+      ),
+    ).toEqual([])
+  })
+})

--- a/packages/business/__tests__/contact-service-update-events.test.ts
+++ b/packages/business/__tests__/contact-service-update-events.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockDbUpdate, mockEmitContactInfoUpdated } = vi.hoisted(() => ({
+  mockDbUpdate: vi.fn(),
+  mockEmitContactInfoUpdated: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  and: vi.fn((...args: unknown[]) => ({ __and: args })),
+  db: { update: mockDbUpdate },
+  eq: vi.fn((left: unknown, right: unknown) => ({ __eq: [left, right] })),
+  findOrFail: vi.fn(),
+  inArray: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  contactInboxModel: {},
+  contactModel: { id: "Contact.id" },
+  conversationModel: {},
+  inboxModel: {},
+}))
+
+vi.mock("@chatbotx.io/event-bus", () => ({
+  emit: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/events", () => ({
+  emitContactCreated: vi.fn(),
+  emitContactInfoUpdated: mockEmitContactInfoUpdated,
+}))
+
+vi.mock("@chatbotx.io/filesystem", () => ({
+  uploadFileFromUrl: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/redis", () => ({
+  invalidateCacheByTags: vi.fn(),
+  withCache: vi.fn(),
+}))
+
+vi.mock("../src/quota-enforcement/service", () => ({
+  quotaEnforcementService: {},
+}))
+
+vi.mock("../src/workspace/service", () => ({
+  workspaceService: {},
+}))
+
+const { contactService } = await import("../src/contact/service")
+
+const buildUpdateClient = (updated: {
+  id: string
+  workspaceId: string
+  phoneNumber: string | null
+  email: string | null
+}) => {
+  const returning = vi.fn().mockResolvedValue([updated])
+  const where = vi.fn(() => ({ returning }))
+  const set = vi.fn(() => ({ where }))
+  const update = vi.fn(() => ({ set }))
+
+  return { returning, set, update, where }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("contactService.update contactInfoUpdated events", () => {
+  test("emits contact info changes on the autocommit path", async () => {
+    const existing = {
+      id: "contact-1",
+      workspaceId: "ws-1",
+      phoneNumber: "+84900000000",
+      email: null,
+    }
+    const updated = {
+      ...existing,
+      phoneNumber: "+84912345678",
+    }
+    const dbUpdateClient = buildUpdateClient(updated)
+    mockDbUpdate.mockImplementation(dbUpdateClient.update)
+    vi.spyOn(contactService, "findByIdOrFail").mockResolvedValue(
+      existing as never,
+    )
+    vi.spyOn(contactService, "invalidate").mockResolvedValue(undefined)
+
+    await contactService.update(
+      { workspaceId: "ws-1", id: "contact-1" },
+      { phoneNumber: "+84912345678" },
+    )
+
+    expect(mockEmitContactInfoUpdated).toHaveBeenCalledExactlyOnceWith(
+      "ws-1",
+      "contact-1",
+      "phone",
+      "+84900000000",
+      "+84912345678",
+    )
+  })
+
+  test("does not emit before a caller-owned transaction commits", async () => {
+    const existing = {
+      id: "contact-1",
+      workspaceId: "ws-1",
+      phoneNumber: "+84900000000",
+      email: null,
+    }
+    const updated = {
+      ...existing,
+      phoneNumber: "+84912345678",
+    }
+    const txUpdateClient = buildUpdateClient(updated)
+    const tx = { update: txUpdateClient.update }
+    vi.spyOn(contactService, "findByIdOrFail").mockResolvedValue(
+      existing as never,
+    )
+    vi.spyOn(contactService, "invalidate").mockResolvedValue(undefined)
+
+    await contactService.update(
+      { workspaceId: "ws-1", id: "contact-1" },
+      { phoneNumber: "+84912345678" },
+      tx as never,
+    )
+
+    expect(mockEmitContactInfoUpdated).not.toHaveBeenCalled()
+  })
+})

--- a/packages/business/__tests__/update-from-message.test.ts
+++ b/packages/business/__tests__/update-from-message.test.ts
@@ -1,23 +1,35 @@
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
-const { mockFindFirstWorkspace, mockUpdate, mockSet, mockWhere } = vi.hoisted(
-  () => ({
-    mockFindFirstWorkspace: vi.fn(),
-    mockUpdate: vi.fn(),
-    mockSet: vi.fn(),
-    mockWhere: vi.fn(),
-  }),
-)
+const {
+  mockFindFirstWorkspace,
+  mockFindFirstContact,
+  mockUpdate,
+  mockSet,
+  mockWhere,
+  mockEmitContactInfoUpdated,
+} = vi.hoisted(() => ({
+  mockFindFirstWorkspace: vi.fn(),
+  mockFindFirstContact: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockSet: vi.fn(),
+  mockWhere: vi.fn(),
+  mockEmitContactInfoUpdated: vi.fn(),
+}))
 
 vi.mock("@chatbotx.io/database/client", () => ({
   db: {
     update: mockUpdate,
     query: {
       workspaceModel: { findFirst: mockFindFirstWorkspace },
+      contactModel: { findFirst: mockFindFirstContact },
     },
   },
   and: vi.fn((...args: unknown[]) => ({ __and: args })),
   eq: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/events", () => ({
+  emitContactInfoUpdated: mockEmitContactInfoUpdated,
 }))
 
 vi.mock("@chatbotx.io/database/schema", () => ({
@@ -34,6 +46,7 @@ import { updateContactFromMessage } from "../src/contact/update-from-message"
 beforeEach(() => {
   vi.clearAllMocks()
   mockFindFirstWorkspace.mockResolvedValue({ targetCountry: "VN" })
+  mockFindFirstContact.mockResolvedValue({ phoneNumber: null, email: null })
   mockSet.mockReturnValue({ where: mockWhere })
   mockWhere.mockResolvedValue(undefined)
   mockUpdate.mockReturnValue({ set: mockSet })
@@ -119,15 +132,63 @@ describe("updateContactFromMessage", () => {
     expect(mockSet).toHaveBeenCalledWith({ phoneNumber: "+84912345678" })
   })
 
-  test("overwrites unconditionally — no SELECT before UPDATE", async () => {
-    // No call to findFirst(contactModel) anywhere — only workspace lookup.
+  test("reads the contact row only on extraction hits — no-match path stays query-free", async () => {
+    await updateContactFromMessage({
+      contactId: "c1",
+      workspaceId: "w1",
+      text: "hello how are you today",
+    })
+    expect(mockFindFirstContact).not.toHaveBeenCalled()
+
     await updateContactFromMessage({
       contactId: "c1",
       workspaceId: "w1",
       text: "new number 0912345678",
     })
-    expect(mockFindFirstWorkspace).toHaveBeenCalledOnce()
+    expect(mockFindFirstContact).toHaveBeenCalledOnce()
     expect(mockSet).toHaveBeenCalledWith({ phoneNumber: "+84912345678" })
+  })
+
+  test("emits contactInfoUpdated with old and new values when the phone changed", async () => {
+    mockFindFirstContact.mockResolvedValueOnce({
+      phoneNumber: "+84900000000",
+      email: null,
+    })
+    await updateContactFromMessage({
+      contactId: "c1",
+      workspaceId: "w1",
+      text: "new number 0912345678",
+    })
+    expect(mockEmitContactInfoUpdated).toHaveBeenCalledExactlyOnceWith(
+      "w1",
+      "c1",
+      "phone",
+      "+84900000000",
+      "+84912345678",
+    )
+  })
+
+  test("does not emit when the extracted value matches the stored value", async () => {
+    mockFindFirstContact.mockResolvedValueOnce({
+      phoneNumber: "+84912345678",
+      email: null,
+    })
+    await updateContactFromMessage({
+      contactId: "c1",
+      workspaceId: "w1",
+      text: "same number 0912345678",
+    })
+    expect(mockEmitContactInfoUpdated).not.toHaveBeenCalled()
+  })
+
+  test("does not emit when the contact row no longer exists", async () => {
+    mockFindFirstContact.mockResolvedValueOnce(undefined)
+    await updateContactFromMessage({
+      contactId: "c1",
+      workspaceId: "w1",
+      text: "new number 0912345678",
+    })
+    expect(mockEmitContactInfoUpdated).not.toHaveBeenCalled()
   })
 
   test("channel-agnostic: same call shape works for any caller (no channel arg)", async () => {

--- a/packages/business/src/broadcast/__tests__/broadcast.service.test.ts
+++ b/packages/business/src/broadcast/__tests__/broadcast.service.test.ts
@@ -151,6 +151,29 @@ vi.mock("@chatbotx.io/database/client", () => ({
 vi.mock("@chatbotx.io/database/queries", () => ({
   buildContactInboxContactFilterSQL: mocks.buildContactInboxContactFilterSQL,
   contactInboxInteractedWithin24hSQL: mocks.contactInboxInteractedWithin24hSQL,
+  pruneEmailPhoneFilterConditions: (
+    contactFilter: { operator: "and" | "or"; conditions: unknown[] },
+    canViewEmailAndPhone: boolean,
+  ) =>
+    canViewEmailAndPhone
+      ? contactFilter
+      : {
+          operator: contactFilter.operator,
+          conditions: contactFilter.conditions.filter((condition) => {
+            const field =
+              typeof condition === "object" && condition !== null
+                ? (condition as { field?: unknown }).field
+                : undefined
+            return ![
+              "email",
+              "phone",
+              "hasContactInfo",
+              "emailWasVerified",
+              "optedInForEmail",
+              "existingContact",
+            ].includes(String(field))
+          }),
+        },
 }))
 
 vi.mock("@chatbotx.io/database/utils", () => ({
@@ -246,6 +269,34 @@ describe("broadcastService.countAudience", () => {
       contactIdColumn: "ContactInbox.contactId",
       workspaceId: "ws-1",
       contactFilter,
+    })
+  })
+
+  test("prunes email/phone contact filters when the audience caller lacks emailAndPhone permission", async () => {
+    mocks.resolveBroadcastInboxIds.mockResolvedValue(["inbox-1"])
+    mocks.count.mockResolvedValue(1)
+    const restrictedFilter = {
+      operator: "and" as const,
+      conditions: [
+        { field: "email", operator: "eq", value: "ada@example.com" },
+        { field: "fullName", operator: "contains", value: "Ada" },
+      ],
+    }
+
+    await broadcastService.countAudience({
+      workspaceId: "ws-1",
+      channels: ["messenger"],
+      canViewEmailAndPhone: false,
+      contactFilter: restrictedFilter,
+    })
+
+    expect(mocks.buildContactInboxContactFilterSQL).toHaveBeenCalledWith({
+      contactIdColumn: "ContactInbox.contactId",
+      workspaceId: "ws-1",
+      contactFilter: {
+        operator: "and",
+        conditions: [{ field: "fullName", operator: "contains", value: "Ada" }],
+      },
     })
   })
 

--- a/packages/business/src/broadcast/schema.ts
+++ b/packages/business/src/broadcast/schema.ts
@@ -10,6 +10,7 @@ export type BroadcastAudienceInput = {
   integrationWhatsappId?: string | null
   integrationMessengerId?: string | null
   contactFilter?: ContactFilterCriteriaInput | null
+  canViewEmailAndPhone?: boolean
   subaction?: BroadcastSubaction | null
   restrictToAssignedUserId?: string
 }

--- a/packages/business/src/broadcast/service.ts
+++ b/packages/business/src/broadcast/service.ts
@@ -17,6 +17,7 @@ import {
 import {
   buildContactInboxContactFilterSQL,
   contactInboxInteractedWithin24hSQL,
+  pruneEmailPhoneFilterConditions,
 } from "@chatbotx.io/database/queries"
 import {
   broadcastModel,
@@ -70,13 +71,18 @@ class BroadcastService extends BaseService {
     inboxIds: string[],
     input: BroadcastAudienceInput,
   ): SQL | undefined {
+    const contactFilter = pruneEmailPhoneFilterConditions(
+      input.contactFilter,
+      input.canViewEmailAndPhone !== false,
+    )
+
     return and(
       inArray(contactInboxModel.inboxId, inboxIds),
-      input.contactFilter
+      contactFilter
         ? buildContactInboxContactFilterSQL({
             contactIdColumn: contactInboxModel.contactId,
             workspaceId: input.workspaceId,
-            contactFilter: input.contactFilter,
+            contactFilter,
           })
         : undefined,
       requiresRecentInteractionWindow(input.subaction)

--- a/packages/business/src/contact/contact-info-changes.ts
+++ b/packages/business/src/contact/contact-info-changes.ts
@@ -1,0 +1,71 @@
+import type { ContactInfoType } from "@chatbotx.io/database/partials"
+import type { ContactModel } from "@chatbotx.io/database/types"
+import { emitContactInfoUpdated } from "@chatbotx.io/events"
+
+export type ContactInfoSnapshot = Pick<ContactModel, "phoneNumber" | "email">
+
+export type ContactInfoChange = {
+  infoType: ContactInfoType
+  oldValue: string | null
+  newValue: string
+}
+
+const CONTACT_INFO_SOURCES = [
+  { infoType: "phone", column: "phoneNumber" },
+  { infoType: "email", column: "email" },
+] as const satisfies ReadonlyArray<{
+  infoType: ContactInfoType
+  column: keyof ContactInfoSnapshot
+}>
+
+const normalizeContactInfoValue = (
+  value: string | null | undefined,
+): string | null => value?.trim() || null
+
+/**
+ * Diffs the contact-info columns between two contact snapshots. Only fields
+ * that gained or changed to a non-empty value count as updated — clearing a
+ * value is not a `contactInfoUpdated` event.
+ */
+export function collectContactInfoChanges(
+  before: ContactInfoSnapshot,
+  after: ContactInfoSnapshot,
+): ContactInfoChange[] {
+  const changes: ContactInfoChange[] = []
+
+  for (const { infoType, column } of CONTACT_INFO_SOURCES) {
+    const oldValue = normalizeContactInfoValue(before[column])
+    const newValue = normalizeContactInfoValue(after[column])
+
+    if (newValue && newValue !== oldValue) {
+      changes.push({ infoType, oldValue, newValue })
+    }
+  }
+
+  return changes
+}
+
+/**
+ * Emits one `contactInfoUpdated` event per phone/email value that changed
+ * between two contact snapshots. Emitters swallow and log their own failures,
+ * so callers on hot write paths can await this without extra error handling.
+ */
+export async function emitContactInfoChangeEvents(
+  workspaceId: string,
+  contactId: string,
+  before: ContactInfoSnapshot,
+  after: ContactInfoSnapshot,
+): Promise<void> {
+  const changes = collectContactInfoChanges(before, after)
+  await Promise.all(
+    changes.map(({ infoType, oldValue, newValue }) =>
+      emitContactInfoUpdated(
+        workspaceId,
+        contactId,
+        infoType,
+        oldValue,
+        newValue,
+      ),
+    ),
+  )
+}

--- a/packages/business/src/contact/index.ts
+++ b/packages/business/src/contact/index.ts
@@ -1,3 +1,4 @@
+export * from "./contact-info-changes"
 export * from "./extract-contact"
 export * from "./service"
 export * from "./update-from-message"

--- a/packages/business/src/contact/service.ts
+++ b/packages/business/src/contact/service.ts
@@ -29,6 +29,7 @@ import { BaseService } from "../base.service"
 import { ChatbotXException, notFoundException } from "../errors"
 import { quotaEnforcementService } from "../quota-enforcement/service"
 import { workspaceService } from "../workspace/service"
+import { emitContactInfoChangeEvents } from "./contact-info-changes"
 
 const NUMERIC_RE = /^\d+$/
 
@@ -177,7 +178,8 @@ class ContactService extends BaseService {
     data: ContactWriteData,
     tx: DatabaseClient = db,
   ): Promise<ContactModel> {
-    await this.findByIdOrFail({
+    const ownsTransaction = tx === db
+    const existing = await this.findByIdOrFail({
       workspaceId: ctx.workspaceId,
       id: ctx.id,
       accessScope: ctx.accessScope,
@@ -189,6 +191,14 @@ class ContactService extends BaseService {
       .where(eq(contactModel.id, ctx.id))
       .returning()
     await this.invalidate({ workspaceId: ctx.workspaceId, ids: [ctx.id] })
+    if (ownsTransaction) {
+      await emitContactInfoChangeEvents(
+        ctx.workspaceId,
+        ctx.id,
+        existing,
+        updated,
+      )
+    }
     return updated
   }
 

--- a/packages/business/src/contact/update-from-message.ts
+++ b/packages/business/src/contact/update-from-message.ts
@@ -1,5 +1,6 @@
 import { and, db, eq } from "@chatbotx.io/database/client"
 import { contactModel } from "@chatbotx.io/database/schema"
+import { emitContactInfoChangeEvents } from "./contact-info-changes"
 import { extractContactInfo } from "./extract-contact"
 
 export type UpdateContactFromMessageProps = {
@@ -65,6 +66,14 @@ export const updateContactFromMessage = async (
   }
 
   if (Object.keys(updates).length > 0) {
+    // Read the current values only on extraction hits (rare relative to
+    // message volume) so `contactInfoUpdated` events carry the old value and
+    // fire only on real changes — the no-match fast path stays query-free.
+    const current = await db.query.contactModel.findFirst({
+      where: { id: contactId, workspaceId },
+      columns: { phoneNumber: true, email: true },
+    })
+
     // Tenant-scoped WHERE: contactId is globally unique today but defence in
     // depth — every multi-tenant write in this codebase pairs the row id with
     // the workspaceId so a stale/spoofed contactId can never bleed across
@@ -78,6 +87,13 @@ export const updateContactFromMessage = async (
           eq(contactModel.workspaceId, workspaceId),
         ),
       )
+
+    if (current) {
+      await emitContactInfoChangeEvents(workspaceId, contactId, current, {
+        phoneNumber: updates.phoneNumber ?? current.phoneNumber,
+        email: updates.email ?? current.email,
+      })
+    }
   }
 
   return extracted

--- a/packages/business/src/system-field/service.ts
+++ b/packages/business/src/system-field/service.ts
@@ -269,6 +269,8 @@ class SystemFieldService extends BaseService {
     // Synchronous v1 is bounded to one contact-inbox; move to BullMQ if this
     // path needs to erase very large histories.
     await db.transaction(async (tx) => {
+      // Clearing phone/email intentionally does not emit contactInfoUpdated. If
+      // that semantic changes, emit after this transaction commits.
       await contactService.update(
         {
           workspaceId: context.payload.workspaceId,

--- a/packages/database/__tests__/contact-filter.test.ts
+++ b/packages/database/__tests__/contact-filter.test.ts
@@ -8,6 +8,7 @@ import {
   buildContactWhere,
   buildSmartKeywordWhere,
   parseConversationAssigneeValues,
+  pruneEmailPhoneFilterConditions,
 } from "../src/queries/contact-filter"
 import { contactInboxModel, contactModel } from "../src/schema"
 import { escapeLikePattern, likeContains } from "../src/utils"
@@ -33,6 +34,54 @@ describe("LIKE pattern helpers", () => {
   test("escapes LIKE metacharacters and wraps contains patterns", () => {
     expect(escapeLikePattern("100%_ready\\")).toBe("100\\%\\_ready\\\\")
     expect(likeContains("100%_ready\\")).toBe("%100\\%\\_ready\\\\%")
+  })
+})
+
+describe("contact filter permission helpers", () => {
+  test("drops only email/phone contact-filter fields when email and phone are denied", () => {
+    const contactFilter = {
+      operator: "and" as const,
+      conditions: [
+        { field: "email", operator: "eq", value: "ada@example.com" },
+        { field: "phone", operator: "eq", value: "+84912345678" },
+        { field: "hasContactInfo", operator: "in", value: ["email"] },
+        { field: "emailWasVerified", operator: "eq", value: "true" },
+        { field: "optedInForEmail", operator: "eq", value: "true" },
+        { field: "existingContact", operator: "eq", value: "true" },
+        { field: "fullName", operator: "contains", value: "Ada" },
+      ],
+    }
+
+    expect(pruneEmailPhoneFilterConditions(contactFilter, false)).toEqual({
+      operator: "and",
+      conditions: [{ field: "fullName", operator: "contains", value: "Ada" }],
+    })
+  })
+
+  test("keeps all contact-filter fields when email and phone are allowed", () => {
+    const contactFilter = {
+      operator: "or" as const,
+      conditions: [
+        { field: "email", operator: "eq", value: "ada@example.com" },
+        { field: "fullName", operator: "contains", value: "Ada" },
+      ],
+    }
+
+    expect(pruneEmailPhoneFilterConditions(contactFilter, true)).toBe(
+      contactFilter,
+    )
+  })
+
+  test("normalizes an emptied filter back to AND", () => {
+    expect(
+      pruneEmailPhoneFilterConditions(
+        {
+          operator: "or",
+          conditions: [{ field: "email", operator: "eq", value: "a@b.co" }],
+        },
+        false,
+      ),
+    ).toEqual({ operator: "and", conditions: [] })
   })
 })
 
@@ -569,6 +618,123 @@ describe("applyContactFilter", () => {
     expect(negative.sql).toContain("NOT (")
     expect(negative.sql).toContain('"Contact"."email" IS NOT NULL')
     expect(negative.sql).toContain('"Contact"."phoneNumber" IS NOT NULL')
+  })
+
+  test("renders hasContactInfo presence predicate for the selected info types", () => {
+    const phoneOnly = renderContactWhere(
+      applyContactFilter({
+        operator: "and",
+        conditions: [
+          {
+            field: "hasContactInfo",
+            operator: operatorTypes.enum.in,
+            value: ["phone"],
+          },
+        ],
+      }),
+    )
+    expect(phoneOnly.sql).toContain('"Contact"."phoneNumber" IS NOT NULL')
+    expect(phoneOnly.sql).not.toContain('"Contact"."email"')
+
+    const phoneOrEmail = renderContactWhere(
+      applyContactFilter({
+        operator: "and",
+        conditions: [
+          {
+            field: "hasContactInfo",
+            operator: operatorTypes.enum.in,
+            value: ["phone", "email"],
+          },
+        ],
+      }),
+    )
+    expect(phoneOrEmail.sql).toContain('"Contact"."phoneNumber" IS NOT NULL')
+    expect(phoneOrEmail.sql).toContain('"Contact"."email" IS NOT NULL')
+    expect(phoneOrEmail.sql).toContain(" OR ")
+  })
+
+  test("renders hasContactInfo phoneAndEmail as a phone AND email presence predicate", () => {
+    const hasBoth = renderContactWhere(
+      applyContactFilter({
+        operator: "and",
+        conditions: [
+          {
+            field: "hasContactInfo",
+            operator: operatorTypes.enum.in,
+            value: ["phoneAndEmail"],
+          },
+        ],
+      }),
+    )
+    expect(hasBoth.sql).toContain('"Contact"."phoneNumber" IS NOT NULL')
+    expect(hasBoth.sql).toContain('"Contact"."email" IS NOT NULL')
+    expect(hasBoth.sql).toContain(" AND ")
+    expect(hasBoth.sql).not.toContain(" OR ")
+
+    const lacksBoth = renderContactWhere(
+      applyContactFilter({
+        operator: "and",
+        conditions: [
+          {
+            field: "hasContactInfo",
+            operator: operatorTypes.enum.notIn,
+            value: ["phoneAndEmail"],
+          },
+        ],
+      }),
+    )
+    expect(lacksBoth.sql).toContain("NOT (")
+    expect(lacksBoth.sql).toContain('"Contact"."phoneNumber" IS NOT NULL')
+    expect(lacksBoth.sql).toContain('"Contact"."email" IS NOT NULL')
+    expect(lacksBoth.sql).toContain(" AND ")
+  })
+
+  test("renders NULL-safe negation for hasContactInfo notIn and isEmpty", () => {
+    const lacksEmail = renderContactWhere(
+      applyContactFilter({
+        operator: "and",
+        conditions: [
+          {
+            field: "hasContactInfo",
+            operator: operatorTypes.enum.notIn,
+            value: ["email"],
+          },
+        ],
+      }),
+    )
+    expect(lacksEmail.sql).toContain("NOT (")
+    expect(lacksEmail.sql).toContain('"Contact"."email" IS NOT NULL')
+    expect(lacksEmail.sql).not.toContain('"Contact"."phoneNumber"')
+
+    const lacksBoth = renderContactWhere(
+      applyContactFilter({
+        operator: "and",
+        conditions: [
+          {
+            field: "hasContactInfo",
+            operator: operatorTypes.enum.isEmpty,
+          },
+        ],
+      }),
+    )
+    expect(lacksBoth.sql).toContain("NOT (")
+    expect(lacksBoth.sql).toContain('"Contact"."email" IS NOT NULL')
+    expect(lacksBoth.sql).toContain('"Contact"."phoneNumber" IS NOT NULL')
+  })
+
+  test("ignores hasContactInfo conditions with unknown info types", () => {
+    const where = applyContactFilter({
+      operator: "and",
+      conditions: [
+        {
+          field: "hasContactInfo",
+          operator: operatorTypes.enum.in,
+          value: ["whatsapp"],
+        },
+      ],
+    })
+
+    expect(where).toEqual({})
   })
 
   test("renders continent country-code expansion and unknown sentinel", () => {

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -51,6 +51,8 @@
     "./utils": "./src/utils.ts",
     "./partials": "./src/partials/index.ts",
     "./queries": "./src/queries/index.ts",
+    "./queries/contact-filter": "./src/queries/contact-filter/index.ts",
+    "./queries/contact-filter/permission": "./src/queries/contact-filter/permission.ts",
     "./repositories": "./src/repositories/index.ts"
   }
 }

--- a/packages/database/src/partials/contact.ts
+++ b/packages/database/src/partials/contact.ts
@@ -116,6 +116,26 @@ export const fillableContactKeys = [
 ] as const
 export type FillableContactKey = (typeof fillableContactKeys)[number]
 
+/**
+ * The atomic contact-info kinds a contact can hold: exactly one is touched per
+ * change, so this is what the `contactInfoUpdated` trigger reports (which info
+ * type was updated).
+ */
+export const contactInfoTypes = z.enum(["phone", "email"])
+export type ContactInfoType = z.infer<typeof contactInfoTypes>
+
+/**
+ * Selectable values for the `hasContactInfo` filter. Extends the atomic
+ * {@link contactInfoTypes} with the `phoneAndEmail` composite so a contact can
+ * be required to have BOTH a phone and an email, not just either one.
+ */
+export const contactInfoFilterValues = z.enum([
+  "phone",
+  "email",
+  "phoneAndEmail",
+])
+export type ContactInfoFilterValue = z.infer<typeof contactInfoFilterValues>
+
 export const contactFilterFields = z.enum([
   "fullName",
   "country",
@@ -156,6 +176,7 @@ export const contactFilterFields = z.enum([
   "appliedJobs",
   "email",
   "phone",
+  "hasContactInfo",
   "tags",
   "completedWhatsAppFlows",
   "messengerList",

--- a/packages/database/src/partials/trigger.ts
+++ b/packages/database/src/partials/trigger.ts
@@ -22,6 +22,7 @@ export const triggerEventTypes = z.enum([
   "tagApplied",
   "tagRemoved",
   "customFieldValueChanged",
+  "contactInfoUpdated",
   "dateTimeBasedTrigger",
   "conversationTransferredToHuman",
   "conversationTransferredToBot",

--- a/packages/database/src/queries/contact-filter/index.ts
+++ b/packages/database/src/queries/contact-filter/index.ts
@@ -23,6 +23,7 @@ import {
   buildDateColumnWhere,
   buildExistingContactWhere,
   buildExistsBooleanWhere,
+  buildHasContactInfoWhere,
   buildLastCommentWhere,
   buildLatestContactInboxDateWhere,
   buildLatestContactInboxMinutesAgoWhere,
@@ -42,6 +43,11 @@ export {
   parseConversationAssigneeValues,
   UNASSIGNED_ASSIGNEE_VALUE,
 } from "./conversation-assignee"
+export {
+  EMAIL_PHONE_FILTER_FIELDS,
+  pruneContactFilterFields,
+  pruneEmailPhoneFilterConditions,
+} from "./permission"
 export { contactInboxInteractedWithin24hSQL } from "./predicates"
 export type {
   ContactFilterConditionInput,
@@ -345,6 +351,9 @@ function buildConditionWhere(condition: FilterConditionInput): ContactWhere {
 
     case "existingContact":
       return buildExistingContactWhere(operator, value)
+
+    case "hasContactInfo":
+      return buildHasContactInfoWhere(operator, value)
 
     case "subscribedToBroadcast":
       return buildBooleanFromTimestamp("broadcastSubscribedAt", operator, value)

--- a/packages/database/src/queries/contact-filter/permission.ts
+++ b/packages/database/src/queries/contact-filter/permission.ts
@@ -1,0 +1,50 @@
+import { type ContactFilterField, contactFilterFields } from "../../partials"
+import type { ContactFilterCriteriaInput } from "./types"
+
+export const EMAIL_PHONE_FILTER_FIELDS = [
+  contactFilterFields.enum.email,
+  contactFilterFields.enum.phone,
+  contactFilterFields.enum.hasContactInfo,
+  contactFilterFields.enum.emailWasVerified,
+  contactFilterFields.enum.optedInForEmail,
+  contactFilterFields.enum.existingContact,
+] as const satisfies readonly ContactFilterField[]
+
+const toConditionWithField = (
+  condition: unknown,
+): { field?: unknown } | undefined =>
+  typeof condition === "object" && condition !== null
+    ? (condition as { field?: unknown })
+    : undefined
+
+export function pruneContactFilterFields(
+  contactFilter: ContactFilterCriteriaInput | null | undefined,
+  excludedFields: readonly ContactFilterField[],
+): ContactFilterCriteriaInput | undefined {
+  if (!contactFilter) {
+    return
+  }
+  if (excludedFields.length === 0 || contactFilter.conditions.length === 0) {
+    return contactFilter
+  }
+
+  const excludedFieldSet = new Set<string>(excludedFields)
+  const conditions = contactFilter.conditions.filter((condition) => {
+    const field = toConditionWithField(condition)?.field
+    return typeof field !== "string" || !excludedFieldSet.has(field)
+  })
+
+  return {
+    operator: conditions.length > 0 ? contactFilter.operator : "and",
+    conditions,
+  }
+}
+
+export function pruneEmailPhoneFilterConditions(
+  contactFilter: ContactFilterCriteriaInput | null | undefined,
+  canViewEmailAndPhone: boolean,
+): ContactFilterCriteriaInput | undefined {
+  return canViewEmailAndPhone
+    ? (contactFilter ?? undefined)
+    : pruneContactFilterFields(contactFilter, EMAIL_PHONE_FILTER_FIELDS)
+}

--- a/packages/database/src/queries/contact-filter/predicates.ts
+++ b/packages/database/src/queries/contact-filter/predicates.ts
@@ -1,5 +1,11 @@
 import { type AnyColumn, type SQL, sql } from "drizzle-orm"
-import { operatorTypes } from "../../partials"
+import {
+  type ContactInfoFilterValue,
+  type ContactInfoType,
+  contactInfoFilterValues,
+  contactInfoTypes,
+  operatorTypes,
+} from "../../partials"
 import { contactInboxModel, messageModel } from "../../schema"
 import { escapeLikePattern, likeContains } from "../../utils"
 import { contactInboxExists } from "./exists"
@@ -321,25 +327,111 @@ export function buildBooleanColumn(
   return {}
 }
 
+const CONTACT_INFO_COLUMN_NAMES = {
+  phone: "phoneNumber",
+  email: "email",
+} as const satisfies Record<ContactInfoType, string>
+
+/** `(column IS NOT NULL AND column <> '')` — NULL-safe both plain and negated. */
+const contactInfoPresenceSQL = (
+  table: RawTable,
+  infoType: ContactInfoType,
+): SQL => {
+  const column = table[CONTACT_INFO_COLUMN_NAMES[infoType]]
+  return sql`(${column} IS NOT NULL AND ${column} <> '')`
+}
+
+const orPredicatesSQL = (predicates: SQL[]): SQL =>
+  sql`(${sql.join(predicates, sql` OR `)})`
+
+const hasAnyContactInfoSQL = (
+  table: RawTable,
+  infoTypes: readonly ContactInfoType[],
+): SQL =>
+  orPredicatesSQL(
+    infoTypes.map((infoType) => contactInfoPresenceSQL(table, infoType)),
+  )
+
+/**
+ * Presence predicate for one `hasContactInfo` filter value. The `phoneAndEmail`
+ * composite requires BOTH columns; atomic values require just their own.
+ */
+const contactInfoFilterValueSQL = (
+  table: RawTable,
+  value: ContactInfoFilterValue,
+): SQL =>
+  value === contactInfoFilterValues.enum.phoneAndEmail
+    ? sql`(${contactInfoPresenceSQL(table, "phone")} AND ${contactInfoPresenceSQL(table, "email")})`
+    : contactInfoPresenceSQL(table, value)
+
+const matchesAnyContactInfoValueSQL = (
+  table: RawTable,
+  values: readonly ContactInfoFilterValue[],
+): SQL =>
+  orPredicatesSQL(
+    values.map((value) => contactInfoFilterValueSQL(table, value)),
+  )
+
+const parseContactInfoFilterValues = (
+  value: unknown,
+): ContactInfoFilterValue[] => {
+  const rawValues = Array.isArray(value) ? value : [value]
+  const parsed = contactInfoFilterValues.array().safeParse(rawValues)
+  return parsed.success ? [...new Set(parsed.data)] : []
+}
+
+export function buildHasContactInfoWhere(
+  operator: string,
+  value: unknown,
+): ContactWhere {
+  if (operator === operatorTypes.enum.isEmpty) {
+    return {
+      RAW: (table: RawTable): SQL =>
+        sql`NOT ${hasAnyContactInfoSQL(table, contactInfoTypes.options)}`,
+    }
+  }
+
+  const selectedValues = parseContactInfoFilterValues(value)
+  if (selectedValues.length === 0) {
+    return {}
+  }
+
+  if (operator === operatorTypes.enum.in) {
+    return {
+      RAW: (table: RawTable): SQL =>
+        matchesAnyContactInfoValueSQL(table, selectedValues),
+    }
+  }
+
+  if (operator === operatorTypes.enum.notIn) {
+    return {
+      RAW: (table: RawTable): SQL =>
+        sql`NOT ${matchesAnyContactInfoValueSQL(table, selectedValues)}`,
+    }
+  }
+
+  return {}
+}
+
 export function buildExistingContactWhere(
   operator: string,
   value: unknown,
 ): ContactWhere {
   const hasEmailOrPhone = (table: RawTable): SQL =>
-    sql`((${table.email} IS NOT NULL AND ${table.email} <> '') OR (${table.phoneNumber} IS NOT NULL AND ${table.phoneNumber} <> ''))`
+    hasAnyContactInfoSQL(table, contactInfoTypes.options)
 
   if (operator === operatorTypes.enum.eq) {
     return {
       RAW: (table: RawTable): SQL =>
         value === "true"
           ? hasEmailOrPhone(table)
-          : sql`NOT (${hasEmailOrPhone(table)})`,
+          : sql`NOT ${hasEmailOrPhone(table)}`,
     }
   }
 
   if (operator === operatorTypes.enum.isEmpty) {
     return {
-      RAW: (table: RawTable): SQL => sql`NOT (${hasEmailOrPhone(table)})`,
+      RAW: (table: RawTable): SQL => sql`NOT ${hasEmailOrPhone(table)}`,
     }
   }
 

--- a/packages/events/src/base-emitter.ts
+++ b/packages/events/src/base-emitter.ts
@@ -1,4 +1,5 @@
 import {
+  type ContactInfoType,
   type TriggerEventType,
   triggerEventTypes,
 } from "@chatbotx.io/database/partials"
@@ -97,6 +98,20 @@ export abstract class BaseEventEmitter {
         oldValue,
         newValue,
       },
+    })
+  }
+
+  async contactInfoUpdated(
+    workspaceId: string,
+    contactId: string,
+    infoType: ContactInfoType,
+    oldValue: string | null,
+    newValue: string,
+  ): Promise<void> {
+    await this.emit(triggerEventTypes.enum.contactInfoUpdated, {
+      workspaceId,
+      contactId,
+      metadata: { sourceId: infoType, infoType, oldValue, newValue },
     })
   }
 

--- a/packages/events/src/event-dispatcher.ts
+++ b/packages/events/src/event-dispatcher.ts
@@ -1,3 +1,4 @@
+import type { ContactInfoType } from "@chatbotx.io/database/partials"
 import type { BaseEventEmitter } from "./base-emitter"
 import { logger } from "./logger"
 import { TriggerEventEmitter } from "./trigger/emitter"
@@ -113,6 +114,23 @@ export const emitCustomFieldChanged = async (
     contactId,
     customFieldId,
     customFieldName,
+    oldValue,
+    newValue,
+  )
+
+// Contact info events
+export const emitContactInfoUpdated = async (
+  workspaceId: string,
+  contactId: string,
+  infoType: ContactInfoType,
+  oldValue: string | null,
+  newValue: string,
+) =>
+  await emitToAllEmitters(
+    "contactInfoUpdated",
+    workspaceId,
+    contactId,
+    infoType,
     oldValue,
     newValue,
   )

--- a/packages/events/src/event-type-registry.ts
+++ b/packages/events/src/event-type-registry.ts
@@ -7,6 +7,7 @@ export const EMITTED_EVENT_TYPES = [
   triggerEventTypes.enum.tagApplied,
   triggerEventTypes.enum.tagRemoved,
   triggerEventTypes.enum.customFieldValueChanged,
+  triggerEventTypes.enum.contactInfoUpdated,
   triggerEventTypes.enum.conversationTransferredToHuman,
   triggerEventTypes.enum.conversationTransferredToBot,
   triggerEventTypes.enum.newContact,

--- a/packages/worker-config/src/queues/default/index.ts
+++ b/packages/worker-config/src/queues/default/index.ts
@@ -42,8 +42,8 @@ export type JobExportContacts = {
     workspaceId: string
     fileId: string
     fields: string[]
-    // Required so the export always states PII visibility explicitly and can
-    // never fail open: an omitted flag must not silently re-enable PII export.
+    // Required so the export always states email/phone visibility explicitly and
+    // can never fail open: an omitted flag must not silently re-enable export.
     canExportEmailAndPhone: boolean
     restrictToAssignedUserId?: string
     outputPath: string


### PR DESCRIPTION
## What

- Filter contacts by phone, email, or both.
- Trigger flows and webhooks when a contact's phone or email is updated.
- Hide phone and email filters from members without permission to view them.
- Keep the older "existing contact" filter working while removing it from the picker.

## Test plan

- [x] Unit tests for filters, triggers, permission handling, and broadcast audience
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`, `pnpm --filter @chatbotx.io/database check-types`, `pnpm --filter worker check-types`, `pnpm --filter @chatbotx.io/business check-types`
