### PR TITLE
fix(conversations): stuck conversations

### DIFF
--- a/apps/worker/__tests__/get-user-data.test.ts
+++ b/apps/worker/__tests__/get-user-data.test.ts
@@ -56,6 +56,7 @@ vi.mock("@chatbotx.io/database/client", () => ({
   },
   eq: vi.fn(),
   findOrFail: vi.fn(async () => findOrFailResult.current),
+  sql: vi.fn(() => "CLEAR_CHALLENGE_SQL"),
 }))
 
 // validateUserData reads the last message via the shard-aware repository, not
@@ -115,6 +116,8 @@ beforeEach(() => {
   chatQueueAdd.mockResolvedValue(undefined)
   waitForChatJobCompletion.mockResolvedValue(undefined)
   contactInboxUpdateTracking.mockClear()
+  vi.mocked(dbUpdateBuilder.set as ReturnType<typeof vi.fn>).mockClear()
+  vi.mocked(dbUpdateBuilder.where as ReturnType<typeof vi.fn>).mockClear()
 })
 
 type StepOverride = Partial<GetUserDataStepSchema>
@@ -123,7 +126,7 @@ function makeProps(
   replyFormat: ReplyFormat,
   overrides: StepOverride = {},
   attempts = 1,
-  lastAttemptAt = new Date(),
+  lastAttemptAt: Date | string | number = new Date(),
 ): ExecuteStepProps<GetUserDataStepSchema> {
   return {
     conversation: {
@@ -192,12 +195,20 @@ function expectNoLastInputFailureUpdate() {
   expect(callsWithLastInputFailure).toHaveLength(0)
 }
 
+function challengeClearCalls() {
+  return vi
+    .mocked(dbUpdateBuilder.set as ReturnType<typeof vi.fn>)
+    .mock.calls.filter(([setValue]) => {
+      const update = setValue as { additionalAttributes?: unknown }
+      return update.additionalAttributes === "CLEAR_CHALLENGE_SQL"
+    })
+}
+
 // --- tests ---
 
 describe("getUserData — validation logic", () => {
   beforeEach(() => {
     chatQueueAdd.mockClear()
-    vi.mocked(dbUpdateBuilder.set as ReturnType<typeof vi.fn>).mockClear?.()
     lastMessage.current = null
   })
 
@@ -328,13 +339,13 @@ describe("getUserData — validation logic", () => {
     await expect(getUserData(makeProps(ReplyFormat.email))).rejects.toBe(
       repositoryError.current,
     )
+    expect(challengeClearCalls()).toHaveLength(0)
   })
 })
 
 describe("getUserData — attempt counter (Bug B fix)", () => {
   beforeEach(() => {
     chatQueueAdd.mockClear()
-    vi.mocked(dbUpdateBuilder.set as ReturnType<typeof vi.fn>).mockClear()
     lastMessage.current = { text: "invalid-email", attachments: [] }
   })
 
@@ -395,13 +406,81 @@ describe("getUserData — auto-skip", () => {
     expect(result.status).toBe("skip")
     expectLastInputFailureUpdate("invalid_input_attempts")
   })
+
+  test("accepts JSON string timestamps when deciding timeout", async () => {
+    lastMessage.current = { text: "invalid", attachments: [] }
+    const result = await getUserData(
+      makeProps(
+        ReplyFormat.email,
+        {
+          autoSkip: true,
+          autoSkipFailAttempts: 3,
+          autoSkipTimeValue: 1,
+          autoSkipTimeUnit: "hours" as const,
+        },
+        1,
+        "2026-01-01T00:00:00.000Z",
+      ),
+    )
+
+    expect(result.status).toBe("skip")
+    expectLastInputFailureUpdate("timeout")
+  })
+})
+
+describe("getUserData — challenge lifecycle", () => {
+  test("clears challenge after successful input", async () => {
+    lastMessage.current = { text: "user@example.com", attachments: [] }
+
+    const result = await getUserData(makeProps(ReplyFormat.email))
+
+    expect(result.status).toBe("success")
+    expect(challengeClearCalls()).toHaveLength(1)
+  })
+
+  test("clears challenge after auto-skip", async () => {
+    lastMessage.current = { text: "invalid", attachments: [] }
+
+    const result = await getUserData(
+      makeProps(
+        ReplyFormat.email,
+        {
+          autoSkip: true,
+          autoSkipFailAttempts: 1,
+          autoSkipTimeValue: 24,
+          autoSkipTimeUnit: "hours" as const,
+        },
+        1,
+      ),
+    )
+
+    expect(result.status).toBe("skip")
+    expect(challengeClearCalls()).toHaveLength(1)
+  })
+
+  test("keeps challenge while retrying invalid input", async () => {
+    lastMessage.current = { text: "invalid", attachments: [] }
+
+    const result = await getUserData(makeProps(ReplyFormat.email))
+
+    expect(result.status).toBe("retry")
+    expect(challengeClearCalls()).toHaveLength(0)
+  })
+
+  test("clears challenge after terminal non-storage errors", async () => {
+    repositoryError.current = new Error("repository failed")
+
+    const result = await getUserData(makeProps(ReplyFormat.email))
+
+    expect(result.status).toBe("error")
+    expect(challengeClearCalls()).toHaveLength(1)
+  })
 })
 
 describe("getUserData — first send (no challenge state)", () => {
   beforeEach(() => {
     chatQueueAdd.mockClear()
     waitForChatJobCompletion.mockClear()
-    vi.mocked(dbUpdateBuilder.where as ReturnType<typeof vi.fn>).mockClear()
   })
 
   test("sends message and returns wait when no challenge active", async () => {
@@ -410,6 +489,7 @@ describe("getUserData — first send (no challenge state)", () => {
     const result = await getUserData(props)
     expect(result.status).toBe("wait")
     expect(chatQueueAdd).toHaveBeenCalledOnce()
+    expect(challengeClearCalls()).toHaveLength(0)
   })
 
   test("writes challenge state before waiting for prompt delivery", async () => {

--- a/apps/worker/src/integration/handlers/get-user-data.ts
+++ b/apps/worker/src/integration/handlers/get-user-data.ts
@@ -1,5 +1,5 @@
 import { contactInboxService } from "@chatbotx.io/business"
-import { db, eq, findOrFail } from "@chatbotx.io/database/client"
+import { db, eq, findOrFail, sql } from "@chatbotx.io/database/client"
 import { isMessageStorageError } from "@chatbotx.io/database/errors"
 import type { ConversationAttributes } from "@chatbotx.io/database/partials"
 import {
@@ -51,6 +51,8 @@ export async function getUserData(
     if (isMessageStorageError(error)) {
       throw error
     }
+
+    await clearChallengeSafely(props.conversation.id)
 
     return { result: undefined, status: "error", errorMessage }
   }
@@ -118,17 +120,7 @@ async function handleSkipOrError(
       })
     }
 
-    // remove challenge from conversation attributes
-    await db
-      .update(conversationModel)
-      .set({
-        additionalAttributes: {
-          ...(props.conversation
-            .additionalAttributes as ConversationAttributes),
-          challenge: undefined,
-        },
-      })
-      .where(eq(conversationModel.id, props.conversation.id))
+    await clearChallenge(props.conversation.id)
 
     return { result: validUserData.userInput, status: "success" }
   }
@@ -143,6 +135,8 @@ async function handleSkipOrError(
         workspaceId: props.conversation.workspaceId,
         data: { lastInputFailure: skipResult.reason },
       })
+
+      await clearChallenge(props.conversation.id)
 
       return { result: undefined, status: "skip" }
     }
@@ -317,12 +311,44 @@ async function sendMessage(
   await waitForChatJobCompletion(job, { conversationId: conversation.id })
 }
 
+async function clearChallenge(conversationId: string): Promise<void> {
+  await db
+    .update(conversationModel)
+    .set({
+      additionalAttributes: sql`${conversationModel.additionalAttributes} - 'challenge'`,
+    })
+    .where(eq(conversationModel.id, conversationId))
+}
+
+async function clearChallengeSafely(conversationId: string): Promise<void> {
+  try {
+    await clearChallenge(conversationId)
+  } catch (error) {
+    logger.warn(
+      { err: error, conversationId },
+      "getUserData: failed to clear challenge after terminal error",
+    )
+  }
+}
+
+function toValidDate(value: unknown): Date | undefined {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? undefined : value
+  }
+
+  if (typeof value === "string" || typeof value === "number") {
+    const date = new Date(value)
+    return Number.isNaN(date.getTime()) ? undefined : date
+  }
+}
+
 function checkSkipCondition(
   step: GetUserDataStepSchema,
   conversationVariables: Record<string, Variable>,
 ): { skip: true; reason: InputFailureReason } | { skip: false } {
   const lastAttemptAt =
-    (conversationVariables.challengeLastAttemptAt?.value as Date) ?? new Date()
+    toValidDate(conversationVariables.challengeLastAttemptAt?.value) ??
+    new Date()
   const attempts =
     (conversationVariables.challengeAttempts?.value as number) ?? 1
 

--- a/packages/database/__tests__/get-safe-since-time.test.ts
+++ b/packages/database/__tests__/get-safe-since-time.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest"
+import { getSafeSinceTime } from "../src/repositories/message"
+
+describe("getSafeSinceTime", () => {
+  test("accepts Date instances", () => {
+    const result = getSafeSinceTime(new Date("2026-07-15T10:34:56.000Z"))
+
+    expect(result?.toISOString()).toBe("2026-07-15T09:00:00.000Z")
+  })
+
+  test("accepts ISO strings from JSON payloads", () => {
+    const result = getSafeSinceTime("2026-07-15T10:34:56.000Z")
+
+    expect(result?.toISOString()).toBe("2026-07-15T09:00:00.000Z")
+  })
+
+  test("accepts numeric timestamps", () => {
+    const timestamp = new Date("2026-07-15T10:34:56.000Z").getTime()
+    const result = getSafeSinceTime(timestamp)
+
+    expect(result?.toISOString()).toBe("2026-07-15T09:00:00.000Z")
+  })
+
+  test("returns undefined for invalid strings", () => {
+    expect(getSafeSinceTime("not-a-date")).toBeUndefined()
+  })
+
+  test("applies an explicit buffer before flooring to the hour", () => {
+    const result = getSafeSinceTime("2026-07-15T10:34:56.000Z", 60 * 60 * 1000)
+
+    expect(result?.toISOString()).toBe("2026-07-15T09:00:00.000Z")
+  })
+})

--- a/packages/database/src/repositories/message/index.ts
+++ b/packages/database/src/repositories/message/index.ts
@@ -29,13 +29,14 @@ export type {
 export * from "./message-repository.factory"
 
 export function getSafeSinceTime(
-  time: Date | number | undefined | null,
+  time: Date | string | number | undefined | null,
   bufferMs?: number,
 ): Date | undefined {
   if (!time) {
     return
   }
-  const ts = time instanceof Date ? time.getTime() : time
+  // Queue payloads and JSON snapshots can turn Date values into ISO strings.
+  const ts = time instanceof Date ? time.getTime() : new Date(time).getTime()
   if (!Number.isFinite(ts)) {
     return
   }


### PR DESCRIPTION
Summary:
- Prevent conversations from staying stuck after the user data step finishes.
- Clean up old stuck state with a migration.
- Add tests for the fixed behavior.

Checks:
- pnpm lint
- pnpm --filter @chatbotx.io/database check-types
- pnpm --filter worker check-types
- pnpm --filter @chatbotx.io/database test
- pnpm --filter worker test
- local database migration run