### PR TITLE
fix(worker): resolve variables in get user data step message

### DIFF
--- a/apps/worker/src/integration/handlers/get-user-data.ts
+++ b/apps/worker/src/integration/handlers/get-user-data.ts
@@ -19,6 +19,7 @@ import {
 } from "@chatbotx.io/flow-config"
 import { IntegrationException, type Variable } from "@chatbotx.io/sdk"
 import { createId } from "@chatbotx.io/utils"
+import { resolveContactVariablesDeep } from "@chatbotx.io/variables"
 import { ChatJobAction, chatQueue } from "@chatbotx.io/worker-config"
 import { add, isBefore } from "date-fns"
 import { logger } from "../../lib/logger"
@@ -277,12 +278,21 @@ async function sendMessage(
     )
   }
 
+  const resolvedText = await resolveContactVariablesDeep(
+    conversation.contactId,
+    text,
+    {
+      contactInbox,
+      conversation,
+    },
+  )
+
   const job = await chatQueue.add(ChatJobAction.sendChatMessage, {
     type: ChatJobAction.sendChatMessage,
     data: {
       contactInbox,
       conversation,
-      text,
+      text: resolvedText,
     },
   })
 


### PR DESCRIPTION
## Summary

The Get User Data step sent its question and retry messages with raw `{{variable}}` placeholders, so contacts received literal text like `{{gender}} {{full_name}}` instead of their actual values. This fix resolves contact variables before the message is queued for delivery, matching the behavior of regular send-message steps.

## Test plan

- [x] `pnpm lint` (changed file clean; 2 pre-existing errors in generated files only)
- [x] `pnpm --filter worker check-types`
- [ ] Manual: run a flow with a Get User Data node whose message contains `{{full_name}}` and verify the sent message shows the contact's name
- [ ] Manual: verify the retry message also resolves variables after invalid input