### PR TITLE
fix(redis): preserve rich types in withCache via superjson envelopes

### DIFF
--- a/packages/ai/src/server/cache.ts
+++ b/packages/ai/src/server/cache.ts
@@ -1,4 +1,4 @@
-import { distributedStore, withCache } from "@chatbotx.io/redis"
+import { invalidateCacheKeys, withCache } from "@chatbotx.io/redis"
 import { env } from "../keys"
 import { getAIIntegrationInDB } from "./factory"
 
@@ -29,14 +29,8 @@ export const invalidateAIIntegrationCache = (
   workspaceId: string,
   provider: string,
 ) =>
-  Promise.all([
-    distributedStore.delete(
-      getAIIntegrationCachedKey({ workspaceId, provider }),
-    ),
-    distributedStore.delete(
-      getAIIntegrationCachedKey({ workspaceId, provider, autoReply: true }),
-    ),
-    distributedStore.delete(
-      getAIIntegrationCachedKey({ workspaceId, provider, autoReply: false }),
-    ),
+  invalidateCacheKeys([
+    getAIIntegrationCachedKey({ workspaceId, provider }),
+    getAIIntegrationCachedKey({ workspaceId, provider, autoReply: true }),
+    getAIIntegrationCachedKey({ workspaceId, provider, autoReply: false }),
   ])

--- a/packages/automated-response/src/utils.ts
+++ b/packages/automated-response/src/utils.ts
@@ -1,5 +1,5 @@
 import { db } from "@chatbotx.io/database/client"
-import { distributedStore, withCache } from "@chatbotx.io/redis"
+import { invalidateCacheKeys, withCache } from "@chatbotx.io/redis"
 
 const getAutomatedResponseCachedKey = (workspaceId: string) =>
   `workspaces:${workspaceId}:automated-responses:all`
@@ -22,6 +22,6 @@ export const automatedResponseService = {
       { ttl: 24 * 60 * 60 },
     ),
   invalidateCache: async (workspaceId: string) => {
-    await distributedStore.delete(getAutomatedResponseCachedKey(workspaceId))
+    await invalidateCacheKeys(getAutomatedResponseCachedKey(workspaceId))
   },
 }

--- a/packages/business/src/automated-response/service.ts
+++ b/packages/business/src/automated-response/service.ts
@@ -15,7 +15,7 @@ import {
   likeContains,
   parseOrderByAsObject,
 } from "@chatbotx.io/database/utils"
-import { distributedStore } from "@chatbotx.io/redis"
+import { invalidateCacheKeys } from "@chatbotx.io/redis"
 import { createId } from "@chatbotx.io/utils"
 import { BaseService } from "../base.service"
 import { notFoundException } from "../errors"
@@ -207,7 +207,7 @@ class AutomatedResponseService extends BaseService {
   }
 
   async invalidateCache(workspaceId: string): Promise<void> {
-    await distributedStore.delete(
+    await invalidateCacheKeys(
       `workspaces:${workspaceId}:automated-responses:all`,
     )
   }

--- a/packages/redis/__tests__/cache-utils.test.ts
+++ b/packages/redis/__tests__/cache-utils.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import { invalidateCacheKeys, withCache } from "../src/cache-utils"
+
+const mocks = vi.hoisted(() => {
+  // In-memory stand-in that replicates the real store's JSON round-trip so
+  // the tests exercise the serialization behavior withCache depends on.
+  const redisData = new Map<string, string>()
+  return {
+    redisData,
+    distributedStore: {
+      get: vi.fn((key: string) => {
+        const value = redisData.get(key)
+        return Promise.resolve(value ? JSON.parse(value) : null)
+      }),
+      put: vi.fn((key: string, value: unknown) => {
+        redisData.set(key, JSON.stringify(value))
+        return Promise.resolve()
+      }),
+      sadd: vi.fn(() => Promise.resolve(1)),
+      expire: vi.fn(() => Promise.resolve(1)),
+      delete: vi.fn((keys: string | string[]) => {
+        const keysArray = Array.isArray(keys) ? keys : [keys]
+        for (const key of keysArray) {
+          redisData.delete(key)
+        }
+        return Promise.resolve()
+      }),
+    },
+  }
+})
+
+vi.mock("../src/index.ts", () => ({
+  distributedStore: mocks.distributedStore,
+}))
+
+vi.mock("@chatbotx.io/logger", () => ({
+  default: { debug: vi.fn() },
+}))
+
+describe("withCache", () => {
+  beforeEach(() => {
+    mocks.redisData.clear()
+    vi.clearAllMocks()
+  })
+
+  test("preserves Date instances across the cache round-trip", async () => {
+    const workspace = {
+      id: "1",
+      name: "Acme",
+      createdAt: new Date("2026-07-01T00:00:00.000Z"),
+      scheduledDeletionAt: null,
+    }
+
+    const firstResult = await withCache("workspaces:1", () =>
+      Promise.resolve(workspace),
+    )
+    expect(firstResult).toEqual(workspace)
+
+    const source = vi.fn()
+    const cachedResult = await withCache<typeof workspace>(
+      "workspaces:1",
+      source,
+    )
+    expect(source).not.toHaveBeenCalled()
+    expect(cachedResult.createdAt).toBeInstanceOf(Date)
+    expect(cachedResult).toEqual(workspace)
+  })
+
+  test("ignores legacy plain-JSON entries written under unprefixed keys", async () => {
+    mocks.redisData.set(
+      "workspaces:legacy",
+      JSON.stringify({ id: "1", createdAt: "2026-07-01T00:00:00.000Z" }),
+    )
+
+    const fresh = { id: "1", createdAt: new Date("2026-07-01T00:00:00.000Z") }
+    const result = await withCache("workspaces:legacy", () =>
+      Promise.resolve(fresh),
+    )
+    expect(result).toBe(fresh)
+  })
+
+  test("registers tags against the prefixed cache key", async () => {
+    await withCache("workspaces:1", () => Promise.resolve({ id: "1" }), {
+      dynamicTags: (result) => [`workspaces:${result.id}`],
+    })
+
+    expect(mocks.distributedStore.sadd).toHaveBeenCalledWith(
+      "tags:workspaces:1",
+      "sj:workspaces:1",
+    )
+  })
+
+  test("invalidateCacheKeys removes entries stored by withCache", async () => {
+    await withCache("workspaces:1", () => Promise.resolve({ id: "1" }))
+    // Legacy entry from a pre-SuperJSON writer under the unprefixed key.
+    mocks.redisData.set("workspaces:1", JSON.stringify({ id: "1" }))
+
+    await invalidateCacheKeys("workspaces:1")
+
+    expect(mocks.redisData.size).toBe(0)
+    const source = vi.fn(() => Promise.resolve({ id: "2" }))
+    const result = await withCache("workspaces:1", source)
+    expect(source).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ id: "2" })
+  })
+
+  test("does not cache null or undefined results", async () => {
+    const result = await withCache("workspaces:missing", () =>
+      Promise.resolve(undefined),
+    )
+    expect(result).toBeUndefined()
+    expect(mocks.distributedStore.put).not.toHaveBeenCalled()
+  })
+})

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -12,6 +12,7 @@
     "async-mutex": "^0.5.0",
     "ioredis": "5.10.1",
     "redlock-universal": "^0.8.4",
+    "superjson": "^2.2.6",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/redis/src/cache-utils.ts
+++ b/packages/redis/src/cache-utils.ts
@@ -1,5 +1,21 @@
 import logger from "@chatbotx.io/logger"
+import type { SuperJSONResult } from "superjson"
+import superjson from "superjson"
 import { distributedStore } from "."
+
+// Cached values are stored as SuperJSON envelopes so rich types (Date, Map,
+// Set, BigInt, …) survive the Redis JSON round-trip — a plain JSON.parse
+// turns Drizzle timestamp columns back into ISO strings, which breaks
+// consumers that expect Date instances (e.g. oRPC output validation).
+//
+// The prefix versions the cache namespace: entries written by pre-SuperJSON
+// code live under the unprefixed keys, are never read again, and expire by
+// TTL. During a rolling deploy old readers keep using the unprefixed keys, so
+// they never see an envelope they cannot decode.
+const CACHE_KEY_PREFIX = "sj:"
+
+const isSuperJsonEnvelope = (value: unknown): value is SuperJSONResult =>
+  typeof value === "object" && value !== null && "json" in value
 
 export const withCache = async <T>(
   key: string,
@@ -11,15 +27,16 @@ export const withCache = async <T>(
   },
 ): Promise<T> => {
   const { ttl = 24 * 60 * 60, tags = [], dynamicTags } = options || {}
+  const cacheKey = `${CACHE_KEY_PREFIX}${key}`
 
   // Cache reads must never break callers: on a Redis failure (timeout, cold
-  // connection, server down) fall back to the source function instead of
-  // propagating. See cache-connection.ts — cache commands are configured to
-  // fail fast so callers can degrade gracefully.
+  // connection, server down) or a malformed envelope fall back to the source
+  // function instead of propagating. See cache-connection.ts — cache commands
+  // are configured to fail fast so callers can degrade gracefully.
   try {
-    const cached = await distributedStore.get<T>(key)
-    if (cached) {
-      return cached
+    const cached = await distributedStore.get<SuperJSONResult>(cacheKey)
+    if (isSuperJsonEnvelope(cached)) {
+      return superjson.deserialize<T>(cached)
     }
   } catch (err) {
     logger.debug({ err, key }, "Cache read failed, falling back to source")
@@ -34,7 +51,7 @@ export const withCache = async <T>(
   // Cache writes are best-effort: a failure here must not break the caller,
   // which already has a valid result from the source function.
   try {
-    await distributedStore.put(key, result, ttl)
+    await distributedStore.put(cacheKey, superjson.serialize(result), ttl)
 
     // Add tags to the cache
     const dynamicTagsResult = dynamicTags?.(result)
@@ -42,7 +59,7 @@ export const withCache = async <T>(
     if (allTags.length > 0) {
       await Promise.all(
         allTags.map(async (tag) => {
-          await distributedStore.sadd(`tags:${tag}`, key)
+          await distributedStore.sadd(`tags:${tag}`, cacheKey)
           await distributedStore.expire(`tags:${tag}`, ttl)
         }),
       )
@@ -52,6 +69,25 @@ export const withCache = async <T>(
   }
 
   return result
+}
+
+/**
+ * Invalidate withCache entries by their logical (unprefixed) key. Callers must
+ * use this instead of `distributedStore.delete(key)` — withCache stores values
+ * under a private namespace prefix, so a raw delete misses the real entry.
+ * The legacy unprefixed key is deleted too, so invalidation stays correct
+ * while pre-SuperJSON writers are still live during a rolling deploy.
+ */
+export const invalidateCacheKeys = async (
+  keys: string | string[],
+): Promise<void> => {
+  const keysArray = Array.isArray(keys) ? keys : [keys]
+  if (keysArray.length === 0) {
+    return
+  }
+  await distributedStore.delete(
+    keysArray.flatMap((key) => [`${CACHE_KEY_PREFIX}${key}`, key]),
+  )
 }
 
 export const invalidateCacheByTags = async (tags: string[]) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2388,6 +2388,9 @@ importers:
       redlock-universal:
         specifier: ^0.8.4
         version: 0.8.4(ioredis@5.10.1)
+      superjson:
+        specifier: ^2.2.6
+        version: 2.2.6
       zod:
         specifier: ^4.3.6
         version: 4.4.3
@@ -7662,6 +7665,10 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  copy-anything@4.0.5:
+    resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
+    engines: {node: '>=18'}
+
   copy-to-clipboard@3.3.3:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
 
@@ -8882,6 +8889,10 @@ packages:
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  is-what@5.5.0:
+    resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
+    engines: {node: '>=18'}
 
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
@@ -10888,6 +10899,10 @@ packages:
 
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
+  superjson@2.2.6:
+    resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
+    engines: {node: '>=16'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -15963,6 +15978,10 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  copy-anything@4.0.5:
+    dependencies:
+      is-what: 5.5.0
+
   copy-to-clipboard@3.3.3:
     dependencies:
       toggle-selection: 1.0.6
@@ -17182,6 +17201,8 @@ snapshots:
   is-promise@4.0.0: {}
 
   is-stream@3.0.0: {}
+
+  is-what@5.5.0: {}
 
   is-wsl@3.1.1:
     dependencies:
@@ -19700,6 +19721,10 @@ snapshots:
   stylis@4.3.6: {}
 
   stylis@4.4.0: {}
+
+  superjson@2.2.6:
+    dependencies:
+      copy-anything: 4.0.5
 
   supports-color@7.2.0:
     dependencies:


### PR DESCRIPTION
## Summary
- `GET /v1/workspaces` returned 500 `Output validation failed` in production: `withCache` round-trips values through plain `JSON.stringify`/`JSON.parse`, so Drizzle `Date` columns came back as ISO strings on cache hits and failed the oRPC `z.date()` output schema. Local didn't reproduce because the cache was cold there.
- `withCache` now stores SuperJSON envelopes under a versioned `sj:` key namespace — `Date`/`Map`/`Set`/`BigInt` survive the Redis round-trip, pre-fix entries are never read again (they expire by TTL), and rolling deploys are safe in both directions.
- Adds `invalidateCacheKeys()` and migrates the three direct `distributedStore.delete` invalidation sites to it (automated-response ×2, AI integration cache) — a raw delete of the unprefixed key would otherwise no longer hit the real entry, leaving stale data until TTL.

## Changes
- `packages/redis/src/cache-utils.ts` — SuperJSON envelope serialization, `sj:` namespace prefix, new `invalidateCacheKeys()` helper (deletes both prefixed and legacy keys)
- `packages/redis/__tests__/cache-utils.test.ts` — new tests: Date round-trip, legacy-entry skip, tag registration with prefixed key, invalidation, null/undefined skip
- `packages/automated-response/src/utils.ts`, `packages/business/src/automated-response/service.ts`, `packages/ai/src/server/cache.ts` — switch direct cache deletes to `invalidateCacheKeys()`
- `packages/redis/package.json` — add `superjson`

## Notes
- One-time effect on deploy: every `withCache` entry misses once (namespace flip) and repopulates lazily.
- Accepted trade-offs: SuperJSON meta adds payload overhead on timestamp-heavy cached trees and an extra serialization pass per op.

## Test plan
- [x] `pnpm --filter @chatbotx.io/redis test` (6/6), `@chatbotx.io/business` (361), `@chatbotx.io/ai` (30), `@chatbotx.io/automated-response` (1)
- [x] `check-types` for all touched packages (pre-commit hook ran repo-wide typecheck, 51/51)
- [x] `ultracite check` clean on touched files
- [ ] manual verification: warm cache hit on `GET /v1/workspaces` returns 200 after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)