### PR TITLE
fix(workspaces): state 24-hour data deletion window in deletion card and alert

### DIFF
--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -572,10 +572,10 @@
     },
     "deletion": {
       "title": "Delete workspace",
-      "description": "Permanently delete this workspace. Contacts and all settings will be removed.",
+      "description": "Permanently delete this workspace. All contacts, settings, and data will be deleted 24 hours after you confirm.",
       "schedule": "Delete workspace",
       "confirmTitle": "Delete this workspace?",
-      "confirmDescription": "Contacts and all settings will be permanently removed. You can undo this before the deletion completes.",
+      "confirmDescription": "All contacts, settings, and data will be permanently deleted 24 hours after you confirm. You can undo the deletion any time before then.",
       "pending": "This workspace will be deleted {countdown} ({date}). You can undo this at any time before then.",
       "pendingFallback": "soon",
       "undone": "Workspace deletion has been canceled",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -572,10 +572,10 @@
     },
     "deletion": {
       "title": "Xóa workspace",
-      "description": "Xóa vĩnh viễn workspace này. Danh bạ và tất cả cài đặt sẽ bị xóa.",
+      "description": "Xóa vĩnh viễn workspace này. Toàn bộ danh bạ, cài đặt và dữ liệu sẽ bị xóa sau 24 giờ kể từ khi bạn xác nhận.",
       "schedule": "Xóa workspace",
       "confirmTitle": "Xóa workspace này?",
-      "confirmDescription": "Danh bạ và tất cả cài đặt sẽ bị xóa vĩnh viễn. Bạn có thể hoàn tác trước khi việc xóa hoàn tất.",
+      "confirmDescription": "Toàn bộ danh bạ, cài đặt và dữ liệu sẽ bị xóa vĩnh viễn sau 24 giờ kể từ khi bạn xác nhận. Bạn có thể hoàn tác bất cứ lúc nào trước thời điểm đó.",
       "pending": "Workspace này sẽ bị xóa {countdown} ({date}). Bạn có thể hoàn tác bất cứ lúc nào trước thời điểm đó.",
       "pendingFallback": "sớm",
       "undone": "Đã hủy lịch xóa workspace",


### PR DESCRIPTION
## Summary
- The workspace deletion card and its confirm alert said data "will be removed" but never stated the concrete grace window, leaving users unsure when deletion actually happens.
- Deletion is a soft-delete: `Workspace.scheduledDeletionAt` is stamped and the hourly `purgeWorkspaces` cron hard-deletes after a 24-hour grace window (AGENTS.md invariant #14). The copy now states this explicitly, which also communicates the undo window.

## Changes
- `apps/builder/messages/en.json` — `workspace.deletion.description` (card body) and `confirmDescription` (alert dialog) now state all data is deleted 24 hours after confirmation.
- `apps/builder/messages/vi.json` — matching Vietnamese translations.
- No component change: `workspace-deletion-card.tsx` already wires both keys via `useTranslations()`.

## Test plan
- [ ] pnpm lint
- [ ] pnpm --filter builder check-types
- [ ] Manual: open a workspace deletion card — body states the 24-hour window; click "Delete workspace" — the confirm alert also states it (verify en + vi)