### PR TITLE
feat(inboxes): add public list inboxes endpoint with internal ids

### DIFF
--- a/apps/builder/src/features/inboxes/api/workspace-token.ts
+++ b/apps/builder/src/features/inboxes/api/workspace-token.ts
@@ -2,10 +2,30 @@ import { workspaceTokenAuthAPI } from "@/orpc"
 import { listInboxes } from "../queries"
 import {
   publicListInboxesResponse,
+  publicListInboxResponse,
   publishInboxesRequest,
 } from "../schema/action"
 
 export const inboxesWorkspaceTokenAPIs = {
+  listInboxesWorkspaceTokenAPI: workspaceTokenAuthAPI
+    .route({
+      method: "GET",
+      path: "/v1/inboxes",
+      summary: "List inboxes",
+      description:
+        "List connected inboxes with their internal IDs. Use `id` as the `inboxId` parameter when sending messages or flows to a contact.",
+      tags: ["Channels"],
+    })
+    .input(publishInboxesRequest)
+    .output(publicListInboxResponse)
+    .handler(
+      async ({ context, input }) =>
+        await listInboxes({
+          ...input,
+          workspaceId: context.workspace.id,
+        }),
+    ),
+
   listChannelsWorkspaceTokenAPI: workspaceTokenAuthAPI
     .route({
       method: "GET",

--- a/apps/builder/src/features/inboxes/queries/index.ts
+++ b/apps/builder/src/features/inboxes/queries/index.ts
@@ -1,11 +1,8 @@
 import type { ListInboxesResponse } from "@chatbotx.io/business"
 import { inboxService, type ListInboxesRequest } from "@chatbotx.io/business"
-import { assertCurrentUserCanAccessChatbot } from "@/lib/auth/utils"
 
 export async function listInboxes(
   input: ListInboxesRequest,
 ): Promise<ListInboxesResponse> {
-  await assertCurrentUserCanAccessChatbot(input.workspaceId)
-
-  return inboxService.list(input)
+  return await inboxService.list(input)
 }

--- a/apps/builder/src/features/inboxes/schema/action.ts
+++ b/apps/builder/src/features/inboxes/schema/action.ts
@@ -13,14 +13,32 @@ export const publishInboxesRequest = listInboxesRequest.omit({
 })
 export type PublishInboxesRequest = z.infer<typeof publishInboxesRequest>
 
+export const publicInboxResource = inboxResource.pick({
+  id: true,
+  name: true,
+  channel: true,
+  status: true,
+})
+
+export const publicListInboxResponse = z.object({
+  data: z.array(publicInboxResource),
+  pageCount: z.number(),
+})
+export type PublicListInboxResponse = z.infer<typeof publicListInboxResponse>
+
 export const publicListInboxesResponse = z.object({
   data: z.array(
-    inboxResource.pick({
-      id: true,
-      name: true,
-      channel: true,
-      status: true,
-    }),
+    inboxResource
+      .pick({
+        name: true,
+        channel: true,
+        status: true,
+      })
+      .extend({
+        // The public API exposes sourceId as id, which is not always numeric
+        // (e.g. TikTok uses the account username)
+        id: z.string(),
+      }),
   ),
   pageCount: z.number(),
 })


### PR DESCRIPTION
## Summary
- Add `GET /v1/inboxes` to the workspace token API so API consumers can list connected inboxes with their **internal ids** — the value expected as `inboxId` when sending messages or flows to a contact. The existing `GET /v1/channels` exposes `sourceId` as `id` (not always numeric, e.g. TikTok username), which cannot be used for that purpose.
- Split the public schemas: `/v1/channels` keeps the `sourceId`-as-string shape, while the new endpoint returns the internal `id` via `publicInboxResource`.
- Remove the session-based `assertCurrentUserCanAccessChatbot` from the `listInboxes` query so it works under token auth. All callers already authorize upstream: the authenticated API uses `workspaceAuthorizedMidddleware`, the dashboard page resolves access via `getCurrentUserAndTargetWorkspace`, and the token API scopes `workspaceId` from the token context.

## Changes
- `apps/builder/src/features/inboxes/api/workspace-token.ts` — new `listInboxesWorkspaceTokenAPI` route
- `apps/builder/src/features/inboxes/schema/action.ts` — add `publicInboxResource` / `publicListInboxResponse`; document the `sourceId`-as-id shape of `/v1/channels`
- `apps/builder/src/features/inboxes/queries/index.ts` — drop session assert from `listInboxes`

## Test plan
- [x] pnpm lint (pre-existing errors in generated files only)
- [x] pnpm --filter builder check-types
- [ ] manual verification: call `GET /v1/inboxes` with a workspace token and confirm `id` matches the internal inbox id usable as `inboxId`