### PR TITLE
feat(workspaces): surface and enforce scheduled-deletion state across the app

### DIFF
--- a/apps/builder/__tests__/accept-invitation-action.test.ts
+++ b/apps/builder/__tests__/accept-invitation-action.test.ts
@@ -43,7 +43,21 @@ vi.mock("@chatbotx.io/business", () => ({
 }))
 
 vi.mock("@chatbotx.io/business/errors", () => ({
-  ChatbotXException: class ChatbotXException extends Error {},
+  ChatbotXException: class ChatbotXException extends Error {
+    code: string
+    httpStatusCode: number
+    constructor(message: string, code = "systemError", httpStatusCode = 400) {
+      super(message)
+      this.code = code
+      this.httpStatusCode = httpStatusCode
+    }
+  },
+}))
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: vi.fn(() =>
+    Promise.resolve(() => "This workspace is no longer available"),
+  ),
 }))
 
 const invalidateCacheByTags = vi.fn()
@@ -177,6 +191,24 @@ describe("acceptInvitationAction", () => {
       "Team member limit reached for this workspace plan",
     )
     expect(dbInsertValues).not.toHaveBeenCalled()
+    expect(invalidateCacheByTags).not.toHaveBeenCalled()
+  })
+
+  test("throws and does not insert when the workspace is scheduled for deletion", async () => {
+    workspaceServiceFind.mockResolvedValue({
+      id: "ws-1",
+      ownerId: "owner-1",
+      scheduledDeletionAt: new Date(),
+    })
+
+    const error = await invoke().catch((caught) => caught)
+
+    expect(error).toMatchObject({
+      code: "workspaceScheduledDeletion",
+      message: "This workspace is no longer available",
+    })
+    expect(dbInsertValues).not.toHaveBeenCalled()
+    expect(tryConsume).not.toHaveBeenCalled()
     expect(invalidateCacheByTags).not.toHaveBeenCalled()
   })
 })

--- a/apps/builder/__tests__/create-webchat-message-action.test.ts
+++ b/apps/builder/__tests__/create-webchat-message-action.test.ts
@@ -364,6 +364,29 @@ describe("handleCreateWebchatMessage", () => {
     })
   })
 
+  test("rejects messages when the workspace is scheduled for deletion", async () => {
+    mockWorkspaceFind.mockResolvedValue({
+      id: "ws-1",
+      ownerId: "owner-1",
+      scheduledDeletionAt: new Date(),
+    })
+
+    await expect(
+      handleCreateWebchatMessage({
+        parsedInput: {
+          text: "hello",
+          workspaceId: "ws-1",
+          webchatId: "webchat-1",
+          guestConversationId: "guest-1",
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "workspaceScheduledDeletion",
+    })
+
+    expect(mockVerifyWebchatAccessToken).not.toHaveBeenCalled()
+  })
+
   test("updates webchat contact inbox message, incoming message, and read timestamps", async () => {
     await handleCreateWebchatMessage({
       parsedInput: {

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -581,7 +581,9 @@
       "undone": "Workspace deletion has been canceled",
       "bannerTitle": "Workspace deletion scheduled",
       "bannerDescription": "This workspace is scheduled for deletion. Undo the deletion below to continue using it.",
-      "pendingBlockedToast": "This workspace is scheduled for deletion. Contact a workspace admin to restore access."
+      "pendingBlockedToast": "This workspace is scheduled for deletion. Contact a workspace admin to restore access.",
+      "navDisabledTooltip": "Unavailable while workspace deletion is scheduled",
+      "badge": "Deletion scheduled"
     }
   },
   "workspaces": {
@@ -2830,6 +2832,7 @@
     "description": "Let your customers get instant automated responses from your business directly from your website",
     "rateLimitExceeded": "Too many requests. Please try again in a moment.",
     "title": "Web Chat",
+    "workspaceUnavailable": "This workspace is no longer available.",
     "unauthorizedDomain": {
       "description": "This website is not authorized to load this chat widget.",
       "title": "Webchat unavailable"
@@ -3086,7 +3089,9 @@
   },
   "invitation": {
     "chatbotInvitationDescription1": "Join {chatbotName}",
-    "chatbotInvitationDescription2": "{userName} has invited you to join {chatbotName}."
+    "chatbotInvitationDescription2": "{userName} has invited you to join {chatbotName}.",
+    "invalidInvitation": "This invitation is invalid or has expired.",
+    "workspaceUnavailable": "This workspace is no longer available."
   },
   "inboxTeams": {
     "title": "Inbox Teams"

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -581,7 +581,9 @@
       "undone": "Đã hủy lịch xóa workspace",
       "bannerTitle": "Đã lên lịch xóa workspace",
       "bannerDescription": "Workspace này đã được lên lịch xóa. Hãy hoàn tác lịch xóa bên dưới để tiếp tục sử dụng workspace.",
-      "pendingBlockedToast": "Workspace này đã được lên lịch xóa. Hãy liên hệ quản trị viên workspace để khôi phục quyền truy cập."
+      "pendingBlockedToast": "Workspace này đã được lên lịch xóa. Hãy liên hệ quản trị viên workspace để khôi phục quyền truy cập.",
+      "navDisabledTooltip": "Không khả dụng khi workspace đã được lên lịch xóa",
+      "badge": "Đã lên lịch xóa"
     }
   },
   "workspaces": {
@@ -2846,6 +2848,7 @@
     "description": "Cho phép khách hàng của bạn nhận phản hồi tự động ngay lập tức từ doanh nghiệp của bạn trực tiếp từ trang web của bạn",
     "rateLimitExceeded": "Quá nhiều yêu cầu. Vui lòng thử lại sau giây lát.",
     "title": "Web Chat",
+    "workspaceUnavailable": "Không gian làm việc này không còn khả dụng.",
     "unauthorizedDomain": {
       "description": "Trang web này không được phép tải tiện ích chat này.",
       "title": "Webchat không khả dụng"
@@ -3102,7 +3105,9 @@
   },
   "invitation": {
     "chatbotInvitationDescription1": "Tham gia {chatbotName}",
-    "chatbotInvitationDescription2": "{userName} đã mời bạn tham gia {chatbotName}."
+    "chatbotInvitationDescription2": "{userName} đã mời bạn tham gia {chatbotName}.",
+    "invalidInvitation": "Lời mời này không hợp lệ hoặc đã hết hạn.",
+    "workspaceUnavailable": "Không gian làm việc này không còn khả dụng."
   },
   "inboxTeams": {
     "title": "Nhóm hộp thư"

--- a/apps/builder/src/app/(no-sidebar)/space/[workspaceId]/layout.tsx
+++ b/apps/builder/src/app/(no-sidebar)/space/[workspaceId]/layout.tsx
@@ -1,9 +1,11 @@
 import { getIdFromParams } from "@chatbotx.io/utils"
 import { notFound, redirect } from "next/navigation"
 import type { ReactNode } from "react"
+import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
 import { enforcePasswordCurrent } from "@/lib/auth/require-password-current"
 import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
 import { logger } from "@/lib/log"
+import { enforceWorkspaceNotScheduledForDeletionFromRequest } from "@/lib/workspace/require-not-scheduled-for-deletion"
 
 export type WorkspaceNoSidebarLayoutProps = {
   params: Promise<{ workspaceId: string }>
@@ -29,6 +31,14 @@ export default async function WorkspaceNoSidebarLayout({
   }
 
   enforcePasswordCurrent(result.user)
+
+  await enforceWorkspaceNotScheduledForDeletionFromRequest(
+    result.targetWorkspace,
+    hasWorkspacePermission(
+      result.targetWorkspaceMember.permissions,
+      "superAdmin",
+    ),
+  )
 
   return children
 }

--- a/apps/builder/src/app/api/guest/messages/route.ts
+++ b/apps/builder/src/app/api/guest/messages/route.ts
@@ -1,4 +1,8 @@
-import { contactInboxService, conversationService } from "@chatbotx.io/business"
+import {
+  contactInboxService,
+  conversationService,
+  workspaceService,
+} from "@chatbotx.io/business"
 import { type NextRequest, NextResponse } from "next/server"
 import { getTranslations } from "next-intl/server"
 import { isOriginAuthorized } from "@/features/integration-webchat/lib/authorized-domain"
@@ -97,6 +101,13 @@ export async function GET(req: NextRequest) {
       id: data.webchatId,
       workspaceId: data.workspaceId,
     })
+
+    const workspace = await workspaceService.find({
+      where: { id: data.workspaceId },
+    })
+    if (workspace?.scheduledDeletionAt) {
+      return await forbiddenResponse(corsHeaders(requestOrigin, false))
+    }
 
     const bearerToken = getBearerToken(req)
     // Bind-on-first-use: always require a token bound to the presented

--- a/apps/builder/src/app/api/guest/messages/route.ts
+++ b/apps/builder/src/app/api/guest/messages/route.ts
@@ -85,6 +85,13 @@ export async function GET(req: NextRequest) {
     const searchParams = Object.fromEntries(req.nextUrl.searchParams)
     const data = listGuestMessagesRequest.parse(searchParams)
 
+    const workspace = await workspaceService.find({
+      where: { id: data.workspaceId },
+    })
+    if (workspace?.scheduledDeletionAt) {
+      return await forbiddenResponse(corsHeaders(requestOrigin, false))
+    }
+
     const rateLimit = await checkGuestRateLimit({
       clientIp: getGuestClientIp(req.headers),
       guestConversationId: data.guestConversationId,
@@ -101,13 +108,6 @@ export async function GET(req: NextRequest) {
       id: data.webchatId,
       workspaceId: data.workspaceId,
     })
-
-    const workspace = await workspaceService.find({
-      where: { id: data.workspaceId },
-    })
-    if (workspace?.scheduledDeletionAt) {
-      return await forbiddenResponse(corsHeaders(requestOrigin, false))
-    }
 
     const bearerToken = getBearerToken(req)
     // Bind-on-first-use: always require a token bound to the presented

--- a/apps/builder/src/app/space/[workspaceId]/(settings)/settings/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(settings)/settings/layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react"
 import { resolveGuardedWorkspaceId } from "@/lib/auth/require-workspace-permission"
+import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
 import { SettingsTab } from "./tab"
 
 type LayoutSettingProps = {
@@ -11,11 +12,15 @@ export default async function SettingLayout({
   children,
   params,
 }: LayoutSettingProps) {
-  await resolveGuardedWorkspaceId(params, "superAdmin")
+  const workspaceId = await resolveGuardedWorkspaceId(params, "superAdmin")
+  const result = await getCurrentUserAndTargetWorkspace(workspaceId)
+  const scheduledForDeletion = Boolean(
+    result?.targetWorkspace.scheduledDeletionAt,
+  )
 
   return (
     <>
-      <SettingsTab />
+      <SettingsTab scheduledForDeletion={scheduledForDeletion} />
       <div>{children}</div>
     </>
   )

--- a/apps/builder/src/app/space/[workspaceId]/(settings)/settings/tab.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(settings)/settings/tab.tsx
@@ -5,7 +5,13 @@ import { useMemo } from "react"
 import { AppTab } from "@/components/app-tab"
 import { useWorkspaceId } from "@/hooks/routing"
 
-export function SettingsTab() {
+const GENERAL_TAB_VALUE = "general"
+
+export function SettingsTab({
+  scheduledForDeletion = false,
+}: {
+  scheduledForDeletion?: boolean
+}) {
   const t = useTranslations()
   const pathname = usePathname()
 
@@ -52,6 +58,10 @@ export function SettingsTab() {
         label: tab.label,
         href: `/space/${workspaceId}/settings/${tab.value}`,
         isActive: activeTab === tab.value,
+        disabled: scheduledForDeletion && tab.value !== GENERAL_TAB_VALUE,
+        disabledTooltip: scheduledForDeletion
+          ? t("workspace.deletion.navDisabledTooltip")
+          : undefined,
       }))}
     />
   )

--- a/apps/builder/src/app/space/[workspaceId]/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/layout.tsx
@@ -16,19 +16,19 @@ import { notFound } from "next/navigation"
 import { AppSidebar } from "@/components/app-sidebar"
 import { ExpiredBanner } from "@/components/expired-banner"
 import type { QuotaSummary } from "@/components/nav-usage"
+import { RefreshOnNavigation } from "@/components/refresh-on-navigation"
 import { ScheduledDeletionBanner } from "@/components/scheduled-deletion-banner"
 import { isCloud } from "@/env"
 import { getTenantSettings } from "@/features/tenant/utils"
 import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
 import { enforcePasswordCurrent } from "@/lib/auth/require-password-current"
 import { getCurrentUser } from "@/lib/auth/utils"
-import { getOriginUrlFromHeader } from "@/lib/domain"
 import {
   buildQuotaMetrics,
   isBlockedFromPlan,
   resolveTrialEndsAt,
 } from "@/lib/quota-metrics"
-import { enforceWorkspaceNotScheduledForDeletion } from "@/lib/workspace/require-not-scheduled-for-deletion"
+import { enforceWorkspaceNotScheduledForDeletionFromRequest } from "@/lib/workspace/require-not-scheduled-for-deletion"
 
 export default async function WorkspaceLayout({
   children,
@@ -69,11 +69,8 @@ export default async function WorkspaceLayout({
     return notFound()
   }
 
-  const originUrl = await getOriginUrlFromHeader()
-  const pathname = originUrl ? new URL(originUrl).pathname : ""
-  enforceWorkspaceNotScheduledForDeletion(
+  await enforceWorkspaceNotScheduledForDeletionFromRequest(
     targetWorkspaceMember.workspace,
-    pathname,
     hasWorkspacePermission(targetWorkspaceMember.permissions, "superAdmin"),
   )
 
@@ -97,6 +94,10 @@ export default async function WorkspaceLayout({
   const cookieStore = await cookies()
   const defaultOpen = cookieStore.get("sidebar_state")?.value === "true"
 
+  const scheduledForDeletion = Boolean(
+    targetWorkspaceMember.workspace.scheduledDeletionAt,
+  )
+
   return (
     <SidebarProvider defaultOpen={defaultOpen}>
       <AppSidebar
@@ -105,15 +106,13 @@ export default async function WorkspaceLayout({
         isSuperAdmin={isSuperAdmin(user)}
         permissions={targetWorkspaceMember.permissions}
         quota={quotaSummary}
+        scheduledForDeletion={scheduledForDeletion}
         workspaceId={workspaceId}
       />
       <SidebarInset>
         <main className="flex min-w-0 flex-1 flex-col gap-4 p-6">
-          <ScheduledDeletionBanner
-            scheduled={Boolean(
-              targetWorkspaceMember.workspace.scheduledDeletionAt,
-            )}
-          />
+          <ScheduledDeletionBanner scheduled={scheduledForDeletion} />
+          {!scheduledForDeletion && <RefreshOnNavigation />}
           <ExpiredBanner blocked={cloud && blocked} />
           {children}
         </main>

--- a/apps/builder/src/components/app-sidebar.tsx
+++ b/apps/builder/src/components/app-sidebar.tsx
@@ -48,6 +48,8 @@ type SidebarNavItem = {
   permission?: WorkspacePermissionKey
 }
 
+const SETTINGS_GENERAL_URL_SEGMENT = "/settings/general"
+
 export function AppSidebar({
   workspaceId,
   allWorkspaces,
@@ -55,6 +57,7 @@ export function AppSidebar({
   isPlatformAdmin,
   permissions,
   quota,
+  scheduledForDeletion = false,
   ...props
 }: ComponentProps<typeof Sidebar> & {
   workspaceId: string
@@ -65,6 +68,7 @@ export function AppSidebar({
   // `hasWorkspacePermission` fails closed on any missing flag.
   permissions: WorkspaceMemberPermissions
   quota: QuotaSummary
+  scheduledForDeletion?: boolean
 }) {
   const t = useTranslations()
   const { data: session } = authClient.useSession()
@@ -145,13 +149,20 @@ export function AppSidebar({
     ] satisfies SidebarNavItem[],
   }
 
-  const navMain = data.navMain.filter(
-    (item) =>
-      !item.permission ||
-      (item.permission === PERMISSION_NAV.contacts
-        ? canAccessContactsSection(permissions)
-        : hasWorkspacePermission(permissions, item.permission)),
-  )
+  const navMain = data.navMain
+    .filter(
+      (item) =>
+        !item.permission ||
+        (item.permission === PERMISSION_NAV.contacts
+          ? canAccessContactsSection(permissions)
+          : hasWorkspacePermission(permissions, item.permission)),
+    )
+    .map((item) => ({
+      ...item,
+      disabled:
+        scheduledForDeletion &&
+        !item.url.endsWith(SETTINGS_GENERAL_URL_SEGMENT),
+    }))
 
   return (
     <Sidebar collapsible="icon" {...props}>
@@ -167,7 +178,10 @@ export function AppSidebar({
         </div>
       </SidebarHeader>
       <SidebarContent>
-        <NavMain items={navMain} />
+        <NavMain
+          disabledTooltip={t("workspace.deletion.navDisabledTooltip")}
+          items={navMain}
+        />
       </SidebarContent>
       <SidebarFooter>
         <NavUsage

--- a/apps/builder/src/components/app-tab.tsx
+++ b/apps/builder/src/components/app-tab.tsx
@@ -1,6 +1,11 @@
 "use client"
 
 import { Card, CardContent } from "@chatbotx.io/ui/components/ui/card"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@chatbotx.io/ui/components/ui/tooltip"
 import Link from "next/link"
 
 type AppTabProps = {
@@ -19,14 +24,17 @@ export function AppTab({ tabs }: AppTabProps) {
       <CardContent className="flex items-center gap-8 px-8">
         {tabs.map((tab) =>
           tab.disabled ? (
-            <span
-              aria-disabled="true"
-              className="cursor-not-allowed border-transparent border-b-2 py-6 font-medium text-gray-400 text-sm opacity-60 dark:text-gray-500"
-              key={tab.href}
-              title={tab.disabledTooltip}
-            >
-              {tab.label}
-            </span>
+            <Tooltip key={tab.href}>
+              <TooltipTrigger asChild>
+                <span
+                  aria-disabled="true"
+                  className="cursor-not-allowed border-transparent border-b-2 py-6 font-medium text-gray-400 text-sm opacity-60 dark:text-gray-500"
+                >
+                  {tab.label}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>{tab.disabledTooltip}</TooltipContent>
+            </Tooltip>
           ) : (
             <Link
               className={`border-b-2 py-6 text-sm ${tab.isActive ? "border-neutral-700 dark:border-white dark:text-gray-50" : "border-transparent font-medium text-gray-800 dark:text-gray-400"}`}

--- a/apps/builder/src/components/app-tab.tsx
+++ b/apps/builder/src/components/app-tab.tsx
@@ -8,6 +8,8 @@ type AppTabProps = {
     label: string
     href: string
     isActive: boolean
+    disabled?: boolean
+    disabledTooltip?: string
   }[]
 }
 
@@ -15,15 +17,26 @@ export function AppTab({ tabs }: AppTabProps) {
   return (
     <Card className="py-0">
       <CardContent className="flex items-center gap-8 px-8">
-        {tabs.map((tab) => (
-          <Link
-            className={`border-b-2 py-6 text-sm ${tab.isActive ? "border-neutral-700 dark:border-white dark:text-gray-50" : "border-transparent font-medium text-gray-800 dark:text-gray-400"}`}
-            href={tab.href}
-            key={tab.href}
-          >
-            {tab.label}
-          </Link>
-        ))}
+        {tabs.map((tab) =>
+          tab.disabled ? (
+            <span
+              aria-disabled="true"
+              className="cursor-not-allowed border-transparent border-b-2 py-6 font-medium text-gray-400 text-sm opacity-60 dark:text-gray-500"
+              key={tab.href}
+              title={tab.disabledTooltip}
+            >
+              {tab.label}
+            </span>
+          ) : (
+            <Link
+              className={`border-b-2 py-6 text-sm ${tab.isActive ? "border-neutral-700 dark:border-white dark:text-gray-50" : "border-transparent font-medium text-gray-800 dark:text-gray-400"}`}
+              href={tab.href}
+              key={tab.href}
+            >
+              {tab.label}
+            </Link>
+          ),
+        )}
       </CardContent>
     </Card>
   )

--- a/apps/builder/src/components/nav-main.tsx
+++ b/apps/builder/src/components/nav-main.tsx
@@ -18,16 +18,62 @@ type NavItem = {
   isActive?: boolean
   items?: { title: string; url: string }[]
   crossZone?: boolean
+  disabled?: boolean
+}
+
+function NavItemContent({
+  item,
+  className,
+  isDisabled,
+  isCrossZone,
+}: {
+  item: NavItem
+  className: string
+  isDisabled: boolean
+  isCrossZone: boolean
+}) {
+  const label = (
+    <>
+      {item.icon && <item.icon className="size-5 shrink-0" />}
+      <span>{item.title}</span>
+    </>
+  )
+
+  if (isDisabled) {
+    return <span className={className}>{label}</span>
+  }
+
+  if (isCrossZone) {
+    // Cross-zone: use <a> to force full navigation outside the Next router
+    return (
+      <a
+        className={className}
+        href={item.url}
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        {label}
+      </a>
+    )
+  }
+
+  return (
+    <Link className={className} href={item.url}>
+      {label}
+    </Link>
+  )
 }
 
 export function NavMain({
   items,
   label,
   crossZone = false,
+  disabledTooltip,
 }: {
   items: NavItem[]
   label?: string
   crossZone?: boolean
+  disabledTooltip?: string
 }) {
   const pathname = usePathname()
 
@@ -38,30 +84,21 @@ export function NavMain({
         {items.map((item) => {
           const isActive = pathname.startsWith(item.url) || item.isActive
           const linkClass = `flex w-full items-center gap-2 p-2 ${isActive ? "dark:text-gray-50" : "dark:text-gray-400"}`
+          const isDisabled = Boolean(item.disabled)
           return (
             <SidebarMenuItem key={item.title}>
               <SidebarMenuButton
+                aria-disabled={isDisabled}
                 className="h-9 cursor-pointer p-0"
                 isActive={isActive}
-                tooltip={item.title}
+                tooltip={isDisabled ? disabledTooltip : item.title}
               >
-                {crossZone || item.crossZone ? (
-                  // Cross-zone: use <a> to force full navigation outside the Next router
-                  <a
-                    className={linkClass}
-                    href={item.url}
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    {item.icon && <item.icon className="size-5 shrink-0" />}
-                    <span>{item.title}</span>
-                  </a>
-                ) : (
-                  <Link className={linkClass} href={item.url}>
-                    {item.icon && <item.icon className="size-5 shrink-0" />}
-                    <span>{item.title}</span>
-                  </Link>
-                )}
+                <NavItemContent
+                  className={linkClass}
+                  isCrossZone={crossZone || Boolean(item.crossZone)}
+                  isDisabled={isDisabled}
+                  item={item}
+                />
               </SidebarMenuButton>
             </SidebarMenuItem>
           )

--- a/apps/builder/src/components/refresh-on-navigation.tsx
+++ b/apps/builder/src/components/refresh-on-navigation.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { usePathname, useRouter } from "next/navigation"
+import { useEffect, useRef } from "react"
+
+export function RefreshOnNavigation() {
+  const pathname = usePathname()
+  const router = useRouter()
+  const isInitialRender = useRef(true)
+
+  useEffect(() => {
+    if (isInitialRender.current) {
+      isInitialRender.current = false
+      return
+    }
+
+    if (pathname) {
+      router.refresh()
+    }
+  }, [pathname, router])
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        router.refresh()
+      }
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange)
+    return () =>
+      document.removeEventListener("visibilitychange", handleVisibilityChange)
+  }, [router])
+
+  return null
+}

--- a/apps/builder/src/components/refresh-on-navigation.tsx
+++ b/apps/builder/src/components/refresh-on-navigation.tsx
@@ -1,23 +1,10 @@
 "use client"
 
-import { usePathname, useRouter } from "next/navigation"
-import { useEffect, useRef } from "react"
+import { useRouter } from "next/navigation"
+import { useEffect } from "react"
 
 export function RefreshOnNavigation() {
-  const pathname = usePathname()
   const router = useRouter()
-  const isInitialRender = useRef(true)
-
-  useEffect(() => {
-    if (isInitialRender.current) {
-      isInitialRender.current = false
-      return
-    }
-
-    if (pathname) {
-      router.refresh()
-    }
-  }, [pathname, router])
 
   useEffect(() => {
     const handleVisibilityChange = () => {

--- a/apps/builder/src/features/invitations/actions/accept-invitation.ts
+++ b/apps/builder/src/features/invitations/actions/accept-invitation.ts
@@ -12,6 +12,7 @@ import {
 } from "@chatbotx.io/database/schema"
 import { invalidateCacheByTags } from "@chatbotx.io/redis"
 import { createId } from "@chatbotx.io/utils"
+import { getTranslations } from "next-intl/server"
 import { z } from "zod"
 import { isCommunity } from "@/env"
 import { getSuperAdminPermissions } from "@/features/workspace-members/helpers"
@@ -55,6 +56,14 @@ export const acceptInvitationAction = authActionClient
     const workspace = await workspaceService.find({
       where: { id: invitation.workspaceId },
     })
+    if (workspace?.scheduledDeletionAt) {
+      const t = await getTranslations("invitation")
+      throw new ChatbotXException(
+        t("workspaceUnavailable"),
+        "workspaceScheduledDeletion",
+        403,
+      )
+    }
     if (workspace) {
       const consumed = await quotaEnforcementService.tryConsume({
         userId: workspace.ownerId,

--- a/apps/builder/src/features/invitations/invitatation-card.tsx
+++ b/apps/builder/src/features/invitations/invitatation-card.tsx
@@ -30,6 +30,7 @@ export function InvitationCard({
 }) {
   const router = useRouter()
   const t = useTranslations()
+  const canJoin = Boolean(workspace) && !workspace?.scheduledDeletionAt
 
   const { execute, isPending } = useAction(acceptInvitationAction, {
     onSuccess: () => {
@@ -45,11 +46,13 @@ export function InvitationCard({
   return (
     <Card className="max-w-lg">
       <CardContent className="flex flex-col gap-4">
-        {workspace ? (
+        {canJoin && workspace ? (
           <WorkspaceInvitationCard user={user} workspace={workspace} />
         ) : (
           <p className="text-muted-foreground">
-            {t("invitation.invalidInvitation")}
+            {workspace?.scheduledDeletionAt
+              ? t("invitation.workspaceUnavailable")
+              : t("invitation.invalidInvitation")}
           </p>
         )}
         <div className="mt-4 flex justify-center gap-2">
@@ -62,7 +65,7 @@ export function InvitationCard({
             {t("actions.cancel")}
           </Button>
           <Button
-            disabled={isPending || !workspace}
+            disabled={isPending || !canJoin}
             onClick={() => execute({ code: invitation.code })}
             type="button"
             variant="default"

--- a/apps/builder/src/features/messages/actions/create-webchat-message.action.ts
+++ b/apps/builder/src/features/messages/actions/create-webchat-message.action.ts
@@ -26,6 +26,7 @@ import {
   conversationModel,
   integrationWebchatModel,
 } from "@chatbotx.io/database/schema"
+import type { WorkspaceModel } from "@chatbotx.io/database/types"
 import { emit } from "@chatbotx.io/event-bus"
 import { emitContactCreated } from "@chatbotx.io/events"
 import { type UploadedFile, uploadMultipleFiles } from "@chatbotx.io/filesystem"
@@ -71,15 +72,6 @@ export async function handleCreateWebchatMessage({
 }: {
   parsedInput: CreateWebchatMessageRequest
 }) {
-  const integrationWebchat = await findOrFail({
-    table: integrationWebchatModel,
-    where: {
-      workspaceId: parsedInput.workspaceId,
-      id: parsedInput.webchatId,
-    },
-    message: "Channel not found",
-  })
-
   const workspace = await workspaceService.find({
     where: { id: parsedInput.workspaceId },
   })
@@ -91,6 +83,15 @@ export async function handleCreateWebchatMessage({
       403,
     )
   }
+
+  const integrationWebchat = await findOrFail({
+    table: integrationWebchatModel,
+    where: {
+      workspaceId: parsedInput.workspaceId,
+      id: parsedInput.webchatId,
+    },
+    message: "Channel not found",
+  })
 
   // Bind-on-first-use: always require a token whose signed origin claim
   // matches the origin the caller is presenting now, regardless of whether
@@ -136,7 +137,7 @@ export async function handleCreateWebchatMessage({
   }
 
   const { conversation, isNewContact, contact, contactInbox } =
-    await getConversationFromInput(parsedInput, integrationWebchat)
+    await getConversationFromInput(parsedInput, integrationWebchat, workspace)
 
   if (
     "init" in parsedInput &&
@@ -389,6 +390,7 @@ export async function handleCreateWebchatMessage({
 async function getConversationFromInput(
   parsedInput: CreateWebchatMessageRequest,
   integrationWebchat: typeof integrationWebchatModel.$inferSelect,
+  workspace: WorkspaceModel | undefined,
 ) {
   const sourceId = parsedInput.guestConversationId
 
@@ -432,9 +434,7 @@ async function getConversationFromInput(
   // `ContactActiveMonthly` presence row written inside the same transaction so
   // the later `message:received` event dedups instead of double-counting. The
   // info-only `contacts` metric is recorded inside `createNewContactWithMac`.
-  const ws = await workspaceService.find({
-    where: { id: parsedInput.workspaceId },
-  })
+  const ws = workspace
   if (!ws) {
     throw new ChatbotXException("Workspace not found", "notFound", 404)
   }

--- a/apps/builder/src/features/messages/actions/create-webchat-message.action.ts
+++ b/apps/builder/src/features/messages/actions/create-webchat-message.action.ts
@@ -80,6 +80,18 @@ export async function handleCreateWebchatMessage({
     message: "Channel not found",
   })
 
+  const workspace = await workspaceService.find({
+    where: { id: parsedInput.workspaceId },
+  })
+  if (workspace?.scheduledDeletionAt) {
+    const t = await getTranslations("webchat")
+    throw new ChatbotXException(
+      t("workspaceUnavailable"),
+      "workspaceScheduledDeletion",
+      403,
+    )
+  }
+
   // Bind-on-first-use: always require a token whose signed origin claim
   // matches the origin the caller is presenting now, regardless of whether
   // authorizedDomains is configured. This closes the "no auth at all when no

--- a/apps/builder/src/features/workspaces/components/workspace-status-switch.tsx
+++ b/apps/builder/src/features/workspaces/components/workspace-status-switch.tsx
@@ -1,11 +1,6 @@
 "use client"
 
 import { Switch } from "@chatbotx.io/ui/components/ui/switch"
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@chatbotx.io/ui/components/ui/tooltip"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { useEffect, useState } from "react"
@@ -25,10 +20,12 @@ export function WorkspaceStatusSwitch({
     isActive: boolean
     startTime: string | null
     endTime: string | null
+    scheduledDeletionAt?: Date | string | null
   }
 }) {
   const t = useTranslations()
   const router = useRouter()
+  const scheduledForDeletion = Boolean(workspace.scheduledDeletionAt)
   const [isActive, setIsActive] = useState(workspace.isActive)
   const [schedule, setSchedule] = useState<Schedule>({
     startTime: workspace.startTime,
@@ -68,32 +65,19 @@ export function WorkspaceStatusSwitch({
     }
   }
 
-  const switchElement = (
-    <Switch
-      checked={isActive}
-      className="absolute top-3 left-3 z-10"
-      disabled={!canManageStatus}
-      onCheckedChange={canManageStatus ? handleCheckedChange : undefined}
-      onClick={(e) => e.stopPropagation()}
-    />
-  )
-
   return (
     <>
-      {canManageStatus ? (
-        switchElement
-      ) : (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="absolute top-3 left-3 z-10 inline-flex">
-              {switchElement}
-            </span>
-          </TooltipTrigger>
-          <TooltipContent>
-            {t("workspace.schedule.permissionRequired")}
-          </TooltipContent>
-        </Tooltip>
-      )}
+      <Switch
+        checked={isActive}
+        className="absolute top-3 left-3 z-10"
+        disabled={!canManageStatus || scheduledForDeletion}
+        onCheckedChange={
+          canManageStatus && !scheduledForDeletion
+            ? handleCheckedChange
+            : undefined
+        }
+        onClick={(e) => e.stopPropagation()}
+      />
 
       <WorkspaceScheduleDialog
         onOpenChange={setShowScheduleDialog}

--- a/apps/builder/src/features/workspaces/components/workspace-status-switch.tsx
+++ b/apps/builder/src/features/workspaces/components/workspace-status-switch.tsx
@@ -1,6 +1,11 @@
 "use client"
 
 import { Switch } from "@chatbotx.io/ui/components/ui/switch"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@chatbotx.io/ui/components/ui/tooltip"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { useEffect, useState } from "react"
@@ -65,19 +70,36 @@ export function WorkspaceStatusSwitch({
     }
   }
 
+  const switchElement = (
+    <Switch
+      checked={isActive}
+      className="absolute top-3 left-3 z-10"
+      disabled={!canManageStatus || scheduledForDeletion}
+      onCheckedChange={
+        canManageStatus && !scheduledForDeletion
+          ? handleCheckedChange
+          : undefined
+      }
+      onClick={(e) => e.stopPropagation()}
+    />
+  )
+
+  const disabledTooltip = scheduledForDeletion
+    ? t("workspace.deletion.navDisabledTooltip")
+    : t("workspace.schedule.permissionRequired")
+
   return (
     <>
-      <Switch
-        checked={isActive}
-        className="absolute top-3 left-3 z-10"
-        disabled={!canManageStatus || scheduledForDeletion}
-        onCheckedChange={
-          canManageStatus && !scheduledForDeletion
-            ? handleCheckedChange
-            : undefined
-        }
-        onClick={(e) => e.stopPropagation()}
-      />
+      {canManageStatus && !scheduledForDeletion ? (
+        switchElement
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="absolute z-10 inline-flex">{switchElement}</span>
+          </TooltipTrigger>
+          <TooltipContent>{disabledTooltip}</TooltipContent>
+        </Tooltip>
+      )}
 
       <WorkspaceScheduleDialog
         onOpenChange={setShowScheduleDialog}

--- a/apps/builder/src/features/workspaces/components/workspaces-list.tsx
+++ b/apps/builder/src/features/workspaces/components/workspaces-list.tsx
@@ -120,6 +120,7 @@ const WorkspaceCard = ({
   const firstLetter = workspace.name?.[0]?.toUpperCase() ?? ""
   const name = workspace.name ?? ""
   const href = `/space/${workspace.id}`
+  const isScheduledForDeletion = Boolean(workspace.scheduledDeletionAt)
   const activeHours =
     workspace.isActive && workspace.startTime && workspace.endTime
       ? t("workspace.schedule.activeHours", {
@@ -143,6 +144,7 @@ const WorkspaceCard = ({
             isActive: workspace.isActive,
             startTime: workspace.startTime,
             endTime: workspace.endTime,
+            scheduledDeletionAt: workspace.scheduledDeletionAt,
           }}
         />
         <Link
@@ -164,6 +166,11 @@ const WorkspaceCard = ({
             {activeHours ? (
               <div className="line-clamp-1 text-center text-muted-foreground text-xs">
                 {activeHours}
+              </div>
+            ) : null}
+            {isScheduledForDeletion ? (
+              <div className="line-clamp-1 text-center text-destructive text-xs">
+                {t("workspace.deletion.badge")}
               </div>
             ) : null}
           </div>

--- a/apps/builder/src/hooks/use-workspace-deletion-pending-toast.ts
+++ b/apps/builder/src/hooks/use-workspace-deletion-pending-toast.ts
@@ -4,7 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { useEffect } from "react"
 import { toast } from "sonner"
-import { WORKSPACE_DELETION_PENDING_PARAM } from "@/lib/workspace/require-not-scheduled-for-deletion"
+import { WORKSPACE_DELETION_PENDING_PARAM } from "@/lib/workspace/deletion-pending-param"
 
 export function useWorkspaceDeletionPendingToast() {
   const t = useTranslations("workspace.deletion")

--- a/apps/builder/src/lib/auth/require-workspace-permission.ts
+++ b/apps/builder/src/lib/auth/require-workspace-permission.ts
@@ -8,6 +8,7 @@ import {
   type WorkspacePermissionKey,
 } from "@/lib/auth/permission-routes"
 import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
+import { enforceWorkspaceNotScheduledForDeletionFromRequest } from "@/lib/workspace/require-not-scheduled-for-deletion"
 
 export async function requireWorkspacePermission(
   workspaceId: string,
@@ -23,6 +24,16 @@ export async function requireWorkspacePermission(
 
   if (!canAccess) {
     notFound()
+  }
+
+  if (userAndWorkspace) {
+    await enforceWorkspaceNotScheduledForDeletionFromRequest(
+      userAndWorkspace.targetWorkspace,
+      hasWorkspacePermission(
+        userAndWorkspace.targetWorkspaceMember.permissions,
+        "superAdmin",
+      ),
+    )
   }
 }
 

--- a/apps/builder/src/lib/workspace/deletion-pending-param.ts
+++ b/apps/builder/src/lib/workspace/deletion-pending-param.ts
@@ -1,0 +1,1 @@
+export const WORKSPACE_DELETION_PENDING_PARAM = "workspaceDeletionPending"

--- a/apps/builder/src/lib/workspace/require-not-scheduled-for-deletion.ts
+++ b/apps/builder/src/lib/workspace/require-not-scheduled-for-deletion.ts
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation"
-
-export const WORKSPACE_DELETION_PENDING_PARAM = "workspaceDeletionPending"
+import { getOriginUrlFromHeader } from "@/lib/domain"
+import { WORKSPACE_DELETION_PENDING_PARAM } from "./deletion-pending-param"
 
 export function enforceWorkspaceNotScheduledForDeletion(
   workspace: { id: string; scheduledDeletionAt: Date | string | null },
@@ -21,4 +21,17 @@ export function enforceWorkspaceNotScheduledForDeletion(
   }
 
   redirect(settingsGeneralPath)
+}
+
+export async function enforceWorkspaceNotScheduledForDeletionFromRequest(
+  workspace: { id: string; scheduledDeletionAt: Date | string | null },
+  canManageDeletion: boolean,
+): Promise<void> {
+  const originUrl = await getOriginUrlFromHeader()
+  const pathname = originUrl ? new URL(originUrl).pathname : ""
+  enforceWorkspaceNotScheduledForDeletion(
+    workspace,
+    pathname,
+    canManageDeletion,
+  )
 }

--- a/apps/builder/src/middlewares/auth.ts
+++ b/apps/builder/src/middlewares/auth.ts
@@ -52,6 +52,12 @@ export const workspaceAuthorizedMidddleware = base.middleware(
       throw new ORPCError("UNAUTHORIZED")
     }
 
+    if (workspaceMember.workspace.scheduledDeletionAt) {
+      throw new ORPCError("FORBIDDEN", {
+        message: "Workspace deletion scheduled",
+      })
+    }
+
     return next({
       context: {
         workspace: workspaceMember.workspace,

--- a/apps/builder/src/middlewares/workspace-token-auth.ts
+++ b/apps/builder/src/middlewares/workspace-token-auth.ts
@@ -21,6 +21,12 @@ export const workspaceTokenAuthMidddleware = base.middleware(
       throw new ORPCError("INVALID_CHATBOT_TOKEN")
     }
 
+    if (workspace.scheduledDeletionAt) {
+      throw new ORPCError("FORBIDDEN", {
+        message: "Workspace deletion scheduled",
+      })
+    }
+
     // Adds session and user to the context
     return await next({
       context: {

--- a/packages/database/drizzle/20260716010748_add_user_quota_due_expired_trial_idx/snapshot.json
+++ b/packages/database/drizzle/20260716010748_add_user_quota_due_expired_trial_idx/snapshot.json
@@ -2,7 +2,7 @@
   "version": "8",
   "dialect": "postgres",
   "id": "5d78d3a0-92b1-4af4-9341-a4c33b454454",
-  "prevIds": ["7cdd16f4-ac5f-4dd4-8d48-b60257ef74ee"],
+  "prevIds": ["2d30b104-461e-408b-a176-086849fa613b"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],


### PR DESCRIPTION
## Summary
- Give users a clear signal when a workspace is scheduled for deletion, and consistently gate interaction on those workspaces to match the guards already enforced server-side.
- Previously the dashboard card and several entry points (guest/webchat, invitations) ignored `Workspace.scheduledDeletionAt`, leaving stale/confusing UI.

## Changes
- **Dashboard card** (`workspaces-list.tsx`, `workspace-status-switch.tsx`): disable the status switch and show a "Deletion scheduled" caption when `scheduledDeletionAt` is set; card click still navigates in.
- **Nav gating** (`app-sidebar.tsx`, `app-tab.tsx`, `nav-main.tsx`, `settings/tab.tsx`, `settings/layout.tsx`): disable non-general nav with a tooltip; add `refresh-on-navigation.tsx`.
- **Access guards** (`require-not-scheduled-for-deletion.ts`, `deletion-pending-param.ts`, `require-workspace-permission.ts`, `middlewares/auth.ts`, `middlewares/workspace-token-auth.ts`, `use-workspace-deletion-pending-toast.ts`): redirect/toast for pending-deletion workspaces.
- **Entry points**: block guest/webchat messages (`api/guest/messages/route.ts`, `create-webchat-message.action.ts`) and invitations (`accept-invitation.ts`, `invitatation-card.tsx`) on scheduled workspaces.
- **i18n** (`en.json`, `vi.json`): add `workspace.deletion.navDisabledTooltip` and `badge`, plus webchat/invitation unavailable strings.
- **Tests**: extend invitation and webchat-message action tests for the new guards.

## Test plan
- [ ] pnpm lint
- [ ] pnpm --filter builder check-types
- [ ] Dashboard: a workspace with `scheduledDeletionAt` shows the caption + disabled switch; clicking still opens it; normal workspaces unchanged
- [ ] Settings tabs / sidebar nav disabled with tooltip on a scheduled workspace
- [ ] Guest/webchat message and invitation-accept are rejected for a scheduled workspace
- [ ] EN and VI locales render the new strings