### PR TITLE
fix(webchat): hide support chat widget on /webchat embed page

### DIFF
--- a/apps/builder/__tests__/support-chat-script.test.tsx
+++ b/apps/builder/__tests__/support-chat-script.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment node
+
+import { isValidElement } from "react"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockUsePathname } = vi.hoisted(() => ({
+  mockUsePathname: vi.fn(),
+}))
+
+vi.mock("next/navigation", () => ({
+  usePathname: mockUsePathname,
+}))
+
+vi.mock("next/script", () => ({
+  default: (props: unknown) => ({ type: "Script", props }),
+}))
+
+const { SupportChatScript } = await import(
+  "../src/components/support-chat-script"
+)
+
+describe("SupportChatScript", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("renders nothing on the /webchat route", () => {
+    mockUsePathname.mockReturnValue("/webchat")
+
+    const result = SupportChatScript({ pageId: "page-123" })
+
+    expect(result).toBeNull()
+  })
+
+  test("renders the pancake script with the encoded page id on other routes", () => {
+    mockUsePathname.mockReturnValue("/dashboard")
+
+    const result = SupportChatScript({ pageId: "page 123" })
+
+    expect(isValidElement(result)).toBe(true)
+    expect((result as unknown as { props: { src: string } }).props.src).toBe(
+      "https://chat-plugin.pancake.vn/main/auto?page_id=page%20123&hide_supplier=true",
+    )
+  })
+})

--- a/apps/builder/__tests__/webchat-page-guards.test.tsx
+++ b/apps/builder/__tests__/webchat-page-guards.test.tsx
@@ -1,0 +1,214 @@
+// @vitest-environment node
+
+import { isValidElement } from "react"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+  mockFindFirst,
+  mockGetDomainFromHeader,
+  mockHeaders,
+  mockWorkspaceFind,
+} = vi.hoisted(() => ({
+  mockFindFirst: vi.fn(),
+  mockGetDomainFromHeader: vi.fn(),
+  mockHeaders: vi.fn(),
+  mockWorkspaceFind: vi.fn(),
+}))
+
+vi.mock("next/headers", () => ({
+  headers: mockHeaders,
+}))
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("notFound")
+  }),
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  workspaceService: { find: mockWorkspaceFind },
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      integrationWebchatModel: { findFirst: mockFindFirst },
+    },
+  },
+}))
+
+vi.mock("@/lib/domain", () => ({
+  getDomainFromHeader: mockGetDomainFromHeader,
+}))
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: vi.fn((namespace?: string) => {
+    const messages: Record<string, string> = {
+      "webchat.chatUnavailable": "This chat is currently unavailable.",
+      "webchat.unauthorizedDomain.title": "Webchat unavailable",
+      "webchat.unauthorizedDomain.description":
+        "This website is not authorized to load this chat widget.",
+    }
+
+    return Promise.resolve(
+      (key: string) => messages[namespace ? `${namespace}.${key}` : key] ?? key,
+    )
+  }),
+}))
+
+vi.mock("@/features/integration-webchat/lib/guest-conversation-id", () => ({
+  createGuestConversationId: vi.fn(() => "workspace-1:guest-1"),
+}))
+
+vi.mock("@/features/integration-webchat/lib/webchat-access-token", () => ({
+  createWebchatAccessToken: vi.fn().mockResolvedValue("access-token"),
+}))
+
+vi.mock(
+  "@/features/integration-webchat/providers/store/guest-session-provider",
+  () => ({
+    GuestSessionStoreProvider: (props: unknown) => ({
+      type: "GuestSessionStoreProvider",
+      props,
+    }),
+  }),
+)
+
+vi.mock(
+  "@/features/integration-webchat/providers/store/lib/webchat-client-config",
+  () => ({
+    toWebchatClientConfig: vi.fn((webchat) => webchat),
+  }),
+)
+
+vi.mock("@/features/integration-webchat/webchat-wrapper", () => ({
+  WebchatWrapper: (props: unknown) => ({ type: "WebchatWrapper", props }),
+}))
+
+const { default: WebchatPage } = await import(
+  "../src/app/(no-sidebar)/webchat/page"
+)
+
+const targetWebchat = {
+  id: "webchat-1",
+  workspaceId: "ws-1",
+  authorizedDomains: ["allowed.example"],
+}
+
+const searchParams = {
+  workspaceId: "ws-1",
+  webchatId: "webchat-1",
+}
+
+const setReferer = (referer: string | null) => {
+  mockHeaders.mockResolvedValue({
+    get: vi.fn((name: string) => (name === "referer" ? referer : null)),
+  })
+}
+
+describe("WebchatPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFindFirst.mockResolvedValue(targetWebchat)
+    mockWorkspaceFind.mockResolvedValue({ scheduledDeletionAt: null })
+    mockGetDomainFromHeader.mockResolvedValue("app.chatbotx.io")
+  })
+
+  test("renders the chat for a direct open with no referer, even with authorizedDomains configured", async () => {
+    setReferer(null)
+
+    const element = await WebchatPage({
+      searchParams: Promise.resolve(searchParams),
+    })
+
+    expect(isValidElement(element)).toBe(true)
+    expect((element as { type: { name: string } }).type.name).toBe(
+      "GuestSessionStoreProvider",
+    )
+  })
+
+  test("renders the chat for a first-party referer matching the app host", async () => {
+    setReferer("https://app.chatbotx.io/some/path")
+
+    const element = await WebchatPage({
+      searchParams: Promise.resolve(searchParams),
+    })
+
+    expect((element as { type: { name: string } }).type.name).toBe(
+      "GuestSessionStoreProvider",
+    )
+  })
+
+  test("shows the unauthorized-domain message for a third-party referer not in authorizedDomains", async () => {
+    setReferer("https://attacker.test")
+
+    const element = await WebchatPage({
+      searchParams: Promise.resolve(searchParams),
+    })
+
+    expect(isValidElement<{ children: unknown }>(element)).toBe(true)
+    const rendered = JSON.stringify(element)
+    expect(rendered).toContain("Webchat unavailable")
+    expect(rendered).toContain(
+      "This website is not authorized to load this chat widget.",
+    )
+  })
+
+  test("still renders the chat for a third-party referer when authorizedDomains is empty", async () => {
+    mockFindFirst.mockResolvedValue({ ...targetWebchat, authorizedDomains: [] })
+    setReferer("https://anyone.example")
+
+    const element = await WebchatPage({
+      searchParams: Promise.resolve(searchParams),
+    })
+
+    expect((element as { type: { name: string } }).type.name).toBe(
+      "GuestSessionStoreProvider",
+    )
+  })
+
+  test("shows the chat-unavailable message when the workspace is scheduled for deletion", async () => {
+    mockWorkspaceFind.mockResolvedValue({
+      scheduledDeletionAt: new Date("2026-01-01T00:00:00Z"),
+    })
+    setReferer(null)
+
+    const element = await WebchatPage({
+      searchParams: Promise.resolve(searchParams),
+    })
+
+    const rendered = JSON.stringify(element)
+    expect(rendered).toContain("This chat is currently unavailable.")
+  })
+
+  test("checks scheduled deletion before the authorized-domain gate", async () => {
+    mockWorkspaceFind.mockResolvedValue({
+      scheduledDeletionAt: new Date("2026-01-01T00:00:00Z"),
+    })
+    setReferer("https://attacker.test")
+
+    const element = await WebchatPage({
+      searchParams: Promise.resolve(searchParams),
+    })
+
+    const rendered = JSON.stringify(element)
+    expect(rendered).toContain("This chat is currently unavailable.")
+    expect(rendered).not.toContain(
+      "This website is not authorized to load this chat widget.",
+    )
+  })
+
+  test("returns notFound when the webchat does not exist", async () => {
+    mockFindFirst.mockResolvedValue(undefined)
+
+    await expect(
+      WebchatPage({ searchParams: Promise.resolve(searchParams) }),
+    ).rejects.toThrow("notFound")
+  })
+
+  test("returns notFound when searchParams fail validation", async () => {
+    await expect(
+      WebchatPage({ searchParams: Promise.resolve({}) }),
+    ).rejects.toThrow("notFound")
+  })
+})

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -2849,6 +2849,7 @@
     "maxMustBeGreaterThanMin": "{maxField} must be greater than or equal to {minField}"
   },
   "webchat": {
+    "chatUnavailable": "This chat is currently unavailable.",
     "description": "Let your customers get instant automated responses from your business directly from your website",
     "rateLimitExceeded": "Too many requests. Please try again in a moment.",
     "title": "Web Chat",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -2865,6 +2865,7 @@
     "maxMustBeGreaterThanMin": "{maxField} phải lớn hơn hoặc bằng {minField}"
   },
   "webchat": {
+    "chatUnavailable": "Cuộc trò chuyện này hiện không khả dụng.",
     "description": "Cho phép khách hàng của bạn nhận phản hồi tự động ngay lập tức từ doanh nghiệp của bạn trực tiếp từ trang web của bạn",
     "rateLimitExceeded": "Quá nhiều yêu cầu. Vui lòng thử lại sau giây lát.",
     "title": "Web Chat",

--- a/apps/builder/src/app/(no-sidebar)/webchat/page.tsx
+++ b/apps/builder/src/app/(no-sidebar)/webchat/page.tsx
@@ -1,3 +1,4 @@
+import { workspaceService } from "@chatbotx.io/business"
 import { db } from "@chatbotx.io/database/client"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import type { SearchParams } from "next/dist/server/request/search-params"
@@ -5,18 +6,34 @@ import { headers } from "next/headers"
 import { notFound } from "next/navigation"
 import { getTranslations } from "next-intl/server"
 import z from "zod"
-import { isOriginAuthorized } from "@/features/integration-webchat/lib/authorized-domain"
+import {
+  getHostFromOrigin,
+  isOriginAuthorized,
+} from "@/features/integration-webchat/lib/authorized-domain"
 import { createGuestConversationId } from "@/features/integration-webchat/lib/guest-conversation-id"
 import { createWebchatAccessToken } from "@/features/integration-webchat/lib/webchat-access-token"
 import { GuestSessionStoreProvider } from "@/features/integration-webchat/providers/store/guest-session-provider"
 import { toWebchatClientConfig } from "@/features/integration-webchat/providers/store/lib/webchat-client-config"
 import { WebchatWrapper } from "@/features/integration-webchat/webchat-wrapper"
+import { getDomainFromHeader } from "@/lib/domain"
 
 type WebchatPageProps = {
   searchParams: Promise<SearchParams>
 }
 
 export const dynamic = "force-dynamic"
+
+function isFirstPartyRequest(
+  refererOrigin: string | null,
+  appHost: string,
+): boolean {
+  if (!refererOrigin) {
+    return true
+  }
+
+  const refererHost = getHostFromOrigin(refererOrigin)
+  return !!refererHost && !!appHost && refererHost === appHost.toLowerCase()
+}
 
 export default async function WebchatPage(props: WebchatPageProps) {
   const searchParams = await props.searchParams
@@ -47,9 +64,33 @@ export default async function WebchatPage(props: WebchatPageProps) {
     return notFound()
   }
 
+  const workspace = await workspaceService.find({
+    where: { id: data.workspaceId },
+  })
+  if (workspace?.scheduledDeletionAt) {
+    const t = await getTranslations("webchat")
+
+    return (
+      <main className="flex h-screen w-screen items-center justify-center bg-background p-6 text-center">
+        <div className="max-w-sm space-y-2">
+          <p className="text-muted-foreground text-sm">
+            {t("chatUnavailable")}
+          </p>
+        </div>
+      </main>
+    )
+  }
+
   const requestHeaders = await headers()
   const embeddingOrigin = requestHeaders.get("referer")
-  if (!isOriginAuthorized(embeddingOrigin, targetWebchat.authorizedDomains)) {
+  const appHost = await getDomainFromHeader()
+  const isDirectOpen = isFirstPartyRequest(embeddingOrigin, appHost)
+  if (
+    !(
+      isDirectOpen ||
+      isOriginAuthorized(embeddingOrigin, targetWebchat.authorizedDomains)
+    )
+  ) {
     const t = await getTranslations("webchat.unauthorizedDomain")
 
     return (

--- a/apps/builder/src/app/layout.tsx
+++ b/apps/builder/src/app/layout.tsx
@@ -1,16 +1,16 @@
-import type { Metadata } from "next"
-import type { ReactNode } from "react"
-import "./globals.css"
-import "./themes.css"
 import { UiProvider } from "@chatbotx.io/ui"
-import Script from "next/script"
+import type { Metadata } from "next"
 import { NextIntlClientProvider } from "next-intl"
 import { getLocale } from "next-intl/server"
+import type { ReactNode } from "react"
 import { PublicEnvScript } from "@/components/public-env-script"
+import { SupportChatScript } from "@/components/support-chat-script"
 import { env } from "@/env"
 import { TenantProvider } from "@/features/tenant"
 import { getTenantSettings } from "@/features/tenant/utils"
 import { getDomainFromHeader } from "@/lib/domain"
+import "./globals.css"
+import "./themes.css"
 
 export async function generateMetadata(): Promise<Metadata> {
   const { name, faviconUrl } = await getTenantSettings()
@@ -50,9 +50,7 @@ export default async function RootLayout({ children }: Props) {
       <head>
         <PublicEnvScript />
         {isBuilderDomain && pancakeChatPageId && (
-          <Script
-            src={`https://chat-plugin.pancake.vn/main/auto?page_id=${encodeURIComponent(pancakeChatPageId)}&hide_supplier=true`}
-          />
+          <SupportChatScript pageId={pancakeChatPageId} />
         )}
       </head>
       <body

--- a/apps/builder/src/components/support-chat-script.tsx
+++ b/apps/builder/src/components/support-chat-script.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { usePathname } from "next/navigation"
+import Script from "next/script"
+
+const WEBCHAT_PATH = "/webchat"
+
+interface SupportChatScriptProps {
+  pageId: string
+}
+
+export function SupportChatScript({ pageId }: SupportChatScriptProps) {
+  const pathname = usePathname()
+
+  if (pathname === WEBCHAT_PATH) {
+    return null
+  }
+
+  return (
+    <Script
+      src={`https://chat-plugin.pancake.vn/main/auto?page_id=${encodeURIComponent(pageId)}&hide_supplier=true`}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- Hides the Pancake support-chat widget on the `/webchat` embed page, since it visually stacked on top of ChatbotX's own embedded webchat widget rendered there.
- `SupportChatScript` gates on `usePathname()` rather than the `x-domain` header, since the middleware matcher excludes `/webchat` and that header is never populated on that route.
- Also includes guard checks on `/webchat` for scheduled-deletion workspaces and unauthorized/non-first-party referers (bundled from prior related work on the same page).

## Changes
- `apps/builder/src/components/support-chat-script.tsx` (new): client component that skips rendering the Pancake `<Script>` when `pathname === "/webchat"`.
- `apps/builder/src/app/layout.tsx`: swaps the inline Pancake `<Script>` for `<SupportChatScript pageId={pancakeChatPageId} />`.
- `apps/builder/src/app/(no-sidebar)/webchat/page.tsx`: blocks rendering for workspaces pending deletion; requires a first-party direct open or an authorized referer domain.
- `apps/builder/messages/{en,vi}.json`: adds `webchat.chatUnavailable` translation key.
- Tests: `apps/builder/__tests__/support-chat-script.test.tsx`, `apps/builder/__tests__/webchat-page-guards.test.tsx`.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [x] `vitest run` for both new test files (10/10 passing)
- [ ] Manual browser verification: Pancake widget shows on normal builder pages, absent on `/webchat`, ChatbotX's own webchat widget unaffected