### PR TITLE
fix(contacts): emit accurate change events for custom fields and tags

### DIFF
--- a/apps/builder/src/features/contacts/actions/add-contact-custom-field.action.ts
+++ b/apps/builder/src/features/contacts/actions/add-contact-custom-field.action.ts
@@ -1,7 +1,11 @@
 "use server"
 
-import { type ContactAccessScope, contactService } from "@chatbotx.io/business"
-import { db, eq, findOrFail } from "@chatbotx.io/database/client"
+import {
+  type ContactAccessScope,
+  contactCustomFieldService,
+  contactService,
+} from "@chatbotx.io/business"
+import { and, db, eq, findOrFail } from "@chatbotx.io/database/client"
 import {
   contactCustomFieldModel,
   customFieldModel,
@@ -37,6 +41,38 @@ export const addContactCustomFieldAction = workspaceActionClient
     })
   })
 
+const computeUpdatedFieldValue = ({
+  currentValue,
+  operation,
+  operationValue,
+}: {
+  currentValue: string
+  operation: FieldOperationType
+  operationValue: string
+}): string | null => {
+  switch (operation) {
+    case FieldOperationType.append:
+      return currentValue + operationValue
+    case FieldOperationType.prepend:
+      return operationValue + currentValue
+    case FieldOperationType.increase:
+    case FieldOperationType.decrease: {
+      const currentNumber = Number(currentValue)
+      const operationNumber = Number(operationValue)
+      if (Number.isNaN(currentNumber) || Number.isNaN(operationNumber)) {
+        return null
+      }
+      const updatedNumber =
+        operation === FieldOperationType.increase
+          ? currentNumber + operationNumber
+          : currentNumber - operationNumber
+      return String(updatedNumber)
+    }
+    default:
+      return operationValue
+  }
+}
+
 export const addContactCustomFields = async ({
   bindArgsParsedInputs: [workspaceId],
   parsedInput,
@@ -64,39 +100,42 @@ export const addContactCustomFields = async ({
     message: "Custom field not found",
   })
 
+  const changes: Array<{
+    contactId: string
+    oldValue: string | null
+    newValue: string
+  }> = []
+
   await db.transaction(async (tx) => {
     await Promise.all(
       contacts.map(async (contact) => {
-        const contactCustomField =
-          await tx.query.contactCustomFieldModel.findFirst({
-            where: {
-              contactId: contact.id,
-              customFieldId: customField.id,
-            },
-          })
+        const [contactCustomField] = await tx
+          .select()
+          .from(contactCustomFieldModel)
+          .where(
+            and(
+              eq(contactCustomFieldModel.contactId, contact.id),
+              eq(contactCustomFieldModel.customFieldId, customField.id),
+            ),
+          )
+          .for("update")
 
         if (contactCustomField) {
-          let value = ""
-          switch (parsedInput.operation) {
-            case FieldOperationType.append:
-              value = contactCustomField.value + String(parsedInput.value)
-              break
-            case FieldOperationType.prepend:
-              value = String(parsedInput.value) + contactCustomField.value
-              break
-            case FieldOperationType.increase:
-              value = String(
-                Number(contactCustomField.value) + Number(parsedInput.value),
-              )
-              break
-            case FieldOperationType.decrease:
-              value = String(
-                Number(contactCustomField.value) - Number(parsedInput.value),
-              )
-              break
-            default:
-              value = parsedInput.value as string
+          const value = computeUpdatedFieldValue({
+            currentValue: contactCustomField.value,
+            operation: parsedInput.operation,
+            operationValue: parsedInput.value,
+          })
+
+          if (value === null || value === contactCustomField.value) {
+            return
           }
+
+          changes.push({
+            contactId: contact.id,
+            oldValue: contactCustomField.value,
+            newValue: value,
+          })
 
           return tx
             .update(contactCustomFieldModel)
@@ -106,24 +145,39 @@ export const addContactCustomFields = async ({
             .where(eq(contactCustomFieldModel.id, contactCustomField.id))
         }
 
-        return tx.insert(contactCustomFieldModel).values({
+        changes.push({
           contactId: contact.id,
-          customFieldId: customField.id,
-          value: parsedInput.value as string,
-          id: createId(),
+          oldValue: null,
+          newValue: parsedInput.value,
         })
+
+        return tx
+          .insert(contactCustomFieldModel)
+          .values({
+            contactId: contact.id,
+            customFieldId: customField.id,
+            value: parsedInput.value,
+            id: createId(),
+          })
+          .onConflictDoUpdate({
+            target: [
+              contactCustomFieldModel.contactId,
+              contactCustomFieldModel.customFieldId,
+            ],
+            set: { value: parsedInput.value },
+          })
       }),
     )
   })
 
-  for (const contact of contacts) {
+  for (const change of changes) {
     await emitCustomFieldChanged(
       workspaceId,
-      contact.id,
+      change.contactId,
       customField.id,
       customField.name,
-      null,
-      parsedInput.value,
+      change.oldValue,
+      change.newValue,
     )
   }
 }
@@ -170,6 +224,10 @@ export const setContactCustomFieldValue = async ({
     },
   })
 
+  if (contactCustomField?.value === value) {
+    return
+  }
+
   if (contactCustomField) {
     await db
       .update(contactCustomFieldModel)
@@ -178,12 +236,21 @@ export const setContactCustomFieldValue = async ({
       })
       .where(eq(contactCustomFieldModel.id, contactCustomField.id))
   } else {
-    await db.insert(contactCustomFieldModel).values({
-      contactId,
-      customFieldId,
-      value,
-      id: createId(),
-    })
+    await db
+      .insert(contactCustomFieldModel)
+      .values({
+        contactId,
+        customFieldId,
+        value,
+        id: createId(),
+      })
+      .onConflictDoUpdate({
+        target: [
+          contactCustomFieldModel.contactId,
+          contactCustomFieldModel.customFieldId,
+        ],
+        set: { value },
+      })
   }
 
   await emitCustomFieldChanged(
@@ -191,7 +258,7 @@ export const setContactCustomFieldValue = async ({
     contactId,
     customField.id,
     customField.name,
-    null,
+    contactCustomField?.value ?? null,
     value,
   )
 }
@@ -213,62 +280,5 @@ export const setContactCustomFieldValues = async ({
     accessScope,
   })
 
-  const customFieldIds = fields.map((f) => f.customFieldId)
-
-  const customFields = await db.query.customFieldModel.findMany({
-    where: { workspaceId, id: { in: customFieldIds } },
-    columns: { id: true, name: true },
-  })
-
-  if (customFields.length === 0) {
-    return
-  }
-
-  const existingValues = await db.query.contactCustomFieldModel.findMany({
-    where: { contactId, customFieldId: { in: customFieldIds } },
-  })
-
-  await db.transaction(async (tx) => {
-    const matchedFields = customFields.flatMap((customField) => {
-      const field = fields.find((f) => f.customFieldId === customField.id)
-      return field ? [{ customField, field }] : []
-    })
-
-    await Promise.all(
-      matchedFields.map(({ customField, field }) => {
-        const existing = existingValues.find(
-          (v) => v.customFieldId === customField.id,
-        )
-
-        if (existing) {
-          return tx
-            .update(contactCustomFieldModel)
-            .set({ value: field.value })
-            .where(eq(contactCustomFieldModel.id, existing.id))
-        }
-
-        return tx.insert(contactCustomFieldModel).values({
-          id: createId(),
-          contactId,
-          customFieldId: customField.id,
-          value: field.value,
-        })
-      }),
-    )
-  })
-
-  for (const customField of customFields) {
-    const field = fields.find((f) => f.customFieldId === customField.id)
-    if (!field) {
-      continue
-    }
-    emitCustomFieldChanged(
-      workspaceId,
-      contactId,
-      customField.id,
-      customField.name,
-      null,
-      field.value,
-    )
-  }
+  await contactCustomFieldService.setValues({ workspaceId, contactId, fields })
 }

--- a/packages/business/src/contact-custom-field/service.ts
+++ b/packages/business/src/contact-custom-field/service.ts
@@ -78,44 +78,61 @@ class ContactCustomFieldService extends BaseService {
       where: { contactId, customFieldId: { in: customFieldIds } },
     })
 
-    await tx.transaction(async (innerTx) => {
-      const matchedFields = customFields.flatMap((customField) => {
-        const field = fields.find((f) => f.customFieldId === customField.id)
-        return field ? [{ customField, field }] : []
-      })
+    const changedFields = customFields.flatMap((customField) => {
+      const field = fields.find((f) => f.customFieldId === customField.id)
+      if (!field) {
+        return []
+      }
+      const existing = existingValues.find(
+        (value) => value.customFieldId === customField.id,
+      )
+      if (existing?.value === field.value) {
+        return []
+      }
+      return [
+        { customField, field, existing, oldValue: existing?.value ?? null },
+      ]
+    })
 
+    if (changedFields.length === 0) {
+      return
+    }
+
+    await tx.transaction(async (innerTx) => {
       await Promise.all(
-        matchedFields.map(({ customField, field }) => {
-          const existing = existingValues.find(
-            (v) => v.customFieldId === customField.id,
-          )
+        changedFields.map(({ customField, field, existing }) => {
           if (existing) {
             return innerTx
               .update(contactCustomFieldModel)
               .set({ value: field.value })
               .where(eq(contactCustomFieldModel.id, existing.id))
           }
-          return innerTx.insert(contactCustomFieldModel).values({
-            id: createId(),
-            contactId,
-            customFieldId: customField.id,
-            value: field.value,
-          })
+          return innerTx
+            .insert(contactCustomFieldModel)
+            .values({
+              id: createId(),
+              contactId,
+              customFieldId: customField.id,
+              value: field.value,
+            })
+            .onConflictDoUpdate({
+              target: [
+                contactCustomFieldModel.contactId,
+                contactCustomFieldModel.customFieldId,
+              ],
+              set: { value: field.value },
+            })
         }),
       )
     })
 
-    for (const customField of customFields) {
-      const field = fields.find((f) => f.customFieldId === customField.id)
-      if (!field) {
-        continue
-      }
+    for (const { customField, field, oldValue } of changedFields) {
       emitCustomFieldChanged(
         workspaceId,
         contactId,
         customField.id,
         customField.name,
-        null,
+        oldValue,
         field.value,
         // biome-ignore lint/suspicious/noEmptyBlockStatements: fire-and-forget
       ).catch(() => {})

--- a/packages/business/src/tag/service.ts
+++ b/packages/business/src/tag/service.ts
@@ -183,15 +183,16 @@ class TagService extends BaseService {
       return
     }
 
-    await tx
+    const newlyAttached = await tx
       .insert(contactsToTagsModel)
       .values(tags.map((tag) => ({ contactId, tagId: tag.id })))
       .onConflictDoNothing({
         target: [contactsToTagsModel.contactId, contactsToTagsModel.tagId],
       })
+      .returning({ tagId: contactsToTagsModel.tagId })
 
-    for (const tag of tags) {
-      emitTagApplied(workspaceId, contactId, tag.id) // biome-ignore lint/suspicious/noEmptyBlockStatements: fire-and-forget
+    for (const pair of newlyAttached) {
+      emitTagApplied(workspaceId, contactId, pair.tagId) // biome-ignore lint/suspicious/noEmptyBlockStatements: fire-and-forget
         .catch(() => {})
     }
   }
@@ -353,7 +354,7 @@ class TagService extends BaseService {
       where: { id: contactId, workspaceId },
     })
 
-    await tx
+    const removed = await tx
       .delete(contactsToTagsModel)
       .where(
         and(
@@ -361,9 +362,10 @@ class TagService extends BaseService {
           inArray(contactsToTagsModel.tagId, tagIds),
         ),
       )
+      .returning({ tagId: contactsToTagsModel.tagId })
 
-    for (const tagId of tagIds) {
-      emitTagRemoved(workspaceId, contactId, tagId) // biome-ignore lint/suspicious/noEmptyBlockStatements: fire-and-forget
+    for (const pair of removed) {
+      emitTagRemoved(workspaceId, contactId, pair.tagId) // biome-ignore lint/suspicious/noEmptyBlockStatements: fire-and-forget
         .catch(() => {})
     }
   }


### PR DESCRIPTION
## Summary

- Only emit `customFieldChanged` when the value actually changes, and pass the real old value instead of `null`.
- Lock contact custom field rows with `FOR UPDATE` during bulk updates and upsert via `onConflictDoUpdate` to avoid duplicate `ContactCustomField` rows under concurrency.
- Emit `tagApplied` / `tagRemoved` only for rows actually inserted/deleted (using `returning()`), so re-applying an existing tag or removing a non-attached tag no longer fires spurious events.
- Delegate `setContactCustomFieldValues` in the builder action to `contactCustomFieldService.setValues` to remove duplicated logic.

## Verification

- `pnpm lint` passes
- `pnpm --filter builder check-types` passes
- `pnpm --filter @chatbotx.io/business check-types` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)