### PR TITLE
feat(ai-agents): move bot reply delay setting into agent actions

### DIFF
--- a/apps/builder/__tests__/update-smart-response-delay-schema.test.ts
+++ b/apps/builder/__tests__/update-smart-response-delay-schema.test.ts
@@ -1,22 +1,12 @@
 import { describe, expect, test } from "vitest"
 import {
   SMART_RESPONSE_DELAY_NONE_VALUE,
-  updateWorkspaceAdvancedRequest,
+  updateSmartResponseDelayRequest,
 } from "../src/features/workspaces/schema/update-workspace-schema"
 
-const baseInput = {
-  defaultReply: "",
-  targetCountry: "VN",
-  language: "vi",
-  timezone: "Asia/Ho_Chi_Minh",
-  brandColor: "#123abc",
-  developmentMode: false,
-}
-
-describe("updateWorkspaceAdvancedRequest.smartResponseDelaySeconds", () => {
+describe("updateSmartResponseDelayRequest.smartResponseDelaySeconds", () => {
   test("transforms a valid delay string into a number", () => {
-    const result = updateWorkspaceAdvancedRequest.parse({
-      ...baseInput,
+    const result = updateSmartResponseDelayRequest.parse({
       smartResponseDelaySeconds: "3",
     })
 
@@ -24,8 +14,7 @@ describe("updateWorkspaceAdvancedRequest.smartResponseDelaySeconds", () => {
   })
 
   test("transforms the none value into null", () => {
-    const result = updateWorkspaceAdvancedRequest.parse({
-      ...baseInput,
+    const result = updateSmartResponseDelayRequest.parse({
       smartResponseDelaySeconds: SMART_RESPONSE_DELAY_NONE_VALUE,
     })
 
@@ -33,30 +22,27 @@ describe("updateWorkspaceAdvancedRequest.smartResponseDelaySeconds", () => {
   })
 
   test("accepts its own output when parsed twice (client resolver then server inputSchema)", () => {
-    const clientParsed = updateWorkspaceAdvancedRequest.parse({
-      ...baseInput,
+    const clientParsed = updateSmartResponseDelayRequest.parse({
       smartResponseDelaySeconds: "3",
     })
 
-    const serverParsed = updateWorkspaceAdvancedRequest.parse(clientParsed)
+    const serverParsed = updateSmartResponseDelayRequest.parse(clientParsed)
 
     expect(serverParsed.smartResponseDelaySeconds).toBe(3)
   })
 
   test("accepts null when parsed twice", () => {
-    const clientParsed = updateWorkspaceAdvancedRequest.parse({
-      ...baseInput,
+    const clientParsed = updateSmartResponseDelayRequest.parse({
       smartResponseDelaySeconds: SMART_RESPONSE_DELAY_NONE_VALUE,
     })
 
-    const serverParsed = updateWorkspaceAdvancedRequest.parse(clientParsed)
+    const serverParsed = updateSmartResponseDelayRequest.parse(clientParsed)
 
     expect(serverParsed.smartResponseDelaySeconds).toBeNull()
   })
 
   test("rejects a delay outside the allowed options", () => {
-    const result = updateWorkspaceAdvancedRequest.safeParse({
-      ...baseInput,
+    const result = updateSmartResponseDelayRequest.safeParse({
       smartResponseDelaySeconds: "7",
     })
 
@@ -64,8 +50,7 @@ describe("updateWorkspaceAdvancedRequest.smartResponseDelaySeconds", () => {
   })
 
   test("rejects a numeric delay outside the allowed options", () => {
-    const result = updateWorkspaceAdvancedRequest.safeParse({
-      ...baseInput,
+    const result = updateSmartResponseDelayRequest.safeParse({
       smartResponseDelaySeconds: 7,
     })
 

--- a/apps/builder/src/app/space/[workspaceId]/(ai)/ai-agents/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(ai)/ai-agents/page.tsx
@@ -1,3 +1,4 @@
+import { workspaceService } from "@chatbotx.io/business"
 import { getIdFromParams } from "@chatbotx.io/utils"
 import { notFound } from "next/navigation"
 import type { SearchParams } from "nuqs/server"
@@ -27,6 +28,7 @@ export default async function AIAgentsPage(props: AIAgentsPageProps) {
       ...listAIAgentsRequest.parse(searchParams),
     }),
     listIntegrationOpenaiCompatible({ workspaceId }),
+    workspaceService.findById({ id: workspaceId }),
   ])
 
   return (

--- a/apps/builder/src/features/ai-agents/ai-agent-table.tsx
+++ b/apps/builder/src/features/ai-agents/ai-agent-table.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import type { AIAgentModel } from "@chatbotx.io/database/types"
+import type { AIAgentModel, WorkspaceModel } from "@chatbotx.io/database/types"
 import { DataTable } from "@chatbotx.io/ui/components/data-table/data-table"
 import { DataTableToolbar } from "@chatbotx.io/ui/components/data-table/data-table-toolbar"
 import {
@@ -18,6 +18,7 @@ import { DeleteAIAgentsDialog } from "@/features/ai-agents/delete-ai-agent"
 import type { listAIAgents } from "@/features/ai-agents/queries"
 import { UpdateAIAgentDialog } from "@/features/ai-agents/update-ai-agent"
 import type { listIntegrationOpenaiCompatible } from "@/features/integration-openai-compatible/queries"
+import { BotReplyDelayDialog } from "./components/bot-reply-delay-dialog"
 import { ChangeDefault } from "./components/change-default"
 import { CreateAIAgentDialog } from "./create-ai-agent"
 import {
@@ -31,12 +32,14 @@ type AIAgentsTableProps = {
     [
       Awaited<ReturnType<typeof listAIAgents>>,
       Awaited<ReturnType<typeof listIntegrationOpenaiCompatible>>,
+      WorkspaceModel,
     ]
   >
 }
 
 export function AIAgentsTable({ workspaceId, promises }: AIAgentsTableProps) {
-  const [{ data, pageCount }, openaiCompatibleIntegrations] = use(promises)
+  const [{ data, pageCount }, openaiCompatibleIntegrations, workspace] =
+    use(promises)
 
   const t = useTranslations()
   const router = useRouter()
@@ -115,6 +118,16 @@ export function AIAgentsTable({ workspaceId, promises }: AIAgentsTableProps) {
             router.refresh()
           }}
           open={rowAction?.variant === "toggleDefault"}
+        />
+
+        <BotReplyDelayDialog
+          onOpenChange={() => setRowAction(null)}
+          onSuccess={() => {
+            router.refresh()
+          }}
+          open={rowAction?.variant === "botReplyDelay"}
+          smartResponseDelaySeconds={workspace.smartResponseDelaySeconds}
+          workspaceId={workspaceId}
         />
       </CardContent>
     </Card>

--- a/apps/builder/src/features/ai-agents/components/bot-reply-delay-dialog.tsx
+++ b/apps/builder/src/features/ai-agents/components/bot-reply-delay-dialog.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import { SelectField } from "@chatbotx.io/ui/components/form/select-field"
+import { Button } from "@chatbotx.io/ui/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@chatbotx.io/ui/components/ui/dialog"
+import { Form } from "@chatbotx.io/ui/components/ui/form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hooks"
+import { Loader2Icon } from "lucide-react"
+import { useTranslations } from "next-intl"
+import { toast } from "sonner"
+import { updateSmartResponseDelayAction } from "@/features/workspaces/actions/update-workspace-action"
+import { getSmartResponseDelaySelectOptions } from "@/features/workspaces/helpers"
+import {
+  SMART_RESPONSE_DELAY_NONE_VALUE,
+  updateSmartResponseDelayRequest,
+} from "@/features/workspaces/schema/update-workspace-schema"
+
+// The delay is stored on the workspace and shared by every agent; this dialog
+// only surfaces it per agent row for discoverability.
+export function BotReplyDelayDialog({
+  workspaceId,
+  smartResponseDelaySeconds,
+  open,
+  onOpenChange,
+  onSuccess,
+}: {
+  workspaceId: string
+  smartResponseDelaySeconds: number | null
+  open: boolean
+  onOpenChange: (val: boolean) => void
+  onSuccess?: () => void
+}) {
+  const t = useTranslations()
+
+  const { form, handleSubmitWithAction } = useHookFormAction(
+    updateSmartResponseDelayAction.bind(null, workspaceId),
+    zodResolver(updateSmartResponseDelayRequest),
+    {
+      actionProps: {
+        onSuccess: () => {
+          toast.success(
+            t("messages.updatedSuccess", {
+              feature: t("fields.smartResponseDelaySeconds.label"),
+            }),
+          )
+
+          onOpenChange(false)
+          onSuccess?.()
+        },
+        onError: ({ error }) => {
+          if (error.serverError) {
+            toast.error(error.serverError)
+          }
+        },
+      },
+      formProps: {
+        mode: "onChange",
+        // `values` (not defaultValues): the dialog stays mounted between opens,
+        // so the field must re-sync after a save refreshes the workspace.
+        values: {
+          smartResponseDelaySeconds:
+            smartResponseDelaySeconds == null
+              ? SMART_RESPONSE_DELAY_NONE_VALUE
+              : String(smartResponseDelaySeconds),
+        },
+      },
+      errorMapProps: {},
+    },
+  )
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {t("fields.smartResponseDelaySeconds.label")}
+          </DialogTitle>
+          <DialogDescription>
+            {t("fields.smartResponseDelaySeconds.description")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={handleSubmitWithAction}>
+            <SelectField
+              name="smartResponseDelaySeconds"
+              options={getSmartResponseDelaySelectOptions(t)}
+              placeholder={t("actions.pleaseSelect")}
+            />
+
+            <DialogFooter className="mt-4 justify-end gap-2 sm:gap-2">
+              <Button
+                onClick={() => onOpenChange(false)}
+                type="button"
+                variant="ghost"
+              >
+                {t("actions.cancel")}
+              </Button>
+              <Button
+                disabled={
+                  !form.formState.isValid || form.formState.isSubmitting
+                }
+                type="submit"
+              >
+                {form.formState.isSubmitting && (
+                  <Loader2Icon aria-hidden className="animate-spin" />
+                )}
+                {t("actions.confirm")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/builder/src/features/ai-agents/table-columns.tsx
+++ b/apps/builder/src/features/ai-agents/table-columns.tsx
@@ -36,6 +36,7 @@ export type AIAgentDataTableRowAction<TData> = {
     | "resend"
     | "enable"
     | "toggleDefault"
+    | "botReplyDelay"
 }
 
 type GetAIAgentsColumnsProps = {
@@ -120,6 +121,12 @@ export function getAIAgentsColumns({
               {row.original.isDefault
                 ? t("actions.unsetDefaultAgent")
                 : t("actions.setAsDefaultAgent")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => setRowAction({ row, variant: "botReplyDelay" })}
+            >
+              <PencilIcon className="mr-2" />
+              {t("fields.smartResponseDelaySeconds.label")}
             </DropdownMenuItem>
             <DropdownMenuItem
               onSelect={() => setRowAction({ row, variant: "update" })}

--- a/apps/builder/src/features/workspaces/actions/update-workspace-action.ts
+++ b/apps/builder/src/features/workspaces/actions/update-workspace-action.ts
@@ -7,8 +7,10 @@ import {
 } from "@/features/common/schemas"
 import { workspaceActionClient } from "@/lib/safe-action"
 import {
+  type UpdateSmartResponseDelayRequest,
   type UpdateWorkspaceAdvancedRequest,
   type UpdateWorkspaceBasicRequest,
+  updateSmartResponseDelayRequest,
   updateWorkspaceAdvancedRequest,
   updateWorkspaceBasicRequest,
 } from "../schema/update-workspace-schema"
@@ -38,6 +40,21 @@ export const updateWorkspaceAdvancedAction = workspaceActionClient
     }: {
       bindArgsParsedInputs: WorkspaceIdRequestParams
       parsedInput: UpdateWorkspaceAdvancedRequest
+    }) => {
+      await workspaceService.update({ id: workspaceId, data: parsedInput })
+    },
+  )
+
+export const updateSmartResponseDelayAction = workspaceActionClient
+  .bindArgsSchemas(workspaceIdrequestParams)
+  .inputSchema(updateSmartResponseDelayRequest)
+  .action(
+    async ({
+      bindArgsParsedInputs: [workspaceId],
+      parsedInput,
+    }: {
+      bindArgsParsedInputs: WorkspaceIdRequestParams
+      parsedInput: UpdateSmartResponseDelayRequest
     }) => {
       await workspaceService.update({ id: workspaceId, data: parsedInput })
     },

--- a/apps/builder/src/features/workspaces/helpers.ts
+++ b/apps/builder/src/features/workspaces/helpers.ts
@@ -1,5 +1,8 @@
+import { SMART_RESPONSE_DELAY_OPTIONS } from "@chatbotx.io/database/partials"
+import type { useTranslations } from "next-intl"
 import { useTenantSettings } from "@/features/tenant"
 import type { WorkspaceResource } from "./schema/resource"
+import { SMART_RESPONSE_DELAY_NONE_VALUE } from "./schema/update-workspace-schema"
 
 export function useWorkspaceLogoUrl(
   workspace: Pick<WorkspaceResource, "logo"> | null | undefined,
@@ -22,4 +25,34 @@ export function formatScheduleTime(time: string): string {
   const [hourStr, minuteStr] = time.split(":")
   const hour = Number(hourStr)
   return minuteStr && minuteStr !== "00" ? `${hour}:${minuteStr}` : String(hour)
+}
+
+export function getSmartResponseDelayOptionLabel(
+  delaySeconds: number,
+  t: ReturnType<typeof useTranslations>,
+): string {
+  if (delaySeconds < 60) {
+    return t("fields.smartResponseDelaySeconds.seconds", {
+      count: delaySeconds,
+    })
+  }
+
+  return t("fields.smartResponseDelaySeconds.minutes", {
+    count: delaySeconds / 60,
+  })
+}
+
+export function getSmartResponseDelaySelectOptions(
+  t: ReturnType<typeof useTranslations>,
+): { value: string; label: string }[] {
+  return [
+    {
+      value: SMART_RESPONSE_DELAY_NONE_VALUE,
+      label: t("fields.smartResponseDelaySeconds.none"),
+    },
+    ...SMART_RESPONSE_DELAY_OPTIONS.map((delaySeconds) => ({
+      value: String(delaySeconds),
+      label: getSmartResponseDelayOptionLabel(delaySeconds, t),
+    })),
+  ]
 }

--- a/apps/builder/src/features/workspaces/schema/update-workspace-schema.ts
+++ b/apps/builder/src/features/workspaces/schema/update-workspace-schema.ts
@@ -45,10 +45,18 @@ export const updateWorkspaceAdvancedRequest = z.object({
   timezone: z.enum(allTimezoneCodes as [string, ...string[]]),
   brandColor: z.string().regex(/^#[0-9A-Fa-f]{6}$/),
   developmentMode: z.boolean(),
-  smartResponseDelaySeconds: smartResponseDelaySecondsSchema,
 })
 export type UpdateWorkspaceAdvancedRequest = z.infer<
   typeof updateWorkspaceAdvancedRequest
+>
+
+// Edited from the AI Agents list (per-agent dialog) but stored on the
+// workspace: the delay is shared by every agent in the workspace.
+export const updateSmartResponseDelayRequest = z.object({
+  smartResponseDelaySeconds: smartResponseDelaySecondsSchema,
+})
+export type UpdateSmartResponseDelayRequest = z.infer<
+  typeof updateSmartResponseDelayRequest
 >
 
 const timeFormat = z

--- a/apps/builder/src/features/workspaces/update-workspace-advanced-form.tsx
+++ b/apps/builder/src/features/workspaces/update-workspace-advanced-form.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { SMART_RESPONSE_DELAY_OPTIONS } from "@chatbotx.io/database/partials"
 import { ColorPickerField } from "@chatbotx.io/ui/components/form/color-picker-field"
 import { ComboboxField } from "@chatbotx.io/ui/components/form/combobox-field"
 import { SelectField } from "@chatbotx.io/ui/components/form/select-field"
@@ -22,25 +21,7 @@ import {
   allTimezoneOptions,
   UNKNOWN_COUNTRY,
 } from "./schema/types"
-import {
-  SMART_RESPONSE_DELAY_NONE_VALUE,
-  updateWorkspaceAdvancedRequest,
-} from "./schema/update-workspace-schema"
-
-const getSmartResponseDelayOptionLabel = (
-  delaySeconds: number,
-  t: ReturnType<typeof useTranslations>,
-) => {
-  if (delaySeconds < 60) {
-    return t("fields.smartResponseDelaySeconds.seconds", {
-      count: delaySeconds,
-    })
-  }
-
-  return t("fields.smartResponseDelaySeconds.minutes", {
-    count: delaySeconds / 60,
-  })
-}
+import { updateWorkspaceAdvancedRequest } from "./schema/update-workspace-schema"
 
 export function UpdateWorkspaceAdvancedForm({
   workspace,
@@ -77,10 +58,6 @@ export function UpdateWorkspaceAdvancedForm({
           timezone: workspace.timezone,
           brandColor: workspace.brandColor,
           developmentMode: workspace.developmentMode,
-          smartResponseDelaySeconds:
-            workspace.smartResponseDelaySeconds == null
-              ? SMART_RESPONSE_DELAY_NONE_VALUE
-              : String(workspace.smartResponseDelaySeconds),
         },
       },
       errorMapProps: {},
@@ -103,26 +80,6 @@ export function UpdateWorkspaceAdvancedForm({
                 emptyText={t("actions.noRecordFound")}
                 name="defaultReply"
                 options={flowOptions}
-                placeholder={t("actions.pleaseSelect")}
-              />
-            </SettingRow>
-
-            <SettingRow
-              description={t("fields.smartResponseDelaySeconds.description")}
-              label={t("fields.smartResponseDelaySeconds.label")}
-            >
-              <SelectField
-                name="smartResponseDelaySeconds"
-                options={[
-                  {
-                    value: SMART_RESPONSE_DELAY_NONE_VALUE,
-                    label: t("fields.smartResponseDelaySeconds.none"),
-                  },
-                  ...SMART_RESPONSE_DELAY_OPTIONS.map((delaySeconds) => ({
-                    value: String(delaySeconds),
-                    label: getSmartResponseDelayOptionLabel(delaySeconds, t),
-                  })),
-                ]}
                 placeholder={t("actions.pleaseSelect")}
               />
             </SettingRow>


### PR DESCRIPTION
## Summary

Moves the **Bot reply delay** setting out of workspace Settings and into the AI Agents screen.

Each AI Agent's Actions menu now has a "Bot reply delay" option that opens a small dialog to change the setting. The value is still shared across the whole workspace — every agent shows and edits the same value; only where you access it has changed.

## Test plan

- [ ] Open the AI Agents list — each agent's Actions menu shows "Bot reply delay"
- [ ] Change the value on one agent, save — the change is applied
- [ ] Open the dialog on another agent — it shows the same value
- [ ] The old setting no longer appears in Settings → General
