### PR TITLE
chore(worker): remove unused questionnaires worker script

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -19,7 +19,6 @@
     "worker:sequence-consumer": "dotenv -e ../../.env -- tsx --watch src/sequence-scheduler/worker-consumer.ts",
     "worker:sequence-producer": "dotenv -e ../../.env -- tsx --watch src/sequence-scheduler/worker-producer.ts",
     "worker:sequence-scheduler": "dotenv -e ../../.env -- tsx --watch src/sequence-scheduler/worker.ts",
-    "worker:questionnaires": "dotenv -e ../../.env -- tsx --watch src/questionnaires/worker.ts",
     "worker:trigger": "dotenv -e ../../.env -- tsx --watch src/trigger/worker.ts",
     "worker:webhook": "dotenv -e ../../.env -- tsx --watch src/webhook/worker.ts"
   },


### PR DESCRIPTION
## Purpose

Remove the `worker:questionnaires` dev script from `apps/worker/package.json` as it is no longer used.

## Changes

- Removed the `worker:questionnaires` script line, which pointed to a non-existent file (`src/questionnaires/worker.ts`).

## Impact

- No impact on running features. This only cleans up a dead dev script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)