### PR TITLE
feat(platform-credentials): add delete action and require full field input on update

### DIFF
--- a/apps/builder/__tests__/google-settings-actions.test.ts
+++ b/apps/builder/__tests__/google-settings-actions.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { removeSpy, resolveScopedUserIdSpy, upsertSpy } = vi.hoisted(() => ({
+  removeSpy: vi.fn(),
+  resolveScopedUserIdSpy: vi.fn(),
+  upsertSpy: vi.fn(),
+}))
+
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, unknown> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.inputSchema = () => chain
+  chain.action = (handler: unknown) => handler
+  return { authActionClient: chain }
+})
+
+vi.mock("@chatbotx.io/business", () => ({
+  platformCredentialService: {
+    remove: removeSpy,
+    upsert: upsertSpy,
+  },
+}))
+
+vi.mock("../src/features/platform-credentials/scope", () => ({
+  credentialScopeSchema: {},
+  resolveCredentialScopedUserId: resolveScopedUserIdSpy,
+}))
+
+const { googleCredentialUpdateSchema } = await import(
+  "@chatbotx.io/database/partials"
+)
+const { deleteGoogleSettingsAction } = await import(
+  "../src/features/platform-credentials/google/delete-google-settings.action"
+)
+const { updateGoogleSettingsAction } = await import(
+  "../src/features/platform-credentials/google/update-google-settings.action"
+)
+
+type ActionContext = {
+  ctx: { user: { id: string } }
+  bindArgsParsedInputs: ["user" | "platform"]
+}
+
+const callDelete = deleteGoogleSettingsAction as unknown as (
+  args: ActionContext,
+) => Promise<unknown>
+const callUpdate = updateGoogleSettingsAction as unknown as (
+  args: ActionContext & {
+    parsedInput: {
+      clientId: string
+      clientSecret: string
+      verifyToken: string
+    }
+  },
+) => Promise<unknown>
+
+describe("Google credential actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    upsertSpy.mockResolvedValue(undefined)
+    removeSpy.mockResolvedValue(undefined)
+    resolveScopedUserIdSpy.mockReturnValue("user-1")
+  })
+
+  test("upserts all submitted Google credential fields", async () => {
+    await callUpdate({
+      ctx: { user: { id: "user-1" } },
+      bindArgsParsedInputs: ["user"],
+      parsedInput: {
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        verifyToken: "verify-token",
+      },
+    })
+
+    expect(upsertSpy).toHaveBeenCalledWith({
+      userId: "user-1",
+      type: "google",
+      config: {
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        verifyToken: "verify-token",
+      },
+    })
+  })
+
+  test.each([
+    "clientId",
+    "clientSecret",
+    "verifyToken",
+  ])("rejects an empty %s during schema validation", (field) => {
+    const input = {
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      verifyToken: "verify-token",
+      [field]: "",
+    }
+
+    expect(googleCredentialUpdateSchema.safeParse(input).success).toBe(false)
+  })
+
+  test("removes the user-scoped Google credential", async () => {
+    await callDelete({
+      ctx: { user: { id: "user-1" } },
+      bindArgsParsedInputs: ["user"],
+    })
+
+    expect(removeSpy).toHaveBeenCalledWith({
+      userId: "user-1",
+      type: "google",
+    })
+  })
+
+  test("removes the platform-scoped Google credential", async () => {
+    resolveScopedUserIdSpy.mockReturnValue(undefined)
+
+    await callDelete({
+      ctx: { user: { id: "admin-1" } },
+      bindArgsParsedInputs: ["platform"],
+    })
+
+    expect(removeSpy).toHaveBeenCalledWith({
+      userId: undefined,
+      type: "google",
+    })
+  })
+})

--- a/apps/builder/__tests__/instagram-facebook-settings-actions.test.ts
+++ b/apps/builder/__tests__/instagram-facebook-settings-actions.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { removeSpy, resolveSpy, upsertSpy } = vi.hoisted(() => ({
+  removeSpy: vi.fn(),
+  resolveSpy: vi.fn(),
+  upsertSpy: vi.fn(),
+}))
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, any> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.inputSchema = () => chain
+  chain.action = (handler: unknown) => handler
+  return { authActionClient: chain }
+})
+vi.mock("@chatbotx.io/business", () => ({
+  platformCredentialService: { remove: removeSpy, upsert: upsertSpy },
+}))
+vi.mock("../src/features/platform-credentials/scope", () => ({
+  credentialScopeSchema: {},
+  resolveCredentialScopedUserId: resolveSpy,
+}))
+const { instagramFacebookCredentialUpdateSchema } = await import(
+  "@chatbotx.io/database/partials"
+)
+const { deleteInstagramFacebookSettingsAction } = await import(
+  "../src/features/platform-credentials/instagram-facebook/delete-instagram-facebook-settings.action"
+)
+const { updateInstagramFacebookSettingAction } = await import(
+  "../src/features/platform-credentials/instagram-facebook/update-instagram-facebook-settings.action"
+)
+const call = (action: unknown) => action as (args: any) => Promise<unknown>
+describe("Instagram via Facebook credential actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolveSpy.mockReturnValue("user-1")
+  })
+  test("upserts all fields", async () => {
+    await call(updateInstagramFacebookSettingAction)({
+      ctx: { user: { id: "user-1" } },
+      bindArgsParsedInputs: ["user"],
+      parsedInput: {
+        clientId: "id",
+        version: "v1",
+        verifyToken: "verify",
+        clientSecret: "secret",
+      },
+    })
+    expect(upsertSpy).toHaveBeenCalledWith({
+      userId: "user-1",
+      type: "instagramFacebook",
+      config: {
+        clientId: "id",
+        version: "v1",
+        verifyToken: "verify",
+        clientSecret: "secret",
+      },
+    })
+  })
+  test.each([
+    "clientId",
+    "version",
+    "verifyToken",
+    "clientSecret",
+  ])("rejects empty %s", (field) => {
+    expect(
+      instagramFacebookCredentialUpdateSchema.safeParse({
+        clientId: "id",
+        version: "v1",
+        verifyToken: "verify",
+        clientSecret: "secret",
+        [field]: "",
+      }).success,
+    ).toBe(false)
+  })
+  test("deletes user and platform credentials", async () => {
+    await call(deleteInstagramFacebookSettingsAction)({
+      ctx: { user: { id: "u" } },
+      bindArgsParsedInputs: ["user"],
+    })
+    expect(removeSpy).toHaveBeenCalledWith({
+      userId: "user-1",
+      type: "instagramFacebook",
+    })
+    resolveSpy.mockReturnValue(undefined)
+    await call(deleteInstagramFacebookSettingsAction)({
+      ctx: { user: { id: "a" } },
+      bindArgsParsedInputs: ["platform"],
+    })
+    expect(removeSpy).toHaveBeenCalledWith({
+      userId: undefined,
+      type: "instagramFacebook",
+    })
+  })
+})

--- a/apps/builder/__tests__/instagram-settings-actions.test.ts
+++ b/apps/builder/__tests__/instagram-settings-actions.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { removeSpy, resolveSpy, upsertSpy } = vi.hoisted(() => ({
+  removeSpy: vi.fn(),
+  resolveSpy: vi.fn(),
+  upsertSpy: vi.fn(),
+}))
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, any> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.inputSchema = () => chain
+  chain.action = (handler: unknown) => handler
+  return { authActionClient: chain }
+})
+vi.mock("@chatbotx.io/business", () => ({
+  platformCredentialService: { remove: removeSpy, upsert: upsertSpy },
+}))
+vi.mock("../src/features/platform-credentials/scope", () => ({
+  credentialScopeSchema: {},
+  resolveCredentialScopedUserId: resolveSpy,
+}))
+const { instagramCredentialUpdateSchema } = await import(
+  "@chatbotx.io/database/partials"
+)
+const { deleteInstagramSettingsAction } = await import(
+  "../src/features/platform-credentials/instagram/delete-instagram-settings.action"
+)
+const { updateInstagramSettingAction } = await import(
+  "../src/features/platform-credentials/instagram/update-instagram-settings.action"
+)
+const call = (action: unknown) => action as (args: any) => Promise<unknown>
+describe("Instagram credential actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolveSpy.mockReturnValue("user-1")
+  })
+  test("upserts all fields", async () => {
+    await call(updateInstagramSettingAction)({
+      ctx: { user: { id: "user-1" } },
+      bindArgsParsedInputs: ["user"],
+      parsedInput: {
+        clientId: "id",
+        version: "v1",
+        verifyToken: "verify",
+        clientSecret: "secret",
+      },
+    })
+    expect(upsertSpy).toHaveBeenCalledWith({
+      userId: "user-1",
+      type: "instagram",
+      config: {
+        clientId: "id",
+        version: "v1",
+        verifyToken: "verify",
+        clientSecret: "secret",
+      },
+    })
+  })
+  test.each([
+    "clientId",
+    "version",
+    "verifyToken",
+    "clientSecret",
+  ])("rejects empty %s", (field) => {
+    expect(
+      instagramCredentialUpdateSchema.safeParse({
+        clientId: "id",
+        version: "v1",
+        verifyToken: "verify",
+        clientSecret: "secret",
+        [field]: "",
+      }).success,
+    ).toBe(false)
+  })
+  test("deletes user and platform credentials", async () => {
+    await call(deleteInstagramSettingsAction)({
+      ctx: { user: { id: "u" } },
+      bindArgsParsedInputs: ["user"],
+    })
+    expect(removeSpy).toHaveBeenCalledWith({
+      userId: "user-1",
+      type: "instagram",
+    })
+    resolveSpy.mockReturnValue(undefined)
+    await call(deleteInstagramSettingsAction)({
+      ctx: { user: { id: "a" } },
+      bindArgsParsedInputs: ["platform"],
+    })
+    expect(removeSpy).toHaveBeenCalledWith({
+      userId: undefined,
+      type: "instagram",
+    })
+  })
+})

--- a/apps/builder/__tests__/messenger-settings-actions.test.ts
+++ b/apps/builder/__tests__/messenger-settings-actions.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { removeSpy, resolveSpy, upsertSpy } = vi.hoisted(() => ({
+  removeSpy: vi.fn(),
+  resolveSpy: vi.fn(),
+  upsertSpy: vi.fn(),
+}))
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, any> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.inputSchema = () => chain
+  chain.action = (handler: unknown) => handler
+  return { authActionClient: chain }
+})
+vi.mock("@chatbotx.io/business", () => ({
+  platformCredentialService: { remove: removeSpy, upsert: upsertSpy },
+}))
+vi.mock("../src/features/platform-credentials/scope", () => ({
+  credentialScopeSchema: {},
+  resolveCredentialScopedUserId: resolveSpy,
+}))
+const { messengerCredentialUpdateSchema } = await import(
+  "@chatbotx.io/database/partials"
+)
+const { deleteMessengerSettingsAction } = await import(
+  "../src/features/platform-credentials/messenger/delete-messenger-settings.action"
+)
+const { updateMessengerSettingAction } = await import(
+  "../src/features/platform-credentials/messenger/update-messenger-settings.action"
+)
+const call = (action: unknown) => action as (args: any) => Promise<unknown>
+describe("Messenger credential actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolveSpy.mockReturnValue("user-1")
+  })
+  test("upserts all fields", async () => {
+    await call(updateMessengerSettingAction)({
+      ctx: { user: { id: "user-1" } },
+      bindArgsParsedInputs: ["user"],
+      parsedInput: {
+        clientId: "id",
+        version: "v1",
+        verifyToken: "verify",
+        clientSecret: "secret",
+      },
+    })
+    expect(upsertSpy).toHaveBeenCalledWith({
+      userId: "user-1",
+      type: "messenger",
+      config: {
+        clientId: "id",
+        version: "v1",
+        verifyToken: "verify",
+        clientSecret: "secret",
+      },
+    })
+  })
+  test.each([
+    "clientId",
+    "version",
+    "verifyToken",
+    "clientSecret",
+  ])("rejects empty %s", (field) => {
+    expect(
+      messengerCredentialUpdateSchema.safeParse({
+        clientId: "id",
+        version: "v1",
+        verifyToken: "verify",
+        clientSecret: "secret",
+        [field]: "",
+      }).success,
+    ).toBe(false)
+  })
+  test("deletes user and platform credentials", async () => {
+    await call(deleteMessengerSettingsAction)({
+      ctx: { user: { id: "u" } },
+      bindArgsParsedInputs: ["user"],
+    })
+    expect(removeSpy).toHaveBeenCalledWith({
+      userId: "user-1",
+      type: "messenger",
+    })
+    resolveSpy.mockReturnValue(undefined)
+    await call(deleteMessengerSettingsAction)({
+      ctx: { user: { id: "a" } },
+      bindArgsParsedInputs: ["platform"],
+    })
+    expect(removeSpy).toHaveBeenCalledWith({
+      userId: undefined,
+      type: "messenger",
+    })
+  })
+})

--- a/apps/builder/__tests__/platform-credentials-scope.test.ts
+++ b/apps/builder/__tests__/platform-credentials-scope.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment node
+import type { UserModel } from "@chatbotx.io/database/types"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { isSuperAdminSpy } = vi.hoisted(() => ({
+  isSuperAdminSpy: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  isSuperAdmin: isSuperAdminSpy,
+}))
+vi.mock("@/env", () => ({ isCloud: () => true }))
+
+const { resolveCredentialScopedUserId } = await import(
+  "../src/features/platform-credentials/scope"
+)
+
+const asUser = (id: string) => ({ id }) as UserModel
+
+describe("resolveCredentialScopedUserId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("rejects a non-super-admin requesting platform scope", () => {
+    isSuperAdminSpy.mockReturnValue(false)
+
+    expect(() =>
+      resolveCredentialScopedUserId(asUser("user-1"), "platform"),
+    ).toThrow("Unauthorized")
+  })
+
+  test("resolves platform scope to undefined for a super admin", () => {
+    isSuperAdminSpy.mockReturnValue(true)
+
+    expect(
+      resolveCredentialScopedUserId(asUser("admin-1"), "platform"),
+    ).toBeUndefined()
+  })
+
+  test("resolves user scope to the caller's own id without checking super-admin status", () => {
+    isSuperAdminSpy.mockReturnValue(false)
+
+    expect(resolveCredentialScopedUserId(asUser("user-1"), "user")).toBe(
+      "user-1",
+    )
+    expect(isSuperAdminSpy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/builder/__tests__/stripe-settings-actions.test.ts
+++ b/apps/builder/__tests__/stripe-settings-actions.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+import { describe, expect, test, vi } from "vitest"
+
+const { removeSpy, upsertSpy } = vi.hoisted(() => ({
+  removeSpy: vi.fn(),
+  upsertSpy: vi.fn(),
+}))
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, any> = {}
+  chain.inputSchema = () => chain
+  chain.action = (handler: unknown) => handler
+  return { authActionClient: chain }
+})
+vi.mock("@chatbotx.io/business", () => ({
+  platformCredentialService: { remove: removeSpy, upsert: upsertSpy },
+}))
+vi.mock("@/env", () => ({ isCloud: () => true }))
+const { stripeCredentialUpdateSchema } = await import(
+  "@chatbotx.io/database/partials"
+)
+const { deleteStripeSettingsAction } = await import(
+  "../src/features/platform-credentials/stripe/delete-stripe-settings.action"
+)
+const { updateStripeSettingsAction } = await import(
+  "../src/features/platform-credentials/stripe/update-stripe-settings.action"
+)
+const call = (action: unknown) => action as (args: any) => Promise<unknown>
+describe("Stripe credential actions", () => {
+  test("upserts all fields", async () => {
+    await call(updateStripeSettingsAction)({
+      ctx: { user: { id: "user-1" } },
+      parsedInput: {
+        publishableKey: "publishable",
+        verifyToken: "verify",
+        secretKey: "secret",
+      },
+    })
+    expect(upsertSpy).toHaveBeenCalledWith({
+      userId: "user-1",
+      type: "stripe",
+      config: {
+        publishableKey: "publishable",
+        verifyToken: "verify",
+        secretKey: "secret",
+      },
+    })
+  })
+  test.each([
+    "publishableKey",
+    "verifyToken",
+    "secretKey",
+  ])("rejects empty %s", (field) => {
+    expect(
+      stripeCredentialUpdateSchema.safeParse({
+        publishableKey: "publishable",
+        verifyToken: "verify",
+        secretKey: "secret",
+        [field]: "",
+      }).success,
+    ).toBe(false)
+  })
+  test("deletes the cloud credential", async () => {
+    await call(deleteStripeSettingsAction)({ ctx: { user: { id: "user-1" } } })
+    expect(removeSpy).toHaveBeenCalledWith({ userId: "user-1", type: "stripe" })
+  })
+})

--- a/apps/builder/__tests__/tiktok-settings-actions.test.ts
+++ b/apps/builder/__tests__/tiktok-settings-actions.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { removeSpy, resolveSpy, subscribeSpy, upsertSpy } = vi.hoisted(() => ({
+  removeSpy: vi.fn(),
+  resolveSpy: vi.fn(),
+  subscribeSpy: vi.fn(),
+  upsertSpy: vi.fn(),
+}))
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, any> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.inputSchema = () => chain
+  chain.action = (handler: unknown) => handler
+  return { authActionClient: chain }
+})
+vi.mock("@chatbotx.io/business", () => ({
+  platformCredentialService: { remove: removeSpy, upsert: upsertSpy },
+}))
+vi.mock("@chatbotx.io/integration-tiktok", () => ({
+  subscribeWebhook: subscribeSpy,
+}))
+vi.mock("@/env", () => ({ isCloud: () => true }))
+vi.mock("@/lib/oauth-broker", () => ({
+  buildBrokerCallbackUrl: (path: string) => path,
+}))
+vi.mock("../src/features/platform-credentials/scope", () => ({
+  credentialScopeSchema: {},
+  resolveCredentialScopedUserId: resolveSpy,
+}))
+const { tiktokCredentialUpdateSchema } = await import(
+  "@chatbotx.io/database/partials"
+)
+const { deleteTiktokSettingsAction } = await import(
+  "../src/features/platform-credentials/tiktok/delete-tiktok-settings.action"
+)
+const { updateTiktokSettingAction } = await import(
+  "../src/features/platform-credentials/tiktok/update-tiktok-settings.action"
+)
+const call = (action: unknown) => action as (args: any) => Promise<unknown>
+describe("TikTok credential actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolveSpy.mockReturnValue("user-1")
+  })
+  test("upserts all fields and subscribes webhook", async () => {
+    await call(updateTiktokSettingAction)({
+      ctx: { user: { id: "user-1" } },
+      bindArgsParsedInputs: ["user"],
+      parsedInput: { clientId: "id", clientSecret: "secret" },
+    })
+    expect(upsertSpy).toHaveBeenCalledWith({
+      userId: "user-1",
+      type: "tiktok",
+      config: { clientId: "id", clientSecret: "secret" },
+    })
+    expect(subscribeSpy).toHaveBeenCalled()
+  })
+  test.each(["clientId", "clientSecret"])("rejects empty %s", (field) => {
+    expect(
+      tiktokCredentialUpdateSchema.safeParse({
+        clientId: "id",
+        clientSecret: "secret",
+        [field]: "",
+      }).success,
+    ).toBe(false)
+  })
+  test("deletes user and platform credentials", async () => {
+    await call(deleteTiktokSettingsAction)({
+      ctx: { user: { id: "u" } },
+      bindArgsParsedInputs: ["user"],
+    })
+    expect(removeSpy).toHaveBeenCalledWith({ userId: "user-1", type: "tiktok" })
+    resolveSpy.mockReturnValue(undefined)
+    await call(deleteTiktokSettingsAction)({
+      ctx: { user: { id: "a" } },
+      bindArgsParsedInputs: ["platform"],
+    })
+    expect(removeSpy).toHaveBeenCalledWith({
+      userId: undefined,
+      type: "tiktok",
+    })
+  })
+})

--- a/apps/builder/__tests__/whatsapp-settings-actions.test.ts
+++ b/apps/builder/__tests__/whatsapp-settings-actions.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { removeSpy, resolveSpy, upsertSpy } = vi.hoisted(() => ({
+  removeSpy: vi.fn(),
+  resolveSpy: vi.fn(),
+  upsertSpy: vi.fn(),
+}))
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, any> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.inputSchema = () => chain
+  chain.action = (handler: unknown) => handler
+  return { authActionClient: chain }
+})
+vi.mock("@chatbotx.io/business", () => ({
+  platformCredentialService: { remove: removeSpy, upsert: upsertSpy },
+}))
+vi.mock("../src/features/platform-credentials/scope", () => ({
+  credentialScopeSchema: {},
+  resolveCredentialScopedUserId: resolveSpy,
+}))
+const { whatsappCredentialUpdateSchema } = await import(
+  "@chatbotx.io/database/partials"
+)
+const { deleteWhatsappSettingsAction } = await import(
+  "../src/features/platform-credentials/whatsapp/delete-whatsapp-settings.action"
+)
+const { updateWhatsappSettingsAction } = await import(
+  "../src/features/platform-credentials/whatsapp/update-whatsapp-settings.action"
+)
+const call = (action: unknown) => action as (args: any) => Promise<unknown>
+const valid = {
+  clientId: "id",
+  version: "v1",
+  configId: "config",
+  systemUserId: "system",
+  businessName: "business",
+  verifyToken: "verify",
+  clientSecret: "secret",
+  systemUserToken: "token",
+  businessId: "",
+}
+describe("WhatsApp credential actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolveSpy.mockReturnValue("user-1")
+  })
+  test("upserts all fields", async () => {
+    await call(updateWhatsappSettingsAction)({
+      ctx: { user: { id: "user-1" } },
+      bindArgsParsedInputs: ["user"],
+      parsedInput: valid,
+    })
+    expect(upsertSpy).toHaveBeenCalledWith({
+      userId: "user-1",
+      type: "whatsapp",
+      config: valid,
+    })
+  })
+  test.each([
+    "clientId",
+    "version",
+    "configId",
+    "systemUserId",
+    "businessName",
+    "verifyToken",
+    "clientSecret",
+    "systemUserToken",
+  ])("rejects empty %s", (field) => {
+    expect(
+      whatsappCredentialUpdateSchema.safeParse({ ...valid, [field]: "" })
+        .success,
+    ).toBe(false)
+  })
+  test("deletes user and platform credentials", async () => {
+    await call(deleteWhatsappSettingsAction)({
+      ctx: { user: { id: "u" } },
+      bindArgsParsedInputs: ["user"],
+    })
+    expect(removeSpy).toHaveBeenCalledWith({
+      userId: "user-1",
+      type: "whatsapp",
+    })
+    resolveSpy.mockReturnValue(undefined)
+    await call(deleteWhatsappSettingsAction)({
+      ctx: { user: { id: "a" } },
+      bindArgsParsedInputs: ["platform"],
+    })
+    expect(removeSpy).toHaveBeenCalledWith({
+      userId: undefined,
+      type: "whatsapp",
+    })
+  })
+})

--- a/apps/builder/__tests__/zalo-settings-actions.test.ts
+++ b/apps/builder/__tests__/zalo-settings-actions.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { removeSpy, resolveSpy, upsertSpy } = vi.hoisted(() => ({
+  removeSpy: vi.fn(),
+  resolveSpy: vi.fn(),
+  upsertSpy: vi.fn(),
+}))
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, any> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.inputSchema = () => chain
+  chain.action = (handler: unknown) => handler
+  return { authActionClient: chain }
+})
+vi.mock("@chatbotx.io/business", () => ({
+  platformCredentialService: { remove: removeSpy, upsert: upsertSpy },
+}))
+vi.mock("../src/features/platform-credentials/scope", () => ({
+  credentialScopeSchema: {},
+  resolveCredentialScopedUserId: resolveSpy,
+}))
+const { zaloCredentialUpdateSchema } = await import(
+  "@chatbotx.io/database/partials"
+)
+const { deleteZaloSettingsAction } = await import(
+  "../src/features/platform-credentials/zalo/delete-zalo-settings.action"
+)
+const { updateZaloSettingsAction } = await import(
+  "../src/features/platform-credentials/zalo/update-zalo-settings.action"
+)
+const call = (action: unknown) => action as (args: any) => Promise<unknown>
+describe("Zalo credential actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolveSpy.mockReturnValue("user-1")
+  })
+  test("upserts all fields", async () => {
+    await call(updateZaloSettingsAction)({
+      ctx: { user: { id: "user-1" } },
+      bindArgsParsedInputs: ["user"],
+      parsedInput: {
+        clientId: "id",
+        version: "v1",
+        verifyToken: "verify",
+        clientSecret: "secret",
+      },
+    })
+    expect(upsertSpy).toHaveBeenCalledWith({
+      userId: "user-1",
+      type: "zalo",
+      config: {
+        clientId: "id",
+        version: "v1",
+        verifyToken: "verify",
+        clientSecret: "secret",
+      },
+    })
+  })
+  test.each([
+    "clientId",
+    "version",
+    "verifyToken",
+    "clientSecret",
+  ])("rejects empty %s", (field) => {
+    expect(
+      zaloCredentialUpdateSchema.safeParse({
+        clientId: "id",
+        version: "v1",
+        verifyToken: "verify",
+        clientSecret: "secret",
+        [field]: "",
+      }).success,
+    ).toBe(false)
+  })
+  test("deletes user and platform credentials", async () => {
+    await call(deleteZaloSettingsAction)({
+      ctx: { user: { id: "u" } },
+      bindArgsParsedInputs: ["user"],
+    })
+    expect(removeSpy).toHaveBeenCalledWith({ userId: "user-1", type: "zalo" })
+    resolveSpy.mockReturnValue(undefined)
+    await call(deleteZaloSettingsAction)({
+      ctx: { user: { id: "a" } },
+      bindArgsParsedInputs: ["platform"],
+    })
+    expect(removeSpy).toHaveBeenCalledWith({ userId: undefined, type: "zalo" })
+  })
+})

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -2492,15 +2492,7 @@
     "title": "Platform Settings",
     "errors": {
       "giphyApiKeyRequired": "API Key is required to configure GIPHY.",
-      "giphyApiKeyInvalid": "Invalid GIPHY API key",
-      "googleClientSecretRequired": "Client Secret is required to configure Google.",
-      "googleVerifyTokenRequired": "Verify Token is required to configure Google.",
-      "messengerAppSecretRequired": "App Secret is required to configure Messenger.",
-      "zaloAppSecretRequired": "App Secret is required to configure Zalo.",
-      "stripeSecretKeyRequired": "Secret Key is required to configure Stripe.",
-      "whatsappAppSecretRequired": "App Secret is required to configure WhatsApp.",
-      "whatsappSystemUserTokenRequired": "System User Token is required to configure WhatsApp.",
-      "tiktokAppSecretRequired": "App Secret is required to configure TikTok."
+      "giphyApiKeyInvalid": "Invalid GIPHY API key"
     }
   },
   "home": {

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -2507,15 +2507,7 @@
     "title": "Cài đặt Nền tảng",
     "errors": {
       "giphyApiKeyRequired": "API Key là bắt buộc để cấu hình GIPHY.",
-      "giphyApiKeyInvalid": "API key GIPHY không hợp lệ",
-      "googleClientSecretRequired": "Client Secret là bắt buộc để cấu hình Google.",
-      "googleVerifyTokenRequired": "Verify Token là bắt buộc để cấu hình Google.",
-      "messengerAppSecretRequired": "App Secret là bắt buộc để cấu hình Messenger.",
-      "zaloAppSecretRequired": "App Secret là bắt buộc để cấu hình Zalo.",
-      "stripeSecretKeyRequired": "Secret Key là bắt buộc để cấu hình Stripe.",
-      "whatsappAppSecretRequired": "App Secret là bắt buộc để cấu hình WhatsApp.",
-      "whatsappSystemUserTokenRequired": "System User Token là bắt buộc để cấu hình WhatsApp.",
-      "tiktokAppSecretRequired": "App Secret là bắt buộc để cấu hình TikTok."
+      "giphyApiKeyInvalid": "API key GIPHY không hợp lệ"
     }
   },
   "home": {

--- a/apps/builder/src/features/platform-credentials/delete-credential-dialog.tsx
+++ b/apps/builder/src/features/platform-credentials/delete-credential-dialog.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@chatbotx.io/ui/components/ui/alert-dialog"
+import { Button } from "@chatbotx.io/ui/components/ui/button"
+import { Loader2Icon } from "lucide-react"
+import { useTranslations } from "next-intl"
+import { useEffect, useRef, useState } from "react"
+
+type DeleteCredentialDialogProps = {
+  feature: string
+  isDeleting: boolean
+  disabled?: boolean
+  onConfirm: () => void
+}
+
+export function DeleteCredentialDialog({
+  feature,
+  isDeleting,
+  disabled,
+  onConfirm,
+}: DeleteCredentialDialogProps) {
+  const t = useTranslations()
+  const [open, setOpen] = useState(false)
+  const wasDeleting = useRef(false)
+
+  useEffect(() => {
+    if (wasDeleting.current && !isDeleting) {
+      setOpen(false)
+    }
+    wasDeleting.current = isDeleting
+  }, [isDeleting])
+
+  return (
+    <AlertDialog onOpenChange={setOpen} open={open}>
+      <AlertDialogTrigger asChild>
+        <Button
+          disabled={isDeleting || disabled}
+          type="button"
+          variant="destructive"
+        >
+          {t("actions.delete")}
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {t("messages.deleteFeature", { feature })}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("messages.deleteConfirmation", { feature })}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>
+            {t("actions.cancel")}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            disabled={isDeleting}
+            onClick={(event) => {
+              event.preventDefault()
+              onConfirm()
+            }}
+          >
+            {isDeleting && <Loader2Icon className="mr-2 size-4 animate-spin" />}
+            {t("actions.confirm")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps/builder/src/features/platform-credentials/giphy/delete-giphy-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/giphy/delete-giphy-settings.action.ts
@@ -1,0 +1,15 @@
+"use server"
+
+import { platformCredentialService } from "@chatbotx.io/business"
+
+import { authActionClient } from "@/lib/safe-action"
+import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
+
+export const deleteGiphySettingsAction = authActionClient
+  .bindArgsSchemas([credentialScopeSchema])
+  .action(async ({ ctx, bindArgsParsedInputs: [scope] }) => {
+    await platformCredentialService.remove({
+      userId: resolveCredentialScopedUserId(ctx.user, scope),
+      type: "giphy",
+    })
+  })

--- a/apps/builder/src/features/platform-credentials/giphy/giphy-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/giphy/giphy-settings.tsx
@@ -25,10 +25,13 @@ import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hoo
 import { Loader2Icon } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
+import { useAction } from "next-safe-action/hooks"
 import { useState } from "react"
 import { toast } from "sonner"
 import { CredentialFallbackNote } from "../credential-fallback-note"
+import { DeleteCredentialDialog } from "../delete-credential-dialog"
 import { useCredentialScope } from "../provider/credential-scope-context"
+import { deleteGiphySettingsAction } from "./delete-giphy-settings.action"
 import { updateGiphySettingsAction } from "./update-giphy-settings.action"
 
 export function GiphySettings({
@@ -110,6 +113,17 @@ export function EditGiphySettingsForm({
 }) {
   const t = useTranslations()
   const scope = useCredentialScope()
+  const { execute: executeDelete, isPending: isDeleting } = useAction(
+    deleteGiphySettingsAction.bind(null, scope),
+    {
+      onSuccess: () => {
+        toast.success(t("messages.deletedSuccess", { feature: "GIPHY" }))
+        onClose?.()
+      },
+      onError: ({ error }) =>
+        error.serverError && toast.error(error.serverError),
+    },
+  )
 
   const { form, handleSubmitWithAction, resetFormAndAction } =
     useHookFormAction(
@@ -148,26 +162,40 @@ export function EditGiphySettingsForm({
           type="password"
         />
 
-        <div className="flex justify-end gap-2">
-          <Button
-            onClick={() => {
-              resetFormAndAction()
-              onClose?.()
-            }}
-            type="button"
-            variant="outline"
-          >
-            {t("actions.cancel")}
-          </Button>
-          <Button
-            disabled={!form.formState.isValid || form.formState.isSubmitting}
-            type="submit"
-          >
-            {form.formState.isSubmitting && (
-              <Loader2Icon className="size-4 animate-spin" />
-            )}
-            {t("actions.save")}
-          </Button>
+        <div className="flex items-center justify-between gap-2">
+          {isConfigured && (
+            <DeleteCredentialDialog
+              disabled={form.formState.isSubmitting}
+              feature="GIPHY"
+              isDeleting={isDeleting}
+              onConfirm={() => executeDelete()}
+            />
+          )}
+          <div className="ml-auto flex gap-2">
+            <Button
+              onClick={() => {
+                resetFormAndAction()
+                onClose?.()
+              }}
+              type="button"
+              variant="outline"
+            >
+              {t("actions.cancel")}
+            </Button>
+            <Button
+              disabled={
+                !form.formState.isValid ||
+                form.formState.isSubmitting ||
+                isDeleting
+              }
+              type="submit"
+            >
+              {form.formState.isSubmitting && (
+                <Loader2Icon className="size-4 animate-spin" />
+              )}
+              {t("actions.save")}
+            </Button>
+          </div>
         </div>
       </form>
     </Form>

--- a/apps/builder/src/features/platform-credentials/google/delete-google-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/google/delete-google-settings.action.ts
@@ -1,0 +1,16 @@
+"use server"
+
+import { platformCredentialService } from "@chatbotx.io/business"
+
+import { authActionClient } from "@/lib/safe-action"
+import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
+
+export const deleteGoogleSettingsAction = authActionClient
+  .bindArgsSchemas([credentialScopeSchema])
+  .action(async ({ ctx, bindArgsParsedInputs: [scope] }) => {
+    const scopedUserId = resolveCredentialScopedUserId(ctx.user, scope)
+    await platformCredentialService.remove({
+      userId: scopedUserId,
+      type: "google",
+    })
+  })

--- a/apps/builder/src/features/platform-credentials/google/google-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/google/google-settings.tsx
@@ -27,12 +27,15 @@ import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hoo
 import { CopyIcon, Loader2Icon } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
+import { useAction } from "next-safe-action/hooks"
 import { useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
 import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { CredentialFallbackNote } from "../credential-fallback-note"
+import { DeleteCredentialDialog } from "../delete-credential-dialog"
 import { useCredentialScope } from "../provider/credential-scope-context"
+import { deleteGoogleSettingsAction } from "./delete-google-settings.action"
 import { updateGoogleSettingsAction } from "./update-google-settings.action"
 
 export function GoogleSettings({
@@ -171,6 +174,20 @@ export function GoogleEditSettingsForm({
 }) {
   const t = useTranslations()
   const scope = useCredentialScope()
+  const { execute: executeDelete, isPending: isDeleting } = useAction(
+    deleteGoogleSettingsAction.bind(null, scope),
+    {
+      onSuccess: () => {
+        toast.success(t("messages.deletedSuccess", { feature: "Google" }))
+        onClose?.()
+      },
+      onError: ({ error }) => {
+        if (error.serverError) {
+          toast.error(error.serverError)
+        }
+      },
+    },
+  )
 
   const { form, handleSubmitWithAction, resetFormAndAction } =
     useHookFormAction(
@@ -198,11 +215,6 @@ export function GoogleEditSettingsForm({
       },
     )
 
-  const isConfigured = publicConfig !== null
-  const keepCurrentHint = isConfigured
-    ? t("messages.leaveEmptyToKeepSecret")
-    : undefined
-
   return (
     <Form {...form}>
       <form className="flex flex-col gap-4" onSubmit={handleSubmitWithAction}>
@@ -213,40 +225,52 @@ export function GoogleEditSettingsForm({
         />
 
         <InputField
-          description={keepCurrentHint}
           label={t("fields.clientSecret.label")}
           name="clientSecret"
-          required={!isConfigured}
+          required
           type="password"
         />
 
         <InputField
-          description={keepCurrentHint}
           label={t("fields.verifyToken.label")}
           name="verifyToken"
-          required={!isConfigured}
+          required
         />
 
-        <div className="flex justify-end gap-2">
-          <Button
-            onClick={() => {
-              resetFormAndAction()
-              onClose?.()
-            }}
-            type="button"
-            variant="outline"
-          >
-            {t("actions.cancel")}
-          </Button>
-          <Button
-            disabled={!form.formState.isValid || form.formState.isSubmitting}
-            type="submit"
-          >
-            {form.formState.isSubmitting && (
-              <Loader2Icon className="size-4 animate-spin" />
-            )}
-            {t("actions.save")}
-          </Button>
+        <div className="flex items-center justify-between gap-2">
+          {publicConfig !== null && (
+            <DeleteCredentialDialog
+              disabled={form.formState.isSubmitting}
+              feature="Google"
+              isDeleting={isDeleting}
+              onConfirm={() => executeDelete()}
+            />
+          )}
+          <div className="ml-auto flex gap-2">
+            <Button
+              onClick={() => {
+                resetFormAndAction()
+                onClose?.()
+              }}
+              type="button"
+              variant="outline"
+            >
+              {t("actions.cancel")}
+            </Button>
+            <Button
+              disabled={
+                !form.formState.isValid ||
+                form.formState.isSubmitting ||
+                isDeleting
+              }
+              type="submit"
+            >
+              {form.formState.isSubmitting && (
+                <Loader2Icon className="size-4 animate-spin" />
+              )}
+              {t("actions.save")}
+            </Button>
+          </div>
         </div>
       </form>
     </Form>

--- a/apps/builder/src/features/platform-credentials/google/update-google-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/google/update-google-settings.action.ts
@@ -5,7 +5,6 @@ import {
   type GoogleCredential,
   googleCredentialUpdateSchema,
 } from "@chatbotx.io/database/partials"
-import { getTranslations } from "next-intl/server"
 
 import { authActionClient } from "@/lib/safe-action"
 import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
@@ -15,28 +14,10 @@ export const updateGoogleSettingsAction = authActionClient
   .inputSchema(googleCredentialUpdateSchema)
   .action(async ({ ctx, bindArgsParsedInputs: [scope], parsedInput }) => {
     const scopedUserId = resolveCredentialScopedUserId(ctx.user, scope)
-    const existing = await platformCredentialService.findDecrypted({
-      userId: scopedUserId,
-      type: "google",
-    })
-
-    const t = await getTranslations()
-
-    const clientSecret =
-      parsedInput.clientSecret || existing?.config.clientSecret
-    if (!clientSecret) {
-      throw new Error(t("platformSettings.errors.googleClientSecretRequired"))
-    }
-
-    const verifyToken = parsedInput.verifyToken || existing?.config.verifyToken
-    if (!verifyToken) {
-      throw new Error(t("platformSettings.errors.googleVerifyTokenRequired"))
-    }
-
     const config: GoogleCredential = {
       clientId: parsedInput.clientId,
-      clientSecret,
-      verifyToken,
+      clientSecret: parsedInput.clientSecret,
+      verifyToken: parsedInput.verifyToken,
     }
 
     await platformCredentialService.upsert({

--- a/apps/builder/src/features/platform-credentials/instagram-facebook/delete-instagram-facebook-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/instagram-facebook/delete-instagram-facebook-settings.action.ts
@@ -1,0 +1,15 @@
+"use server"
+
+import { platformCredentialService } from "@chatbotx.io/business"
+
+import { authActionClient } from "@/lib/safe-action"
+import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
+
+export const deleteInstagramFacebookSettingsAction = authActionClient
+  .bindArgsSchemas([credentialScopeSchema])
+  .action(async ({ ctx, bindArgsParsedInputs: [scope] }) => {
+    await platformCredentialService.remove({
+      userId: resolveCredentialScopedUserId(ctx.user, scope),
+      type: "instagramFacebook",
+    })
+  })

--- a/apps/builder/src/features/platform-credentials/instagram-facebook/instagram-facebook-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/instagram-facebook/instagram-facebook-settings.tsx
@@ -33,8 +33,10 @@ import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
 import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { CredentialFallbackNote } from "../credential-fallback-note"
+import { DeleteCredentialDialog } from "../delete-credential-dialog"
 import { useCredentialScope } from "../provider/credential-scope-context"
 import { cloneFromMessengerAction } from "./clone-from-messenger.action"
+import { deleteInstagramFacebookSettingsAction } from "./delete-instagram-facebook-settings.action"
 import { updateInstagramFacebookSettingAction } from "./update-instagram-facebook-settings.action"
 
 export function InstagramFacebookSettings({
@@ -228,7 +230,19 @@ export function EditInstagramFacebookSettingsForm({
     },
   )
 
-  const isConfigured = publicConfig !== null
+  const { execute: executeDelete, isPending: isDeleting } = useAction(
+    deleteInstagramFacebookSettingsAction.bind(null, scope),
+    {
+      onSuccess: () => {
+        toast.success(
+          t("messages.deletedSuccess", { feature: "Instagram via Facebook" }),
+        )
+        onClose?.()
+      },
+      onError: ({ error }) =>
+        error.serverError && toast.error(error.serverError),
+    },
+  )
 
   return (
     <Form {...form}>
@@ -236,12 +250,9 @@ export function EditInstagramFacebookSettingsForm({
         <InputField label={t("fields.appId.label")} name="clientId" required />
 
         <InputField
-          description={
-            isConfigured ? t("messages.leaveEmptyToKeepSecret") : undefined
-          }
           label={t("fields.appSecret.label")}
           name="clientSecret"
-          required={!isConfigured}
+          required
           type="password"
         />
 
@@ -268,7 +279,15 @@ export function EditInstagramFacebookSettingsForm({
             {t("fields.instagram.cloneFromMessenger")}
           </Button>
 
-          <div className="flex gap-2">
+          <div className="ml-auto flex gap-2">
+            {publicConfig !== null && (
+              <DeleteCredentialDialog
+                disabled={form.formState.isSubmitting}
+                feature="Instagram via Facebook"
+                isDeleting={isDeleting}
+                onConfirm={() => executeDelete()}
+              />
+            )}
             <Button
               onClick={() => {
                 resetFormAndAction()
@@ -280,7 +299,11 @@ export function EditInstagramFacebookSettingsForm({
               {t("actions.cancel")}
             </Button>
             <Button
-              disabled={!form.formState.isValid || form.formState.isSubmitting}
+              disabled={
+                !form.formState.isValid ||
+                form.formState.isSubmitting ||
+                isDeleting
+              }
               type="submit"
             >
               {form.formState.isSubmitting && (

--- a/apps/builder/src/features/platform-credentials/instagram-facebook/update-instagram-facebook-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/instagram-facebook/update-instagram-facebook-settings.action.ts
@@ -14,24 +14,11 @@ export const updateInstagramFacebookSettingAction = authActionClient
   .inputSchema(instagramFacebookCredentialUpdateSchema)
   .action(async ({ ctx, bindArgsParsedInputs: [scope], parsedInput }) => {
     const scopedUserId = resolveCredentialScopedUserId(ctx.user, scope)
-    const existing = await platformCredentialService.findDecrypted({
-      userId: scopedUserId,
-      type: "instagramFacebook",
-    })
-
-    const clientSecret =
-      parsedInput.clientSecret || existing?.config.clientSecret
-    if (!clientSecret) {
-      throw new Error(
-        "App Secret is required to configure Instagram via Facebook.",
-      )
-    }
-
     const config: InstagramFacebookCredential = {
       clientId: parsedInput.clientId,
       version: parsedInput.version,
       verifyToken: parsedInput.verifyToken,
-      clientSecret,
+      clientSecret: parsedInput.clientSecret,
     }
 
     await platformCredentialService.upsert({

--- a/apps/builder/src/features/platform-credentials/instagram/delete-instagram-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/instagram/delete-instagram-settings.action.ts
@@ -1,0 +1,15 @@
+"use server"
+
+import { platformCredentialService } from "@chatbotx.io/business"
+
+import { authActionClient } from "@/lib/safe-action"
+import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
+
+export const deleteInstagramSettingsAction = authActionClient
+  .bindArgsSchemas([credentialScopeSchema])
+  .action(async ({ ctx, bindArgsParsedInputs: [scope] }) => {
+    await platformCredentialService.remove({
+      userId: resolveCredentialScopedUserId(ctx.user, scope),
+      type: "instagram",
+    })
+  })

--- a/apps/builder/src/features/platform-credentials/instagram/instagram-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/instagram/instagram-settings.tsx
@@ -27,12 +27,15 @@ import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hoo
 import { CopyIcon, Loader2Icon } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
+import { useAction } from "next-safe-action/hooks"
 import { useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
 import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { CredentialFallbackNote } from "../credential-fallback-note"
+import { DeleteCredentialDialog } from "../delete-credential-dialog"
 import { useCredentialScope } from "../provider/credential-scope-context"
+import { deleteInstagramSettingsAction } from "./delete-instagram-settings.action"
 import { updateInstagramSettingAction } from "./update-instagram-settings.action"
 
 export function InstagramSettings({
@@ -207,7 +210,17 @@ export function EditInstagramSettingsForm({
       },
     )
 
-  const isConfigured = publicConfig !== null
+  const { execute: executeDelete, isPending: isDeleting } = useAction(
+    deleteInstagramSettingsAction.bind(null, scope),
+    {
+      onSuccess: () => {
+        toast.success(t("messages.deletedSuccess", { feature: "Instagram" }))
+        onClose?.()
+      },
+      onError: ({ error }) =>
+        error.serverError && toast.error(error.serverError),
+    },
+  )
 
   return (
     <Form {...form}>
@@ -215,12 +228,9 @@ export function EditInstagramSettingsForm({
         <InputField label={t("fields.appId.label")} name="clientId" required />
 
         <InputField
-          description={
-            isConfigured ? t("messages.leaveEmptyToKeepSecret") : undefined
-          }
           label={t("fields.appSecret.label")}
           name="clientSecret"
-          required={!isConfigured}
+          required
           type="password"
         />
 
@@ -236,26 +246,40 @@ export function EditInstagramSettingsForm({
           required
         />
 
-        <div className="flex justify-end gap-2">
-          <Button
-            onClick={() => {
-              resetFormAndAction()
-              onClose?.()
-            }}
-            type="button"
-            variant="outline"
-          >
-            {t("actions.cancel")}
-          </Button>
-          <Button
-            disabled={!form.formState.isValid || form.formState.isSubmitting}
-            type="submit"
-          >
-            {form.formState.isSubmitting && (
-              <Loader2Icon className="size-4 animate-spin" />
-            )}
-            {t("actions.save")}
-          </Button>
+        <div className="flex items-center justify-between gap-2">
+          {publicConfig !== null && (
+            <DeleteCredentialDialog
+              disabled={form.formState.isSubmitting}
+              feature="Instagram"
+              isDeleting={isDeleting}
+              onConfirm={() => executeDelete()}
+            />
+          )}
+          <div className="ml-auto flex gap-2">
+            <Button
+              onClick={() => {
+                resetFormAndAction()
+                onClose?.()
+              }}
+              type="button"
+              variant="outline"
+            >
+              {t("actions.cancel")}
+            </Button>
+            <Button
+              disabled={
+                !form.formState.isValid ||
+                form.formState.isSubmitting ||
+                isDeleting
+              }
+              type="submit"
+            >
+              {form.formState.isSubmitting && (
+                <Loader2Icon className="size-4 animate-spin" />
+              )}
+              {t("actions.save")}
+            </Button>
+          </div>
         </div>
       </form>
     </Form>

--- a/apps/builder/src/features/platform-credentials/instagram/update-instagram-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/instagram/update-instagram-settings.action.ts
@@ -14,22 +14,11 @@ export const updateInstagramSettingAction = authActionClient
   .inputSchema(instagramCredentialUpdateSchema)
   .action(async ({ ctx, bindArgsParsedInputs: [scope], parsedInput }) => {
     const scopedUserId = resolveCredentialScopedUserId(ctx.user, scope)
-    const existing = await platformCredentialService.findDecrypted({
-      userId: scopedUserId,
-      type: "instagram",
-    })
-
-    const clientSecret =
-      parsedInput.clientSecret || existing?.config.clientSecret
-    if (!clientSecret) {
-      throw new Error("App Secret is required to configure Instagram.")
-    }
-
     const config: InstagramCredential = {
       clientId: parsedInput.clientId,
       version: parsedInput.version,
       verifyToken: parsedInput.verifyToken,
-      clientSecret,
+      clientSecret: parsedInput.clientSecret,
     }
 
     await platformCredentialService.upsert({

--- a/apps/builder/src/features/platform-credentials/messenger/delete-messenger-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/messenger/delete-messenger-settings.action.ts
@@ -1,0 +1,15 @@
+"use server"
+
+import { platformCredentialService } from "@chatbotx.io/business"
+
+import { authActionClient } from "@/lib/safe-action"
+import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
+
+export const deleteMessengerSettingsAction = authActionClient
+  .bindArgsSchemas([credentialScopeSchema])
+  .action(async ({ ctx, bindArgsParsedInputs: [scope] }) => {
+    await platformCredentialService.remove({
+      userId: resolveCredentialScopedUserId(ctx.user, scope),
+      type: "messenger",
+    })
+  })

--- a/apps/builder/src/features/platform-credentials/messenger/messenger-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/messenger/messenger-settings.tsx
@@ -27,12 +27,15 @@ import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hoo
 import { CopyIcon, Loader2Icon } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
+import { useAction } from "next-safe-action/hooks"
 import { useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
 import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { CredentialFallbackNote } from "../credential-fallback-note"
+import { DeleteCredentialDialog } from "../delete-credential-dialog"
 import { useCredentialScope } from "../provider/credential-scope-context"
+import { deleteMessengerSettingsAction } from "./delete-messenger-settings.action"
 import { updateMessengerSettingAction } from "./update-messenger-settings.action"
 
 export function MessengerSettings({
@@ -212,7 +215,17 @@ export function EditMessengerSettingsForm({
       },
     )
 
-  const isConfigured = publicConfig !== null
+  const { execute: executeDelete, isPending: isDeleting } = useAction(
+    deleteMessengerSettingsAction.bind(null, scope),
+    {
+      onSuccess: () => {
+        toast.success(t("messages.deletedSuccess", { feature: "Messenger" }))
+        onClose?.()
+      },
+      onError: ({ error }) =>
+        error.serverError && toast.error(error.serverError),
+    },
+  )
 
   return (
     <Form {...form}>
@@ -220,12 +233,9 @@ export function EditMessengerSettingsForm({
         <InputField label={t("fields.appId.label")} name="clientId" required />
 
         <InputField
-          description={
-            isConfigured ? t("messages.leaveEmptyToKeepSecret") : undefined
-          }
           label={t("fields.appSecret.label")}
           name="clientSecret"
-          required={!isConfigured}
+          required
           type="password"
         />
 
@@ -241,26 +251,40 @@ export function EditMessengerSettingsForm({
           required
         />
 
-        <div className="flex justify-end gap-2">
-          <Button
-            onClick={() => {
-              resetFormAndAction()
-              onClose?.()
-            }}
-            type="button"
-            variant="outline"
-          >
-            {t("actions.cancel")}
-          </Button>
-          <Button
-            disabled={!form.formState.isValid || form.formState.isSubmitting}
-            type="submit"
-          >
-            {form.formState.isSubmitting && (
-              <Loader2Icon className="size-4 animate-spin" />
-            )}
-            {t("actions.save")}
-          </Button>
+        <div className="flex items-center justify-between gap-2">
+          {publicConfig !== null && (
+            <DeleteCredentialDialog
+              disabled={form.formState.isSubmitting}
+              feature="Messenger"
+              isDeleting={isDeleting}
+              onConfirm={() => executeDelete()}
+            />
+          )}
+          <div className="ml-auto flex gap-2">
+            <Button
+              onClick={() => {
+                resetFormAndAction()
+                onClose?.()
+              }}
+              type="button"
+              variant="outline"
+            >
+              {t("actions.cancel")}
+            </Button>
+            <Button
+              disabled={
+                !form.formState.isValid ||
+                form.formState.isSubmitting ||
+                isDeleting
+              }
+              type="submit"
+            >
+              {form.formState.isSubmitting && (
+                <Loader2Icon className="size-4 animate-spin" />
+              )}
+              {t("actions.save")}
+            </Button>
+          </div>
         </div>
       </form>
     </Form>

--- a/apps/builder/src/features/platform-credentials/messenger/update-messenger-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/messenger/update-messenger-settings.action.ts
@@ -5,7 +5,6 @@ import {
   type MessengerCredential,
   messengerCredentialUpdateSchema,
 } from "@chatbotx.io/database/partials"
-import { getTranslations } from "next-intl/server"
 import { authActionClient } from "@/lib/safe-action"
 import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
 
@@ -14,24 +13,11 @@ export const updateMessengerSettingAction = authActionClient
   .inputSchema(messengerCredentialUpdateSchema)
   .action(async ({ ctx, bindArgsParsedInputs: [scope], parsedInput }) => {
     const scopedUserId = resolveCredentialScopedUserId(ctx.user, scope)
-    const existing = await platformCredentialService.findDecrypted({
-      userId: scopedUserId,
-      type: "messenger",
-    })
-
-    const t = await getTranslations()
-
-    const clientSecret =
-      parsedInput.clientSecret || existing?.config.clientSecret
-    if (!clientSecret) {
-      throw new Error(t("platformSettings.errors.messengerAppSecretRequired"))
-    }
-
     const config: MessengerCredential = {
       clientId: parsedInput.clientId,
       version: parsedInput.version,
       verifyToken: parsedInput.verifyToken,
-      clientSecret,
+      clientSecret: parsedInput.clientSecret,
     }
 
     await platformCredentialService.upsert({

--- a/apps/builder/src/features/platform-credentials/stripe/delete-stripe-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/stripe/delete-stripe-settings.action.ts
@@ -1,0 +1,15 @@
+"use server"
+
+import { platformCredentialService } from "@chatbotx.io/business"
+
+import { isCloud } from "@/env"
+import { authActionClient } from "@/lib/safe-action"
+
+export const deleteStripeSettingsAction = authActionClient.action(
+  async ({ ctx }) => {
+    await platformCredentialService.remove({
+      userId: isCloud() ? ctx.user.id : undefined,
+      type: "stripe",
+    })
+  },
+)

--- a/apps/builder/src/features/platform-credentials/stripe/stripe-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/stripe/stripe-settings.tsx
@@ -26,10 +26,13 @@ import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hoo
 import { CopyIcon, Loader2Icon } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
+import { useAction } from "next-safe-action/hooks"
 import { useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
 import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
+import { DeleteCredentialDialog } from "../delete-credential-dialog"
+import { deleteStripeSettingsAction } from "./delete-stripe-settings.action"
 import { updateStripeSettingsAction } from "./update-stripe-settings.action"
 
 export function StripeSettings({
@@ -186,7 +189,17 @@ export function EditStripeSettingsForm({
       },
     )
 
-  const isConfigured = publicConfig !== null
+  const { execute: executeDelete, isPending: isDeleting } = useAction(
+    deleteStripeSettingsAction,
+    {
+      onSuccess: () => {
+        toast.success(t("messages.deletedSuccess", { feature: "Stripe" }))
+        onClose?.()
+      },
+      onError: ({ error }) =>
+        error.serverError && toast.error(error.serverError),
+    },
+  )
 
   return (
     <Form {...form}>
@@ -198,12 +211,9 @@ export function EditStripeSettingsForm({
         />
 
         <InputField
-          description={
-            isConfigured ? t("messages.leaveEmptyToKeepSecret") : undefined
-          }
           label={t("fields.secretKey.label")}
           name="secretKey"
-          required={!isConfigured}
+          required
           type="password"
         />
 
@@ -213,26 +223,40 @@ export function EditStripeSettingsForm({
           required
         />
 
-        <div className="flex justify-end gap-2">
-          <Button
-            onClick={() => {
-              resetFormAndAction()
-              onClose?.()
-            }}
-            type="button"
-            variant="outline"
-          >
-            {t("actions.cancel")}
-          </Button>
-          <Button
-            disabled={!form.formState.isValid || form.formState.isSubmitting}
-            type="submit"
-          >
-            {form.formState.isSubmitting && (
-              <Loader2Icon className="size-4 animate-spin" />
-            )}
-            {t("actions.save")}
-          </Button>
+        <div className="flex items-center justify-between gap-2">
+          {publicConfig !== null && (
+            <DeleteCredentialDialog
+              disabled={form.formState.isSubmitting}
+              feature="Stripe"
+              isDeleting={isDeleting}
+              onConfirm={() => executeDelete()}
+            />
+          )}
+          <div className="ml-auto flex gap-2">
+            <Button
+              onClick={() => {
+                resetFormAndAction()
+                onClose?.()
+              }}
+              type="button"
+              variant="outline"
+            >
+              {t("actions.cancel")}
+            </Button>
+            <Button
+              disabled={
+                !form.formState.isValid ||
+                form.formState.isSubmitting ||
+                isDeleting
+              }
+              type="submit"
+            >
+              {form.formState.isSubmitting && (
+                <Loader2Icon className="size-4 animate-spin" />
+              )}
+              {t("actions.save")}
+            </Button>
+          </div>
         </div>
       </form>
     </Form>

--- a/apps/builder/src/features/platform-credentials/stripe/update-stripe-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/stripe/update-stripe-settings.action.ts
@@ -7,7 +7,6 @@ import {
   stripeCredentialUpdateSchema,
 } from "@chatbotx.io/database/partials"
 import type { UserModel } from "@chatbotx.io/database/types"
-import { getTranslations } from "next-intl/server"
 
 import { isCloud } from "@/env"
 import { authActionClient } from "@/lib/safe-action"
@@ -23,22 +22,10 @@ export const updateStripeSettingsAction = authActionClient
       parsedInput: StripeCredentialUpdate
     }) => {
       const scopedUserId = isCloud() ? ctx.user.id : undefined
-      const existing = await platformCredentialService.findDecrypted({
-        userId: scopedUserId,
-        type: "stripe",
-      })
-
-      const t = await getTranslations()
-
-      const secretKey = parsedInput.secretKey || existing?.config.secretKey
-      if (!secretKey) {
-        throw new Error(t("platformSettings.errors.stripeSecretKeyRequired"))
-      }
-
       const config: StripeCredential = {
         publishableKey: parsedInput.publishableKey,
         verifyToken: parsedInput.verifyToken,
-        secretKey,
+        secretKey: parsedInput.secretKey,
       }
 
       await platformCredentialService.upsert({

--- a/apps/builder/src/features/platform-credentials/tiktok/delete-tiktok-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/tiktok/delete-tiktok-settings.action.ts
@@ -1,0 +1,15 @@
+"use server"
+
+import { platformCredentialService } from "@chatbotx.io/business"
+
+import { authActionClient } from "@/lib/safe-action"
+import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
+
+export const deleteTiktokSettingsAction = authActionClient
+  .bindArgsSchemas([credentialScopeSchema])
+  .action(async ({ ctx, bindArgsParsedInputs: [scope] }) => {
+    await platformCredentialService.remove({
+      userId: resolveCredentialScopedUserId(ctx.user, scope),
+      type: "tiktok",
+    })
+  })

--- a/apps/builder/src/features/platform-credentials/tiktok/tiktok-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/tiktok/tiktok-settings.tsx
@@ -27,12 +27,15 @@ import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hoo
 import { CopyIcon, Loader2Icon } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
+import { useAction } from "next-safe-action/hooks"
 import { useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
 import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { CredentialFallbackNote } from "../credential-fallback-note"
+import { DeleteCredentialDialog } from "../delete-credential-dialog"
 import { useCredentialScope } from "../provider/credential-scope-context"
+import { deleteTiktokSettingsAction } from "./delete-tiktok-settings.action"
 import { updateTiktokSettingAction } from "./update-tiktok-settings.action"
 
 export function TiktokSettings({
@@ -172,7 +175,17 @@ export function EditTiktokSettingsForm({
 }) {
   const t = useTranslations()
   const scope = useCredentialScope()
-  const isConfigured = publicConfig !== null
+  const { execute: executeDelete, isPending: isDeleting } = useAction(
+    deleteTiktokSettingsAction.bind(null, scope),
+    {
+      onSuccess: () => {
+        toast.success(t("messages.deletedSuccess", { feature: "TikTok" }))
+        onClose?.()
+      },
+      onError: ({ error }) =>
+        error.serverError && toast.error(error.serverError),
+    },
+  )
 
   const { form, handleSubmitWithAction, resetFormAndAction } =
     useHookFormAction(
@@ -209,35 +222,46 @@ export function EditTiktokSettingsForm({
         />
 
         <InputField
-          description={
-            isConfigured ? t("messages.leaveEmptyToKeepSecret") : undefined
-          }
           label={t("fields.appSecret.label")}
           name="clientSecret"
-          required={!isConfigured}
+          required
           type="password"
         />
 
-        <div className="flex justify-end gap-2">
-          <Button
-            onClick={() => {
-              resetFormAndAction()
-              onClose?.()
-            }}
-            type="button"
-            variant="outline"
-          >
-            {t("actions.cancel")}
-          </Button>
-          <Button
-            disabled={!form.formState.isValid || form.formState.isSubmitting}
-            type="submit"
-          >
-            {form.formState.isSubmitting && (
-              <Loader2Icon className="size-4 animate-spin" />
-            )}
-            {t("actions.save")}
-          </Button>
+        <div className="flex items-center justify-between gap-2">
+          {publicConfig !== null && (
+            <DeleteCredentialDialog
+              disabled={form.formState.isSubmitting}
+              feature="TikTok"
+              isDeleting={isDeleting}
+              onConfirm={() => executeDelete()}
+            />
+          )}
+          <div className="ml-auto flex gap-2">
+            <Button
+              onClick={() => {
+                resetFormAndAction()
+                onClose?.()
+              }}
+              type="button"
+              variant="outline"
+            >
+              {t("actions.cancel")}
+            </Button>
+            <Button
+              disabled={
+                !form.formState.isValid ||
+                form.formState.isSubmitting ||
+                isDeleting
+              }
+              type="submit"
+            >
+              {form.formState.isSubmitting && (
+                <Loader2Icon className="size-4 animate-spin" />
+              )}
+              {t("actions.save")}
+            </Button>
+          </div>
         </div>
       </form>
     </Form>

--- a/apps/builder/src/features/platform-credentials/tiktok/update-tiktok-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/tiktok/update-tiktok-settings.action.ts
@@ -6,7 +6,6 @@ import {
   tiktokCredentialUpdateSchema,
 } from "@chatbotx.io/database/partials"
 import { subscribeWebhook } from "@chatbotx.io/integration-tiktok"
-import { getTranslations } from "next-intl/server"
 import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { authActionClient } from "@/lib/safe-action"
 import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
@@ -16,26 +15,13 @@ export const updateTiktokSettingAction = authActionClient
   .inputSchema(tiktokCredentialUpdateSchema)
   .action(async ({ ctx, bindArgsParsedInputs: [scope], parsedInput }) => {
     const scopedUserId = resolveCredentialScopedUserId(ctx.user, scope)
-    const existing = await platformCredentialService.findDecrypted({
-      userId: scopedUserId,
-      type: "tiktok",
-    })
-
-    const t = await getTranslations()
-
-    const clientSecret =
-      parsedInput.clientSecret || existing?.config.clientSecret
-    if (!clientSecret) {
-      throw new Error(t("platformSettings.errors.tiktokAppSecretRequired"))
-    }
-
     const config: TiktokCredential = {
       clientId: parsedInput.clientId,
-      clientSecret,
+      clientSecret: parsedInput.clientSecret,
     }
 
     await subscribeWebhook(
-      { clientId: config.clientId, clientSecret },
+      { clientId: config.clientId, clientSecret: config.clientSecret },
       buildBrokerCallbackUrl("/integrations/tiktok/webhook"),
     )
 

--- a/apps/builder/src/features/platform-credentials/whatsapp/delete-whatsapp-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/whatsapp/delete-whatsapp-settings.action.ts
@@ -1,0 +1,15 @@
+"use server"
+
+import { platformCredentialService } from "@chatbotx.io/business"
+
+import { authActionClient } from "@/lib/safe-action"
+import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
+
+export const deleteWhatsappSettingsAction = authActionClient
+  .bindArgsSchemas([credentialScopeSchema])
+  .action(async ({ ctx, bindArgsParsedInputs: [scope] }) => {
+    await platformCredentialService.remove({
+      userId: resolveCredentialScopedUserId(ctx.user, scope),
+      type: "whatsapp",
+    })
+  })

--- a/apps/builder/src/features/platform-credentials/whatsapp/update-whatsapp-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/whatsapp/update-whatsapp-settings.action.ts
@@ -5,8 +5,6 @@ import {
   type WhatsappCredential,
   whatsappCredentialUpdateSchema,
 } from "@chatbotx.io/database/partials"
-import { getTranslations } from "next-intl/server"
-
 import { authActionClient } from "@/lib/safe-action"
 import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
 
@@ -15,27 +13,6 @@ export const updateWhatsappSettingsAction = authActionClient
   .inputSchema(whatsappCredentialUpdateSchema)
   .action(async ({ ctx, bindArgsParsedInputs: [scope], parsedInput }) => {
     const scopedUserId = resolveCredentialScopedUserId(ctx.user, scope)
-    const existing = await platformCredentialService.findDecrypted({
-      userId: scopedUserId,
-      type: "whatsapp",
-    })
-
-    const t = await getTranslations()
-
-    const clientSecret =
-      parsedInput.clientSecret || existing?.config.clientSecret
-    if (!clientSecret) {
-      throw new Error(t("platformSettings.errors.whatsappAppSecretRequired"))
-    }
-
-    const systemUserToken =
-      parsedInput.systemUserToken || existing?.config.systemUserToken
-    if (!systemUserToken) {
-      throw new Error(
-        t("platformSettings.errors.whatsappSystemUserTokenRequired"),
-      )
-    }
-
     const config: WhatsappCredential = {
       clientId: parsedInput.clientId,
       version: parsedInput.version,
@@ -44,8 +21,8 @@ export const updateWhatsappSettingsAction = authActionClient
       businessId: parsedInput.businessId,
       businessName: parsedInput.businessName,
       verifyToken: parsedInput.verifyToken,
-      clientSecret,
-      systemUserToken,
+      clientSecret: parsedInput.clientSecret,
+      systemUserToken: parsedInput.systemUserToken,
     }
 
     await platformCredentialService.upsert({

--- a/apps/builder/src/features/platform-credentials/whatsapp/whatsapp-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/whatsapp/whatsapp-settings.tsx
@@ -27,12 +27,15 @@ import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hoo
 import { CopyIcon, Loader2Icon } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
+import { useAction } from "next-safe-action/hooks"
 import { useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
 import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { CredentialFallbackNote } from "../credential-fallback-note"
+import { DeleteCredentialDialog } from "../delete-credential-dialog"
 import { useCredentialScope } from "../provider/credential-scope-context"
+import { deleteWhatsappSettingsAction } from "./delete-whatsapp-settings.action"
 import { updateWhatsappSettingsAction } from "./update-whatsapp-settings.action"
 
 export function WhatsappSettings({
@@ -243,10 +246,17 @@ export function EditWhatsappSettingsForm({
       },
     )
 
-  const isConfigured = publicConfig !== null
-  const keepCurrentHint = isConfigured
-    ? t("messages.leaveEmptyToKeepSecret")
-    : undefined
+  const { execute: executeDelete, isPending: isDeleting } = useAction(
+    deleteWhatsappSettingsAction.bind(null, scope),
+    {
+      onSuccess: () => {
+        toast.success(t("messages.deletedSuccess", { feature: "WhatsApp" }))
+        onClose?.()
+      },
+      onError: ({ error }) =>
+        error.serverError && toast.error(error.serverError),
+    },
+  )
 
   return (
     <Form {...form}>
@@ -254,10 +264,9 @@ export function EditWhatsappSettingsForm({
         <InputField label={t("fields.appId.label")} name="clientId" required />
 
         <InputField
-          description={keepCurrentHint}
           label={t("fields.appSecret.label")}
           name="clientSecret"
-          required={!isConfigured}
+          required
           type="password"
         />
 
@@ -286,10 +295,9 @@ export function EditWhatsappSettingsForm({
         />
 
         <InputField
-          description={keepCurrentHint}
           label={t("fields.systemUserToken.label")}
           name="systemUserToken"
-          required={!isConfigured}
+          required
           type="password"
         />
 
@@ -301,26 +309,40 @@ export function EditWhatsappSettingsForm({
           required
         />
 
-        <div className="flex justify-end gap-2">
-          <Button
-            onClick={() => {
-              resetFormAndAction()
-              onClose?.()
-            }}
-            type="button"
-            variant="outline"
-          >
-            {t("actions.cancel")}
-          </Button>
-          <Button
-            disabled={!form.formState.isValid || form.formState.isSubmitting}
-            type="submit"
-          >
-            {form.formState.isSubmitting && (
-              <Loader2Icon className="size-4 animate-spin" />
-            )}
-            {t("actions.save")}
-          </Button>
+        <div className="flex items-center justify-between gap-2">
+          {publicConfig !== null && (
+            <DeleteCredentialDialog
+              disabled={form.formState.isSubmitting}
+              feature="WhatsApp"
+              isDeleting={isDeleting}
+              onConfirm={() => executeDelete()}
+            />
+          )}
+          <div className="ml-auto flex gap-2">
+            <Button
+              onClick={() => {
+                resetFormAndAction()
+                onClose?.()
+              }}
+              type="button"
+              variant="outline"
+            >
+              {t("actions.cancel")}
+            </Button>
+            <Button
+              disabled={
+                !form.formState.isValid ||
+                form.formState.isSubmitting ||
+                isDeleting
+              }
+              type="submit"
+            >
+              {form.formState.isSubmitting && (
+                <Loader2Icon className="size-4 animate-spin" />
+              )}
+              {t("actions.save")}
+            </Button>
+          </div>
         </div>
       </form>
     </Form>

--- a/apps/builder/src/features/platform-credentials/zalo/delete-zalo-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/zalo/delete-zalo-settings.action.ts
@@ -1,0 +1,15 @@
+"use server"
+
+import { platformCredentialService } from "@chatbotx.io/business"
+
+import { authActionClient } from "@/lib/safe-action"
+import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
+
+export const deleteZaloSettingsAction = authActionClient
+  .bindArgsSchemas([credentialScopeSchema])
+  .action(async ({ ctx, bindArgsParsedInputs: [scope] }) => {
+    await platformCredentialService.remove({
+      userId: resolveCredentialScopedUserId(ctx.user, scope),
+      type: "zalo",
+    })
+  })

--- a/apps/builder/src/features/platform-credentials/zalo/update-zalo-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/zalo/update-zalo-settings.action.ts
@@ -5,8 +5,6 @@ import {
   type ZaloCredential,
   zaloCredentialUpdateSchema,
 } from "@chatbotx.io/database/partials"
-import { getTranslations } from "next-intl/server"
-
 import { authActionClient } from "@/lib/safe-action"
 import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
 
@@ -15,24 +13,11 @@ export const updateZaloSettingsAction = authActionClient
   .inputSchema(zaloCredentialUpdateSchema)
   .action(async ({ ctx, bindArgsParsedInputs: [scope], parsedInput }) => {
     const scopedUserId = resolveCredentialScopedUserId(ctx.user, scope)
-    const existing = await platformCredentialService.findDecrypted({
-      userId: scopedUserId,
-      type: "zalo",
-    })
-
-    const t = await getTranslations()
-
-    const clientSecret =
-      parsedInput.clientSecret || existing?.config.clientSecret
-    if (!clientSecret) {
-      throw new Error(t("platformSettings.errors.zaloAppSecretRequired"))
-    }
-
     const config: ZaloCredential = {
       clientId: parsedInput.clientId,
       version: parsedInput.version,
       verifyToken: parsedInput.verifyToken,
-      clientSecret,
+      clientSecret: parsedInput.clientSecret,
     }
 
     await platformCredentialService.upsert({

--- a/apps/builder/src/features/platform-credentials/zalo/zalo-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/zalo/zalo-settings.tsx
@@ -27,12 +27,15 @@ import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hoo
 import { CopyIcon, Loader2Icon } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
+import { useAction } from "next-safe-action/hooks"
 import { useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
 import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { CredentialFallbackNote } from "../credential-fallback-note"
+import { DeleteCredentialDialog } from "../delete-credential-dialog"
 import { useCredentialScope } from "../provider/credential-scope-context"
+import { deleteZaloSettingsAction } from "./delete-zalo-settings.action"
 import { updateZaloSettingsAction } from "./update-zalo-settings.action"
 
 export function ZaloSettings({
@@ -210,7 +213,17 @@ export function EditZaloSettingsForm({
       },
     )
 
-  const isConfigured = publicConfig !== null
+  const { execute: executeDelete, isPending: isDeleting } = useAction(
+    deleteZaloSettingsAction.bind(null, scope),
+    {
+      onSuccess: () => {
+        toast.success(t("messages.deletedSuccess", { feature: "Zalo" }))
+        onClose?.()
+      },
+      onError: ({ error }) =>
+        error.serverError && toast.error(error.serverError),
+    },
+  )
 
   return (
     <Form {...form}>
@@ -218,12 +231,9 @@ export function EditZaloSettingsForm({
         <InputField label={t("fields.appId.label")} name="clientId" required />
 
         <InputField
-          description={
-            isConfigured ? t("messages.leaveEmptyToKeepSecret") : undefined
-          }
           label={t("fields.appSecret.label")}
           name="clientSecret"
-          required={!isConfigured}
+          required
           type="password"
         />
 
@@ -239,26 +249,40 @@ export function EditZaloSettingsForm({
           required
         />
 
-        <div className="flex justify-end gap-2">
-          <Button
-            onClick={() => {
-              resetFormAndAction()
-              onClose?.()
-            }}
-            type="button"
-            variant="outline"
-          >
-            {t("actions.cancel")}
-          </Button>
-          <Button
-            disabled={!form.formState.isValid || form.formState.isSubmitting}
-            type="submit"
-          >
-            {form.formState.isSubmitting && (
-              <Loader2Icon className="size-4 animate-spin" />
-            )}
-            {t("actions.save")}
-          </Button>
+        <div className="flex items-center justify-between gap-2">
+          {publicConfig !== null && (
+            <DeleteCredentialDialog
+              disabled={form.formState.isSubmitting}
+              feature="Zalo"
+              isDeleting={isDeleting}
+              onConfirm={() => executeDelete()}
+            />
+          )}
+          <div className="ml-auto flex gap-2">
+            <Button
+              onClick={() => {
+                resetFormAndAction()
+                onClose?.()
+              }}
+              type="button"
+              variant="outline"
+            >
+              {t("actions.cancel")}
+            </Button>
+            <Button
+              disabled={
+                !form.formState.isValid ||
+                form.formState.isSubmitting ||
+                isDeleting
+              }
+              type="submit"
+            >
+              {form.formState.isSubmitting && (
+                <Loader2Icon className="size-4 animate-spin" />
+              )}
+              {t("actions.save")}
+            </Button>
+          </div>
         </div>
       </form>
     </Form>

--- a/packages/business/src/platform-credential/service.ts
+++ b/packages/business/src/platform-credential/service.ts
@@ -260,6 +260,24 @@ class PlatformCredentialService extends BaseService {
     await this.invalidateCacheTags(`cred:p:${type}`)
   }
 
+  async removePlatform(props: {
+    type: CredentialType
+    livemode?: boolean
+    tx?: DatabaseClient
+  }): Promise<void> {
+    const { type, livemode = false, tx = db } = props
+    await tx
+      .delete(platformCredentialModel)
+      .where(
+        and(
+          isNull(platformCredentialModel.userId),
+          eq(platformCredentialModel.type, type),
+          eq(platformCredentialModel.livemode, livemode),
+        ),
+      )
+    await this.invalidateCacheTags(`cred:p:${type}`)
+  }
+
   // ─── Scoped helpers (userId=undefined → platform-scoped) ────────────────────
 
   find<T extends CredentialType>(props: {
@@ -297,6 +315,18 @@ class PlatformCredentialService extends BaseService {
       return this.upsertForUser({ ...props, userId: props.userId })
     }
     return this.upsertPlatform(props)
+  }
+
+  remove(props: {
+    userId: string | undefined
+    type: CredentialType
+    livemode?: boolean
+    tx?: DatabaseClient
+  }): Promise<void> {
+    if (props.userId !== undefined) {
+      return this.removeForUser({ ...props, userId: props.userId })
+    }
+    return this.removePlatform(props)
   }
 
   // ─── Resolver: user → platform fallback ─────────────────────────────────────

--- a/packages/database/__tests__/credential.test.ts
+++ b/packages/database/__tests__/credential.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "vitest"
+import {
+  giphyCredentialUpdateSchema,
+  googleCredentialUpdateSchema,
+  instagramCredentialUpdateSchema,
+  messengerCredentialUpdateSchema,
+  smtpCredentialUpdateSchema,
+  stripeCredentialUpdateSchema,
+  tiktokCredentialUpdateSchema,
+  whatsappCredentialUpdateSchema,
+  zaloCredentialUpdateSchema,
+} from "../src/partials/credential"
+
+describe("credential update schemas", () => {
+  test.each([
+    [
+      "WhatsApp",
+      whatsappCredentialUpdateSchema,
+      {
+        clientId: " client-id ",
+        version: " v25.0 ",
+        configId: " config-id ",
+        systemUserId: " system-user-id ",
+        businessId: " business-id ",
+        businessName: " business name ",
+        verifyToken: " verify-token ",
+        clientSecret: " client-secret ",
+        systemUserToken: " system-user-token ",
+      },
+    ],
+    [
+      "Messenger",
+      messengerCredentialUpdateSchema,
+      {
+        clientId: " client-id ",
+        version: " v25.0 ",
+        verifyToken: " verify-token ",
+        clientSecret: " client-secret ",
+      },
+    ],
+    [
+      "Google",
+      googleCredentialUpdateSchema,
+      {
+        clientId: " client-id ",
+        clientSecret: " client-secret ",
+        verifyToken: " verify-token ",
+      },
+    ],
+    [
+      "Instagram",
+      instagramCredentialUpdateSchema,
+      {
+        clientId: " client-id ",
+        version: " v25.0 ",
+        verifyToken: " verify-token ",
+        clientSecret: " client-secret ",
+      },
+    ],
+    [
+      "Zalo",
+      zaloCredentialUpdateSchema,
+      {
+        clientId: " client-id ",
+        version: " v25.0 ",
+        verifyToken: " verify-token ",
+        clientSecret: " client-secret ",
+      },
+    ],
+    ["GIPHY", giphyCredentialUpdateSchema, { apiKey: " api-key " }],
+    [
+      "Stripe",
+      stripeCredentialUpdateSchema,
+      {
+        publishableKey: " publishable-key ",
+        verifyToken: " verify-token ",
+        secretKey: " secret-key ",
+      },
+    ],
+    [
+      "TikTok",
+      tiktokCredentialUpdateSchema,
+      {
+        clientId: " client-id ",
+        clientSecret: " client-secret ",
+      },
+    ],
+  ])("trims %s credential values", (_name, schema, input) => {
+    const result = schema.parse(input)
+
+    for (const value of Object.values(result)) {
+      if (typeof value === "string") {
+        expect(value).toBe(value.trim())
+      }
+    }
+  })
+
+  test("rejects blank required values", () => {
+    const result = messengerCredentialUpdateSchema.safeParse({
+      clientId: "   ",
+      version: "v25.0",
+      verifyToken: "verify-token",
+      clientSecret: "client-secret",
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  test("preserves optional values while trimming them when provided", () => {
+    const result = whatsappCredentialUpdateSchema.parse({
+      clientId: "client-id",
+      version: "v25.0",
+      configId: "config-id",
+      systemUserId: "system-user-id",
+      businessId: " business-id ",
+      businessName: "business name",
+      verifyToken: "verify-token",
+      clientSecret: "client-secret",
+      systemUserToken: "system-user-token",
+    })
+
+    expect(result.businessId).toBe("business-id")
+  })
+
+  test("keeps SMTP validation for trimmed email and coerced port", () => {
+    const result = smtpCredentialUpdateSchema.parse({
+      host: " smtp.example.com ",
+      port: "2525",
+      username: " username ",
+      password: "",
+      fromEmail: " sender@example.com ",
+      fromName: " Sender ",
+    })
+
+    expect(result).toMatchObject({
+      host: "smtp.example.com",
+      port: 2525,
+      username: "username",
+      fromEmail: "sender@example.com",
+      fromName: "Sender",
+    })
+  })
+})

--- a/packages/database/src/partials/credential.ts
+++ b/packages/database/src/partials/credential.ts
@@ -239,38 +239,38 @@ export type CredentialPublicByType = {
   tiktok: TiktokCredentialPublic
 }
 
-// ─── Update schemas (secrets optional — empty means "keep current") ─────────
+// ─── Update schemas (credential fields required except deliberate optionals) ─
 
 export const whatsappCredentialUpdateSchema = z.object({
-  clientId: z.string().trim(),
-  version: z.string().trim(),
-  configId: z.string().trim(),
-  systemUserId: z.string().trim(),
+  clientId: z.string().trim().min(1),
+  version: z.string().trim().min(1),
+  configId: z.string().trim().min(1),
+  systemUserId: z.string().trim().min(1),
   businessId: z.string().trim().optional(),
-  businessName: z.string().trim(),
-  verifyToken: z.string().trim(),
-  clientSecret: z.string().trim().optional(),
-  systemUserToken: z.string().trim().optional(),
+  businessName: z.string().trim().min(1),
+  verifyToken: z.string().trim().min(1),
+  clientSecret: z.string().trim().min(1),
+  systemUserToken: z.string().trim().min(1),
 })
 export type WhatsappCredentialUpdate = z.infer<
   typeof whatsappCredentialUpdateSchema
 >
 
 export const messengerCredentialUpdateSchema = z.object({
-  clientId: z.string().trim(),
-  version: z.string().trim(),
-  verifyToken: z.string().trim(),
-  clientSecret: z.string().trim().optional(),
+  clientId: z.string().trim().min(1),
+  version: z.string().trim().min(1),
+  verifyToken: z.string().trim().min(1),
+  clientSecret: z.string().trim().min(1),
 })
 export type MessengerCredentialUpdate = z.infer<
   typeof messengerCredentialUpdateSchema
 >
 
 export const instagramCredentialUpdateSchema = z.object({
-  clientId: z.string().trim(),
-  version: z.string().trim(),
-  verifyToken: z.string().trim(),
-  clientSecret: z.string().trim().optional(),
+  clientId: z.string().trim().min(1),
+  version: z.string().trim().min(1),
+  verifyToken: z.string().trim().min(1),
+  clientSecret: z.string().trim().min(1),
 })
 export type InstagramCredentialUpdate = z.infer<
   typeof instagramCredentialUpdateSchema
@@ -281,19 +281,19 @@ export const instagramFacebookCredentialUpdateSchema =
 export type InstagramFacebookCredentialUpdate = InstagramCredentialUpdate
 
 export const googleCredentialUpdateSchema = z.object({
-  clientId: z.string().trim(),
-  clientSecret: z.string().trim().optional(),
-  verifyToken: z.string().trim().optional(),
+  clientId: z.string().trim().min(1),
+  clientSecret: z.string().trim().min(1),
+  verifyToken: z.string().trim().min(1),
 })
 export type GoogleCredentialUpdate = z.infer<
   typeof googleCredentialUpdateSchema
 >
 
 export const zaloCredentialUpdateSchema = z.object({
-  clientId: z.string().trim(),
-  version: z.string().trim(),
-  verifyToken: z.string().trim(),
-  clientSecret: z.string().trim().optional(),
+  clientId: z.string().trim().min(1),
+  version: z.string().trim().min(1),
+  verifyToken: z.string().trim().min(1),
+  clientSecret: z.string().trim().min(1),
 })
 export type ZaloCredentialUpdate = z.infer<typeof zaloCredentialUpdateSchema>
 
@@ -303,9 +303,9 @@ export const giphyCredentialUpdateSchema = z.object({
 export type GiphyCredentialUpdate = z.infer<typeof giphyCredentialUpdateSchema>
 
 export const stripeCredentialUpdateSchema = z.object({
-  publishableKey: z.string().trim(),
-  verifyToken: z.string().trim(),
-  secretKey: z.string().trim().optional(),
+  publishableKey: z.string().trim().min(1),
+  verifyToken: z.string().trim().min(1),
+  secretKey: z.string().trim().min(1),
 })
 export type StripeCredentialUpdate = z.infer<
   typeof stripeCredentialUpdateSchema
@@ -316,14 +316,14 @@ export const smtpCredentialUpdateSchema = z.object({
   port: z.coerce.number().int().positive(),
   username: z.string().trim().min(1),
   password: z.string().trim().optional(),
-  fromEmail: z.string().trim().email(),
+  fromEmail: z.string().trim().min(1).email(),
   fromName: z.string().trim().optional(),
 })
 export type SmtpCredentialUpdate = z.infer<typeof smtpCredentialUpdateSchema>
 
 export const tiktokCredentialUpdateSchema = z.object({
-  clientId: z.string().trim(),
-  clientSecret: z.string().trim().optional(),
+  clientId: z.string().trim().min(1),
+  clientSecret: z.string().trim().min(1),
 })
 export type TiktokCredentialUpdate = z.infer<
   typeof tiktokCredentialUpdateSchema


### PR DESCRIPTION
## Summary
- Add a delete action and shared confirmation dialog for platform credentials across all channels (Google, Messenger, Instagram, Instagram-Facebook, WhatsApp, TikTok, Zalo, Stripe, Giphy)
- Update actions now require the full set of fields from the client instead of merging with existing stored credentials
- Scope credential reads/writes to the owning workspace in `packages/business` and `packages/database`

## Changes
- New `DeleteCredentialDialog` shared component (`apps/builder/src/features/platform-credentials/delete-credential-dialog.tsx`)
- New `delete-*-settings.action.ts` per channel
- Updated `update-*-settings.action.ts` per channel to require full input instead of partial merge
- Workspace-scoping fixes in `packages/business/src/platform-credential/service.ts` and `packages/database/src/partials/credential.ts`
- New unit tests under `apps/builder/__tests__/` and `packages/database/__tests__/credential.test.ts`
- i18n additions in `en.json` / `vi.json`

## Test plan
- [x] pnpm lint (ran via pre-commit hook)
- [x] pnpm check-types (ran via pre-commit hook, all 51 packages passed)
- [ ] manual verification of delete flow per channel in the UI