### PR TITLE
fix(instagram): use real access token for webhook unsubscribe

### DIFF
--- a/apps/worker/src/services/orphaned-integration-cleanup.ts
+++ b/apps/worker/src/services/orphaned-integration-cleanup.ts
@@ -62,7 +62,10 @@ const ORPHAN_CLEANUP_STRATEGIES: Partial<
   [integrationTypes.enum.instagram]: {
     credentialType: integrationTypes.enum.instagram,
     unsubscribe: ({ identifier, appAccessToken }) =>
-      unsubscribePageFromInstagramWebhook({ igId: identifier, appAccessToken }),
+      unsubscribePageFromInstagramWebhook({
+        igId: identifier,
+        accessToken: appAccessToken,
+      }),
   },
 }
 

--- a/integrations/instagram/__tests__/unsubscribe-instagram-webhook.test.ts
+++ b/integrations/instagram/__tests__/unsubscribe-instagram-webhook.test.ts
@@ -4,7 +4,7 @@ import { unsubscribePageFromInstagramWebhook } from "../src/apis/page"
 import { DEFAULT_API_VERSION, INSTAGRAM_API_URL } from "../src/constants"
 
 describe("unsubscribePageFromInstagramWebhook", () => {
-  test("DELETEs the ig subscribed_apps endpoint with the app token in the header", async () => {
+  test("DELETEs the ig subscribed_apps endpoint with the user access token in the header", async () => {
     let captured: Request | null = null
     server.use(
       http.delete(
@@ -18,7 +18,7 @@ describe("unsubscribePageFromInstagramWebhook", () => {
 
     await unsubscribePageFromInstagramWebhook({
       igId: "ig-1",
-      appAccessToken: "client-id|client-secret",
+      accessToken: "ig-user-access-token",
       version: DEFAULT_API_VERSION,
     })
 
@@ -27,7 +27,7 @@ describe("unsubscribePageFromInstagramWebhook", () => {
     expect(url.pathname).toBe(`/${DEFAULT_API_VERSION}/ig-1/subscribed_apps`)
     expect(url.search).toBe("")
     expect((captured as Request).headers.get("authorization")).toBe(
-      "Bearer client-id|client-secret",
+      "Bearer ig-user-access-token",
     )
   })
 
@@ -42,7 +42,7 @@ describe("unsubscribePageFromInstagramWebhook", () => {
     await expect(
       unsubscribePageFromInstagramWebhook({
         igId: "ig-2",
-        appAccessToken: "client-id|client-secret",
+        accessToken: "ig-user-access-token",
         version: DEFAULT_API_VERSION,
       }),
     ).rejects.toThrow()

--- a/integrations/instagram/src/apis/page.ts
+++ b/integrations/instagram/src/apis/page.ts
@@ -100,7 +100,7 @@ export const subscribePageToInstagramWebhook = (props: {
 
 export const unsubscribePageFromInstagramWebhook = (props: {
   igId: string
-  appAccessToken: string
+  accessToken: string
   version?: string
 }): Promise<void> => {
   const { version = DEFAULT_API_VERSION } = props
@@ -111,7 +111,7 @@ export const unsubscribePageFromInstagramWebhook = (props: {
       success?: boolean
     }>(endpoint, {
       headers: {
-        Authorization: `Bearer ${props.appAccessToken}`,
+        Authorization: `Bearer ${props.accessToken}`,
       },
     })
     if (response.success !== true) {

--- a/integrations/instagram/src/integration.ts
+++ b/integrations/instagram/src/integration.ts
@@ -52,7 +52,7 @@ const config: IntegrationDefinition<
   disconnect: async (auth: InstagramAuthValue): Promise<void> => {
     await unsubscribePageFromInstagramWebhook({
       igId: auth.metadata.igId,
-      appAccessToken: `${auth.clientId}|${auth.clientSecret}`,
+      accessToken: auth.tokens.accessToken,
       version: auth.metadata.version,
     })
   },


### PR DESCRIPTION
## Summary
- Instagram Business Login disconnect failed with Facebook error "Access token does not contain a valid app ID" because `unsubscribePageFromInstagramWebhook` sent an app access token (`clientId|clientSecret`) as the Bearer token to `DELETE /{ig-id}/subscribed_apps` on `graph.instagram.com`.
- Per Meta's Instagram Platform docs, that endpoint requires an Instagram User access token or Facebook Page access token, not an app access token — confirmed the fix is correct against the official docs before applying it.
- Updated the disconnect handler to send the real, long-lived access token already stored on the integration (`auth.tokens.accessToken`), matching what's used elsewhere in the same package (subscribe, send message, etc.).
- Also fixed the one other caller (`apps/worker/src/services/orphaned-integration-cleanup.ts`) that broke against the renamed parameter, keeping its existing (pre-existing, unrelated) behavior of passing the platform app access token there since no real user token is available in that orphaned-cleanup context.

## Changes
- `integrations/instagram/src/apis/page.ts` — `unsubscribePageFromInstagramWebhook` now takes `accessToken` instead of `appAccessToken`.
- `integrations/instagram/src/integration.ts` — `disconnect()` passes `auth.tokens.accessToken` instead of `${clientId}|${clientSecret}`.
- `integrations/instagram/__tests__/unsubscribe-instagram-webhook.test.ts` — updated assertions for the renamed parameter/token value.
- `apps/worker/src/services/orphaned-integration-cleanup.ts` — updated to the renamed parameter (no behavior change for this path).

## Test plan
- [x] `pnpm --filter @chatbotx.io/integration-instagram check-types`
- [x] `pnpm --filter builder check-types`
- [x] `pnpm --filter worker check-types`
- [x] `npx turbo check-types` (full repo)
- [x] `integrations/instagram/__tests__/unsubscribe-instagram-webhook.test.ts` (2/2 passing)
- [ ] Manual verification: disconnect an Instagram Business Login integration in a real workspace and confirm no "Access token does not contain a valid app ID" error