### PR TITLE
fix(telegram): redirect duplicate-error to original workspace id

### DIFF
--- a/apps/builder/src/features/integration-telegram/actions/connect.action.ts
+++ b/apps/builder/src/features/integration-telegram/actions/connect.action.ts
@@ -27,16 +27,18 @@ export const connectTelegramAction = authActionClient
   .inputSchema(connectTelegramRequest)
   .action(
     async ({
-      parsedInput: { botToken, workspaceId },
+      parsedInput,
       ctx,
     }: {
       parsedInput: ConnectTelegramRequest
       ctx: { user: UserModel }
     }) => {
       try {
+        let workspaceId = parsedInput.workspaceId
+
         // Validate bot token and fetch bot info from Telegram
         const botData = await integrations.telegram.runAction("connect", {
-          botToken,
+          botToken: parsedInput.botToken,
         })
 
         // Resolve ownerId before the transaction to avoid an extra read inside it
@@ -58,7 +60,7 @@ export const connectTelegramAction = authActionClient
         return await db.transaction(async (tx) => {
           const auth: TelegramAuthValue = {
             authType: "secretText",
-            secretText: botToken,
+            secretText: parsedInput.botToken,
           }
 
           if (!workspaceId) {
@@ -101,7 +103,7 @@ export const connectTelegramAction = authActionClient
             `/integrations/telegram/webhook?botId=${botData.id}`,
           )
           await integrations.telegram.runAction("registerWebhook", {
-            botToken,
+            botToken: parsedInput.botToken,
             webhookUrl,
           })
 
@@ -109,9 +111,9 @@ export const connectTelegramAction = authActionClient
         })
       } catch (error) {
         if (error instanceof ChatbotXException) {
-          if (error.code === "channelDuplicated" && workspaceId) {
+          if (error.code === "channelDuplicated" && parsedInput.workspaceId) {
             redirect(
-              `/space/${workspaceId}/settings/channels?channel=telegram&error=duplicated`,
+              `/space/${parsedInput.workspaceId}/settings/channels?channel=telegram&error=duplicated`,
             )
           }
           throw error


### PR DESCRIPTION
## Summary
- Fixed a 404 when creating a new workspace + connecting Telegram with a bot token that's already used elsewhere: the duplicate-token error rolled back the transaction (including the freshly created `Workspace` row), but the redirect still pointed to that rolled-back workspace id.
- The action now uses `parsedInput.workspaceId` (the original, unmutated request value) instead of the local `workspaceId` variable that gets reassigned inside the transaction — matching the existing pattern already used in the messenger and instagram connect actions.

## Changes
- `apps/builder/src/features/integration-telegram/actions/connect.action.ts`: destructure `parsedInput` as a whole, keep `parsedInput.workspaceId`/`parsedInput.botToken` as the source of truth, and use `parsedInput.workspaceId` in the duplicate-error catch-block redirect.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [ ] Manual: create a new workspace → connect Telegram with a bot token already connected elsewhere → confirm no 404, error toast shown in the dialog
- [ ] Manual: connect Telegram into an existing workspace with a duplicate bot token → confirm redirect to `/space/{id}/settings/channels?channel=telegram&error=duplicated` still works (unchanged behavior)