### PR TITLE
fix(integrations): prevent duplicate workspace creation on oauth resubmit

### DIFF
--- a/apps/builder/src/app/integrations/[...integration]/callback.ts
+++ b/apps/builder/src/app/integrations/[...integration]/callback.ts
@@ -60,6 +60,7 @@ import {
 import { logger } from "@/lib/log"
 import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { resolveRelayTarget, sanitizeReferer } from "@/lib/oauth-referer"
+import { createWorkspaceForNewOauthState } from "@/lib/oauth-workspace"
 
 const stateValidationSchema = z.object({
   workspaceId: zodBigintAsString().optional(),
@@ -193,12 +194,9 @@ export const handleCallback = async (
 
   const workspace = stateParams.workspaceId
     ? await workspaceService.findById({ id: stateParams.workspaceId })
-    : await workspaceService.create({
-        data: {
-          name: "New Workspace",
-          ownerId: userId,
-        },
-        createdBy: userId,
+    : await createWorkspaceForNewOauthState({
+        state: url.searchParams.get("state") ?? "",
+        userId,
       })
 
   if (

--- a/apps/builder/src/components/workspace-switcher.tsx
+++ b/apps/builder/src/components/workspace-switcher.tsx
@@ -91,7 +91,7 @@ export function WorkspaceSwitcher({
                   activeWorkspace?.id === workspace.id &&
                     "bg-sidebar-accent text-sidebar-accent-foreground",
                 )}
-                key={workspace.name}
+                key={workspace.id}
                 onClick={() => setActiveWorkspace(workspace)}
               >
                 <Link href={`/space/${workspace.id}`}>

--- a/apps/builder/src/lib/oauth-workspace.ts
+++ b/apps/builder/src/lib/oauth-workspace.ts
@@ -1,0 +1,76 @@
+import { createHash } from "node:crypto"
+import { workspaceService } from "@chatbotx.io/business"
+import type { WorkspaceModel } from "@chatbotx.io/database/types"
+import { distributedLock, distributedStore } from "@chatbotx.io/redis"
+
+const DEDUPE_TTL_SECONDS = 600
+const LOCK_TIMEOUT_SECONDS = 30
+
+/**
+ * Every OAuth channel callback (Messenger/Instagram/TikTok/Zalo/…) shares one
+ * "create a workspace when the state carries no workspaceId" branch. A slow
+ * provider round-trip plus an impatient re-submit hits that branch twice with
+ * the SAME `state` (it's fixed at authorize time) for the SAME user, and
+ * without this guard each hit would create its own "New Workspace" and
+ * consume a "workspaces" quota unit — only the first hit ever gets a channel
+ * attached, leaving the rest as empty, quota-consuming orphans. Locking +
+ * caching the result by `state` + `userId` makes a repeat hit from the same
+ * user reuse the workspace the first hit already created instead of spinning
+ * up another one.
+ *
+ * `userId` is folded into the key (not just `state`) because `state` alone is
+ * identical for every user starting the same "connect a new workspace" flow
+ * — it carries no nonce or user identity. Keying on `state` alone would let
+ * two unrelated users racing this branch within the TTL window collide onto
+ * the same cached workspace.
+ *
+ * The lock and the cached value use DIFFERENT Redis keys: the lock's own
+ * internal SET/DEL bookkeeping would otherwise land on the exact key the
+ * cached value is stored under, and overwriting that value from inside the
+ * critical section breaks the lock's own release (a compare-and-delete that
+ * no longer matches), leaving the key stuck until its TTL and turning the
+ * next duplicate hit into a ~30s hang followed by a thrown lock error.
+ */
+export async function createWorkspaceForNewOauthState(args: {
+  state: string
+  userId: string
+}): Promise<WorkspaceModel> {
+  const hash = createHash("sha256")
+    .update(`${args.state}:${args.userId}`)
+    .digest("hex")
+  const lockKey = `oauth-create-workspace-lock:${hash}`
+  const cacheKey = `oauth-create-workspace:${hash}`
+
+  return await distributedLock.runExclusive({
+    key: lockKey,
+    timeoutInSeconds: LOCK_TIMEOUT_SECONDS,
+    fn: async () => {
+      const existingWorkspaceId = await distributedStore.get<string>(cacheKey)
+      if (existingWorkspaceId) {
+        const cached = await findCachedWorkspace(existingWorkspaceId)
+        if (cached) {
+          return cached
+        }
+      }
+
+      const created = await workspaceService.create({
+        data: { name: "New Workspace", ownerId: args.userId },
+        createdBy: args.userId,
+      })
+      // TTL only needs to outlive the re-submits of a single OAuth attempt.
+      await distributedStore.put(cacheKey, created.id, DEDUPE_TTL_SECONDS)
+      return created
+    },
+  })
+}
+
+// The cached id can outlive the workspace it points to (deleted in the
+// interim); fall back to creating a fresh one instead of throwing, unlike
+// every other outcome of `workspaceService.findById`.
+async function findCachedWorkspace(id: string): Promise<WorkspaceModel | null> {
+  try {
+    return await workspaceService.findById({ id })
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- The shared OAuth callback (Messenger/Instagram/TikTok/Zalo/...) creates a new workspace whenever `state` carries no `workspaceId`, with no protection against the same OAuth attempt hitting the callback twice (slow provider round-trip + an impatient re-submit). Each hit created its own "New Workspace" and consumed a "workspaces" quota unit — only the first ever got a channel attached, leaving the rest as empty, quota-consuming orphans (visibly for TikTok/Zalo via a "duplicate" error, silently for Messenger/Instagram via pending-auth cookie overwrite).
- Add `createWorkspaceForNewOauthState` (`apps/builder/src/lib/oauth-workspace.ts`): locks and caches the created workspace by a hash of `state` + `userId` for 600s, so a repeat hit from the same user reuses the workspace instead of creating another one. The lock and the cached value use separate Redis keys — sharing one key would let the cache write clobber the lock's own release bookkeeping. Falls back to creating fresh if a cached id points at a workspace deleted in the interim.
- Fix `workspace-switcher.tsx` using `workspace.name` (not `workspace.id`) as a list key — duplicate "New Workspace" names (the default name for every fresh OAuth-created workspace) were triggering React's duplicate-key warning.

## Changes
- `apps/builder/src/app/integrations/[...integration]/callback.ts` — delegate new-workspace creation on the shared OAuth callback to the deduping helper.
- `apps/builder/src/lib/oauth-workspace.ts` (new) — lock + cache the created workspace per `state` + `userId`, with a graceful fallback if the cached workspace was deleted.
- `apps/builder/src/components/workspace-switcher.tsx` — key list items by `workspace.id` instead of `workspace.name`.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [ ] Manual verification: trigger the same "connect new workspace via TikTok" OAuth flow twice in a row (simulating a slow-response resubmit) and confirm only one workspace + one quota unit is created, with the second hit reusing the same workspace.
- [ ] Manual verification: two different user accounts connecting a brand-new workspace around the same time do NOT collide onto the same workspace.