### PR TITLE
fix(database): default sequential migrations to enabled

### DIFF
--- a/packages/database/drizzle/20260716155004_add_follow_up_smart_delay/snapshot.json
+++ b/packages/database/drizzle/20260716155004_add_follow_up_smart_delay/snapshot.json
@@ -2,10 +2,7 @@
   "version": "8",
   "dialect": "postgres",
   "id": "11706f70-db60-4abd-a098-097391ae9a0f",
-  "prevIds": [
-    "2d30b104-461e-408b-a176-086849fa613b",
-    "e6c453c1-649b-49f5-a9a4-32c376171709"
-  ],
+  "prevIds": ["e6c453c1-649b-49f5-a9a4-32c376171709"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],

--- a/packages/database/drizzle/20260717190748_add_contact_inbox_last_user_input/snapshot.json
+++ b/packages/database/drizzle/20260717190748_add_contact_inbox_last_user_input/snapshot.json
@@ -2,7 +2,7 @@
   "version": "8",
   "dialect": "postgres",
   "id": "4a57917d-6045-42b0-a5fb-ba7c153377a5",
-  "prevIds": ["2625e71b-a031-4994-825a-837870278ab9"],
+  "prevIds": ["5cb0a369-a599-4951-826f-57d692621f4b"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],

--- a/packages/database/drizzle/20260719020251_create_questionnaires/snapshot.json
+++ b/packages/database/drizzle/20260719020251_create_questionnaires/snapshot.json
@@ -2,7 +2,7 @@
   "version": "8",
   "dialect": "postgres",
   "id": "9f87995b-ed61-4b6f-9d7a-2858cb60a537",
-  "prevIds": ["2625e71b-a031-4994-825a-837870278ab9"],
+  "prevIds": ["4a57917d-6045-42b0-a5fb-ba7c153377a5"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],

--- a/packages/database/drizzle/20260719103321_add_questionnaire_submission_last_answered_message/snapshot.json
+++ b/packages/database/drizzle/20260719103321_add_questionnaire_submission_last_answered_message/snapshot.json
@@ -2,10 +2,7 @@
   "version": "8",
   "dialect": "postgres",
   "id": "4b35d03d-aabc-4691-9887-f1fdb8adc05a",
-  "prevIds": [
-    "4a57917d-6045-42b0-a5fb-ba7c153377a5",
-    "9f87995b-ed61-4b6f-9d7a-2858cb60a537"
-  ],
+  "prevIds": ["9f87995b-ed61-4b6f-9d7a-2858cb60a537"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],

--- a/packages/database/drizzle/20260720033741_add_integration_user_info/snapshot.json
+++ b/packages/database/drizzle/20260720033741_add_integration_user_info/snapshot.json
@@ -2,10 +2,7 @@
   "version": "8",
   "dialect": "postgres",
   "id": "28986ae9-dd91-4d3b-a360-dc22c744f068",
-  "prevIds": [
-    "4b35d03d-aabc-4691-9887-f1fdb8adc05a",
-    "5cb0a369-a599-4951-826f-57d692621f4b"
-  ],
+  "prevIds": ["4b35d03d-aabc-4691-9887-f1fdb8adc05a"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],

--- a/packages/database/drizzle/20260720144723_add-user-quota-bot-messages/snapshot.json
+++ b/packages/database/drizzle/20260720144723_add-user-quota-bot-messages/snapshot.json
@@ -2,7 +2,7 @@
   "version": "8",
   "dialect": "postgres",
   "id": "09178432-52b0-4fda-aed3-40f6df3b4614",
-  "prevIds": ["e6c453c1-649b-49f5-a9a4-32c376171709"],
+  "prevIds": ["28986ae9-dd91-4d3b-a360-dc22c744f068"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],

--- a/packages/database/scripts/run-migrations.mjs
+++ b/packages/database/scripts/run-migrations.mjs
@@ -17,6 +17,12 @@ import { Pool } from "pg"
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const migrationsFolder = join(__dirname, "..", "drizzle")
 const migrationLockName = "chatbotx:database:migrations"
+
+// Drizzle's default migrator runs all pending migrations in one transaction.
+// PostgreSQL does not allow a newly created enum to be used before that
+// transaction commits, so migrations must run one at a time by default.
+// Set DATABASE_MIGRATIONS_SEQUENTIAL=false only when this constraint is not
+// relevant to the pending migrations.
 const useSequentialMigrations =
   process.env.DATABASE_MIGRATIONS_SEQUENTIAL !== "false"
 

--- a/packages/database/scripts/run-migrations.mjs
+++ b/packages/database/scripts/run-migrations.mjs
@@ -18,7 +18,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const migrationsFolder = join(__dirname, "..", "drizzle")
 const migrationLockName = "chatbotx:database:migrations"
 const useSequentialMigrations =
-  process.env.DATABASE_MIGRATIONS_SEQUENTIAL === "true"
+  process.env.DATABASE_MIGRATIONS_SEQUENTIAL !== "false"
 
 const databaseUrl = process.env.DATABASE_URL
 if (!databaseUrl) {


### PR DESCRIPTION
## Summary
- Flip `DATABASE_MIGRATIONS_SEQUENTIAL` to opt-out instead of opt-in — migrations now run sequentially by default unless the env var is explicitly set to `"false"`.
- Regenerate drizzle `snapshot.json` files that had drifted from the current schema state.

## Changes
- `packages/database/scripts/run-migrations.mjs` — default flip
- `packages/database/drizzle/*/snapshot.json` — regenerated snapshots (6 migrations)

## Test plan
- [ ] pnpm lint
- [ ] pnpm --filter @chatbotx.io/database check-types
- [ ] manual verification: run migrations locally with and without `DATABASE_MIGRATIONS_SEQUENTIAL` set