### PR TITLE
fix(builder): restrict /manage menu access to cloud edition

### DIFF
--- a/apps/builder/src/components/nav-user.tsx
+++ b/apps/builder/src/components/nav-user.tsx
@@ -157,7 +157,7 @@ export function NavUser({
                       </Link>
                     </DropdownMenuItem>
                   )}
-                  {isPlatformAdmin && (
+                  {isCloud() && isPlatformAdmin && (
                     <DropdownMenuItem asChild>
                       <Link href="/manage">
                         <Settings2 className="h-4 w-4" />

--- a/apps/builder/src/features/workspaces/components/account-rail.tsx
+++ b/apps/builder/src/features/workspaces/components/account-rail.tsx
@@ -110,7 +110,7 @@ export const AccountRail = async ({
                 {t("actions.admin")}
               </Link>
             )}
-            {isPlatformAdmin && (
+            {cloud && isPlatformAdmin && (
               <Link
                 className="flex items-center gap-2 px-2 py-1.5"
                 href="/manage"


### PR DESCRIPTION
## Summary
- The admin "/manage" menu link (nav-user dropdown and account-rail) was shown to any platform admin regardless of edition.
- Gated both entry points behind `isCloud()` so self-hosted/OSS admins no longer see a cloud-only management surface.

## Changes
- `apps/builder/src/components/nav-user.tsx`: require `isCloud() && isPlatformAdmin` for the `/manage` menu item.
- `apps/builder/src/features/workspaces/components/account-rail.tsx`: require `cloud && isPlatformAdmin` (reuses existing `cloud = isCloud()` local) for the `/manage` link.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [ ] manual verification: platform admin on OSS/self-hosted build no longer sees `/manage`; platform admin on cloud build still sees it