### PR TITLE
fix(integrations): stop oauth referer from looping back to the connect page

### DIFF
--- a/apps/builder/src/features/integration-instagram/libs/oauth-facebook.ts
+++ b/apps/builder/src/features/integration-instagram/libs/oauth-facebook.ts
@@ -1,6 +1,6 @@
 import type { InstagramCredentialPublic } from "@chatbotx.io/database/partials"
 import { generateAuthUrl } from "@chatbotx.io/integration-instagram-facebook"
-import { getOriginUrlFromHeader } from "@/lib/domain"
+import { getOriginFromHeader } from "@/lib/domain"
 import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 
 export async function generateInstagramFacebookRedirectUri(
@@ -10,7 +10,7 @@ export async function generateInstagramFacebookRedirectUri(
   const redirectUrl = buildBrokerCallbackUrl(
     "/integrations/instagram-facebook/callback",
   )
-  const baseUrl = await getOriginUrlFromHeader()
+  const baseUrl = await getOriginFromHeader()
   const referer = workspaceId
     ? new URL(`/space/${workspaceId}/dashboard`, baseUrl).toString()
     : baseUrl

--- a/apps/builder/src/features/integration-instagram/libs/oauth.ts
+++ b/apps/builder/src/features/integration-instagram/libs/oauth.ts
@@ -1,6 +1,6 @@
 import type { InstagramCredentialPublic } from "@chatbotx.io/database/partials"
 import { generateAuthUrl } from "@chatbotx.io/integration-instagram"
-import { getOriginUrlFromHeader } from "@/lib/domain"
+import { getOriginFromHeader } from "@/lib/domain"
 import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 
 export async function generateInstagramRedirectUri(
@@ -12,7 +12,7 @@ export async function generateInstagramRedirectUri(
   // always send Facebook to the fixed broker callback and recover the originating
   // branded domain from `referer` (the callback relays back to it).
   const redirectUrl = buildBrokerCallbackUrl("/integrations/instagram/callback")
-  const baseUrl = await getOriginUrlFromHeader()
+  const baseUrl = await getOriginFromHeader()
   const referer = workspaceId
     ? new URL(`/space/${workspaceId}`, baseUrl).toString()
     : baseUrl

--- a/apps/builder/src/features/integration-messenger/libs/oauth.ts
+++ b/apps/builder/src/features/integration-messenger/libs/oauth.ts
@@ -1,6 +1,6 @@
 import type { MessengerCredentialPublic } from "@chatbotx.io/database/partials"
 import { generateAuthUrl } from "@chatbotx.io/integration-messenger"
-import { getOriginUrlFromHeader } from "@/lib/domain"
+import { getOriginFromHeader } from "@/lib/domain"
 import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 
 export async function generateMessengerRedirectUri(
@@ -12,7 +12,7 @@ export async function generateMessengerRedirectUri(
   // always send Facebook to the fixed broker callback and recover the originating
   // branded domain from `referer` (the callback relays back to it).
   const redirectUrl = buildBrokerCallbackUrl("/integrations/messenger/callback")
-  const baseUrl = await getOriginUrlFromHeader()
+  const baseUrl = await getOriginFromHeader()
   const referer = workspaceId
     ? new URL(`/space/${workspaceId}`, baseUrl).toString()
     : baseUrl

--- a/apps/builder/src/features/integration-tiktok/libs/tiktok.ts
+++ b/apps/builder/src/features/integration-tiktok/libs/tiktok.ts
@@ -1,6 +1,6 @@
 import type { TiktokCredentialPublic } from "@chatbotx.io/database/partials"
 import { generateAuthUrl } from "@chatbotx.io/integration-tiktok"
-import { getOriginUrlFromHeader } from "@/lib/domain"
+import { getOriginFromHeader } from "@/lib/domain"
 import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 
 export async function generateTiktokRedirectUri(
@@ -12,7 +12,7 @@ export async function generateTiktokRedirectUri(
   // always send TikTok to the fixed broker callback and recover the originating
   // branded domain from `referer` (the callback relays back to it).
   const redirectUrl = buildBrokerCallbackUrl("/integrations/tiktok/callback")
-  const baseUrl = await getOriginUrlFromHeader()
+  const baseUrl = await getOriginFromHeader()
   const referer = workspaceId
     ? new URL(`/space/${workspaceId}`, baseUrl).toString()
     : baseUrl

--- a/apps/builder/src/features/integration-zalo/libs/zalo.ts
+++ b/apps/builder/src/features/integration-zalo/libs/zalo.ts
@@ -1,13 +1,13 @@
 import type { ZaloCredentialPublic } from "@chatbotx.io/database/partials"
 import { generateAuthUrl } from "@chatbotx.io/integration-zalo"
-import { getOriginUrlFromHeader } from "@/lib/domain"
+import { getOriginFromHeader } from "@/lib/domain"
 import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 
 export async function generateZaloRedirectUri(
   publicConfig: ZaloCredentialPublic,
   workspaceId?: string | null,
 ) {
-  const baseUrl = await getOriginUrlFromHeader()
+  const baseUrl = await getOriginFromHeader()
 
   // The OAuth redirect_uri must be registered in the Zalo app. A white-label
   // custom domain (the live request host) is not registered there, so send Zalo

--- a/apps/builder/src/lib/domain.ts
+++ b/apps/builder/src/lib/domain.ts
@@ -16,3 +16,17 @@ export async function getOriginUrlFromHeader() {
 
   return originUrl
 }
+
+/**
+ * `x-url` (see `getOriginUrlFromHeader`) carries the full current request URL
+ * — path and query included — not just the origin its name suggests. OAuth
+ * "referer" fallbacks (the page to land on when the flow started with no
+ * workspace yet) must be the app's origin only: using the raw header value
+ * there sends the user back to the exact page that kicked off the OAuth
+ * redirect (e.g. `/channels/create?channel=tiktok`), which immediately
+ * re-triggers the same redirect and loops the user back to the provider.
+ */
+export async function getOriginFromHeader() {
+  const originUrl = await getOriginUrlFromHeader()
+  return originUrl ? new URL(originUrl).origin : ""
+}


### PR DESCRIPTION
## Summary
- `getOriginUrlFromHeader()` returns the full current request URL (path + query included, via the `x-url` header `proxy.ts` sets from `request.url`), not just the origin its name implies.
- Every "connect a new workspace via OAuth" flow (Messenger/Instagram/InstagramFacebook/Zalo/TikTok) used this value directly as the post-auth landing page (`referer`) whenever no `workspaceId` existed yet — so `referer` ended up as the exact URL of the `/channels/create?channel=<x>` page that kicked off the OAuth redirect, instead of the app's origin.
- After a successful connection, the callback's `redirect(safeReferer)` sent the user back to that same `/channels/create?channel=<x>` page, which immediately re-triggered the same provider redirect — the flow visibly bounces back to the OAuth provider right after successfully connecting, even though the workspace and channel were already created correctly on the first pass.

## Changes
- `apps/builder/src/lib/domain.ts` — add `getOriginFromHeader()`, which strips the path/query down to just the origin. `getOriginUrlFromHeader()` itself is left unchanged since other callers (`shared-folder-slot.tsx`, `require-not-scheduled-for-deletion.ts`) rely on its current full-URL behavior.
- `apps/builder/src/features/integration-tiktok/libs/tiktok.ts`, `integration-zalo/libs/zalo.ts`, `integration-messenger/libs/oauth.ts`, `integration-instagram/libs/oauth.ts`, `integration-instagram/libs/oauth-facebook.ts` — switch the redirect-uri builders' `baseUrl` from `getOriginUrlFromHeader()` to `getOriginFromHeader()`.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [ ] Manual verification: connect a brand-new workspace via TikTok (no existing workspace) end-to-end and confirm the post-connect redirect lands on the app's home page, not back on `/channels/create?channel=tiktok` (and does not bounce back to TikTok).
- [ ] Manual verification: repeat for Messenger, Instagram, Instagram-via-Facebook, and Zalo new-workspace connect flows.