### PR TITLE
fix(integrations): don't fail channel connect on branding write error

### DIFF
--- a/apps/builder/src/features/integration-instagram/actions/select-account-facebook.action.ts
+++ b/apps/builder/src/features/integration-instagram/actions/select-account-facebook.action.ts
@@ -189,15 +189,24 @@ export const selectFacebookAccountAction = authActionClient
           },
         })
 
-        await integrationInstagramFacebook.runChannelHandler(
-          "bot",
-          "addBranding",
-          {
-            ctx: brandingCtx,
-            title: BRANDING_TITLE,
-            url: getBrandingUrl("instagram", appUrl),
-          },
-        )
+        // Best-effort: the connection is already live, so a failed branding
+        // write must never fail the action.
+        try {
+          await integrationInstagramFacebook.runChannelHandler(
+            "bot",
+            "addBranding",
+            {
+              ctx: brandingCtx,
+              title: BRANDING_TITLE,
+              url: getBrandingUrl("instagram", appUrl),
+            },
+          )
+        } catch (error) {
+          logger.warn(
+            { err: error },
+            "Failed to add branding to Instagram persistent menu",
+          )
+        }
 
         // Invalidate the pending-auth cookie now that the account is connected.
         const cookieStore = await cookies()

--- a/apps/builder/src/features/integration-instagram/actions/select-account.action.ts
+++ b/apps/builder/src/features/integration-instagram/actions/select-account.action.ts
@@ -150,11 +150,25 @@ export const selectAccountAction = authActionClient
               },
             })
 
-            await integrationInstagram.runChannelHandler("bot", "addBranding", {
-              ctx: brandingCtx,
-              title: BRANDING_TITLE,
-              url: getBrandingUrl("instagram", appUrl),
-            })
+            // Best-effort: the connection is already live, so a failed
+            // branding write must never roll back the transaction or fail
+            // the action.
+            try {
+              await integrationInstagram.runChannelHandler(
+                "bot",
+                "addBranding",
+                {
+                  ctx: brandingCtx,
+                  title: BRANDING_TITLE,
+                  url: getBrandingUrl("instagram", appUrl),
+                },
+              )
+            } catch (error) {
+              logger.warn(
+                { err: error },
+                "Failed to add branding to Instagram persistent menu",
+              )
+            }
 
             return { brandingCtx, integrationId: integrationRow.id }
           },

--- a/apps/builder/src/features/integration-messenger/actions/select-page.action.ts
+++ b/apps/builder/src/features/integration-messenger/actions/select-page.action.ts
@@ -182,11 +182,21 @@ export const selectPageAction = authActionClient
             integration: { ...integrationRow, auth },
           })
 
-          await integrationMessenger.runChannelHandler("bot", "addBranding", {
-            ctx: brandingCtx,
-            title: BRANDING_TITLE,
-            url: getBrandingUrl("messenger", appUrl),
-          })
+          // Best-effort: the connection is already live, so a failed
+          // branding write must never roll back the transaction or fail
+          // the action.
+          try {
+            await integrationMessenger.runChannelHandler("bot", "addBranding", {
+              ctx: brandingCtx,
+              title: BRANDING_TITLE,
+              url: getBrandingUrl("messenger", appUrl),
+            })
+          } catch (error) {
+            logger.warn(
+              { err: error },
+              "Failed to add branding to Messenger persistent menu",
+            )
+          }
 
           return { brandingCtx }
         })


### PR DESCRIPTION
## Summary
- The `addBranding` channel-handler call ran unguarded during Messenger and Instagram connect, so a branding write failure aborted the whole connect action.
- For Messenger and direct-login Instagram it sat inside the connect `db.transaction`, so a branding failure rolled back the already-created integration; for Instagram-via-Facebook it sat outside the transaction but still threw and aborted the action.
- Wrapped each `addBranding` call in try/catch + `logger.warn`, matching the existing best-effort pattern already used for `persistIntegrationUserInfo` in the same files — the connection is live by that point, so branding failures should only be logged, never surfaced as a connect failure.

## Changes
- `apps/builder/src/features/integration-messenger/actions/select-page.action.ts`
- `apps/builder/src/features/integration-instagram/actions/select-account.action.ts`
- `apps/builder/src/features/integration-instagram/actions/select-account-facebook.action.ts`

## Test plan
- [x] pnpm lint
- [x] pnpm --filter builder check-types
- [ ] manual verification: connect a Messenger/Instagram page and confirm connect succeeds even when the branding call fails