### PR TITLE
feat(broadcasts): add Instagram and Telegram broadcast channels

### DIFF
--- a/apps/builder/__tests__/create-broadcast-action.test.ts
+++ b/apps/builder/__tests__/create-broadcast-action.test.ts
@@ -110,7 +110,7 @@ describe("createBroadcastAction", () => {
       parsedInput: {
         channel: channelTypes.enum.messenger,
         flowId: "flow-1",
-        subaction: broadcastSubactions.enum.allContacts,
+        subaction: broadcastSubactions.enum.messengerActiveContacts,
         schedulesType: broadcastScheduleTypes.enum.future,
         schedulesAt: "2099-01-01T00:00:00.000Z",
         contactFilter,
@@ -143,7 +143,7 @@ describe("createBroadcastAction", () => {
       parsedInput: {
         channel: channelTypes.enum.messenger,
         flowId: "flow-1",
-        subaction: broadcastSubactions.enum.allContacts,
+        subaction: broadcastSubactions.enum.messengerActiveContacts,
         schedulesType: broadcastScheduleTypes.enum.future,
         schedulesAt: "2099-01-01T00:00:00.000Z",
         contactFilter: null,

--- a/apps/builder/__tests__/create-broadcast.action.test.ts
+++ b/apps/builder/__tests__/create-broadcast.action.test.ts
@@ -97,7 +97,7 @@ beforeEach(() => {
 
 const baseInput = {
   channel: "whatsapp" as const,
-  subaction: "flow" as const,
+  subaction: "whatsappWithin24Hours" as const,
   schedulesType: "now" as const,
   schedulesAt: null,
   contactFilter: null,
@@ -164,6 +164,7 @@ describe("createBroadcastAction — messenger template validation", () => {
       parsedInput: {
         ...baseInput,
         channel: "messenger",
+        subaction: "messengerTemplateMessage",
         templateId: "tpl-1",
         integrationMessengerId: "int-1",
       },
@@ -189,6 +190,7 @@ describe("createBroadcastAction — messenger template validation", () => {
       parsedInput: {
         ...baseInput,
         channel: "messenger",
+        subaction: "messengerTemplateMessage",
         templateId: "tpl-1",
         integrationMessengerId: "int-1",
       },
@@ -217,6 +219,7 @@ describe("createBroadcastAction — whatsapp template validation", () => {
       bindArgsParsedInputs: [WORKSPACE_ID],
       parsedInput: {
         ...baseInput,
+        subaction: "whatsappTemplateMessage",
         channel: "whatsapp",
         templateId: "tpl-2",
         integrationWhatsappId: "wa-int-1",
@@ -242,6 +245,7 @@ describe("createBroadcastAction — whatsapp template validation", () => {
       bindArgsParsedInputs: [WORKSPACE_ID],
       parsedInput: {
         ...baseInput,
+        subaction: "whatsappTemplateMessage",
         channel: "whatsapp",
         templateId: "tpl-2",
         integrationWhatsappId: "wa-int-1",
@@ -260,6 +264,7 @@ describe("createBroadcastAction — happy path insert", () => {
     vi.clearAllMocks()
     mockInsertValues.mockReturnValue({ returning: mockInsertReturning })
     mockDbInsert.mockReturnValue({ values: mockInsertValues })
+    mockFlowFindFirst.mockResolvedValue({ id: "flow-1", name: "Flow Name" })
   })
 
   test("inserts with status 'scheduled' and returns the broadcast", async () => {
@@ -270,7 +275,7 @@ describe("createBroadcastAction — happy path insert", () => {
       createBroadcastAction as (props: unknown) => Promise<unknown>
     )({
       bindArgsParsedInputs: [WORKSPACE_ID],
-      parsedInput: { ...baseInput, flowId: undefined, templateId: undefined },
+      parsedInput: { ...baseInput, flowId: "flow-1" },
     })
 
     const insertedValues = mockInsertValues.mock.calls[0]?.[0] as {
@@ -292,6 +297,8 @@ describe("createBroadcastAction — happy path insert", () => {
       parsedInput: {
         ...baseInput,
         channel: "messenger",
+        subaction: "messengerActiveContacts",
+        flowId: "flow-1",
         integrationMessengerId: "int-999",
       },
     })
@@ -317,6 +324,8 @@ describe("createBroadcastAction — happy path insert", () => {
       parsedInput: {
         ...baseInput,
         channel: "messenger",
+        subaction: "messengerActiveContacts",
+        flowId: "flow-1",
         integrationMessengerId: "foreign-int",
       },
     })
@@ -342,6 +351,7 @@ describe("createBroadcastAction — happy path insert", () => {
       bindArgsParsedInputs: [WORKSPACE_ID],
       parsedInput: {
         ...baseInput,
+        flowId: "flow-1",
         channel: "whatsapp",
         integrationWhatsappId: "foreign-wa-int",
       },
@@ -370,6 +380,7 @@ describe("createBroadcastAction — happy path insert", () => {
       bindArgsParsedInputs: [WORKSPACE_ID],
       parsedInput: {
         ...baseInput,
+        flowId: "flow-1",
         templateData,
         buttons,
       },
@@ -391,13 +402,121 @@ describe("createBroadcastAction — happy path insert", () => {
 
     await (createBroadcastAction as (props: unknown) => Promise<unknown>)({
       bindArgsParsedInputs: [WORKSPACE_ID],
-      parsedInput: { ...baseInput },
+      parsedInput: { ...baseInput, flowId: "flow-1" },
     })
 
     const insertedValues = mockInsertValues.mock.calls[0]?.[0] as {
       templateData: null
     }
     expect(insertedValues.templateData).toBeNull()
+  })
+
+  test.each([
+    {
+      channel: "instagram" as const,
+      subaction: "instagramActiveContacts" as const,
+    },
+    {
+      channel: "telegram" as const,
+      subaction: "telegramAllContacts" as const,
+    },
+  ])("accepts $channel flow broadcasts", async ({ channel, subaction }) => {
+    const mockBroadcast = { id: `bc-${channel}` }
+    mockInsertReturning.mockResolvedValue([mockBroadcast])
+
+    const result = await (
+      createBroadcastAction as (props: unknown) => Promise<unknown>
+    )({
+      bindArgsParsedInputs: [WORKSPACE_ID],
+      parsedInput: {
+        ...baseInput,
+        channel,
+        subaction,
+        flowId: "flow-1",
+      },
+    })
+
+    expect(result).toBe(mockBroadcast)
+    expect(mockInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel,
+        subaction,
+        flowId: "flow-1",
+      }),
+    )
+  })
+
+  test("rejects non-broadcastable channels such as TikTok", async () => {
+    const result = await (
+      createBroadcastAction as (props: unknown) => Promise<unknown>
+    )({
+      bindArgsParsedInputs: [WORKSPACE_ID],
+      parsedInput: {
+        ...baseInput,
+        channel: "tiktok",
+        subaction: "telegramAllContacts",
+        flowId: "flow-1",
+      },
+    })
+
+    expect(mockReturnValidationErrors).toHaveBeenCalledOnce()
+    const [, errors] = mockReturnValidationErrors.mock.calls[0] as [
+      unknown,
+      { channel: { _errors: string[] } },
+    ]
+    expect(errors.channel._errors).toContain("Unsupported broadcast channel")
+    expect(mockInsertValues).not.toHaveBeenCalled()
+    expect(result).toMatchObject({ __validationError: expect.anything() })
+  })
+
+  test("rejects template broadcasts for Telegram", async () => {
+    const result = await (
+      createBroadcastAction as (props: unknown) => Promise<unknown>
+    )({
+      bindArgsParsedInputs: [WORKSPACE_ID],
+      parsedInput: {
+        ...baseInput,
+        channel: "telegram",
+        subaction: "telegramAllContacts",
+        templateId: "template-1",
+      },
+    })
+
+    expect(mockReturnValidationErrors).toHaveBeenCalledOnce()
+    const [, errors] = mockReturnValidationErrors.mock.calls[0] as [
+      unknown,
+      { templateId: { _errors: string[] } },
+    ]
+    expect(errors.templateId._errors).toContain(
+      "Template broadcasts are not supported for this channel",
+    )
+    expect(mockInsertValues).not.toHaveBeenCalled()
+    expect(result).toMatchObject({ __validationError: expect.anything() })
+  })
+
+  test("rejects template broadcasts for Instagram", async () => {
+    const result = await (
+      createBroadcastAction as (props: unknown) => Promise<unknown>
+    )({
+      bindArgsParsedInputs: [WORKSPACE_ID],
+      parsedInput: {
+        ...baseInput,
+        channel: "instagram",
+        subaction: "instagramActiveContacts",
+        templateId: "template-1",
+      },
+    })
+
+    expect(mockReturnValidationErrors).toHaveBeenCalledOnce()
+    const [, errors] = mockReturnValidationErrors.mock.calls[0] as [
+      unknown,
+      { templateId: { _errors: string[] } },
+    ]
+    expect(errors.templateId._errors).toContain(
+      "Template broadcasts are not supported for this channel",
+    )
+    expect(mockInsertValues).not.toHaveBeenCalled()
+    expect(result).toMatchObject({ __validationError: expect.anything() })
   })
 
   test("schedulesAt is set to startOfMinute of the provided date string", async () => {
@@ -408,7 +527,7 @@ describe("createBroadcastAction — happy path insert", () => {
 
     await (createBroadcastAction as (props: unknown) => Promise<unknown>)({
       bindArgsParsedInputs: [WORKSPACE_ID],
-      parsedInput: { ...baseInput, schedulesAt },
+      parsedInput: { ...baseInput, flowId: "flow-1", schedulesAt },
     })
 
     const insertedValues = mockInsertValues.mock.calls[0]?.[0] as {
@@ -419,18 +538,26 @@ describe("createBroadcastAction — happy path insert", () => {
     expect(insertedValues.schedulesAt.getMinutes()).toBe(34)
   })
 
-  test("uses default name 'Broadcast' when no flowId or templateId", async () => {
+  test("rejects when neither flowId nor templateId is provided", async () => {
     const mockBroadcast = { id: "bc-9" }
     mockInsertReturning.mockResolvedValue([mockBroadcast])
 
-    await (createBroadcastAction as (props: unknown) => Promise<unknown>)({
+    const result = await (
+      createBroadcastAction as (props: unknown) => Promise<unknown>
+    )({
       bindArgsParsedInputs: [WORKSPACE_ID],
       parsedInput: { ...baseInput },
     })
 
-    const insertedValues = mockInsertValues.mock.calls[0]?.[0] as {
-      name: string
-    }
-    expect(insertedValues.name).toBe("Broadcast")
+    expect(mockReturnValidationErrors).toHaveBeenCalledOnce()
+    const [, errors] = mockReturnValidationErrors.mock.calls[0] as [
+      unknown,
+      { flowId: { _errors: string[] } },
+    ]
+    expect(errors.flowId._errors).toContain(
+      "Either flow or template must be selected",
+    )
+    expect(mockInsertValues).not.toHaveBeenCalled()
+    expect(result).toMatchObject({ __validationError: expect.anything() })
   })
 })

--- a/apps/builder/__tests__/resend-broadcast.action.test.ts
+++ b/apps/builder/__tests__/resend-broadcast.action.test.ts
@@ -93,7 +93,7 @@ const baseBroadcast = {
   flowId: "flow-1",
   integrationWhatsappId: "wa-1",
   integrationMessengerId: "msg-1",
-  subaction: "flow" as const,
+  subaction: "whatsappWithin24Hours" as const,
   templateId: null,
   templateData: null,
   schedulesType: "now" as const,

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -379,6 +379,14 @@
       "title": "Active contacts within 24 hours",
       "description": "May contain promotions and will only be sent to users who messaged your bot within the last 24h."
     },
+    "instagramActiveContacts": {
+      "title": "Instagram",
+      "description": "May contain promotions and will only be sent to users who messaged your bot within the last 24h."
+    },
+    "telegramAllContacts": {
+      "title": "Telegram",
+      "description": "Use this message type if you want to send a broadcast to your Telegram contacts."
+    },
     "flowType": {
       "flow": {
         "title": "Flow",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -379,6 +379,14 @@
       "title": "Liên hệ hoạt động trong 24 giờ",
       "description": "Có thể chứa khuyến mãi và sẽ chỉ được gửi cho người dùng đã nhắn tin cho bot của bạn trong vòng 24 giờ qua."
     },
+    "instagramActiveContacts": {
+      "title": "Instagram",
+      "description": "Có thể chứa khuyến mãi và sẽ chỉ được gửi cho người dùng đã nhắn tin cho bot của bạn trong vòng 24 giờ qua."
+    },
+    "telegramAllContacts": {
+      "title": "Telegram",
+      "description": "Dùng loại tin nhắn này nếu bạn muốn gửi broadcast đến các liên hệ Telegram của mình."
+    },
     "flowType": {
       "flow": {
         "title": "Luồng",

--- a/apps/builder/src/features/broadcasts/actions/create-broadcast.action.ts
+++ b/apps/builder/src/features/broadcasts/actions/create-broadcast.action.ts
@@ -1,6 +1,7 @@
 "use server"
 
 import { db } from "@chatbotx.io/database/client"
+import { findBroadcastChannelCapability } from "@chatbotx.io/database/partials"
 import { pruneEmailPhoneFilterConditions } from "@chatbotx.io/database/queries/contact-filter/permission"
 import { broadcastModel } from "@chatbotx.io/database/schema"
 import { startOfMinute } from "date-fns"
@@ -10,6 +11,7 @@ import { canViewContactEmailAndPhone } from "@/features/contacts/permissions"
 import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
 import { workspaceActionClient } from "@/lib/safe-action"
 import { createBroadcastRequest } from "../schemas/action"
+
 export const createBroadcastAction = workspaceActionClient
   .bindArgsSchemas(workspaceIdrequestParams)
   .inputSchema(createBroadcastRequest)
@@ -26,6 +28,43 @@ export const createBroadcastAction = workspaceActionClient
           userAndWorkspace.targetWorkspaceMember.permissions,
         )
       : false
+
+    const capability = findBroadcastChannelCapability(parsedInput.channel)
+    if (!capability) {
+      return returnValidationErrors(createBroadcastRequest, {
+        _errors: ["Validation Exception"],
+        channel: {
+          _errors: ["Unsupported broadcast channel"],
+        },
+      })
+    }
+
+    if (!capability.subactions.includes(parsedInput.subaction)) {
+      return returnValidationErrors(createBroadcastRequest, {
+        _errors: ["Validation Exception"],
+        subaction: {
+          _errors: ["Unsupported broadcast subaction"],
+        },
+      })
+    }
+
+    if (!(parsedInput.flowId || parsedInput.templateId)) {
+      return returnValidationErrors(createBroadcastRequest, {
+        _errors: ["Validation Exception"],
+        flowId: {
+          _errors: ["Either flow or template must be selected"],
+        },
+      })
+    }
+
+    if (parsedInput.templateId && !capability.supportsTemplateBroadcast) {
+      return returnValidationErrors(createBroadcastRequest, {
+        _errors: ["Validation Exception"],
+        templateId: {
+          _errors: ["Template broadcasts are not supported for this channel"],
+        },
+      })
+    }
 
     // Never trust integration ids from the client: they scope the audience,
     // so a foreign id would let a broadcast target another workspace's pages.

--- a/apps/builder/src/features/broadcasts/create-broadcast-form.tsx
+++ b/apps/builder/src/features/broadcasts/create-broadcast-form.tsx
@@ -4,10 +4,11 @@ import {
   type BroadcastFlowType,
   type BroadcastScheduleType,
   type BroadcastSubaction,
+  broadcastChannelCapabilities,
   broadcastFlowTypes,
   broadcastSubactions,
   type ChannelType,
-  channelTypes,
+  findBroadcastChannelCapability,
 } from "@chatbotx.io/database/partials"
 import {
   extractMessengerFlowButtons,
@@ -70,63 +71,21 @@ type BroadcastConfig = {
 }
 
 const getConfigs = (t: ReturnType<typeof useTranslations>) =>
-  [
-    {
-      value: channelTypes.enum.omnichannel,
-      description:
-        "Send a flow to all contacts. You can send messages or executes actions.",
-      subactions: [
-        {
-          value: broadcastSubactions.enum.allContacts,
-          name: t("broadcasts.allContacts.title"),
-          description: t("broadcasts.allContacts.description"),
-        },
-      ],
-    },
-    {
-      value: "messenger",
+  broadcastChannelCapabilities.map((capability) => {
+    const subactions = capability.subactions.map((subaction) => ({
+      value: subaction,
+      name: t(`broadcasts.${subaction}.title`),
+      description: t(`broadcasts.${subaction}.description`),
+    }))
+
+    return {
+      value: capability.channel,
+      // Channel-level copy is not rendered (the channel step shows only the icon);
+      // per-subaction title/description drive every visible label.
       description: "",
-      subactions: [
-        {
-          value: broadcastSubactions.enum.messengerTemplateMessage,
-          name: t("broadcasts.messengerTemplateMessage.title"),
-          description: t("broadcasts.messengerTemplateMessage.description"),
-        },
-        {
-          value: broadcastSubactions.enum.messengerActiveContacts,
-          name: t("broadcasts.messengerActiveContacts.title"),
-          description: t("broadcasts.messengerActiveContacts.description"),
-        },
-      ],
-    },
-    {
-      value: "whatsapp",
-      description: "",
-      subactions: [
-        {
-          value: broadcastSubactions.enum.whatsappTemplateMessage,
-          name: t("broadcasts.whatsappTemplateMessage.title"),
-          description: t("broadcasts.whatsappTemplateMessage.description"),
-        },
-        {
-          value: broadcastSubactions.enum.whatsappWithin24Hours,
-          name: t("broadcasts.whatsappWithin24Hours.title"),
-          description: t("broadcasts.whatsappWithin24Hours.description"),
-        },
-      ],
-    },
-    {
-      value: "zalo",
-      description: "",
-      subactions: [
-        {
-          value: broadcastSubactions.enum.allContacts,
-          name: t("broadcasts.allContacts.title"),
-          description: t("broadcasts.allContacts.description"),
-        },
-      ],
-    },
-  ] as BroadcastConfig[]
+      subactions,
+    }
+  }) satisfies BroadcastConfig[]
 
 type CreateBroadcastFormProps = {
   canViewEmailAndPhone?: boolean
@@ -261,14 +220,12 @@ function CreateBroadcastChooseChannel() {
   const handleChooseChannel = useCallback(
     (channel: ChannelType) => {
       setValue("channel", channel)
-      if (
-        channel === channelTypes.enum.messenger ||
-        channel === channelTypes.enum.whatsapp
-      ) {
-        setValue("subaction", null)
-      } else {
-        setValue("subaction", broadcastSubactions.enum.allContacts)
-      }
+      const capability = findBroadcastChannelCapability(channel)
+      const mustPickSubaction = (capability?.subactions.length ?? 0) > 1
+      setValue(
+        "subaction",
+        mustPickSubaction ? null : (capability?.defaultSubaction ?? null),
+      )
     },
     [setValue],
   )
@@ -507,9 +464,8 @@ function CreateBroadcastChooseFlow(props: CreateBroadcastChooseFlowProps) {
     description: string
   }>({
     value: broadcastSubactions.enum.allContacts,
-    name: "Omnichannel",
-    description:
-      "Send a flow to all contacts. You can send messages or executes actions.",
+    name: "",
+    description: "",
   })
 
   const { control, setValue, formState } = useFormContext()

--- a/apps/builder/src/features/broadcasts/lib/__tests__/broadcast-filter-fields.test.ts
+++ b/apps/builder/src/features/broadcasts/lib/__tests__/broadcast-filter-fields.test.ts
@@ -55,6 +55,27 @@ describe("getBroadcastExcludedFilterFields", () => {
     ])
   })
 
+  test("excludes current channel and interacted-in-last-24h for Instagram active-contact broadcasts", () => {
+    expect(
+      getBroadcastExcludedFilterFields({
+        channel: channelTypes.enum.instagram,
+        subaction: broadcastSubactions.enum.instagramActiveContacts,
+      }),
+    ).toEqual([
+      contactFilterFields.enum.currentChannel,
+      contactFilterFields.enum.interactedInLast24h,
+    ])
+  })
+
+  test("keeps inbox for Telegram all-contact broadcasts", () => {
+    expect(
+      getBroadcastExcludedFilterFields({
+        channel: channelTypes.enum.telegram,
+        subaction: broadcastSubactions.enum.telegramAllContacts,
+      }),
+    ).toEqual([contactFilterFields.enum.currentChannel])
+  })
+
   test("keeps inbox for all-contact broadcasts", () => {
     expect(
       getBroadcastExcludedFilterFields({

--- a/apps/worker/__tests__/prepare-broadcast.test.ts
+++ b/apps/worker/__tests__/prepare-broadcast.test.ts
@@ -2,9 +2,11 @@ import { beforeEach, describe, expect, test, vi } from "vitest"
 
 const findFirstBroadcast = vi.fn()
 const findFirstMessengerTemplate = vi.fn()
-const findManyConversation = vi.fn()
+const findDMByContactIds = vi.fn()
 const forEachAudienceChunk = vi.fn()
 const scheduleAddSpy = vi.fn()
+const loggerInfoSpy = vi.fn()
+const loggerWarnSpy = vi.fn()
 
 type UpdateCall = {
   table: unknown
@@ -26,6 +28,9 @@ vi.mock("@chatbotx.io/business", () => ({
   broadcastService: {
     forEachAudienceChunk: (...args: unknown[]) => forEachAudienceChunk(...args),
   },
+  conversationService: {
+    findDMByContactIds: (...args: unknown[]) => findDMByContactIds(...args),
+  },
 }))
 
 vi.mock("@chatbotx.io/database/partials", async () =>
@@ -45,9 +50,6 @@ vi.mock("@chatbotx.io/database/client", () => ({
       },
       messengerMessageTemplateModel: {
         findFirst: (...args: unknown[]) => findFirstMessengerTemplate(...args),
-      },
-      conversationModel: {
-        findMany: (...args: unknown[]) => findManyConversation(...args),
       },
     },
     update: (table: unknown) => ({
@@ -71,6 +73,13 @@ vi.mock("@chatbotx.io/database/client", () => ({
     }),
   },
   eq: (left: unknown, right: unknown) => ({ __eq: [left, right] }),
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: {
+    info: (...args: unknown[]) => loggerInfoSpy(...args),
+    warn: (...args: unknown[]) => loggerWarnSpy(...args),
+  },
 }))
 
 vi.mock("@chatbotx.io/worker-config", () => ({
@@ -110,9 +119,11 @@ beforeEach(() => {
   insertCalls.length = 0
   findFirstBroadcast.mockResolvedValue(undefined)
   findFirstMessengerTemplate.mockResolvedValue(undefined)
-  findManyConversation.mockResolvedValue([])
+  findDMByContactIds.mockResolvedValue([])
   forEachAudienceChunk.mockResolvedValue(undefined)
   scheduleAddSpy.mockReset()
+  loggerInfoSpy.mockReset()
+  loggerWarnSpy.mockReset()
   onConflictSpy.mockReset()
 })
 
@@ -251,9 +262,9 @@ describe("prepareBroadcast", () => {
     })
   })
 
-  test("inserts recipients, marks sending, and enqueues sendBroadcast when contacts are found", async () => {
+  test("inserts recipients with DM conversations, skips missing conversations, and enqueues sendBroadcast", async () => {
     findFirstBroadcast.mockResolvedValue(baseBroadcast())
-    findManyConversation.mockResolvedValue([
+    findDMByContactIds.mockResolvedValue([
       { id: "conv-1", contactId: "contact-1" },
     ])
     forEachAudienceChunk.mockImplementation(
@@ -272,11 +283,9 @@ describe("prepareBroadcast", () => {
 
     await prepareBroadcast(BROADCAST_ID)
 
-    expect(findManyConversation).toHaveBeenCalledWith({
-      where: {
-        contactId: { in: ["contact-1", "contact-2"] },
-        workspaceId: WORKSPACE_ID,
-      },
+    expect(findDMByContactIds).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      contactIds: ["contact-1", "contact-2"],
     })
     expect(insertCalls).toHaveLength(1)
     expect(onConflictSpy).toHaveBeenCalledTimes(1)
@@ -287,17 +296,15 @@ describe("prepareBroadcast", () => {
         contactInboxId: "ci-1",
         conversationId: "conv-1",
       },
-      {
-        broadcastId: BROADCAST_ID,
-        contactId: "contact-2",
-        contactInboxId: "ci-2",
-        conversationId: "",
-      },
     ])
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      { broadcastId: BROADCAST_ID, skippedCount: 1 },
+      "Skipped broadcast contacts without a DM conversation",
+    )
     expect(updateCalls).toHaveLength(1)
     expect(updateCalls[0].values).toMatchObject({
       status: "sending",
-      contactCount: 2,
+      contactCount: 1,
     })
     expect(scheduleAddSpy).toHaveBeenCalledWith(
       "sendBroadcast",
@@ -311,6 +318,35 @@ describe("prepareBroadcast", () => {
         removeOnComplete: true,
         removeOnFail: true,
       },
+    )
+  })
+
+  test("does not insert or enqueue when all audience contacts lack a DM conversation", async () => {
+    findFirstBroadcast.mockResolvedValue(baseBroadcast())
+    findDMByContactIds.mockResolvedValue([])
+    forEachAudienceChunk.mockImplementation(
+      async (
+        _input: unknown,
+        onChunk: (
+          rows: Array<{ id: string; contactId: string }>,
+        ) => Promise<unknown>,
+      ) => {
+        await onChunk([{ id: "ci-1", contactId: "contact-1" }])
+      },
+    )
+
+    await prepareBroadcast(BROADCAST_ID)
+
+    expect(insertCalls).toHaveLength(0)
+    expect(updateCalls).toHaveLength(1)
+    expect(updateCalls[0].values).toMatchObject({
+      status: "sent",
+      contactCount: 0,
+    })
+    expect(scheduleAddSpy).not.toHaveBeenCalled()
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      { broadcastId: BROADCAST_ID, skippedCount: 1 },
+      "Skipped broadcast contacts without a DM conversation",
     )
   })
 

--- a/apps/worker/__tests__/process-broadcast-contacts.test.ts
+++ b/apps/worker/__tests__/process-broadcast-contacts.test.ts
@@ -74,6 +74,8 @@ vi.mock("@chatbotx.io/database/partials", () => ({
       omnichannel: "omnichannel",
       whatsapp: "whatsapp",
       messenger: "messenger",
+      instagram: "instagram",
+      telegram: "telegram",
     },
   },
 }))
@@ -226,6 +228,31 @@ describe("processBroadcastContacts", () => {
 
       await processBroadcastContacts(BROADCAST_ID)
 
+      expect(chatAddSpy).not.toHaveBeenCalled()
+    })
+
+    test.each([
+      "instagram",
+      "telegram",
+    ] as const)("enqueues %s flow broadcasts through the integration queue only", async (channel) => {
+      findManyBroadcast.mockResolvedValue([
+        makeBroadcast({ flowId: "flow-1", channel }),
+      ])
+      findManyContactsOnBroadcasts.mockResolvedValue([makeContactOnBroadcast()])
+
+      await processBroadcastContacts(BROADCAST_ID)
+
+      expect(integrationAddSpy).toHaveBeenCalledWith(
+        "sendFlow",
+        expect.objectContaining({
+          type: "sendFlow",
+          data: expect.objectContaining({
+            flowId: "flow-1",
+            contactInboxId: "ci-1",
+          }),
+        }),
+        expect.any(Object),
+      )
       expect(chatAddSpy).not.toHaveBeenCalled()
     })
   })

--- a/apps/worker/src/schedule/handlers/prepare-broadcast.ts
+++ b/apps/worker/src/schedule/handlers/prepare-broadcast.ts
@@ -1,4 +1,4 @@
-import { broadcastService } from "@chatbotx.io/business"
+import { broadcastService, conversationService } from "@chatbotx.io/business"
 import { db, eq } from "@chatbotx.io/database/client"
 import {
   type BroadcastStatus,
@@ -17,6 +17,7 @@ import {
   scheduleQueue,
 } from "@chatbotx.io/worker-config"
 import { isBlockedWorkspace } from "../../lib/is-blocked-workspace"
+import { logger } from "../../lib/logger"
 
 export const prepareBroadcast = async (broadcastId: string) => {
   const broadcast = await db.query.broadcastModel.findFirst({
@@ -27,7 +28,7 @@ export const prepareBroadcast = async (broadcastId: string) => {
   })
 
   if (!broadcast) {
-    console.error("Broadcast not found or not scheduled", broadcastId)
+    logger.warn({ broadcastId }, "Broadcast not found or not scheduled")
     return
   }
 
@@ -74,19 +75,11 @@ export const prepareBroadcast = async (broadcastId: string) => {
       subaction: parsedSubaction.success ? parsedSubaction.data : undefined,
     },
     async (contactInboxes): Promise<boolean | undefined> => {
-      hasContactOnBroadcast = true
-
-      const conversations = await db.query.conversationModel.findMany({
-        where: {
-          contactId: {
-            in: Array.from(
-              new Set(
-                contactInboxes.map((contactInbox) => contactInbox.contactId),
-              ),
-            ),
-          },
-          workspaceId: broadcast.workspaceId,
-        },
+      const conversations = await conversationService.findDMByContactIds({
+        workspaceId: broadcast.workspaceId,
+        contactIds: contactInboxes.map(
+          (contactInbox) => contactInbox.contactId,
+        ),
       })
 
       const conversationMap = new Map(
@@ -96,20 +89,42 @@ export const prepareBroadcast = async (broadcastId: string) => {
         ]),
       )
 
-      await db
-        .insert(contactsOnBroadcastsModel)
-        .values(
-          contactInboxes.map((contactInbox) => ({
+      const recipients = contactInboxes.flatMap((contactInbox) => {
+        const conversation = conversationMap.get(contactInbox.contactId)
+        if (!conversation) {
+          return []
+        }
+
+        return [
+          {
             broadcastId,
             contactId: contactInbox.contactId,
             contactInboxId: contactInbox.id,
-            conversationId:
-              conversationMap.get(contactInbox.contactId)?.id || "",
-          })),
+            conversationId: conversation.id,
+          },
+        ]
+      })
+      const skippedCount = contactInboxes.length - recipients.length
+
+      if (skippedCount > 0) {
+        logger.info(
+          { broadcastId, skippedCount },
+          "Skipped broadcast contacts without a DM conversation",
         )
+      }
+
+      if (recipients.length === 0) {
+        return
+      }
+
+      hasContactOnBroadcast = true
+
+      await db
+        .insert(contactsOnBroadcastsModel)
+        .values(recipients)
         .onConflictDoNothing()
 
-      contactCount += contactInboxes.length
+      contactCount += recipients.length
 
       return
     },

--- a/packages/business/src/broadcast/__tests__/broadcast.service.test.ts
+++ b/packages/business/src/broadcast/__tests__/broadcast.service.test.ts
@@ -272,6 +272,20 @@ describe("broadcastService.countAudience", () => {
     })
   })
 
+  test("includes the 24h predicate for Instagram active contacts", async () => {
+    mocks.resolveBroadcastInboxIds.mockResolvedValue(["inbox-instagram"])
+    mocks.count.mockResolvedValue(5)
+
+    await broadcastService.countAudience({
+      workspaceId: "ws-1",
+      channels: ["instagram"],
+      subaction: "instagramActiveContacts",
+    })
+
+    const where = mocks.count.mock.calls[0]?.[1] as { __and?: unknown[] }
+    expect(where.__and).toContainEqual({ RAW: "recent-interaction" })
+  })
+
   test("prunes email/phone contact filters when the audience caller lacks emailAndPhone permission", async () => {
     mocks.resolveBroadcastInboxIds.mockResolvedValue(["inbox-1"])
     mocks.count.mockResolvedValue(1)
@@ -316,6 +330,20 @@ describe("broadcastService.countAudience", () => {
     })
     expect(where.__and).not.toContainEqual({ RAW: "recent-interaction" })
     expect(mocks.buildContactInboxContactFilterSQL).not.toHaveBeenCalled()
+  })
+
+  test("omits the 24h predicate for Telegram all contacts", async () => {
+    mocks.resolveBroadcastInboxIds.mockResolvedValue(["inbox-telegram"])
+    mocks.count.mockResolvedValue(8)
+
+    await broadcastService.countAudience({
+      workspaceId: "ws-1",
+      channels: ["telegram"],
+      subaction: "telegramAllContacts",
+    })
+
+    const where = mocks.count.mock.calls[0]?.[1] as { __and?: unknown[] }
+    expect(where.__and).not.toContainEqual({ RAW: "recent-interaction" })
   })
 
   test("forwards integrationMessengerId when resolving the audience inboxes", async () => {

--- a/packages/business/src/conversation/__tests__/conversation.service.test.ts
+++ b/packages/business/src/conversation/__tests__/conversation.service.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  conversationFindMany: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      conversationModel: {
+        findMany: mocks.conversationFindMany,
+      },
+    },
+  },
+  and: vi.fn(),
+  eq: vi.fn(),
+  inArray: vi.fn(),
+  sql: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  conversationModel: {},
+}))
+
+vi.mock("@chatbotx.io/redis", () => ({
+  withCache: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/event-bus", () => ({
+  emit: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/events", () => ({
+  emitConversationArchived: vi.fn(),
+  emitConversationAssigned: vi.fn(),
+  emitConversationFollowUp: vi.fn(),
+  emitConversationTransferredToBot: vi.fn(),
+  emitConversationTransferredToHuman: vi.fn(),
+  emitConversationUnassigned: vi.fn(),
+}))
+
+vi.mock("../../contact-inbox/service", () => ({
+  contactInboxService: {},
+}))
+
+const { conversationService } = await import("../service")
+
+const WORKSPACE_ID = "ws-1"
+
+beforeEach(() => {
+  mocks.conversationFindMany.mockReset()
+})
+
+describe("ConversationService.findDMByContactIds", () => {
+  test("queries only DM conversations (sourceId IS NULL) scoped to the workspace", async () => {
+    const rows = [
+      { id: "conv-1", contactId: "contact-1" },
+      { id: "conv-2", contactId: "contact-2" },
+    ]
+    mocks.conversationFindMany.mockResolvedValue(rows)
+
+    const result = await conversationService.findDMByContactIds({
+      workspaceId: WORKSPACE_ID,
+      contactIds: ["contact-1", "contact-2"],
+    })
+
+    expect(result).toEqual(rows)
+    expect(mocks.conversationFindMany).toHaveBeenCalledWith({
+      where: {
+        workspaceId: WORKSPACE_ID,
+        contactId: { in: ["contact-1", "contact-2"] },
+        sourceId: { isNull: true },
+      },
+    })
+  })
+
+  test("deduplicates contactIds before querying", async () => {
+    mocks.conversationFindMany.mockResolvedValue([])
+
+    await conversationService.findDMByContactIds({
+      workspaceId: WORKSPACE_ID,
+      contactIds: ["contact-1", "contact-1", "contact-2"],
+    })
+
+    expect(mocks.conversationFindMany).toHaveBeenCalledWith({
+      where: {
+        workspaceId: WORKSPACE_ID,
+        contactId: { in: ["contact-1", "contact-2"] },
+        sourceId: { isNull: true },
+      },
+    })
+  })
+
+  test("short-circuits with an empty result and no query when contactIds is empty", async () => {
+    const result = await conversationService.findDMByContactIds({
+      workspaceId: WORKSPACE_ID,
+      contactIds: [],
+    })
+
+    expect(result).toEqual([])
+    expect(mocks.conversationFindMany).not.toHaveBeenCalled()
+  })
+
+  test("uses the provided transaction client instead of the default db", async () => {
+    const txFindMany = vi.fn().mockResolvedValue([{ id: "conv-tx" }])
+    const tx = {
+      query: { conversationModel: { findMany: txFindMany } },
+    } as unknown as Parameters<
+      typeof conversationService.findDMByContactIds
+    >[0]["tx"]
+
+    const result = await conversationService.findDMByContactIds({
+      workspaceId: WORKSPACE_ID,
+      contactIds: ["contact-1"],
+      tx,
+    })
+
+    expect(result).toEqual([{ id: "conv-tx" }])
+    expect(txFindMany).toHaveBeenCalledOnce()
+    expect(mocks.conversationFindMany).not.toHaveBeenCalled()
+  })
+})

--- a/packages/business/src/conversation/service.ts
+++ b/packages/business/src/conversation/service.ts
@@ -128,6 +128,26 @@ class ConversationService extends BaseService {
     })
   }
 
+  async findDMByContactIds(props: {
+    workspaceId: string
+    contactIds: string[]
+    tx?: DatabaseClient
+  }): Promise<ConversationModel[]> {
+    const { tx = db, workspaceId, contactIds } = props
+    const uniqueContactIds = Array.from(new Set(contactIds))
+    if (uniqueContactIds.length === 0) {
+      return []
+    }
+
+    return await tx.query.conversationModel.findMany({
+      where: {
+        workspaceId,
+        contactId: { in: uniqueContactIds },
+        sourceId: { isNull: true },
+      },
+    })
+  }
+
   async updateChallenge(props: {
     workspaceId: string
     conversationId: string

--- a/packages/business/src/inbox/__tests__/resolve-broadcast-inbox-ids.test.ts
+++ b/packages/business/src/inbox/__tests__/resolve-broadcast-inbox-ids.test.ts
@@ -161,6 +161,36 @@ describe("InboxService.resolveBroadcastInboxIds", () => {
     })
   })
 
+  test("filters inboxes by Instagram channel", async () => {
+    mocks.inboxFindMany.mockResolvedValue([{ id: "inbox-instagram" }])
+
+    const result = await inboxService.resolveBroadcastInboxIds({
+      workspaceId: "ws-1",
+      channels: ["instagram"],
+    })
+
+    expect(result).toEqual(["inbox-instagram"])
+    expect(mocks.inboxFindMany).toHaveBeenCalledWith({
+      where: { workspaceId: "ws-1", channel: "instagram" },
+      columns: { id: true },
+    })
+  })
+
+  test("filters inboxes by Telegram channel", async () => {
+    mocks.inboxFindMany.mockResolvedValue([{ id: "inbox-telegram" }])
+
+    const result = await inboxService.resolveBroadcastInboxIds({
+      workspaceId: "ws-1",
+      channels: ["telegram"],
+    })
+
+    expect(result).toEqual(["inbox-telegram"])
+    expect(mocks.inboxFindMany).toHaveBeenCalledWith({
+      where: { workspaceId: "ws-1", channel: "telegram" },
+      columns: { id: true },
+    })
+  })
+
   test("filters inboxes by multiple specific channels", async () => {
     mocks.inboxFindMany.mockResolvedValue([
       { id: "inbox-1" },

--- a/packages/database/__tests__/broadcast-partial.test.ts
+++ b/packages/database/__tests__/broadcast-partial.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "vitest"
 import {
+  broadcastChannelCapabilities,
+  broadcastSubactionAudienceRules,
   broadcastSubactions,
+  findBroadcastChannelCapability,
   requiresRecentInteractionWindow,
 } from "../src/partials/broadcast"
 
@@ -16,9 +19,14 @@ describe("requiresRecentInteractionWindow", () => {
         broadcastSubactions.enum.whatsappWithin24Hours,
       ),
     ).toBe(true)
+    expect(
+      requiresRecentInteractionWindow(
+        broadcastSubactions.enum.instagramActiveContacts,
+      ),
+    ).toBe(true)
   })
 
-  test("does not require the 24h messaging window for templates, all contacts, or unset subactions", () => {
+  test("does not require the 24h messaging window for templates, all contacts, Telegram, or unset subactions", () => {
     expect(
       requiresRecentInteractionWindow(broadcastSubactions.enum.allContacts),
     ).toBe(false)
@@ -32,7 +40,53 @@ describe("requiresRecentInteractionWindow", () => {
         broadcastSubactions.enum.whatsappTemplateMessage,
       ),
     ).toBe(false)
+    expect(
+      requiresRecentInteractionWindow(
+        broadcastSubactions.enum.telegramAllContacts,
+      ),
+    ).toBe(false)
     expect(requiresRecentInteractionWindow(null)).toBe(false)
     expect(requiresRecentInteractionWindow(undefined)).toBe(false)
+  })
+
+  test("declares an audience rule for every broadcast subaction", () => {
+    expect(Object.keys(broadcastSubactionAudienceRules).sort()).toEqual(
+      broadcastSubactions.options.toSorted(),
+    )
+  })
+})
+
+describe("broadcastChannelCapabilities", () => {
+  test("declares default subactions that belong to each channel capability", () => {
+    for (const capability of broadcastChannelCapabilities) {
+      expect(capability.subactions).toContain(capability.defaultSubaction)
+    }
+  })
+
+  test("finds Instagram and Telegram capabilities and excludes non-broadcast channels", () => {
+    expect(findBroadcastChannelCapability("instagram")).toMatchObject({
+      channel: "instagram",
+      defaultSubaction: broadcastSubactions.enum.instagramActiveContacts,
+    })
+    expect(findBroadcastChannelCapability("telegram")).toMatchObject({
+      channel: "telegram",
+      defaultSubaction: broadcastSubactions.enum.telegramAllContacts,
+    })
+    expect(findBroadcastChannelCapability("webchat")).toBeUndefined()
+  })
+
+  test("marks only Messenger and WhatsApp as supporting template broadcasts", () => {
+    const templateChannels = broadcastChannelCapabilities
+      .filter((capability) => capability.supportsTemplateBroadcast)
+      .map((capability) => capability.channel)
+      .toSorted()
+
+    expect(templateChannels).toEqual(["messenger", "whatsapp"])
+    expect(
+      findBroadcastChannelCapability("instagram")?.supportsTemplateBroadcast,
+    ).toBe(false)
+    expect(
+      findBroadcastChannelCapability("telegram")?.supportsTemplateBroadcast,
+    ).toBe(false)
   })
 })

--- a/packages/database/src/partials/broadcast.ts
+++ b/packages/database/src/partials/broadcast.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import type { ChannelType } from "./channel"
 
 export const broadcastScheduleTypes = z.enum(["now", "future"])
 export type BroadcastScheduleType = z.infer<typeof broadcastScheduleTypes>
@@ -12,15 +13,90 @@ export const broadcastSubactions = z.enum([
   "messengerTemplateMessage",
   "whatsappTemplateMessage",
   "whatsappWithin24Hours",
+  "instagramActiveContacts",
+  "telegramAllContacts",
 ])
 export type BroadcastSubaction = z.infer<typeof broadcastSubactions>
 
-// Non-template Messenger/WhatsApp sends can only reach contacts inside Meta's 24h window.
+type BroadcastAudienceRule = {
+  requiresRecentInteractionWindow: boolean
+}
+
+export const broadcastSubactionAudienceRules: Record<
+  BroadcastSubaction,
+  BroadcastAudienceRule
+> = {
+  allContacts: { requiresRecentInteractionWindow: false },
+  messengerActiveContacts: { requiresRecentInteractionWindow: true },
+  messengerTemplateMessage: { requiresRecentInteractionWindow: false },
+  whatsappTemplateMessage: { requiresRecentInteractionWindow: false },
+  whatsappWithin24Hours: { requiresRecentInteractionWindow: true },
+  instagramActiveContacts: { requiresRecentInteractionWindow: true },
+  telegramAllContacts: { requiresRecentInteractionWindow: false },
+}
+
 export const requiresRecentInteractionWindow = (
   subaction: BroadcastSubaction | null | undefined,
 ): boolean =>
-  subaction === broadcastSubactions.enum.messengerActiveContacts ||
-  subaction === broadcastSubactions.enum.whatsappWithin24Hours
+  subaction
+    ? broadcastSubactionAudienceRules[subaction].requiresRecentInteractionWindow
+    : false
+
+export type BroadcastChannelCapability = {
+  channel: ChannelType
+  subactions: readonly BroadcastSubaction[]
+  defaultSubaction: BroadcastSubaction
+  // Only Messenger/WhatsApp expose a template-message broadcast; other channels
+  // are flow-only. Keeping this on the registry is the single source of truth.
+  supportsTemplateBroadcast: boolean
+}
+
+export const broadcastChannelCapabilities: readonly BroadcastChannelCapability[] =
+  [
+    {
+      channel: "omnichannel",
+      subactions: ["allContacts"],
+      defaultSubaction: "allContacts",
+      supportsTemplateBroadcast: false,
+    },
+    {
+      channel: "messenger",
+      subactions: ["messengerTemplateMessage", "messengerActiveContacts"],
+      defaultSubaction: "messengerTemplateMessage",
+      supportsTemplateBroadcast: true,
+    },
+    {
+      channel: "whatsapp",
+      subactions: ["whatsappTemplateMessage", "whatsappWithin24Hours"],
+      defaultSubaction: "whatsappTemplateMessage",
+      supportsTemplateBroadcast: true,
+    },
+    {
+      channel: "zalo",
+      subactions: ["allContacts"],
+      defaultSubaction: "allContacts",
+      supportsTemplateBroadcast: false,
+    },
+    {
+      channel: "instagram",
+      subactions: ["instagramActiveContacts"],
+      defaultSubaction: "instagramActiveContacts",
+      supportsTemplateBroadcast: false,
+    },
+    {
+      channel: "telegram",
+      subactions: ["telegramAllContacts"],
+      defaultSubaction: "telegramAllContacts",
+      supportsTemplateBroadcast: false,
+    },
+  ]
+
+export const findBroadcastChannelCapability = (
+  channel: ChannelType,
+): BroadcastChannelCapability | undefined =>
+  broadcastChannelCapabilities.find(
+    (capability) => capability.channel === channel,
+  )
 
 export const broadcastFlowTypes = z.enum(["flow", "template"])
 export type BroadcastFlowType = z.infer<typeof broadcastFlowTypes>


### PR DESCRIPTION
## What

Adds **Instagram** and **Telegram** as broadcast channels, alongside the existing Messenger, WhatsApp, and Zalo.

- **Instagram** — sent to contacts who messaged the bot within the last 24 hours.
- **Telegram** — sent to all of the bot's Telegram contacts.

Both use the same "Flow to send", scheduling ("When to send"), and optional targeting as the other channels.

## Test plan

- [x] Automated tests pass (worker, business, database, builder)
- [ ] Send a test Instagram broadcast in staging
- [ ] Send a test Telegram broadcast in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
