### PR TITLE
fix(worker): make smart delay recovery more reliable

### DIFF
--- a/apps/worker/__tests__/scan-smart-delay.test.ts
+++ b/apps/worker/__tests__/scan-smart-delay.test.ts
@@ -1,17 +1,23 @@
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
-const { integrationQueueAddBulk, loggerInfo, loggerWarn, smartDelayService } =
-  vi.hoisted(() => ({
-    integrationQueueAddBulk: vi.fn(),
-    loggerInfo: vi.fn(),
-    loggerWarn: vi.fn(),
-    smartDelayService: {
-      claimForRun: vi.fn(),
-      claimDueRows: vi.fn(),
-      resetToPending: vi.fn(),
-      sweepStuckScheduled: vi.fn(),
-    },
-  }))
+const {
+  integrationQueueAddBulk,
+  integrationQueueRemove,
+  loggerInfo,
+  loggerWarn,
+  smartDelayService,
+} = vi.hoisted(() => ({
+  integrationQueueAddBulk: vi.fn(),
+  integrationQueueRemove: vi.fn(),
+  loggerInfo: vi.fn(),
+  loggerWarn: vi.fn(),
+  smartDelayService: {
+    claimForRun: vi.fn(),
+    claimDueRows: vi.fn(),
+    listStuckScheduled: vi.fn(),
+    resetToPending: vi.fn(),
+  },
+}))
 
 vi.mock("@chatbotx.io/business/smart-delay", () => ({ smartDelayService }))
 
@@ -24,6 +30,7 @@ vi.mock("@chatbotx.io/worker-config", () => ({
   integrationQueue: {
     add: vi.fn(),
     addBulk: integrationQueueAddBulk,
+    remove: integrationQueueRemove,
   },
 }))
 
@@ -60,29 +67,211 @@ describe("scanSmartDelay", () => {
     vi.clearAllMocks()
     vi.useFakeTimers()
     vi.setSystemTime(new Date("2026-07-16T00:00:00.000Z"))
-    smartDelayService.sweepStuckScheduled.mockResolvedValue(0)
+    smartDelayService.listStuckScheduled.mockResolvedValue([])
     smartDelayService.claimForRun.mockResolvedValue(true)
+    smartDelayService.resetToPending.mockImplementation(
+      ({ ids }: { ids: string[] }) => Promise.resolve(ids.length),
+    )
     integrationQueueAddBulk.mockResolvedValue(undefined)
+    integrationQueueRemove.mockResolvedValue(1)
   })
 
   test("returns zero counts when no smart-delay rows are due", async () => {
     smartDelayService.claimDueRows.mockResolvedValueOnce([])
 
     await expect(scanSmartDelay()).resolves.toEqual({ scanned: 0, enqueued: 0 })
-    expect(smartDelayService.sweepStuckScheduled).toHaveBeenCalledWith({
+    expect(smartDelayService.listStuckScheduled).toHaveBeenCalledWith({
       olderThan: new Date("2026-07-15T23:50:00.000Z"),
+      limit: 500,
     })
+    expect(integrationQueueRemove).not.toHaveBeenCalled()
+    expect(smartDelayService.resetToPending).not.toHaveBeenCalled()
     expect(integrationQueueAddBulk).not.toHaveBeenCalled()
   })
 
-  test("logs and resets stuck scheduled rows before claiming due rows", async () => {
-    smartDelayService.sweepStuckScheduled.mockResolvedValueOnce(3)
+  test("removes stale wake-up jobs before resetting stuck rows to pending", async () => {
+    smartDelayService.listStuckScheduled.mockResolvedValueOnce([
+      { id: "stuck-1", triggerAt: new Date("2026-07-15T23:40:00.000Z") },
+      { id: "stuck-2", triggerAt: new Date("2026-07-15T23:41:00.000Z") },
+    ])
+    smartDelayService.claimDueRows.mockResolvedValueOnce([])
+
+    await expect(scanSmartDelay()).resolves.toEqual({ scanned: 0, enqueued: 0 })
+
+    expect(integrationQueueRemove).toHaveBeenCalledWith(
+      "smart-delay-stuck-1-1784158800000",
+    )
+    expect(integrationQueueRemove).toHaveBeenCalledWith(
+      "smart-delay-stuck-2-1784158860000",
+    )
+    expect(smartDelayService.resetToPending).toHaveBeenCalledWith({
+      ids: ["stuck-1", "stuck-2"],
+      triggerAtBefore: new Date("2026-07-15T23:50:00.000Z"),
+    })
+    // The stale job must be removed BEFORE the row becomes claimable again,
+    // otherwise the scanner's re-add hits BullMQ jobId dedup ("duplicated").
+    const removeOrder = integrationQueueRemove.mock.invocationCallOrder[0]
+    const resetOrder =
+      smartDelayService.resetToPending.mock.invocationCallOrder[0]
+    expect(removeOrder).toBeLessThan(resetOrder)
+    expect(loggerWarn).toHaveBeenCalledWith(
+      { count: 2, failedRemovals: 0 },
+      "Reset stuck scheduled smart delay rows to pending",
+    )
+  })
+
+  test("keeps claiming batches until a partial batch signals the backlog is drained", async () => {
+    const fullBatch = Array.from({ length: 500 }, (_, index) =>
+      makeRow({ id: `bulk-row-${index}` }),
+    )
+    smartDelayService.claimDueRows
+      .mockResolvedValueOnce(fullBatch)
+      .mockResolvedValueOnce([makeRow({ id: "tail-row" })])
+
+    await expect(scanSmartDelay()).resolves.toEqual({
+      scanned: 501,
+      enqueued: 501,
+    })
+
+    expect(smartDelayService.claimDueRows).toHaveBeenCalledTimes(2)
+    expect(integrationQueueAddBulk).toHaveBeenCalledTimes(2)
+  })
+
+  test("sweeps stuck rows in batches until a partial batch", async () => {
+    const fullBatch = Array.from({ length: 500 }, (_, index) => ({
+      id: `stuck-${index}`,
+      triggerAt: new Date("2026-07-15T23:40:00.000Z"),
+    }))
+    smartDelayService.listStuckScheduled
+      .mockResolvedValueOnce(fullBatch)
+      .mockResolvedValueOnce([
+        { id: "stuck-tail", triggerAt: new Date("2026-07-15T23:41:00.000Z") },
+      ])
+    smartDelayService.claimDueRows.mockResolvedValueOnce([])
+
+    await expect(scanSmartDelay()).resolves.toEqual({ scanned: 0, enqueued: 0 })
+
+    expect(smartDelayService.listStuckScheduled).toHaveBeenCalledTimes(2)
+    expect(integrationQueueRemove).toHaveBeenCalledTimes(501)
+    expect(smartDelayService.resetToPending).toHaveBeenCalledTimes(2)
+    expect(loggerWarn).toHaveBeenCalledWith(
+      { count: 501, failedRemovals: 0 },
+      "Reset stuck scheduled smart delay rows to pending",
+    )
+  })
+
+  test("reports only rows the CAS actually reset when one completed mid-sweep", async () => {
+    smartDelayService.listStuckScheduled.mockResolvedValueOnce([
+      { id: "stuck-1", triggerAt: new Date("2026-07-15T23:40:00.000Z") },
+      { id: "stuck-2", triggerAt: new Date("2026-07-15T23:41:00.000Z") },
+    ])
+    // "stuck-2" was completed by its in-flight resume between the sweep's read
+    // and write — the guarded reset returns 1, and the log must not overcount.
+    smartDelayService.resetToPending.mockResolvedValueOnce(1)
     smartDelayService.claimDueRows.mockResolvedValueOnce([])
 
     await expect(scanSmartDelay()).resolves.toEqual({ scanned: 0, enqueued: 0 })
 
     expect(loggerWarn).toHaveBeenCalledWith(
-      { count: 3 },
+      { count: 1, failedRemovals: 0 },
+      "Reset stuck scheduled smart delay rows to pending",
+    )
+  })
+
+  test("treats an unremovable active job as fulfilled and defers to the CAS", async () => {
+    smartDelayService.listStuckScheduled.mockResolvedValueOnce([
+      { id: "stuck-1", triggerAt: new Date("2026-07-15T23:40:00.000Z") },
+    ])
+    // BullMQ resolves 0 (not a rejection) when the job is locked/active.
+    integrationQueueRemove.mockResolvedValueOnce(0)
+    smartDelayService.claimDueRows.mockResolvedValueOnce([])
+
+    await expect(scanSmartDelay()).resolves.toEqual({ scanned: 0, enqueued: 0 })
+
+    expect(smartDelayService.resetToPending).toHaveBeenCalledWith({
+      ids: ["stuck-1"],
+      triggerAtBefore: new Date("2026-07-15T23:50:00.000Z"),
+    })
+    expect(loggerWarn).toHaveBeenCalledWith(
+      { count: 1, failedRemovals: 0 },
+      "Reset stuck scheduled smart delay rows to pending",
+    )
+  })
+
+  test("continues claiming when the sweep itself fails", async () => {
+    smartDelayService.listStuckScheduled.mockRejectedValueOnce(
+      new Error("db unavailable"),
+    )
+    smartDelayService.claimDueRows.mockResolvedValueOnce([makeRow()])
+
+    await expect(scanSmartDelay()).resolves.toEqual({ scanned: 1, enqueued: 1 })
+  })
+
+  test("warns when the sweep exhausts its per-run batch cap", async () => {
+    const fullBatch = Array.from({ length: 500 }, (_, index) => ({
+      id: `stuck-${index}`,
+      triggerAt: new Date("2026-07-15T23:40:00.000Z"),
+    }))
+    smartDelayService.listStuckScheduled.mockResolvedValue(fullBatch)
+    smartDelayService.claimDueRows.mockResolvedValueOnce([])
+
+    await scanSmartDelay()
+
+    expect(smartDelayService.listStuckScheduled).toHaveBeenCalledTimes(20)
+    expect(loggerWarn).toHaveBeenCalledWith(
+      { maxBatches: 20, batchSize: 500 },
+      "Smart delay sweep hit its per-run batch cap; backlog remains for the next tick",
+    )
+  })
+
+  test("warns when the claim loop exhausts its per-run batch cap", async () => {
+    const fullBatch = Array.from({ length: 500 }, (_, index) =>
+      makeRow({ id: `bulk-row-${index}` }),
+    )
+    smartDelayService.claimDueRows.mockResolvedValue(fullBatch)
+
+    await expect(scanSmartDelay()).resolves.toEqual({
+      scanned: 100_000,
+      enqueued: 100_000,
+    })
+
+    expect(smartDelayService.claimDueRows).toHaveBeenCalledTimes(200)
+    expect(loggerWarn).toHaveBeenCalledWith(
+      { scanned: 100_000, maxBatches: 200 },
+      "Smart delay claim hit its per-run batch cap; backlog remains for the next tick",
+    )
+  })
+
+  test("completes remaining enqueueable rows when a terminal-row update fails", async () => {
+    smartDelayService.claimForRun.mockRejectedValueOnce(new Error("db timeout"))
+    smartDelayService.claimDueRows.mockResolvedValueOnce([
+      makeRow({ id: "terminal-row", nodeId: null }),
+      makeRow({ id: "resumable-row" }),
+    ])
+
+    await expect(scanSmartDelay()).resolves.toEqual({ scanned: 2, enqueued: 1 })
+
+    expect(integrationQueueAddBulk).toHaveBeenCalledTimes(1)
+  })
+
+  test("still resets stuck rows when removing a stale job fails", async () => {
+    smartDelayService.listStuckScheduled.mockResolvedValueOnce([
+      { id: "stuck-1", triggerAt: new Date("2026-07-15T23:40:00.000Z") },
+      { id: "stuck-2", triggerAt: new Date("2026-07-15T23:41:00.000Z") },
+    ])
+    smartDelayService.claimDueRows.mockResolvedValueOnce([])
+    integrationQueueRemove
+      .mockRejectedValueOnce(new Error("job is active"))
+      .mockResolvedValueOnce(1)
+
+    await expect(scanSmartDelay()).resolves.toEqual({ scanned: 0, enqueued: 0 })
+
+    expect(smartDelayService.resetToPending).toHaveBeenCalledWith({
+      ids: ["stuck-1", "stuck-2"],
+      triggerAtBefore: new Date("2026-07-15T23:50:00.000Z"),
+    })
+    expect(loggerWarn).toHaveBeenCalledWith(
+      { count: 2, failedRemovals: 1 },
       "Reset stuck scheduled smart delay rows to pending",
     )
   })
@@ -97,6 +286,7 @@ describe("scanSmartDelay", () => {
 
     expect(smartDelayService.claimDueRows).toHaveBeenCalledWith({
       windowUntil: new Date("2026-07-16T00:05:59.999Z"),
+      limit: 500,
     })
     expect(integrationQueueAddBulk).toHaveBeenCalledWith([
       {

--- a/apps/worker/src/schedule/handlers/scan-smart-delay.ts
+++ b/apps/worker/src/schedule/handlers/scan-smart-delay.ts
@@ -1,39 +1,96 @@
-import { smartDelayService } from "@chatbotx.io/business/smart-delay"
+import {
+  type SmartDelayRow,
+  smartDelayService,
+} from "@chatbotx.io/business/smart-delay"
 import { buildJobId, ENQUEUE_DELAY_MS } from "@chatbotx.io/flow-config"
 import { integrationQueue } from "@chatbotx.io/worker-config"
 import { endOfMinute, subMilliseconds } from "date-fns"
 import { smartDelayResumeJobFactories } from "../../integration/handlers/smart-delay"
 import { logger } from "../../lib/logger"
 
-const ENQUEUE_BULK_SIZE = 500
+// This table can grow by hundreds of thousands of rows per minute, so every
+// step works in bounded batches. Per-run caps keep one cron tick from hogging
+// the schedule worker; the backlog carries over to the next tick, and
+// FOR UPDATE SKIP LOCKED inside claimDueRows lets overlapping runs split the
+// work instead of double-claiming.
+const SCAN_BATCH_SIZE = 500
+const MAX_SWEEP_BATCHES_PER_RUN = 20
+const MAX_CLAIM_BATCHES_PER_RUN = 200
 const STUCK_SCHEDULED_GRACE_MS = 10 * 60 * 1000
 
-export const scanSmartDelay = async () => {
-  const now = new Date()
-  const windowUntil = endOfMinute(new Date(now.getTime() + ENQUEUE_DELAY_MS))
-  const swept = await smartDelayService.sweepStuckScheduled({
-    olderThan: subMilliseconds(now, STUCK_SCHEDULED_GRACE_MS),
-  })
+const sweepStuckScheduled = async (olderThan: Date): Promise<void> => {
+  let swept = 0
+  let failedRemovals = 0
+  let lastBatchSize = 0
+
+  for (let batch = 0; batch < MAX_SWEEP_BATCHES_PER_RUN; batch++) {
+    const stuckRows = await smartDelayService.listStuckScheduled({
+      olderThan,
+      limit: SCAN_BATCH_SIZE,
+    })
+    lastBatchSize = stuckRows.length
+    if (stuckRows.length === 0) {
+      break
+    }
+
+    // Remove the stale wake-up jobs FIRST: their deterministic jobId would make
+    // the scanner's re-add a silent BullMQ "duplicated" no-op while a stuck
+    // delayed or failed job still occupies the id. Removal is best-effort in
+    // both directions: a rejection is just Redis flakiness, and an
+    // actively-processing job RESOLVES with 0 (it cannot be removed) — either
+    // way correctness is guaranteed by the CAS inside resetToPending, which
+    // only touches rows that are still 'scheduled'.
+    const removals = await Promise.allSettled(
+      stuckRows.map((row) =>
+        integrationQueue.remove(buildJobId(row.id, row.triggerAt)),
+      ),
+    )
+    failedRemovals += removals.filter(
+      (removal) => removal.status === "rejected",
+    ).length
+
+    swept += await smartDelayService.resetToPending({
+      ids: stuckRows.map((row) => row.id),
+      triggerAtBefore: olderThan,
+    })
+
+    if (stuckRows.length < SCAN_BATCH_SIZE) {
+      break
+    }
+  }
+
   if (swept > 0) {
     logger.warn(
-      { count: swept },
+      { count: swept, failedRemovals },
       "Reset stuck scheduled smart delay rows to pending",
     )
   }
-
-  const claimed = await smartDelayService.claimDueRows({ windowUntil })
-
-  if (claimed.length === 0) {
-    return { scanned: 0, enqueued: 0 }
+  if (lastBatchSize === SCAN_BATCH_SIZE) {
+    logger.warn(
+      { maxBatches: MAX_SWEEP_BATCHES_PER_RUN, batchSize: SCAN_BATCH_SIZE },
+      "Smart delay sweep hit its per-run batch cap; backlog remains for the next tick",
+    )
   }
+}
 
+const enqueueClaimedBatch = async (claimed: SmartDelayRow[]) => {
   const terminalRows = claimed.filter((row) => !row.nodeId)
   if (terminalRows.length > 0) {
-    await Promise.all(
+    // allSettled: one failed terminal update must not abort the enqueueable
+    // part of an already-claimed batch; a failed row stays 'scheduled' and the
+    // stuck-sweep recovers it on a later tick.
+    const results = await Promise.allSettled(
       terminalRows.map((row) =>
         smartDelayService.claimForRun({ id: row.id, to: "completed" }),
       ),
     )
+    const failed = results.filter((result) => result.status === "rejected")
+    if (failed.length > 0) {
+      logger.error(
+        { count: failed.length },
+        "Failed to complete some terminal smart delay rows; sweep will retry them",
+      )
+    }
     logger.info(
       { ids: terminalRows.map((row) => row.id) },
       "Smart delay rows without nodeId marked completed (terminal wait)",
@@ -41,44 +98,84 @@ export const scanSmartDelay = async () => {
   }
 
   const enqueueable = claimed.filter((row) => row.nodeId)
-  let enqueued = 0
+  if (enqueueable.length === 0) {
+    return 0
+  }
 
-  for (let index = 0; index < enqueueable.length; index += ENQUEUE_BULK_SIZE) {
-    const batch = enqueueable.slice(index, index + ENQUEUE_BULK_SIZE)
+  try {
+    await integrationQueue.addBulk(
+      enqueueable.map((row) => {
+        const job = smartDelayResumeJobFactories[row.type](row)
+        return {
+          name: job.name,
+          data: job.data,
+          opts: {
+            jobId: buildJobId(row.id, row.triggerAt),
+            delay: Math.max(0, row.triggerAt.getTime() - Date.now()),
+          },
+        }
+      }),
+    )
+    return enqueueable.length
+  } catch (err) {
+    logger.error(
+      { err, ids: enqueueable.map((row) => row.id) },
+      "Failed to enqueue smart delay batch, resetting to pending for retry",
+    )
+
     try {
-      await integrationQueue.addBulk(
-        batch.map((row) => {
-          const job = smartDelayResumeJobFactories[row.type](row)
-          return {
-            name: job.name,
-            data: job.data,
-            opts: {
-              jobId: buildJobId(row.id, row.triggerAt),
-              delay: Math.max(0, row.triggerAt.getTime() - Date.now()),
-            },
-          }
-        }),
-      )
-
-      enqueued += batch.length
-    } catch (err) {
+      await smartDelayService.resetToPending({
+        ids: enqueueable.map((row) => row.id),
+      })
+    } catch (updateErr) {
       logger.error(
-        { err, ids: batch.map((row) => row.id) },
-        "Failed to enqueue smart delay batch, resetting to pending for retry",
+        { err: updateErr, ids: enqueueable.map((row) => row.id) },
+        "Failed to reset smart delay batch status to pending",
       )
+    }
+    return 0
+  }
+}
 
-      try {
-        await smartDelayService.resetToPending({
-          ids: batch.map((row) => row.id),
-        })
-      } catch (updateErr) {
-        logger.error(
-          { err: updateErr, ids: batch.map((row) => row.id) },
-          "Failed to reset smart delay batch status to pending",
-        )
-      }
+export const scanSmartDelay = async () => {
+  const now = new Date()
+  const windowUntil = endOfMinute(new Date(now.getTime() + ENQUEUE_DELAY_MS))
+
+  // A sweep hiccup must never block claiming fresh due rows in the same tick.
+  try {
+    await sweepStuckScheduled(subMilliseconds(now, STUCK_SCHEDULED_GRACE_MS))
+  } catch (err) {
+    logger.error({ err }, "Smart delay sweep failed; continuing with claim")
+  }
+
+  let scanned = 0
+  let enqueued = 0
+  let lastBatchSize = 0
+
+  for (let batch = 0; batch < MAX_CLAIM_BATCHES_PER_RUN; batch++) {
+    const claimed = await smartDelayService.claimDueRows({
+      windowUntil,
+      limit: SCAN_BATCH_SIZE,
+    })
+    lastBatchSize = claimed.length
+    if (claimed.length === 0) {
+      break
+    }
+
+    scanned += claimed.length
+    enqueued += await enqueueClaimedBatch(claimed)
+
+    if (claimed.length < SCAN_BATCH_SIZE) {
+      break
     }
   }
 
-  return { scanned: claimed.length, enqueued }
+  if (lastBatchSize === SCAN_BATCH_SIZE) {
+    logger.warn(
+      { scanned, maxBatches: MAX_CLAIM_BATCHES_PER_RUN },
+      "Smart delay claim hit its per-run batch cap; backlog remains for the next tick",
+    )
+  }
+
+  return { scanned, enqueued }
 }

--- a/packages/business/__tests__/smart-delay-service.test.ts
+++ b/packages/business/__tests__/smart-delay-service.test.ts
@@ -3,9 +3,12 @@ import { beforeEach, describe, expect, test, vi } from "vitest"
 const {
   mockCount,
   mockDbFindFirst,
+  mockDbFor,
   mockDbFrom,
   mockDbGroupBy,
   mockDbInsert,
+  mockDbLimit,
+  mockDbOrderBy,
   mockDbOnConflictDoUpdate,
   mockDbReturning,
   mockDbSelect,
@@ -39,11 +42,17 @@ const {
   updateChain.set.mockReturnValue(updateChain)
   updateChain.where.mockReturnValue(updateChain)
   const selectChain = {
+    for: vi.fn(),
     from: vi.fn(),
     groupBy: vi.fn(),
+    limit: vi.fn(),
+    orderBy: vi.fn(),
     where: vi.fn(),
   }
+  selectChain.for.mockReturnValue(selectChain)
   selectChain.from.mockReturnValue(selectChain)
+  selectChain.limit.mockReturnValue(selectChain)
+  selectChain.orderBy.mockReturnValue(selectChain)
   selectChain.where.mockReturnValue(selectChain)
   selectChain.groupBy.mockResolvedValue([])
 
@@ -51,8 +60,11 @@ const {
     mockCount: vi.fn(() => "count()"),
     mockDbFindFirst: vi.fn(),
     mockDbFrom: selectChain.from,
+    mockDbFor: selectChain.for,
     mockDbGroupBy: selectChain.groupBy,
     mockDbInsert,
+    mockDbLimit: selectChain.limit,
+    mockDbOrderBy: selectChain.orderBy,
     mockDbOnConflictDoUpdate: insertChain.onConflictDoUpdate,
     mockDbReturning,
     mockDbSelect: vi.fn(() => selectChain),
@@ -220,18 +232,23 @@ describe("smartDelayService", () => {
     expect(mockDbWhere).toHaveBeenCalledTimes(2)
   })
 
-  test("claimDueRows claims pending rows up to the window", async () => {
+  test("claimDueRows claims a bounded, lock-skipping batch up to the window", async () => {
     mockDbReturning.mockResolvedValueOnce([
       { ...smartDelayRow, status: "scheduled" },
     ])
     const windowUntil = new Date("2026-07-16T00:05:00.000Z")
 
     await expect(
-      smartDelayService.claimDueRows({ windowUntil }),
+      smartDelayService.claimDueRows({ windowUntil, limit: 500 }),
     ).resolves.toEqual([{ ...smartDelayRow, status: "scheduled" }])
 
     expect(mockDbSet).toHaveBeenCalledWith({ status: "scheduled" })
     expect(mockLte).toHaveBeenCalledWith(expect.anything(), windowUntil)
+    // Batch bound + SKIP LOCKED: concurrent scanners split the backlog
+    // instead of double-claiming or loading everything into memory.
+    expect(mockDbLimit).toHaveBeenCalledWith(500)
+    expect(mockDbFor).toHaveBeenCalledWith("update", { skipLocked: true })
+    expect(mockInArray).toHaveBeenCalledOnce()
     expect(mockDbReturning).toHaveBeenCalledOnce()
   })
 
@@ -251,30 +268,54 @@ describe("smartDelayService", () => {
     ).resolves.toBe(false)
   })
 
-  test("sweepStuckScheduled resets overdue scheduled rows", async () => {
-    mockDbReturning.mockResolvedValueOnce([{ id: "row-1" }, { id: "row-2" }])
+  test("listStuckScheduled returns a bounded batch of overdue scheduled rows", async () => {
     const olderThan = new Date("2026-07-16T00:10:00.000Z")
+    const stuckRows = [
+      { id: "row-1", triggerAt: new Date("2026-07-16T00:00:00.000Z") },
+      { id: "row-2", triggerAt: new Date("2026-07-16T00:01:00.000Z") },
+    ]
+    mockDbLimit.mockResolvedValueOnce(stuckRows)
 
     await expect(
-      smartDelayService.sweepStuckScheduled({ olderThan }),
-    ).resolves.toBe(2)
+      smartDelayService.listStuckScheduled({ olderThan, limit: 500 }),
+    ).resolves.toEqual(stuckRows)
 
-    expect(mockDbSet).toHaveBeenCalledWith({ status: "pending" })
+    expect(mockDbSelect).toHaveBeenCalledWith({
+      id: expect.anything(),
+      triggerAt: expect.anything(),
+    })
+    expect(mockEq).toHaveBeenCalledWith(expect.anything(), "scheduled")
     expect(mockLt).toHaveBeenCalledWith(expect.anything(), olderThan)
+    expect(mockDbOrderBy).toHaveBeenCalledOnce()
+    expect(mockDbLimit).toHaveBeenCalledWith(500)
   })
 
-  test("resetToPending updates only the provided ids", async () => {
-    await smartDelayService.resetToPending({ ids: ["row-1", "row-2"] })
+  test("resetToPending only resets rows still scheduled and reports the real count", async () => {
+    // CAS: a concurrent resume completed "row-2" between read and write — the
+    // guarded UPDATE must not resurrect it, and the count reflects that.
+    mockDbReturning.mockResolvedValueOnce([{ id: "row-1" }])
+
+    const triggerAtBefore = new Date("2026-07-16T00:05:00.000Z")
+    await expect(
+      smartDelayService.resetToPending({
+        ids: ["row-1", "row-2"],
+        triggerAtBefore,
+      }),
+    ).resolves.toBe(1)
 
     expect(mockDbSet).toHaveBeenCalledWith({ status: "pending" })
     expect(mockInArray).toHaveBeenCalledWith(expect.anything(), [
       "row-1",
       "row-2",
     ])
+    expect(mockEq).toHaveBeenCalledWith(expect.anything(), "scheduled")
+    // Rescheduled rows with a fresh future triggerAt are excluded.
+    expect(mockLt).toHaveBeenCalledWith(expect.anything(), triggerAtBefore)
+    expect(mockDbReturning).toHaveBeenCalledOnce()
   })
 
   test("resetToPending skips empty batches", async () => {
-    await smartDelayService.resetToPending({ ids: [] })
+    await expect(smartDelayService.resetToPending({ ids: [] })).resolves.toBe(0)
 
     expect(mockDbUpdate).not.toHaveBeenCalled()
   })

--- a/packages/business/src/smart-delay/service.ts
+++ b/packages/business/src/smart-delay/service.ts
@@ -165,18 +165,36 @@ class SmartDelayService extends BaseService {
     )
   }
 
+  // Claims one bounded batch: this table can grow by hundreds of thousands of
+  // rows per minute, so the claim must never load the whole backlog at once.
+  // FOR UPDATE SKIP LOCKED lets concurrent scanner runs split the backlog
+  // instead of double-claiming the same rows.
   async claimDueRows(props: {
     tx?: DatabaseClient
     windowUntil: Date
+    limit: number
   }): Promise<SmartDelayRow[]> {
-    const { tx = db, windowUntil } = props
+    const { tx = db, windowUntil, limit } = props
+    const dueRowIds = tx
+      .select({ id: contactOnSmartDelayModel.id })
+      .from(contactOnSmartDelayModel)
+      .where(
+        and(
+          eq(contactOnSmartDelayModel.status, smartDelayStatuses.enum.pending),
+          lte(contactOnSmartDelayModel.triggerAt, windowUntil),
+        ),
+      )
+      .orderBy(contactOnSmartDelayModel.triggerAt)
+      .limit(limit)
+      .for("update", { skipLocked: true })
+
     const rows = await tx
       .update(contactOnSmartDelayModel)
       .set({ status: smartDelayStatuses.enum.scheduled })
       .where(
         and(
           eq(contactOnSmartDelayModel.status, smartDelayStatuses.enum.pending),
-          lte(contactOnSmartDelayModel.triggerAt, windowUntil),
+          inArray(contactOnSmartDelayModel.id, dueRowIds),
         ),
       )
       .returning()
@@ -207,14 +225,22 @@ class SmartDelayService extends BaseService {
     return rows.length > 0
   }
 
-  async sweepStuckScheduled(props: {
+  // Recovery input for the scanner sweeper: scheduled rows whose wake-up never
+  // ran (lost or stuck BullMQ job). Returns triggerAt too so the caller can
+  // rebuild the deterministic jobId and remove the stale job BEFORE the row is
+  // reset to pending — otherwise the re-add is dropped as a BullMQ duplicate.
+  async listStuckScheduled(props: {
     tx?: DatabaseClient
     olderThan: Date
-  }): Promise<number> {
-    const { tx = db, olderThan } = props
-    const rows = await tx
-      .update(contactOnSmartDelayModel)
-      .set({ status: smartDelayStatuses.enum.pending })
+    limit: number
+  }): Promise<Pick<SmartDelayRow, "id" | "triggerAt">[]> {
+    const { tx = db, olderThan, limit } = props
+    return await tx
+      .select({
+        id: contactOnSmartDelayModel.id,
+        triggerAt: contactOnSmartDelayModel.triggerAt,
+      })
+      .from(contactOnSmartDelayModel)
       .where(
         and(
           eq(
@@ -224,24 +250,44 @@ class SmartDelayService extends BaseService {
           lt(contactOnSmartDelayModel.triggerAt, olderThan),
         ),
       )
-      .returning({ id: contactOnSmartDelayModel.id })
-
-    return rows.length
+      .orderBy(contactOnSmartDelayModel.triggerAt)
+      .limit(limit)
   }
 
+  // CAS: only rows still 'scheduled' go back to pending. A concurrent resume
+  // may complete/cancel a row between the caller's read and this write — an
+  // unguarded reset would resurrect it and re-run its side effects.
+  // `triggerAtBefore` (sweep path) additionally skips rows that were
+  // rescheduled to a fresh future triggerAt in that same window.
+  // Returns how many rows were actually reset.
   async resetToPending(props: {
     tx?: DatabaseClient
     ids: string[]
-  }): Promise<void> {
-    const { tx = db, ids } = props
+    triggerAtBefore?: Date
+  }): Promise<number> {
+    const { tx = db, ids, triggerAtBefore } = props
     if (ids.length === 0) {
-      return
+      return 0
     }
 
-    await tx
+    const rows = await tx
       .update(contactOnSmartDelayModel)
       .set({ status: smartDelayStatuses.enum.pending })
-      .where(inArray(contactOnSmartDelayModel.id, ids))
+      .where(
+        and(
+          inArray(contactOnSmartDelayModel.id, ids),
+          eq(
+            contactOnSmartDelayModel.status,
+            smartDelayStatuses.enum.scheduled,
+          ),
+          triggerAtBefore
+            ? lt(contactOnSmartDelayModel.triggerAt, triggerAtBefore)
+            : undefined,
+        ),
+      )
+      .returning({ id: contactOnSmartDelayModel.id })
+
+    return rows.length
   }
 
   private async markStatus(props: {

--- a/packages/worker-config/src/lib/connection.ts
+++ b/packages/worker-config/src/lib/connection.ts
@@ -49,4 +49,5 @@ export const fakeQueue = {
   add: () => Promise.resolve(""),
   addBulk: () => Promise.resolve(""),
   getJob: () => Promise.resolve(undefined),
+  remove: () => Promise.resolve(0),
 }


### PR DESCRIPTION
## Summary
- Delayed messages (Wait and Follow Up steps) now recover automatically when they get stuck, instead of staying silent forever
- Recovery never sends the same message twice, even when many things happen at the same time
- The system stays fast and stable under very high message volume by working in small chunks

## Test plan
- [x] All automated tests pass (business 435, worker 1093, full suite green)
- [x] Type checks and lint pass
- [ ] After deploy: confirm a stuck delayed message is delivered within ~15 minutes and only once