### PR TITLE
feat(broadcasts): add tiktok broadcast channel

### DIFF
--- a/apps/builder/__tests__/contact-filter-config.test.ts
+++ b/apps/builder/__tests__/contact-filter-config.test.ts
@@ -456,7 +456,7 @@ describe("contact filter field config helpers", () => {
     ])
   })
 
-  test("hides existingContact from the picker but keeps its config for rendering", () => {
+  test("hides retired fields from the picker but keeps their configs for rendering", () => {
     const configs = getFieldConfigs({
       t,
       tagOptions: [],
@@ -470,6 +470,9 @@ describe("contact filter field config helpers", () => {
     )
     expect(existingContactConfig).toBeDefined()
     expect(existingContactConfig?.hidden).toBe(true)
+    const localeConfig = configs.find((config) => config.name === "locale")
+    expect(localeConfig).toBeDefined()
+    expect(localeConfig?.hidden).toBe(true)
 
     const collectValues = (options: SelectOption[]): string[] =>
       options.flatMap((option) =>
@@ -477,7 +480,9 @@ describe("contact filter field config helpers", () => {
       )
     const pickerValues = collectValues(getFieldOptions(configs, t))
     expect(pickerValues).not.toContain("existingContact")
+    expect(pickerValues).not.toContain("locale")
     expect(pickerValues).toContain("hasContactInfo")
+    expect(pickerValues).toContain("language")
   })
 
   test("converts custom field types and formats values for display", () => {

--- a/apps/builder/__tests__/create-broadcast.action.test.ts
+++ b/apps/builder/__tests__/create-broadcast.action.test.ts
@@ -420,6 +420,10 @@ describe("createBroadcastAction — happy path insert", () => {
       channel: "telegram" as const,
       subaction: "telegramAllContacts" as const,
     },
+    {
+      channel: "tiktok" as const,
+      subaction: "tiktokActiveContacts" as const,
+    },
   ])("accepts $channel flow broadcasts", async ({ channel, subaction }) => {
     const mockBroadcast = { id: `bc-${channel}` }
     mockInsertReturning.mockResolvedValue([mockBroadcast])
@@ -446,15 +450,15 @@ describe("createBroadcastAction — happy path insert", () => {
     )
   })
 
-  test("rejects non-broadcastable channels such as TikTok", async () => {
+  test("rejects non-broadcastable channels such as Webchat", async () => {
     const result = await (
       createBroadcastAction as (props: unknown) => Promise<unknown>
     )({
       bindArgsParsedInputs: [WORKSPACE_ID],
       parsedInput: {
         ...baseInput,
-        channel: "tiktok",
-        subaction: "telegramAllContacts",
+        channel: "webchat",
+        subaction: "allContacts",
         flowId: "flow-1",
       },
     })
@@ -465,6 +469,31 @@ describe("createBroadcastAction — happy path insert", () => {
       { channel: { _errors: string[] } },
     ]
     expect(errors.channel._errors).toContain("Unsupported broadcast channel")
+    expect(mockInsertValues).not.toHaveBeenCalled()
+    expect(result).toMatchObject({ __validationError: expect.anything() })
+  })
+
+  test("rejects template broadcasts for TikTok", async () => {
+    const result = await (
+      createBroadcastAction as (props: unknown) => Promise<unknown>
+    )({
+      bindArgsParsedInputs: [WORKSPACE_ID],
+      parsedInput: {
+        ...baseInput,
+        channel: "tiktok",
+        subaction: "tiktokActiveContacts",
+        templateId: "template-1",
+      },
+    })
+
+    expect(mockReturnValidationErrors).toHaveBeenCalledOnce()
+    const [, errors] = mockReturnValidationErrors.mock.calls[0] as [
+      unknown,
+      { templateId: { _errors: string[] } },
+    ]
+    expect(errors.templateId._errors).toContain(
+      "Template broadcasts are not supported for this channel",
+    )
     expect(mockInsertValues).not.toHaveBeenCalled()
     expect(result).toMatchObject({ __validationError: expect.anything() })
   })

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -387,6 +387,10 @@
       "title": "Telegram",
       "description": "Use this message type if you want to send a broadcast to your Telegram contacts."
     },
+    "tiktokActiveContacts": {
+      "title": "TikTok",
+      "description": "May contain promotions and will only be sent to users who messaged your bot within the last 24h. TikTok supports text and images only; long flows may be truncated by TikTok's 10-message limit."
+    },
     "flowType": {
       "flow": {
         "title": "Flow",

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -389,7 +389,7 @@
     },
     "tiktokActiveContacts": {
       "title": "TikTok",
-      "description": "May contain promotions and will only be sent to users who messaged your bot within the last 24h. TikTok supports text and images only; long flows may be truncated by TikTok's 10-message limit."
+      "description": "May contain promotions and will only be sent to users who messaged your bot within the last 24h. TikTok broadcasts support text and images only."
     },
     "flowType": {
       "flow": {

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -387,6 +387,10 @@
       "title": "Telegram",
       "description": "Dùng loại tin nhắn này nếu bạn muốn gửi broadcast đến các liên hệ Telegram của mình."
     },
+    "tiktokActiveContacts": {
+      "title": "TikTok",
+      "description": "Có thể chứa khuyến mãi và chỉ được gửi cho người dùng đã nhắn tin cho bot của bạn trong vòng 24 giờ qua. TikTok chỉ hỗ trợ văn bản và hình ảnh; luồng dài có thể bị cắt bớt do giới hạn 10 tin nhắn của TikTok."
+    },
     "flowType": {
       "flow": {
         "title": "Luồng",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -389,7 +389,7 @@
     },
     "tiktokActiveContacts": {
       "title": "TikTok",
-      "description": "Có thể chứa khuyến mãi và chỉ được gửi cho người dùng đã nhắn tin cho bot của bạn trong vòng 24 giờ qua. TikTok chỉ hỗ trợ văn bản và hình ảnh; luồng dài có thể bị cắt bớt do giới hạn 10 tin nhắn của TikTok."
+      "description": "Có thể chứa khuyến mãi và chỉ được gửi cho người dùng đã nhắn tin cho bot của bạn trong vòng 24 giờ qua. Broadcast TikTok chỉ hỗ trợ văn bản và hình ảnh."
     },
     "flowType": {
       "flow": {

--- a/apps/builder/src/features/broadcasts/lib/__tests__/broadcast-filter-fields.test.ts
+++ b/apps/builder/src/features/broadcasts/lib/__tests__/broadcast-filter-fields.test.ts
@@ -67,6 +67,18 @@ describe("getBroadcastExcludedFilterFields", () => {
     ])
   })
 
+  test("excludes current channel and interacted-in-last-24h for TikTok active-contact broadcasts", () => {
+    expect(
+      getBroadcastExcludedFilterFields({
+        channel: channelTypes.enum.tiktok,
+        subaction: broadcastSubactions.enum.tiktokActiveContacts,
+      }),
+    ).toEqual([
+      contactFilterFields.enum.currentChannel,
+      contactFilterFields.enum.interactedInLast24h,
+    ])
+  })
+
   test("keeps inbox for Telegram all-contact broadcasts", () => {
     expect(
       getBroadcastExcludedFilterFields({

--- a/apps/builder/src/features/contact-filter/schemas/definitions.ts
+++ b/apps/builder/src/features/contact-filter/schemas/definitions.ts
@@ -61,6 +61,9 @@ export const CONTACT_FILTER_FIELD_DEFINITIONS = [
     field: contactFilterFields.enum.locale,
     schemaKind: "multiSelect",
     optionSource: "languages",
+    // Superseded by inbox-level `language`; hidden from the picker but still
+    // valid so existing saved filters keep resolving.
+    hidden: true,
   },
   {
     field: contactFilterFields.enum.language,

--- a/apps/worker/__tests__/process-broadcast-contacts.test.ts
+++ b/apps/worker/__tests__/process-broadcast-contacts.test.ts
@@ -76,6 +76,7 @@ vi.mock("@chatbotx.io/database/partials", () => ({
       messenger: "messenger",
       instagram: "instagram",
       telegram: "telegram",
+      tiktok: "tiktok",
     },
   },
 }))
@@ -234,6 +235,7 @@ describe("processBroadcastContacts", () => {
     test.each([
       "instagram",
       "telegram",
+      "tiktok",
     ] as const)("enqueues %s flow broadcasts through the integration queue only", async (channel) => {
       findManyBroadcast.mockResolvedValue([
         makeBroadcast({ flowId: "flow-1", channel }),

--- a/packages/business/__tests__/live-counter-store.test.ts
+++ b/packages/business/__tests__/live-counter-store.test.ts
@@ -23,6 +23,7 @@ const METRIC_ORDER = [
   "teamMembers",
   "contacts",
   "mac",
+  "botMessages",
 ] as const
 
 const redisClient = {
@@ -55,6 +56,7 @@ const dbRow = {
   teamMembersUsed: 30,
   contactsUsed: 40,
   macUsed: 50,
+  botMessagesUsed: 60,
 }
 
 beforeEach(() => {
@@ -65,7 +67,7 @@ beforeEach(() => {
 
 describe("LiveCounterStore.getLiveCounts (via getLiveUsage)", () => {
   test("returns parsed live values in one HMGET without touching the DB", async () => {
-    redisClient.hmget.mockResolvedValue(["1", "2", "3", "4", "5"])
+    redisClient.hmget.mockResolvedValue(["1", "2", "3", "4", "5", "6"])
 
     const usage = await userQuotaService.getLiveUsage(USER)
 
@@ -75,6 +77,7 @@ describe("LiveCounterStore.getLiveCounts (via getLiveUsage)", () => {
       teamMembers: 3,
       contacts: 4,
       mac: 5,
+      botMessages: 6,
     })
     expect(redisClient.hmget).toHaveBeenCalledTimes(1)
     expect(redisClient.hmget).toHaveBeenCalledWith(
@@ -88,7 +91,7 @@ describe("LiveCounterStore.getLiveCounts (via getLiveUsage)", () => {
 
   test("cold-seeds a missing field from a single DB fetch", async () => {
     // mac field absent (cold start); the rest are live.
-    redisClient.hmget.mockResolvedValue(["1", "2", "3", "4", null])
+    redisClient.hmget.mockResolvedValue(["1", "2", "3", "4", null, "6"])
 
     const usage = await userQuotaService.getLiveUsage(USER)
 
@@ -99,6 +102,7 @@ describe("LiveCounterStore.getLiveCounts (via getLiveUsage)", () => {
       teamMembers: 3,
       contacts: 4,
       mac: 50,
+      botMessages: 6,
     })
     // One row fetch shared across all missing fields, and the field is seeded.
     expect(findFirstQuota).toHaveBeenCalledTimes(1)
@@ -111,7 +115,14 @@ describe("LiveCounterStore.getLiveCounts (via getLiveUsage)", () => {
 
   test("fails closed on a corrupt field by using the DB value", async () => {
     // contacts is non-numeric → must not coerce to NaN.
-    redisClient.hmget.mockResolvedValue(["1", "2", "3", "not-a-number", "5"])
+    redisClient.hmget.mockResolvedValue([
+      "1",
+      "2",
+      "3",
+      "not-a-number",
+      "5",
+      "6",
+    ])
 
     const usage = await userQuotaService.getLiveUsage(USER)
 
@@ -131,6 +142,7 @@ describe("LiveCounterStore.getLiveCounts (via getLiveUsage)", () => {
       teamMembers: 30,
       contacts: 40,
       mac: 50,
+      botMessages: 60,
     })
     expect(findFirstQuota).toHaveBeenCalledTimes(1)
   })

--- a/packages/business/src/broadcast/__tests__/broadcast.service.test.ts
+++ b/packages/business/src/broadcast/__tests__/broadcast.service.test.ts
@@ -286,6 +286,20 @@ describe("broadcastService.countAudience", () => {
     expect(where.__and).toContainEqual({ RAW: "recent-interaction" })
   })
 
+  test("includes the 24h predicate for TikTok active contacts", async () => {
+    mocks.resolveBroadcastInboxIds.mockResolvedValue(["inbox-tiktok"])
+    mocks.count.mockResolvedValue(5)
+
+    await broadcastService.countAudience({
+      workspaceId: "ws-1",
+      channels: ["tiktok"],
+      subaction: "tiktokActiveContacts",
+    })
+
+    const where = mocks.count.mock.calls[0]?.[1] as { __and?: unknown[] }
+    expect(where.__and).toContainEqual({ RAW: "recent-interaction" })
+  })
+
   test("prunes email/phone contact filters when the audience caller lacks emailAndPhone permission", async () => {
     mocks.resolveBroadcastInboxIds.mockResolvedValue(["inbox-1"])
     mocks.count.mockResolvedValue(1)

--- a/packages/business/src/inbox/__tests__/resolve-broadcast-inbox-ids.test.ts
+++ b/packages/business/src/inbox/__tests__/resolve-broadcast-inbox-ids.test.ts
@@ -191,6 +191,21 @@ describe("InboxService.resolveBroadcastInboxIds", () => {
     })
   })
 
+  test("filters inboxes by TikTok channel", async () => {
+    mocks.inboxFindMany.mockResolvedValue([{ id: "inbox-tiktok" }])
+
+    const result = await inboxService.resolveBroadcastInboxIds({
+      workspaceId: "ws-1",
+      channels: ["tiktok"],
+    })
+
+    expect(result).toEqual(["inbox-tiktok"])
+    expect(mocks.inboxFindMany).toHaveBeenCalledWith({
+      where: { workspaceId: "ws-1", channel: "tiktok" },
+      columns: { id: true },
+    })
+  })
+
   test("filters inboxes by multiple specific channels", async () => {
     mocks.inboxFindMany.mockResolvedValue([
       { id: "inbox-1" },

--- a/packages/database/__tests__/broadcast-partial.test.ts
+++ b/packages/database/__tests__/broadcast-partial.test.ts
@@ -24,6 +24,11 @@ describe("requiresRecentInteractionWindow", () => {
         broadcastSubactions.enum.instagramActiveContacts,
       ),
     ).toBe(true)
+    expect(
+      requiresRecentInteractionWindow(
+        broadcastSubactions.enum.tiktokActiveContacts,
+      ),
+    ).toBe(true)
   })
 
   test("does not require the 24h messaging window for templates, all contacts, Telegram, or unset subactions", () => {
@@ -63,7 +68,7 @@ describe("broadcastChannelCapabilities", () => {
     }
   })
 
-  test("finds Instagram and Telegram capabilities and excludes non-broadcast channels", () => {
+  test("finds Instagram, Telegram, and TikTok capabilities and excludes non-broadcast channels", () => {
     expect(findBroadcastChannelCapability("instagram")).toMatchObject({
       channel: "instagram",
       defaultSubaction: broadcastSubactions.enum.instagramActiveContacts,
@@ -71,6 +76,10 @@ describe("broadcastChannelCapabilities", () => {
     expect(findBroadcastChannelCapability("telegram")).toMatchObject({
       channel: "telegram",
       defaultSubaction: broadcastSubactions.enum.telegramAllContacts,
+    })
+    expect(findBroadcastChannelCapability("tiktok")).toMatchObject({
+      channel: "tiktok",
+      defaultSubaction: broadcastSubactions.enum.tiktokActiveContacts,
     })
     expect(findBroadcastChannelCapability("webchat")).toBeUndefined()
   })
@@ -87,6 +96,9 @@ describe("broadcastChannelCapabilities", () => {
     ).toBe(false)
     expect(
       findBroadcastChannelCapability("telegram")?.supportsTemplateBroadcast,
+    ).toBe(false)
+    expect(
+      findBroadcastChannelCapability("tiktok")?.supportsTemplateBroadcast,
     ).toBe(false)
   })
 })

--- a/packages/database/src/partials/broadcast.ts
+++ b/packages/database/src/partials/broadcast.ts
@@ -15,6 +15,7 @@ export const broadcastSubactions = z.enum([
   "whatsappWithin24Hours",
   "instagramActiveContacts",
   "telegramAllContacts",
+  "tiktokActiveContacts",
 ])
 export type BroadcastSubaction = z.infer<typeof broadcastSubactions>
 
@@ -33,6 +34,7 @@ export const broadcastSubactionAudienceRules: Record<
   whatsappWithin24Hours: { requiresRecentInteractionWindow: true },
   instagramActiveContacts: { requiresRecentInteractionWindow: true },
   telegramAllContacts: { requiresRecentInteractionWindow: false },
+  tiktokActiveContacts: { requiresRecentInteractionWindow: true },
 }
 
 export const requiresRecentInteractionWindow = (
@@ -87,6 +89,12 @@ export const broadcastChannelCapabilities: readonly BroadcastChannelCapability[]
       channel: "telegram",
       subactions: ["telegramAllContacts"],
       defaultSubaction: "telegramAllContacts",
+      supportsTemplateBroadcast: false,
+    },
+    {
+      channel: "tiktok",
+      subactions: ["tiktokActiveContacts"],
+      defaultSubaction: "tiktokActiveContacts",
       supportsTemplateBroadcast: false,
     },
   ]


### PR DESCRIPTION
## What this does

Adds **TikTok** as a broadcast channel, so you can send a flow to your TikTok contacts directly from the Broadcasts screen — alongside the existing Messenger, WhatsApp, Zalo, Instagram, and Telegram channels.

- **TikTok** — sent to contacts who messaged your bot within the last 24 hours (text and images).

You can pick a flow to send, choose when to send it (now or scheduled), and optionally target specific contacts.

## Also included

- A few small fixes and test updates.

## Test plan

- [x] Automated tests cover audience targeting, validation, and delivery for the TikTok channel.
- [ ] Create and send a TikTok broadcast and confirm it reaches the expected contacts.
