### PR TITLE
fix(broadcasts): make TikTok broadcasts reach their recipients

### DIFF
--- a/apps/worker/__tests__/prepare-broadcast.test.ts
+++ b/apps/worker/__tests__/prepare-broadcast.test.ts
@@ -286,6 +286,7 @@ describe("prepareBroadcast", () => {
     expect(findDMByContactIds).toHaveBeenCalledWith({
       workspaceId: WORKSPACE_ID,
       contactIds: ["contact-1", "contact-2"],
+      channel: "messenger",
     })
     expect(insertCalls).toHaveLength(1)
     expect(onConflictSpy).toHaveBeenCalledTimes(1)
@@ -319,6 +320,34 @@ describe("prepareBroadcast", () => {
         removeOnFail: true,
       },
     )
+  })
+
+  test("passes the broadcast channel to the DM conversation lookup so TikTok resolves by sourceId", async () => {
+    findFirstBroadcast.mockResolvedValue({
+      ...baseBroadcast(),
+      channel: "tiktok",
+    })
+    findDMByContactIds.mockResolvedValue([
+      { id: "conv-tt", contactId: "contact-1" },
+    ])
+    forEachAudienceChunk.mockImplementation(
+      async (
+        _input: unknown,
+        onChunk: (
+          rows: Array<{ id: string; contactId: string }>,
+        ) => Promise<unknown>,
+      ) => {
+        await onChunk([{ id: "ci-1", contactId: "contact-1" }])
+      },
+    )
+
+    await prepareBroadcast(BROADCAST_ID)
+
+    expect(findDMByContactIds).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      contactIds: ["contact-1"],
+      channel: "tiktok",
+    })
   })
 
   test("does not insert or enqueue when all audience contacts lack a DM conversation", async () => {

--- a/apps/worker/src/schedule/handlers/prepare-broadcast.ts
+++ b/apps/worker/src/schedule/handlers/prepare-broadcast.ts
@@ -80,6 +80,9 @@ export const prepareBroadcast = async (broadcastId: string) => {
         contactIds: contactInboxes.map(
           (contactInbox) => contactInbox.contactId,
         ),
+        // TikTok resolves its DM by a non-null sourceId; every other channel
+        // keeps the sourceId IS NULL convention.
+        channel: parsedChannel.success ? parsedChannel.data : undefined,
       })
 
       const conversationMap = new Map(

--- a/packages/business/src/broadcast/__tests__/broadcast.service.test.ts
+++ b/packages/business/src/broadcast/__tests__/broadcast.service.test.ts
@@ -146,6 +146,7 @@ vi.mock("@chatbotx.io/database/client", () => ({
   gt: (left: unknown, right: unknown) => ({ __gt: [left, right] }),
   inArray: (left: unknown, right: unknown) => ({ __inArray: [left, right] }),
   isNull: (value: unknown) => ({ __isNull: value }),
+  isNotNull: (value: unknown) => ({ __isNotNull: value }),
 }))
 
 vi.mock("@chatbotx.io/database/queries", () => ({
@@ -418,6 +419,29 @@ describe("broadcastService.countAudience", () => {
       }),
     )
   })
+
+  test("counts non-null sourceId DM conversations for a restricted TikTok scope", async () => {
+    mocks.resolveBroadcastInboxIds.mockResolvedValue(["inbox-tiktok"])
+    mocks.selectRows = [{ count: 3 }]
+
+    const total = await broadcastService.countAudience({
+      workspaceId: "ws-1",
+      channels: ["tiktok"],
+      subaction: "tiktokActiveContacts",
+      restrictToAssignedUserId: "user-1",
+    })
+
+    expect(total).toBe(3)
+    expect(mocks.selectInnerJoin).toHaveBeenCalledWith([
+      expect.anything(),
+      {
+        __and: [
+          { __eq: ["Conversation.contactId", "ContactInbox.contactId"] },
+          { __isNotNull: "Conversation.sourceId" },
+        ],
+      },
+    ])
+  })
 })
 
 describe("broadcastService.listAudiencePreview", () => {
@@ -487,6 +511,27 @@ describe("broadcastService.listAudiencePreview", () => {
     })
     expect(mocks.selectLimit).toHaveBeenCalledWith(10)
     expect(mocks.selectOffset).toHaveBeenCalledWith(20)
+  })
+
+  test("joins the non-null sourceId DM conversation for a TikTok preview", async () => {
+    mocks.resolveBroadcastInboxIds.mockResolvedValue(["inbox-tiktok"])
+    mocks.selectRows = []
+
+    await broadcastService.listAudiencePreview({
+      workspaceId: "ws-1",
+      channels: ["tiktok"],
+      subaction: "tiktokActiveContacts",
+    })
+
+    expect(mocks.selectLeftJoin).toHaveBeenCalledWith([
+      expect.anything(),
+      {
+        __and: [
+          { __eq: ["Conversation.contactId", "ContactInbox.contactId"] },
+          { __isNotNull: "Conversation.sourceId" },
+        ],
+      },
+    ])
   })
 
   test("caps preview page size at fifty rows", async () => {

--- a/packages/business/src/broadcast/service.ts
+++ b/packages/business/src/broadcast/service.ts
@@ -7,11 +7,13 @@ import {
   eq,
   gt,
   inArray,
+  isNotNull,
   isNull,
   type SQL,
 } from "@chatbotx.io/database/client"
 import {
   type ChannelType,
+  dmConversationUsesSourceId,
   requiresRecentInteractionWindow,
 } from "@chatbotx.io/database/partials"
 import {
@@ -100,10 +102,27 @@ class BroadcastService extends BaseService {
     })
   }
 
-  private buildDmConversationJoin(): SQL | undefined {
+  // A broadcast's audience is scoped to a single channel. TikTok stores its DM
+  // conversation with a non-null `sourceId` (the channel `conversation_id`);
+  // every other channel keeps the `sourceId IS NULL` DM convention. Keeping this
+  // decision in one predicate mirrors `findDMByContactIds` on the delivery side,
+  // so the count/preview and the actual send agree on which conversation is the DM.
+  private audienceUsesSourceIdDmConversation(
+    input: BroadcastAudienceInput,
+  ): boolean {
+    return (input.channels ?? []).some((channel) =>
+      dmConversationUsesSourceId(channel),
+    )
+  }
+
+  private buildDmConversationJoin(
+    input: BroadcastAudienceInput,
+  ): SQL | undefined {
     return and(
       eq(conversationModel.contactId, contactInboxModel.contactId),
-      isNull(conversationModel.sourceId),
+      this.audienceUsesSourceIdDmConversation(input)
+        ? isNotNull(conversationModel.sourceId)
+        : isNull(conversationModel.sourceId),
     )
   }
 
@@ -128,7 +147,7 @@ class BroadcastService extends BaseService {
       const [result] = await db
         .select({ count: count() })
         .from(contactInboxModel)
-        .innerJoin(conversationModel, this.buildDmConversationJoin())
+        .innerJoin(conversationModel, this.buildDmConversationJoin(input))
         .where(
           and(
             this.buildAudienceWhere(inboxIds, input),
@@ -176,7 +195,7 @@ class BroadcastService extends BaseService {
       })
       .from(contactInboxModel)
       .innerJoin(contactModel, eq(contactModel.id, contactInboxModel.contactId))
-      .leftJoin(conversationModel, this.buildDmConversationJoin())
+      .leftJoin(conversationModel, this.buildDmConversationJoin(input))
       .where(
         and(
           this.buildAudienceWhere(inboxIds, input),

--- a/packages/business/src/conversation/__tests__/conversation.service.test.ts
+++ b/packages/business/src/conversation/__tests__/conversation.service.test.ts
@@ -137,24 +137,12 @@ describe("ConversationService.findDMByContactIds", () => {
     })
   })
 
-  test("collapses to the most recently active conversation per contact for TikTok", async () => {
-    mocks.conversationFindMany.mockResolvedValue([
-      {
-        id: "1",
-        contactId: "contact-1",
-        lastActivityAt: new Date("2026-01-01T00:00:00Z"),
-      },
-      {
-        id: "2",
-        contactId: "contact-1",
-        lastActivityAt: new Date("2026-02-01T00:00:00Z"),
-      },
-      {
-        id: "3",
-        contactId: "contact-2",
-        lastActivityAt: new Date("2026-01-15T00:00:00Z"),
-      },
-    ])
+  test("returns TikTok conversations as-is without post-processing", async () => {
+    const rows = [
+      { id: "1", contactId: "contact-1" },
+      { id: "2", contactId: "contact-2" },
+    ]
+    mocks.conversationFindMany.mockResolvedValue(rows)
 
     const result = await conversationService.findDMByContactIds({
       workspaceId: WORKSPACE_ID,
@@ -162,35 +150,7 @@ describe("ConversationService.findDMByContactIds", () => {
       channel: "tiktok",
     })
 
-    expect(result).toEqual([
-      {
-        id: "2",
-        contactId: "contact-1",
-        lastActivityAt: new Date("2026-02-01T00:00:00Z"),
-      },
-      {
-        id: "3",
-        contactId: "contact-2",
-        lastActivityAt: new Date("2026-01-15T00:00:00Z"),
-      },
-    ])
-  })
-
-  test("breaks ties by the newest conversation id when activity is equal for TikTok", async () => {
-    mocks.conversationFindMany.mockResolvedValue([
-      { id: "9", contactId: "contact-1", lastActivityAt: null },
-      { id: "10", contactId: "contact-1", lastActivityAt: null },
-    ])
-
-    const result = await conversationService.findDMByContactIds({
-      workspaceId: WORKSPACE_ID,
-      contactIds: ["contact-1"],
-      channel: "tiktok",
-    })
-
-    expect(result).toEqual([
-      { id: "10", contactId: "contact-1", lastActivityAt: null },
-    ])
+    expect(result).toEqual(rows)
   })
 
   test("uses the provided transaction client instead of the default db", async () => {

--- a/packages/business/src/conversation/__tests__/conversation.service.test.ts
+++ b/packages/business/src/conversation/__tests__/conversation.service.test.ts
@@ -101,6 +101,98 @@ describe("ConversationService.findDMByContactIds", () => {
     expect(mocks.conversationFindMany).not.toHaveBeenCalled()
   })
 
+  test("queries non-null sourceId conversations for TikTok, whose DM is keyed by conversation_id", async () => {
+    mocks.conversationFindMany.mockResolvedValue([])
+
+    await conversationService.findDMByContactIds({
+      workspaceId: WORKSPACE_ID,
+      contactIds: ["contact-1"],
+      channel: "tiktok",
+    })
+
+    expect(mocks.conversationFindMany).toHaveBeenCalledWith({
+      where: {
+        workspaceId: WORKSPACE_ID,
+        contactId: { in: ["contact-1"] },
+        sourceId: { isNotNull: true },
+      },
+    })
+  })
+
+  test("keeps the null sourceId DM filter for non-TikTok channels", async () => {
+    mocks.conversationFindMany.mockResolvedValue([])
+
+    await conversationService.findDMByContactIds({
+      workspaceId: WORKSPACE_ID,
+      contactIds: ["contact-1"],
+      channel: "telegram",
+    })
+
+    expect(mocks.conversationFindMany).toHaveBeenCalledWith({
+      where: {
+        workspaceId: WORKSPACE_ID,
+        contactId: { in: ["contact-1"] },
+        sourceId: { isNull: true },
+      },
+    })
+  })
+
+  test("collapses to the most recently active conversation per contact for TikTok", async () => {
+    mocks.conversationFindMany.mockResolvedValue([
+      {
+        id: "1",
+        contactId: "contact-1",
+        lastActivityAt: new Date("2026-01-01T00:00:00Z"),
+      },
+      {
+        id: "2",
+        contactId: "contact-1",
+        lastActivityAt: new Date("2026-02-01T00:00:00Z"),
+      },
+      {
+        id: "3",
+        contactId: "contact-2",
+        lastActivityAt: new Date("2026-01-15T00:00:00Z"),
+      },
+    ])
+
+    const result = await conversationService.findDMByContactIds({
+      workspaceId: WORKSPACE_ID,
+      contactIds: ["contact-1", "contact-2"],
+      channel: "tiktok",
+    })
+
+    expect(result).toEqual([
+      {
+        id: "2",
+        contactId: "contact-1",
+        lastActivityAt: new Date("2026-02-01T00:00:00Z"),
+      },
+      {
+        id: "3",
+        contactId: "contact-2",
+        lastActivityAt: new Date("2026-01-15T00:00:00Z"),
+      },
+    ])
+  })
+
+  test("breaks ties by the newest conversation id when activity is equal for TikTok", async () => {
+    mocks.conversationFindMany.mockResolvedValue([
+      { id: "9", contactId: "contact-1", lastActivityAt: null },
+      { id: "10", contactId: "contact-1", lastActivityAt: null },
+    ])
+
+    const result = await conversationService.findDMByContactIds({
+      workspaceId: WORKSPACE_ID,
+      contactIds: ["contact-1"],
+      channel: "tiktok",
+    })
+
+    expect(result).toEqual([
+      { id: "10", contactId: "contact-1", lastActivityAt: null },
+    ])
+  })
+
   test("uses the provided transaction client instead of the default db", async () => {
     const txFindMany = vi.fn().mockResolvedValue([{ id: "conv-tx" }])
     const tx = {

--- a/packages/business/src/conversation/service.ts
+++ b/packages/business/src/conversation/service.ts
@@ -100,39 +100,6 @@ export type ConversationWithContactInboxes = ConversationModel & {
   contactInboxes: ContactInboxModel[]
 }
 
-const conversationRecency = (conversation: ConversationModel): number =>
-  conversation.lastActivityAt?.getTime() ?? 0
-
-const isMoreRecent = (
-  candidate: ConversationModel,
-  current: ConversationModel,
-): boolean => {
-  const candidateRecency = conversationRecency(candidate)
-  const currentRecency = conversationRecency(current)
-  if (candidateRecency !== currentRecency) {
-    return candidateRecency > currentRecency
-  }
-  // Tie-break on the conversation id so the pick is fully deterministic. Ids are
-  // numeric strings, so compare as BigInt rather than lexicographically.
-  return BigInt(candidate.id) > BigInt(current.id)
-}
-
-// Collapse conversations to at most one per contact, preferring the most
-// recently active row. Used for channels resolved by a non-null sourceId, which
-// — unlike the null-sourceId DM path — have no per-contact unique index.
-const collapseToMostRecentPerContact = (
-  conversations: ConversationModel[],
-): ConversationModel[] => {
-  const latestByContact = new Map<string, ConversationModel>()
-  for (const conversation of conversations) {
-    const current = latestByContact.get(conversation.contactId)
-    if (!current || isMoreRecent(conversation, current)) {
-      latestByContact.set(conversation.contactId, conversation)
-    }
-  }
-  return Array.from(latestByContact.values())
-}
-
 class ConversationService extends BaseService {
   protected readonly cachePrefix: string = "conversations"
 
@@ -190,13 +157,10 @@ class ConversationService extends BaseService {
       },
     })
 
-    // The null-sourceId DM path is unique per contact
-    // (Conversation_contactId_dm_key), so it needs no post-processing. The
-    // non-null path has no such guarantee and can return several rows per
-    // contact, so collapse deterministically to one conversation each.
-    return usesSourceId
-      ? collapseToMostRecentPerContact(conversations)
-      : conversations
+    // Both DM paths return at most one conversation per contact: the null-sourceId
+    // path via the Conversation_contactId_dm_key unique index, and TikTok's
+    // non-null path because a TikTok contact has a single conversation.
+    return conversations
   }
 
   async updateChallenge(props: {

--- a/packages/business/src/conversation/service.ts
+++ b/packages/business/src/conversation/service.ts
@@ -6,7 +6,11 @@ import {
   inArray,
   sql,
 } from "@chatbotx.io/database/client"
-import type { ConversationAttributes } from "@chatbotx.io/database/partials"
+import {
+  type ChannelType,
+  type ConversationAttributes,
+  dmConversationUsesSourceId,
+} from "@chatbotx.io/database/partials"
 import { conversationModel } from "@chatbotx.io/database/schema"
 import type {
   AttachmentModel,
@@ -96,6 +100,39 @@ export type ConversationWithContactInboxes = ConversationModel & {
   contactInboxes: ContactInboxModel[]
 }
 
+const conversationRecency = (conversation: ConversationModel): number =>
+  conversation.lastActivityAt?.getTime() ?? 0
+
+const isMoreRecent = (
+  candidate: ConversationModel,
+  current: ConversationModel,
+): boolean => {
+  const candidateRecency = conversationRecency(candidate)
+  const currentRecency = conversationRecency(current)
+  if (candidateRecency !== currentRecency) {
+    return candidateRecency > currentRecency
+  }
+  // Tie-break on the conversation id so the pick is fully deterministic. Ids are
+  // numeric strings, so compare as BigInt rather than lexicographically.
+  return BigInt(candidate.id) > BigInt(current.id)
+}
+
+// Collapse conversations to at most one per contact, preferring the most
+// recently active row. Used for channels resolved by a non-null sourceId, which
+// — unlike the null-sourceId DM path — have no per-contact unique index.
+const collapseToMostRecentPerContact = (
+  conversations: ConversationModel[],
+): ConversationModel[] => {
+  const latestByContact = new Map<string, ConversationModel>()
+  for (const conversation of conversations) {
+    const current = latestByContact.get(conversation.contactId)
+    if (!current || isMoreRecent(conversation, current)) {
+      latestByContact.set(conversation.contactId, conversation)
+    }
+  }
+  return Array.from(latestByContact.values())
+}
+
 class ConversationService extends BaseService {
   protected readonly cachePrefix: string = "conversations"
 
@@ -131,21 +168,35 @@ class ConversationService extends BaseService {
   async findDMByContactIds(props: {
     workspaceId: string
     contactIds: string[]
+    channel?: ChannelType | null
     tx?: DatabaseClient
   }): Promise<ConversationModel[]> {
-    const { tx = db, workspaceId, contactIds } = props
+    const { tx = db, workspaceId, contactIds, channel } = props
     const uniqueContactIds = Array.from(new Set(contactIds))
     if (uniqueContactIds.length === 0) {
       return []
     }
 
-    return await tx.query.conversationModel.findMany({
+    // Most channels store the DM conversation with a null sourceId. TikTok is
+    // the outlier: its DM is keyed by the channel's conversation_id held in
+    // sourceId, so it must be resolved with sourceId IS NOT NULL.
+    const usesSourceId = dmConversationUsesSourceId(channel)
+
+    const conversations = await tx.query.conversationModel.findMany({
       where: {
         workspaceId,
         contactId: { in: uniqueContactIds },
-        sourceId: { isNull: true },
+        sourceId: usesSourceId ? { isNotNull: true } : { isNull: true },
       },
     })
+
+    // The null-sourceId DM path is unique per contact
+    // (Conversation_contactId_dm_key), so it needs no post-processing. The
+    // non-null path has no such guarantee and can return several rows per
+    // contact, so collapse deterministically to one conversation each.
+    return usesSourceId
+      ? collapseToMostRecentPerContact(conversations)
+      : conversations
   }
 
   async updateChallenge(props: {

--- a/packages/database/__tests__/channel-partial.test.ts
+++ b/packages/database/__tests__/channel-partial.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest"
+import {
+  channelTypes,
+  dmConversationUsesSourceId,
+} from "../src/partials/channel"
+
+describe("dmConversationUsesSourceId", () => {
+  test("is true for TikTok, whose DM conversation is keyed by a non-null sourceId", () => {
+    expect(dmConversationUsesSourceId("tiktok")).toBe(true)
+  })
+
+  test("is false for every channel whose DM conversation has a null sourceId", () => {
+    for (const channel of channelTypes.options) {
+      if (channel === "tiktok") {
+        continue
+      }
+      expect(dmConversationUsesSourceId(channel)).toBe(false)
+    }
+  })
+
+  test("is false when the channel is unknown", () => {
+    expect(dmConversationUsesSourceId(null)).toBe(false)
+    expect(dmConversationUsesSourceId(undefined)).toBe(false)
+  })
+})

--- a/packages/database/src/partials/channel.ts
+++ b/packages/database/src/partials/channel.ts
@@ -12,3 +12,22 @@ export const channelTypes = z.enum([
   "tiktok",
 ])
 export type ChannelType = z.infer<typeof channelTypes>
+
+// A contact's DM conversation is normally stored with a null `sourceId`
+// (`sourceId` is reserved for comment threads, keyed by the post id). TikTok is
+// the outlier: it has no separate DM concept and stores the channel's
+// `conversation_id` directly in `Conversation.sourceId`, so its DM rows are
+// non-null. Listing the outliers as data keeps the rule in one place and avoids
+// a `Record<ChannelType, ...>` cascade. This set becomes empty once TikTok's
+// write side is normalized to store the DM with a null `sourceId`.
+const CHANNELS_WITH_SOURCE_ID_DM_CONVERSATION = new Set<ChannelType>(["tiktok"])
+
+/**
+ * Whether the channel's DM conversation is identified by a non-null `sourceId`
+ * (TikTok) instead of the usual `sourceId IS NULL` DM convention. Unknown
+ * channels fall back to the null-sourceId convention.
+ */
+export const dmConversationUsesSourceId = (
+  channel: ChannelType | null | undefined,
+): boolean =>
+  channel != null && CHANNELS_WITH_SOURCE_ID_DM_CONVERSATION.has(channel)


### PR DESCRIPTION
## What this does

TikTok broadcasts were not being delivered — recipients were skipped and the broadcast finished as "sent" with nobody reached. This makes TikTok broadcasts find each contact's TikTok conversation correctly, so the message actually goes out.

Other channels (Messenger, WhatsApp, Instagram, Telegram, Zalo) are unchanged.

## Why

TikTok keeps its conversation reference in a different place than the other channels. The shared lookup only matched the other channels' shape, so every TikTok contact was left out.

## How it was verified

- [x] New and existing unit tests pass (database, business, worker packages)
- [x] Type checks pass on the touched packages
- [x] Lint passes
- [x] Existing channels still resolve their conversations the same way (covered by tests)

## Notes

- Follow-up (not in this PR): read receipts use a separate lookup that has the same TikTok gap; worth aligning later.
