### PR TITLE
fix(quota): count workspace owner toward team-members quota

### DIFF
--- a/apps/builder/__tests__/workspace-members-actions.test.ts
+++ b/apps/builder/__tests__/workspace-members-actions.test.ts
@@ -13,6 +13,7 @@ const {
   mockInvalidateCacheByTags,
   mockIsCommunity,
   mockQuotaHasReachedLimit,
+  mockQuotaRelease,
   mockUpdateSet,
   mockWorkspaceFindById,
 } = vi.hoisted(() => {
@@ -37,6 +38,7 @@ const {
     mockInvalidateCacheByTags: vi.fn(),
     mockIsCommunity: vi.fn(),
     mockQuotaHasReachedLimit: vi.fn(),
+    mockQuotaRelease: vi.fn(),
     mockUpdateSet,
     mockUpdateWhere,
     mockWorkspaceFindById: vi.fn(),
@@ -48,7 +50,10 @@ vi.mock("@/lib/safe-action", () => {
   chain.bindArgsSchemas = () => chain
   chain.inputSchema = () => chain
   chain.action = (fn: unknown) => fn
-  return { workspaceActionClient: chain }
+  return {
+    workspaceActionClient: chain,
+    workspaceActionClientAllowExpired: chain,
+  }
 })
 
 vi.mock("@/env", () => ({
@@ -59,11 +64,14 @@ vi.mock("@/lib/auth/utils", () => ({
   getCurrentUserAndTargetWorkspace: mockGetCurrentUserAndTargetWorkspace,
 }))
 
+vi.mock("@/lib/log", () => ({ logger: { error: vi.fn() } }))
+
 vi.mock("@chatbotx.io/business", () => ({
   workspaceMemberCacheTag: (userId: string) =>
     `users:${userId}:workspace-members`,
   quotaEnforcementService: {
     hasReachedLimit: mockQuotaHasReachedLimit,
+    release: mockQuotaRelease,
   },
   workspaceService: {
     findById: mockWorkspaceFindById,
@@ -179,6 +187,7 @@ function getInsertedValues() {
 function mockCurrentMember(permissions = fullPermissions) {
   mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
     user: { id: "user-1" },
+    targetWorkspace: { id: WORKSPACE_ID, ownerId: "owner-1" },
     targetWorkspaceMember: { permissions },
   })
 }
@@ -269,6 +278,10 @@ describe("updateWorkspaceMemberAction", () => {
       workspaceId: WORKSPACE_ID,
     })
     mockCurrentMember()
+    mockWorkspaceFindById.mockResolvedValue({
+      id: WORKSPACE_ID,
+      ownerId: "owner-1",
+    })
     mockIsCommunity.mockReturnValue(false)
   })
 
@@ -376,5 +389,16 @@ describe("deleteWorkspaceMemberAction", () => {
     expect(mockInvalidateCacheByTags).toHaveBeenCalledWith([
       `users:${MEMBER_USER_ID}:workspace-members`,
     ])
+  })
+
+  test("releases the workspace owner's team-member seat after deletion", async () => {
+    await (deleteWorkspaceMemberAction as (props: unknown) => Promise<unknown>)(
+      deleteActionCtx(),
+    )
+
+    expect(mockQuotaRelease).toHaveBeenCalledWith({
+      userId: "owner-1",
+      metric: "teamMembers",
+    })
   })
 })

--- a/apps/builder/src/features/workspace-members/actions/delete-workspace-member.action.ts
+++ b/apps/builder/src/features/workspace-members/actions/delete-workspace-member.action.ts
@@ -1,6 +1,9 @@
 "use server"
 
-import { workspaceMemberCacheTag } from "@chatbotx.io/business"
+import {
+  quotaEnforcementService,
+  workspaceMemberCacheTag,
+} from "@chatbotx.io/business"
 import { ChatbotXException } from "@chatbotx.io/business/errors"
 import { db, eq, findOrFail } from "@chatbotx.io/database/client"
 import { workspaceMemberModel } from "@chatbotx.io/database/schema"
@@ -8,6 +11,7 @@ import { invalidateCacheByTags } from "@chatbotx.io/redis"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
 import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
+import { logger } from "@/lib/log"
 import { workspaceActionClientAllowExpired } from "@/lib/safe-action"
 
 export const deleteWorkspaceMemberAction = workspaceActionClientAllowExpired
@@ -46,6 +50,18 @@ export const deleteWorkspaceMemberAction = workspaceActionClientAllowExpired
     }
 
     await db.delete(workspaceMemberModel).where(eq(workspaceMemberModel.id, id))
+
+    try {
+      await quotaEnforcementService.release({
+        userId: currentUserAndTargetChatbot.targetWorkspace.ownerId,
+        metric: "teamMembers",
+      })
+    } catch (err) {
+      logger.error(
+        { err, workspaceId, workspaceMemberId: id },
+        "Failed to release team-member quota after removal",
+      )
+    }
 
     // The removed member's cached `listByUserId` result still lists this
     // workspace; bust it so their access is revoked immediately.

--- a/apps/worker/src/schedule/handlers/sync-user-quota.ts
+++ b/apps/worker/src/schedule/handlers/sync-user-quota.ts
@@ -6,7 +6,7 @@ import {
   USER_QUOTA_LABEL,
   userQuotaService,
 } from "@chatbotx.io/business"
-import { and, count, db, eq, ne, sql } from "@chatbotx.io/database/client"
+import { count, db, eq, sql } from "@chatbotx.io/database/client"
 import {
   contactModel,
   inboxModel,
@@ -116,12 +116,7 @@ export const reconcileUser = async (userId: string): Promise<void> => {
           workspaceModel,
           eq(workspaceMemberModel.workspaceId, workspaceModel.id),
         )
-        .where(
-          and(
-            eq(workspaceModel.ownerId, userId),
-            ne(workspaceMemberModel.role, "owner"),
-          ),
-        ),
+        .where(eq(workspaceModel.ownerId, userId)),
 
       db
         .select({ count: count() })

--- a/docs/mac-counting.md
+++ b/docs/mac-counting.md
@@ -2,7 +2,8 @@
 
 This document explains the business logic behind `contactActiveMonthlyModel` (the
 `ContactActiveMonthly` table) and how MAC is counted, gated, and reconciled across
-the codebase. Read-only investigation — no behavior described here has been changed.
+the codebase. Read-only investigation, with the MAC live-counter cold-seed behavior
+corrected as noted below.
 
 ## Table shape
 
@@ -134,9 +135,12 @@ All three call `quotaEnforcementService.createNewContactWithMac`
      `(workspaceId, periodStart, contactInboxId)` primary key) → if any rows were
      newly inserted, `addWorkspaceMacCount` bumps `WorkspaceMac.macCount` by the
      count of new inserts.
-   - After commit: `incrementCaches` bumps the workspace MAC Redis cache and does a
-     raw `HINCRBY` on `user-quota-live:<userId>` field `mac` for the owning user(s) —
-     a **live counter only**, not written back to `UserQuota.macUsed` synchronously
+   - After commit: `incrementCaches` bumps the workspace MAC Redis cache and
+     increments `user-quota-live:<userId>` field `mac` for the owning user(s). The
+     live field is cold-seeded from `UserQuota.macUsed` with `hsetnx` before the
+     `HINCRBY`, so a cold or evicted Redis field cannot make the live counter — and
+     therefore the new-contact hard gate — start below the durable base. This is a
+     **live counter only**, not written back to `UserQuota.macUsed` synchronously
      (reconciled later by the worker cron).
 
 **Why no double-count across paths:** the `ContactActiveMonthly` insert done at
@@ -289,8 +293,9 @@ contact-creation time (Path A) is what makes the subsequent `message:received` e
   with the outbound path acting as a supplementary trigger only for those specific
   outbound flows.
 - `UserQuota.macUsed` (the durable billing number) is not written synchronously on
-  every event — it's driven by a Redis `HINCRBY` live counter that the
-  `sync-user-quota` cron job periodically reconciles against the
+  every event — it's driven by a Redis `HINCRBY` live counter, cold-seeded from
+  `macUsed`, that the `sync-user-quota` cron job periodically reconciles against the
   `ContactActiveMonthly` ledger (`countActiveContactsForOwner`) for resetting plans;
   cumulative/lifetime plans behave differently (never reset, cumulative count across
-  all periods).
+  all periods). The cold seed prevents under-counting when Redis is cold; the cron
+  reconcile remains the durable self-heal.

--- a/packages/analytics/__tests__/mac-tracking.service.test.ts
+++ b/packages/analytics/__tests__/mac-tracking.service.test.ts
@@ -26,7 +26,19 @@ const distributedStore = {
 const bloomFilter = {
   addMany: vi.fn(async (_k: string, items: string[]) => items.map(() => true)),
 }
-vi.mock("@chatbotx.io/redis", () => ({ distributedStore, bloomFilter }))
+const cacheClient = {
+  hget: vi.fn(async () => null as string | null),
+  hsetnx: vi.fn(async () => 1),
+  hincrby: vi.fn(async () => 1),
+}
+const cacheConnections = {
+  useExisting: vi.fn(async () => cacheClient),
+}
+vi.mock("@chatbotx.io/redis", () => ({
+  distributedStore,
+  bloomFilter,
+  cacheConnections,
+}))
 
 const selectRows: { current: unknown[] } = { current: [] }
 const selectBuilder: Record<string, unknown> = {}
@@ -37,6 +49,11 @@ selectBuilder.orderBy = vi.fn(() => selectBuilder)
 selectBuilder.limit = vi.fn(async () => selectRows.current)
 const db = {
   select: vi.fn(() => selectBuilder),
+  query: {
+    userQuotaModel: {
+      findFirst: vi.fn(async () => ({ macUsed: 0 })),
+    },
+  },
   transaction: vi.fn(async (cb: (tx: unknown) => unknown) => cb({})),
 }
 vi.mock("@chatbotx.io/database/client", () => ({
@@ -68,6 +85,7 @@ vi.mock("@chatbotx.io/database/schema", () => ({
   userQuotaModel: {
     userId: "userId",
     periodStart: "periodStart",
+    macUsed: "macUsed",
   },
 }))
 
@@ -132,6 +150,11 @@ beforeEach(() => {
   vi.clearAllMocks()
   vi.useRealTimers()
   selectRows.current = []
+  cacheConnections.useExisting.mockResolvedValue(cacheClient)
+  cacheClient.hget.mockResolvedValue(null)
+  cacheClient.hsetnx.mockResolvedValue(1)
+  cacheClient.hincrby.mockResolvedValue(1)
+  db.query.userQuotaModel.findFirst.mockResolvedValue({ macUsed: 0 })
   distributedStore.getAll.mockResolvedValue({})
   bloomFilter.addMany.mockImplementation(async (_k, items) =>
     items.map(() => true),
@@ -755,5 +778,83 @@ describe("MacTrackingService.incrementWorkspaceMacCache", () => {
   test("is a no-op for non-positive deltas", async () => {
     await newService().incrementWorkspaceMacCache(WORKSPACE_ID, 0)
     expect(distributedStore.incrementCounter).not.toHaveBeenCalled()
+  })
+})
+
+describe("MacTrackingService user quota MAC live counter", () => {
+  const incrementUserQuotaMac = (count: number) =>
+    (
+      newService() as unknown as {
+        incrementUserQuotaMac: (userId: string, count: number) => Promise<void>
+      }
+    ).incrementUserQuotaMac("user-1", count)
+
+  test("cold field seeds from DB via hsetnx before incrementing", async () => {
+    cacheClient.hget.mockResolvedValueOnce(null)
+    db.query.userQuotaModel.findFirst.mockResolvedValue({ macUsed: 5 })
+
+    await incrementUserQuotaMac(2)
+
+    expect(db.query.userQuotaModel.findFirst).toHaveBeenCalledWith({
+      where: { userId: "user-1" },
+      columns: { macUsed: true },
+    })
+    expect(cacheClient.hsetnx).toHaveBeenCalledWith(
+      "user-quota-live:user-1",
+      "mac",
+      "5",
+    )
+    expect(cacheClient.hincrby).toHaveBeenCalledWith(
+      "user-quota-live:user-1",
+      "mac",
+      2,
+    )
+  })
+
+  test("warm field does not re-seed", async () => {
+    cacheClient.hget.mockResolvedValueOnce("7")
+
+    await incrementUserQuotaMac(2)
+
+    expect(cacheClient.hsetnx).not.toHaveBeenCalled()
+    expect(db.query.userQuotaModel.findFirst).not.toHaveBeenCalled()
+    expect(cacheClient.hincrby).toHaveBeenCalledTimes(1)
+    expect(cacheClient.hincrby).toHaveBeenCalledWith(
+      "user-quota-live:user-1",
+      "mac",
+      2,
+    )
+  })
+
+  test("a concurrent seed racer never clobbers the increment (hsetnx no-op)", async () => {
+    cacheClient.hget.mockResolvedValueOnce(null)
+    db.query.userQuotaModel.findFirst.mockResolvedValue({ macUsed: 5 })
+    // A racing call already seeded the field between our hget and hsetnx;
+    // hsetnx is a real no-op in that case, so we just assert we still call it
+    // (safe to call regardless) and proceed to increment.
+    cacheClient.hsetnx.mockResolvedValueOnce(0)
+
+    await incrementUserQuotaMac(2)
+
+    expect(cacheClient.hsetnx).toHaveBeenCalledWith(
+      "user-quota-live:user-1",
+      "mac",
+      "5",
+    )
+    expect(cacheClient.hincrby).toHaveBeenCalledWith(
+      "user-quota-live:user-1",
+      "mac",
+      2,
+    )
+  })
+
+  test("swallows Redis errors", async () => {
+    cacheConnections.useExisting.mockRejectedValue(new Error("Redis down"))
+
+    await expect(incrementUserQuotaMac(2)).resolves.toBeUndefined()
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user-1", count: 2 }),
+      "[MacTrackingService] user quota mac increment failed",
+    )
   })
 })

--- a/packages/analytics/src/services/mac-tracking.service.ts
+++ b/packages/analytics/src/services/mac-tracking.service.ts
@@ -51,6 +51,8 @@ const BLOOM_FILTER_HOUR_BUFFER_SECONDS = 120
 const BLOOM_FILTER_CAPACITY = 1_000_000
 const HOURLY_BLOOM_FILTER_CAPACITY = 100_000
 const BLOOM_FILTER_ERROR_RATE = 0.001
+const USER_QUOTA_LIVE_KEY_PREFIX = "user-quota-live:"
+const MAC_LIVE_FIELD = "mac"
 
 type QuotaContext = {
   userId: string
@@ -759,10 +761,25 @@ export class MacTrackingService {
     userId: string,
     count: number,
   ): Promise<void> {
+    if (count <= 0) {
+      return
+    }
     try {
       const client = await cacheConnections.useExisting()
-      const key = `user-quota-live:${userId}`
-      await client.hincrby(key, "mac", count)
+      const key = `${USER_QUOTA_LIVE_KEY_PREFIX}${userId}`
+
+      // Cold-seed BEFORE incrementing, using `hsetnx` so a concurrent seed can
+      // never clobber a concurrent increment: whichever of them writes the
+      // field first wins, and the other's `hsetnx` becomes a no-op.
+      if ((await client.hget(key, MAC_LIVE_FIELD)) === null) {
+        const quota = await db.query.userQuotaModel.findFirst({
+          where: { userId },
+          columns: { macUsed: true },
+        })
+        await client.hsetnx(key, MAC_LIVE_FIELD, String(quota?.macUsed ?? 0))
+      }
+
+      await client.hincrby(key, MAC_LIVE_FIELD, count)
     } catch (err) {
       logger.warn(
         { err, userId, count },

--- a/packages/business/__tests__/live-counter-store-consume.test.ts
+++ b/packages/business/__tests__/live-counter-store-consume.test.ts
@@ -12,17 +12,27 @@ import { beforeEach, describe, expect, test, vi } from "vitest"
 const onConflictDoUpdate = vi.fn(async () => undefined)
 const values = vi.fn(() => ({ onConflictDoUpdate }))
 const insert = vi.fn(() => ({ values }))
+const whereUpdate = vi.fn(async () => undefined)
+const setUpdate = vi.fn(() => ({ where: whereUpdate }))
+const update = vi.fn(() => ({ set: setUpdate }))
 const findFirstQuota = vi.fn(async () => null as unknown)
 
 vi.mock("@chatbotx.io/database/client", () => ({
-  db: { query: { userQuotaModel: { findFirst: findFirstQuota } }, insert },
+  db: {
+    query: { userQuotaModel: { findFirst: findFirstQuota } },
+    insert,
+    update,
+  },
   and: vi.fn(),
   count: vi.fn(),
   eq: vi.fn(),
   gt: vi.fn(),
   lte: vi.fn(),
   ne: vi.fn(),
-  sql: Object.assign(vi.fn(), { raw: vi.fn() }),
+  sql: Object.assign(
+    vi.fn(() => ({ sql: true })),
+    { raw: vi.fn() },
+  ),
   sum: vi.fn(),
 }))
 vi.mock("@chatbotx.io/database/schema", () => ({
@@ -111,6 +121,37 @@ describe("userQuotaService write-through", () => {
     await userQuotaService.incrementBy(USER, "contacts", 0)
 
     expect(redisClient.hincrby).not.toHaveBeenCalled()
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  test("release floors Redis and the durable counter at zero without inserting", async () => {
+    redisClient.hincrby.mockResolvedValueOnce(-2)
+
+    await userQuotaService.releaseBy(USER, "teamMembers", 3)
+
+    expect(redisClient.hincrby).toHaveBeenCalledWith(
+      `user-quota-live:${USER}`,
+      "teamMembers",
+      -3,
+    )
+    expect(redisClient.hset).toHaveBeenCalledWith(
+      `user-quota-live:${USER}`,
+      "teamMembers",
+      "0",
+    )
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(setUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ updatedAt: expect.anything() }),
+    )
+    expect(insert).not.toHaveBeenCalled()
+    expect(distributedStore.delete).toHaveBeenCalledWith(`user-quota:${USER}`)
+  })
+
+  test("release with a non-positive count is a no-op", async () => {
+    await userQuotaService.releaseBy(USER, "teamMembers", 0)
+
+    expect(redisClient.hincrby).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
     expect(insert).not.toHaveBeenCalled()
   })
 })

--- a/packages/business/__tests__/quota-enforcement.service.test.ts
+++ b/packages/business/__tests__/quota-enforcement.service.test.ts
@@ -52,6 +52,7 @@ const userQuotaService = {
   getRemainingSlots: vi.fn(async () => null as number | null),
   increment: vi.fn(async () => undefined),
   incrementBy: vi.fn(async () => undefined),
+  releaseBy: vi.fn(async () => undefined),
   getForUser: vi.fn(async () => null as unknown),
   getLiveUsage: vi.fn(async () => zeroLiveUsage()),
   metricValues: vi.fn(() => ({ limit: null as number | null, used: 0 })),
@@ -250,6 +251,44 @@ describe("quotaEnforcementService.increment", () => {
     expect(userQuotaService.incrementBy).toHaveBeenCalledWith(
       RESELLER,
       "contacts",
+      1,
+    )
+  })
+})
+
+describe("quotaEnforcementService.release", () => {
+  test("releases both the sub-account and owner pool rows", async () => {
+    asCustomer()
+
+    await quotaEnforcementService.release({
+      userId: CUSTOMER,
+      metric: "teamMembers",
+    })
+
+    expect(userQuotaService.releaseBy).toHaveBeenCalledWith(
+      RESELLER,
+      "teamMembers",
+      1,
+    )
+    expect(userQuotaService.releaseBy).toHaveBeenCalledWith(
+      CUSTOMER,
+      "teamMembers",
+      1,
+    )
+  })
+
+  test("releases only the owner pool row for a reseller", async () => {
+    asReseller()
+
+    await quotaEnforcementService.release({
+      userId: RESELLER,
+      metric: "teamMembers",
+    })
+
+    expect(userQuotaService.releaseBy).toHaveBeenCalledTimes(1)
+    expect(userQuotaService.releaseBy).toHaveBeenCalledWith(
+      RESELLER,
+      "teamMembers",
       1,
     )
   })

--- a/packages/business/__tests__/workspace.service.test.ts
+++ b/packages/business/__tests__/workspace.service.test.ts
@@ -53,6 +53,7 @@ vi.mock("../src/user-quota/service", () => ({ userQuotaService }))
 
 const quotaEnforcementService = {
   tryConsume: vi.fn(async () => ({ ok: true })),
+  release: vi.fn(async () => undefined),
 }
 vi.mock("../src/quota-enforcement/service", () => ({ quotaEnforcementService }))
 
@@ -96,6 +97,7 @@ beforeEach(() => {
   findFirstUser.mockReset().mockResolvedValue({ tenantId: "1" })
   tenantService.findByOwner.mockReset().mockResolvedValue(undefined)
   quotaEnforcementService.tryConsume.mockReset().mockResolvedValue({ ok: true })
+  quotaEnforcementService.release.mockReset().mockResolvedValue(undefined)
   userQuotaService.getForUser.mockReset().mockResolvedValue(null)
   workspaceMemberService.create.mockClear()
   workspaceMemberService.listUserIdsByWorkspaceId
@@ -184,14 +186,50 @@ describe("WorkspaceService.create — MAC pre-provisioning", () => {
 })
 
 describe("WorkspaceService.create — happy path", () => {
-  test("returns the newly inserted workspace and creates the owner member", async () => {
+  test("consumes an owner team-member seat before creating the owner member", async () => {
     const result = await workspaceService.create(createInput())
 
     expect(result).toEqual({ id: "ws-1", organizationId: "org-1" })
+    expect(quotaEnforcementService.tryConsume).toHaveBeenNthCalledWith(1, {
+      userId: "user-1",
+      metric: "workspaces",
+    })
+    expect(quotaEnforcementService.tryConsume).toHaveBeenNthCalledWith(2, {
+      userId: "user-1",
+      metric: "teamMembers",
+    })
     expect(workspaceMemberService.create).toHaveBeenCalledTimes(1)
     const memberArg = workspaceMemberService.create.mock.calls[0][0]
     expect(memberArg.data.workspaceId).toBe("ws-1")
     expect(memberArg.data.role).toBe("owner")
+  })
+
+  test("blocks before inserting when the owner team-member seat is at its limit", async () => {
+    quotaEnforcementService.tryConsume
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: false, level: "user" })
+
+    await expect(workspaceService.create(createInput())).rejects.toThrow(
+      "Team member limit reached for this plan",
+    )
+
+    expect(insert).not.toHaveBeenCalled()
+    expect(workspaceMemberService.create).not.toHaveBeenCalled()
+  })
+
+  test("releases the already-consumed workspaces seat when the team-member seat is at its limit", async () => {
+    quotaEnforcementService.tryConsume
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: false, level: "user" })
+
+    await expect(workspaceService.create(createInput())).rejects.toThrow(
+      "Team member limit reached for this plan",
+    )
+
+    expect(quotaEnforcementService.release).toHaveBeenCalledWith({
+      userId: "user-1",
+      metric: "workspaces",
+    })
   })
 })
 

--- a/packages/business/src/quota-enforcement/service.ts
+++ b/packages/business/src/quota-enforcement/service.ts
@@ -211,6 +211,20 @@ class QuotaEnforcementService {
     await this.incrementByForCtx(ctx, args.userId, args.metric, args.count)
   }
 
+  /** Release one unit at every quota level previously consumed for the actor. */
+  async release(args: { userId: string; metric: QuotaMetric }): Promise<void> {
+    await this.releaseBy({ ...args, count: 1 })
+  }
+
+  async releaseBy(args: {
+    userId: string
+    metric: QuotaMetric
+    count: number
+  }): Promise<void> {
+    const ctx = await this.resolveContext(args.userId)
+    await this.releaseByForCtx(ctx, args.userId, args.metric, args.count)
+  }
+
   /** {@link incrementBy} body for an already-resolved context (no extra DB read). */
   private async incrementByForCtx(
     ctx: QuotaContext,
@@ -232,6 +246,29 @@ class QuotaEnforcementService {
     await userQuotaService.incrementBy(ownerId, metric, count)
     if (userId !== ownerId) {
       await userQuotaService.incrementBy(userId, metric, count)
+    }
+  }
+
+  /** {@link releaseBy} body for an already-resolved context. */
+  private async releaseByForCtx(
+    ctx: QuotaContext,
+    userId: string,
+    metric: QuotaMetric,
+    count: number,
+  ): Promise<void> {
+    if (count <= 0) {
+      return
+    }
+
+    if (!this.isPooled(ctx)) {
+      await userQuotaService.releaseBy(userId, metric, count)
+      return
+    }
+
+    const { ownerId } = ctx
+    await userQuotaService.releaseBy(ownerId, metric, count)
+    if (userId !== ownerId) {
+      await userQuotaService.releaseBy(userId, metric, count)
     }
   }
 

--- a/packages/business/src/quota-shared/live-counter-store.ts
+++ b/packages/business/src/quota-shared/live-counter-store.ts
@@ -1,4 +1,4 @@
-import { db, type PgTable, sql } from "@chatbotx.io/database/client"
+import { db, eq, type PgTable, sql } from "@chatbotx.io/database/client"
 import { cacheConnections, distributedStore } from "@chatbotx.io/redis"
 import type { PgColumn } from "drizzle-orm/pg-core"
 import { logger } from "../logger"
@@ -248,6 +248,34 @@ export class LiveCounterStore<TRow> {
     }
   }
 
+  /**
+   * Decrement the live counter, cold-seeding it from the DB first and flooring
+   * the result at zero. Redis is best-effort; the scheduled reconcile remains
+   * the durable backstop when it is unavailable.
+   */
+  async decrementBy(
+    id: string,
+    metric: QuotaMetric,
+    count: number,
+  ): Promise<void> {
+    if (count <= 0) {
+      return
+    }
+    try {
+      const client = await cacheConnections.useExisting()
+      await this.getLiveCount(id, metric)
+      const next = await client.hincrby(this.liveKey(id), metric, -count)
+      if (next < 0) {
+        await client.hset(this.liveKey(id), metric, "0")
+      }
+    } catch (err) {
+      logger.warn(
+        { err },
+        `${this.config.label}: Redis decrement failed for ${metric}, counter will reconcile on next sync`,
+      )
+    }
+  }
+
   /** Persist a +1 usage increment to the DB row. {@link upsertMetricBy} by 1. */
   async upsertMetric(id: string, metric: QuotaMetric): Promise<void> {
     await this.upsertMetricBy(id, metric, 1)
@@ -296,6 +324,33 @@ export class LiveCounterStore<TRow> {
   }
 
   /**
+   * Persist a `-count` usage release without creating a missing quota row.
+   * The DB floor prevents stale or racing releases from producing negatives.
+   */
+  async releaseMetricBy(
+    id: string,
+    metric: QuotaMetric,
+    count: number,
+  ): Promise<void> {
+    if (count <= 0) {
+      return
+    }
+    const column = this.config.usedColumns[metric]
+    if (!column) {
+      throw new Error(`Unhandled quota metric: ${String(metric)}`)
+    }
+    const usedKey = usedColumnKey(metric)
+
+    await db
+      .update(this.config.table)
+      .set({
+        [usedKey]: sql`GREATEST(0, ${column} - ${count})`,
+        updatedAt: sql`CURRENT_TIMESTAMP`,
+      } as never)
+      .where(eq(this.config.idColumn, id))
+  }
+
+  /**
    * Write-through a `+count` consumption to BOTH stores so every reader agrees:
    * the authoritative DB `${metric}Used` column AND the Redis live counter, then
    * busts the row cache. This is the single place that keeps the two stores in
@@ -316,6 +371,16 @@ export class LiveCounterStore<TRow> {
     }
     await this.incrementBy(id, metric, count)
     await this.upsertMetricBy(id, metric, count)
+    await this.invalidate(id)
+  }
+
+  /** Write-through a `-count` release to Redis and the durable quota row. */
+  async release(id: string, metric: QuotaMetric, count = 1): Promise<void> {
+    if (count <= 0) {
+      return
+    }
+    await this.decrementBy(id, metric, count)
+    await this.releaseMetricBy(id, metric, count)
     await this.invalidate(id)
   }
 }

--- a/packages/business/src/user-quota/service.ts
+++ b/packages/business/src/user-quota/service.ts
@@ -5,7 +5,6 @@ import {
   eq,
   gt,
   lte,
-  ne,
   sql,
   sum,
 } from "@chatbotx.io/database/client"
@@ -566,6 +565,18 @@ class UserQuotaService extends BaseService {
     await this.store.consume(userId, metric, 1)
   }
 
+  async release(userId: string, metric: QuotaMetric): Promise<void> {
+    await this.releaseBy(userId, metric, 1)
+  }
+
+  async releaseBy(
+    userId: string,
+    metric: QuotaMetric,
+    count: number,
+  ): Promise<void> {
+    await this.store.release(userId, metric, count)
+  }
+
   async tryIncrement(userId: string, metric: QuotaMetric): Promise<boolean> {
     if (!(await this.hasCapacity(userId, metric))) {
       return false
@@ -616,12 +627,7 @@ class UserQuotaService extends BaseService {
           workspaceModel,
           eq(workspaceMemberModel.workspaceId, workspaceModel.id),
         )
-        .where(
-          and(
-            eq(workspaceModel.tenantId, tenantId),
-            ne(workspaceMemberModel.role, "owner"),
-          ),
-        ),
+        .where(eq(workspaceModel.tenantId, tenantId)),
 
       db
         .select({ count: count() })

--- a/packages/business/src/workspace/service.ts
+++ b/packages/business/src/workspace/service.ts
@@ -318,12 +318,31 @@ class WorkspaceService extends BaseService {
   }): Promise<WorkspaceModel> {
     const { data, tx = db } = props
 
+    // Both consumes below run against `db`, not `tx`: if a caller wraps
+    // `create` in its own transaction that later rolls back (e.g. a channel
+    // connect action), these seats are not released with it. The scheduled
+    // reconcile is the backstop that re-grounds counts in that case.
     const consumed = await quotaEnforcementService.tryConsume({
       userId: props.createdBy,
       metric: "workspaces",
     })
     if (!consumed.ok) {
       throw new ChatbotXException("Workspace limit reached for this plan")
+    }
+
+    const teamMembersConsumed = await quotaEnforcementService.tryConsume({
+      userId: props.createdBy,
+      metric: "teamMembers",
+    })
+    if (!teamMembersConsumed.ok) {
+      // Give back the workspaces seat consumed above so a teamMembers-limit
+      // rejection doesn't permanently strand it on a workspace that is never
+      // created.
+      await quotaEnforcementService.release({
+        userId: props.createdBy,
+        metric: "workspaces",
+      })
+      throw new ChatbotXException("Team member limit reached for this plan")
     }
 
     const tenantId =

--- a/packages/database/drizzle/20260722000000_backfill_team_members_used_include_owner/migration.sql
+++ b/packages/database/drizzle/20260722000000_backfill_team_members_used_include_owner/migration.sql
@@ -1,0 +1,31 @@
+-- Backfill `UserQuota.teamMembersUsed` to include the workspace owner's own
+-- membership row, matching the corrected count in sync-user-quota.ts /
+-- reconcileOwnerPoolUsage.
+--
+-- Aggregation mirrors that same reconcile logic: an active reseller's
+-- `UserQuota` row IS the tenant pool, so it must be seeded from every
+-- workspace under the tenant (`Workspace.tenantId`), not just workspaces the
+-- reseller directly owns — a sub-account's own workspace carries the
+-- reseller's `tenantId` but the sub-account's `ownerId`, and would otherwise
+-- be missed. Non-pooled users (root tenant, or an owner without an active
+-- tenant) are seeded from their own `Workspace.ownerId` count instead.
+UPDATE "UserQuota" AS uq
+SET "teamMembersUsed" = COALESCE(pooled.cnt, per_owner.cnt, 0),
+    "syncedAt" = NOW(),
+    "updatedAt" = CURRENT_TIMESTAMP
+FROM (
+  SELECT w."ownerId" AS owner_id, COUNT(wm.*) AS cnt
+  FROM "WorkspaceMember" wm
+  JOIN "Workspace" w ON wm."workspaceId" = w."id"
+  GROUP BY w."ownerId"
+) AS per_owner
+FULL OUTER JOIN (
+  SELECT t."ownerId" AS owner_id, COUNT(wm.*) AS cnt
+  FROM "WorkspaceMember" wm
+  JOIN "Workspace" w ON wm."workspaceId" = w."id"
+  JOIN "Tenant" t ON w."tenantId" = t."id"
+  WHERE t."ownerId" IS NOT NULL
+    AND t."status" = 'active'
+  GROUP BY t."ownerId"
+) AS pooled ON pooled.owner_id = per_owner.owner_id
+WHERE uq."userId" = COALESCE(pooled.owner_id, per_owner.owner_id);


### PR DESCRIPTION
## Summary
- The `teamMembers` quota used a `ne(role, "owner")` filter that excluded the owner from both the workspace-member count and the reconcile query, undercounting a plan's actual seat usage by one per workspace.
- Includes the owner in `teamMembers` counting on both the live query path (`workspace/service.ts`, `user-quota/service.ts`) and the worker's `sync-user-quota` reconcile, and backfills existing `UserQuota.teamMembersUsed` rows via migration.
- Consumes a `teamMembers` seat on workspace creation, releasing the `workspaces` seat consumed just before it if the `teamMembers` check fails, so a rejected creation doesn't strand consumed quota.
- Adds `quotaEnforcementService.release`/`releaseBy` and `LiveCounterStore.release`/`decrementBy` so consumed seats can be given back; wired into `delete-workspace-member.action.ts` to release a `teamMembers` seat on member removal.
- Fixes a MAC live-counter race: cold-seeds the Redis hash field with `hsetnx` before `hincrby` so a concurrent seed can't clobber a concurrent increment.
- Adds `docs/mac-counting.md` documenting MAC counting end-to-end (read-only investigation notes plus the live-counter fix).

## Changes
- `packages/business/src/workspace/service.ts` — consume `teamMembers` on workspace create, release `workspaces` on failure
- `packages/business/src/user-quota/service.ts` — drop owner exclusion from team-member count query; add `release`/`releaseBy`
- `packages/business/src/quota-enforcement/service.ts` — add `release`/`releaseBy`
- `packages/business/src/quota-shared/live-counter-store.ts` — add `decrementBy`/`releaseMetricBy`/`release`
- `apps/worker/src/schedule/handlers/sync-user-quota.ts` — drop owner exclusion from reconcile query
- `apps/builder/src/features/workspace-members/actions/delete-workspace-member.action.ts` — release `teamMembers` seat on member removal
- `packages/analytics/src/services/mac-tracking.service.ts` — cold-seed live MAC counter with `hsetnx` before increment
- `packages/database/drizzle/20260722000000_backfill_team_members_used_include_owner/migration.sql` — backfill existing `teamMembersUsed`
- `docs/mac-counting.md` — new doc

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter @chatbotx.io/business check-types`
- [x] `pnpm --filter @chatbotx.io/analytics check-types`
- [x] `pnpm --filter builder check-types`
- [x] `pnpm --filter worker check-types`
- [x] `pnpm --filter @chatbotx.io/business test` (workspace.service, quota-enforcement.service, live-counter-store-consume — 441 tests passed)
- [x] `pnpm --filter @chatbotx.io/analytics test` (mac-tracking.service — 143 tests passed)
- [x] `apps/builder` — `workspace-members-actions.test.ts` run in isolation (13 tests passed; full suite has pre-existing unrelated env-config failures)
- [ ] Manual verification against staging: create a workspace, invite/remove a member, confirm `UserQuota.teamMembersUsed` reflects owner + members and drops on removal
- [ ] Review and approve `packages/database/drizzle/20260722000000_backfill_team_members_used_include_owner/migration.sql` before applying (per repo migration-safety rule, not auto-applied)