### PR TITLE
fix(quota): count teamMembers as distinct humans via live DB read

### DIFF
--- a/apps/builder/__tests__/accept-invitation-action.test.ts
+++ b/apps/builder/__tests__/accept-invitation-action.test.ts
@@ -31,11 +31,11 @@ vi.mock("@chatbotx.io/database/schema", () => ({
   workspaceMemberModel: {},
 }))
 
-const tryConsume = vi.fn()
+const hasReachedLimit = vi.fn()
 const workspaceServiceFind = vi.fn()
 vi.mock("@chatbotx.io/business", () => ({
   quotaEnforcementService: {
-    tryConsume: (...args: unknown[]) => tryConsume(...args),
+    hasReachedLimit: (...args: unknown[]) => hasReachedLimit(...args),
   },
   workspaceService: {
     find: (...args: unknown[]) => workspaceServiceFind(...args),
@@ -115,7 +115,7 @@ describe("acceptInvitationAction", () => {
     getSuperAdminPermissions.mockReturnValue({ superAdmin: true })
     workspaceMemberFindFirst.mockResolvedValue(undefined)
     workspaceServiceFind.mockResolvedValue({ id: "ws-1", ownerId: "owner-1" })
-    tryConsume.mockResolvedValue({ ok: true })
+    hasReachedLimit.mockResolvedValue(false)
     findOrFail.mockResolvedValue({
       code: "abc123",
       workspaceId: "ws-1",
@@ -185,13 +185,17 @@ describe("acceptInvitationAction", () => {
   })
 
   test("throws and does not insert or invalidate cache when team member quota is exceeded", async () => {
-    tryConsume.mockResolvedValue({ ok: false, level: "user" })
+    hasReachedLimit.mockResolvedValue(true)
 
     await expect(invoke()).rejects.toThrow(
       "Team member limit reached for this workspace plan",
     )
     expect(dbInsertValues).not.toHaveBeenCalled()
     expect(invalidateCacheByTags).not.toHaveBeenCalled()
+    expect(hasReachedLimit).toHaveBeenCalledWith({
+      userId: "owner-1",
+      metric: "teamMembers",
+    })
   })
 
   test("throws and does not insert when the workspace is scheduled for deletion", async () => {
@@ -208,7 +212,7 @@ describe("acceptInvitationAction", () => {
       message: "This workspace is no longer available",
     })
     expect(dbInsertValues).not.toHaveBeenCalled()
-    expect(tryConsume).not.toHaveBeenCalled()
+    expect(hasReachedLimit).not.toHaveBeenCalled()
     expect(invalidateCacheByTags).not.toHaveBeenCalled()
   })
 })

--- a/apps/builder/__tests__/workspace-members-actions.test.ts
+++ b/apps/builder/__tests__/workspace-members-actions.test.ts
@@ -13,7 +13,6 @@ const {
   mockInvalidateCacheByTags,
   mockIsCommunity,
   mockQuotaHasReachedLimit,
-  mockQuotaRelease,
   mockUpdateSet,
   mockWorkspaceFindById,
 } = vi.hoisted(() => {
@@ -38,7 +37,6 @@ const {
     mockInvalidateCacheByTags: vi.fn(),
     mockIsCommunity: vi.fn(),
     mockQuotaHasReachedLimit: vi.fn(),
-    mockQuotaRelease: vi.fn(),
     mockUpdateSet,
     mockUpdateWhere,
     mockWorkspaceFindById: vi.fn(),
@@ -64,14 +62,11 @@ vi.mock("@/lib/auth/utils", () => ({
   getCurrentUserAndTargetWorkspace: mockGetCurrentUserAndTargetWorkspace,
 }))
 
-vi.mock("@/lib/log", () => ({ logger: { error: vi.fn() } }))
-
 vi.mock("@chatbotx.io/business", () => ({
   workspaceMemberCacheTag: (userId: string) =>
     `users:${userId}:workspace-members`,
   quotaEnforcementService: {
     hasReachedLimit: mockQuotaHasReachedLimit,
-    release: mockQuotaRelease,
   },
   workspaceService: {
     findById: mockWorkspaceFindById,
@@ -391,14 +386,14 @@ describe("deleteWorkspaceMemberAction", () => {
     ])
   })
 
-  test("releases the workspace owner's team-member seat after deletion", async () => {
+  test("deletes the member without mutating team-member quota", async () => {
     await (deleteWorkspaceMemberAction as (props: unknown) => Promise<unknown>)(
       deleteActionCtx(),
     )
 
-    expect(mockQuotaRelease).toHaveBeenCalledWith({
-      userId: "owner-1",
-      metric: "teamMembers",
-    })
+    expect(mockDbDelete).toHaveBeenCalledOnce()
+    expect(mockInvalidateCacheByTags).toHaveBeenCalledWith([
+      `users:${MEMBER_USER_ID}:workspace-members`,
+    ])
   })
 })

--- a/apps/builder/src/features/invitations/actions/accept-invitation.ts
+++ b/apps/builder/src/features/invitations/actions/accept-invitation.ts
@@ -65,11 +65,11 @@ export const acceptInvitationAction = authActionClient
       )
     }
     if (workspace) {
-      const consumed = await quotaEnforcementService.tryConsume({
+      const atLimit = await quotaEnforcementService.hasReachedLimit({
         userId: workspace.ownerId,
         metric: "teamMembers",
       })
-      if (!consumed.ok) {
+      if (atLimit) {
         throw new ChatbotXException(
           "Team member limit reached for this workspace plan",
         )

--- a/apps/builder/src/features/workspace-members/actions/delete-workspace-member.action.ts
+++ b/apps/builder/src/features/workspace-members/actions/delete-workspace-member.action.ts
@@ -1,9 +1,6 @@
 "use server"
 
-import {
-  quotaEnforcementService,
-  workspaceMemberCacheTag,
-} from "@chatbotx.io/business"
+import { workspaceMemberCacheTag } from "@chatbotx.io/business"
 import { ChatbotXException } from "@chatbotx.io/business/errors"
 import { db, eq, findOrFail } from "@chatbotx.io/database/client"
 import { workspaceMemberModel } from "@chatbotx.io/database/schema"
@@ -11,7 +8,6 @@ import { invalidateCacheByTags } from "@chatbotx.io/redis"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
 import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
-import { logger } from "@/lib/log"
 import { workspaceActionClientAllowExpired } from "@/lib/safe-action"
 
 export const deleteWorkspaceMemberAction = workspaceActionClientAllowExpired
@@ -50,18 +46,6 @@ export const deleteWorkspaceMemberAction = workspaceActionClientAllowExpired
     }
 
     await db.delete(workspaceMemberModel).where(eq(workspaceMemberModel.id, id))
-
-    try {
-      await quotaEnforcementService.release({
-        userId: currentUserAndTargetChatbot.targetWorkspace.ownerId,
-        metric: "teamMembers",
-      })
-    } catch (err) {
-      logger.error(
-        { err, workspaceId, workspaceMemberId: id },
-        "Failed to release team-member quota after removal",
-      )
-    }
 
     // The removed member's cached `listByUserId` result still lists this
     // workspace; bust it so their access is revoked immediately.

--- a/apps/builder/src/features/workspace-members/actions/invite-workspace-member.action.ts
+++ b/apps/builder/src/features/workspace-members/actions/invite-workspace-member.action.ts
@@ -24,9 +24,8 @@ export const inviteWorkspaceMemberAction = workspaceActionClient
   .bindArgsSchemas(workspaceIdrequestParams)
   .inputSchema(inviteWorkspaceMemberRequest)
   .action(async ({ ctx, parsedInput, bindArgsParsedInputs: [workspaceId] }) => {
-    // Read-only gate: the team-member quota is consumed when the invitation
-    // is accepted (accept-invitation.ts), so block issuing a new invitation
-    // once the workspace owner is already at the limit (own or reseller pool).
+    // Read-only gate: team-member usage is reconcile-counted after acceptance,
+    // so block issuing an invitation once the owner is already at the limit.
     const workspace = await workspaceService.findById({ id: workspaceId })
     const currentUserAndTargetChatbot =
       await getCurrentUserAndTargetWorkspace(workspaceId)

--- a/apps/worker/__tests__/sync-user-quota-reconcile.test.ts
+++ b/apps/worker/__tests__/sync-user-quota-reconcile.test.ts
@@ -1,8 +1,13 @@
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
+const { mockCountDistinct } = vi.hoisted(() => ({
+  mockCountDistinct: vi.fn((column: unknown) => ({ countDistinct: column })),
+}))
+
 // ---------------------------------------------------------------------------
 // Regression: the Redis→DB reconcile must write the *current* authoritative
-// COUNT(*) for contacts/teamMembers/workspaces/channels — not a high-water max —
+// COUNT(*) for contacts/workspaces/channels and COUNT(DISTINCT userId) for
+// teamMembers — not a high-water max —
 // so deleting any of them frees quota slots. See reconcileUser.
 //
 // vi.mock factories are hoisted; per-test state flows through the shared
@@ -51,6 +56,7 @@ vi.mock("@chatbotx.io/database/client", () => ({
   },
   and: vi.fn((...a: unknown[]) => ({ and: a })),
   count: vi.fn(() => ({ count: true })),
+  countDistinct: mockCountDistinct,
   eq: vi.fn((a: unknown, b: unknown) => ({ eq: [a, b] })),
   ne: vi.fn((a: unknown, b: unknown) => ({ ne: [a, b] })),
   sql: (strings: TemplateStringsArray, ...vals: unknown[]) => ({
@@ -76,6 +82,9 @@ vi.mock("@chatbotx.io/business", () => ({
   userQuotaService: {
     invalidate: vi.fn(async () => undefined),
     reconcileOwnerPoolUsage: vi.fn(async () => undefined),
+    countDistinctTeamMembersForOwner: vi.fn(
+      async () => state.countResults.shift() ?? 0,
+    ),
   },
   // Non-reseller users: `findByOwner` returns nothing, so reconcileUser keeps
   // the per-user self-count path these tests exercise.
@@ -96,7 +105,11 @@ vi.mock("@chatbotx.io/database/schema", () => ({
     channelsUsed: "userQuota.channelsUsed",
     macUsed: "userQuota.macUsed",
   },
-  workspaceMemberModel: { workspaceId: "wm.workspaceId", role: "wm.role" },
+  workspaceMemberModel: {
+    workspaceId: "wm.workspaceId",
+    userId: "wm.userId",
+    role: "wm.role",
+  },
   workspaceModel: { id: "ws.id", ownerId: "ws.ownerId" },
 }))
 
@@ -136,7 +149,10 @@ const { tenantService, userQuotaService } = (await import(
     findByOwner: ReturnType<typeof vi.fn>
     listActiveOwnerIds: ReturnType<typeof vi.fn>
   }
-  userQuotaService: { reconcileOwnerPoolUsage: ReturnType<typeof vi.fn> }
+  userQuotaService: {
+    reconcileOwnerPoolUsage: ReturnType<typeof vi.fn>
+    countDistinctTeamMembersForOwner: ReturnType<typeof vi.fn>
+  }
 }
 
 describe("reconcileUser — contacts/teamMembers reflect the current count", () => {
@@ -152,7 +168,7 @@ describe("reconcileUser — contacts/teamMembers reflect the current count", () 
   })
 
   test("writes the recomputed count even when LOWER than the stored value (deletions free slots)", async () => {
-    // Source-of-truth COUNT(*) after deletions:
+    // Source-of-truth counts after deletions. Team members are distinct humans:
     // [contacts, teamMembers, workspaces, channels].
     state.countResults = [3, 1, 2, 4]
     // DB previously stored a higher (high-water) value.
@@ -186,6 +202,19 @@ describe("reconcileUser — contacts/teamMembers reflect the current count", () 
       "channels",
       "4",
     ])
+  })
+
+  test("counts a human shared across workspaces once", async () => {
+    // Two workspaces with the owner and one shared teammate produce four
+    // membership rows but only two distinct people.
+    state.countResults = [0, 2, 2, 0]
+
+    await reconcileUser("user-1")
+
+    expect(
+      userQuotaService.countDistinctTeamMembersForOwner,
+    ).toHaveBeenCalledWith("user-1")
+    expect(state.capturedSets[0].teamMembersUsed).toBe(2)
   })
 
   test("writes increases too (count grew since last sync)", async () => {

--- a/apps/worker/src/schedule/handlers/sync-user-quota.ts
+++ b/apps/worker/src/schedule/handlers/sync-user-quota.ts
@@ -11,7 +11,6 @@ import {
   contactModel,
   inboxModel,
   userQuotaModel,
-  workspaceMemberModel,
   workspaceModel,
 } from "@chatbotx.io/database/schema"
 import { cacheConnections } from "@chatbotx.io/redis"
@@ -96,7 +95,7 @@ export const reconcileUser = async (userId: string): Promise<void> => {
 
     const [
       [contactsResult],
-      [teamMembersResult],
+      teamMembersUsed,
       [workspacesResult],
       [channelsResult],
     ] = await Promise.all([
@@ -109,14 +108,7 @@ export const reconcileUser = async (userId: string): Promise<void> => {
         )
         .where(eq(workspaceModel.ownerId, userId)),
 
-      db
-        .select({ count: count() })
-        .from(workspaceMemberModel)
-        .innerJoin(
-          workspaceModel,
-          eq(workspaceMemberModel.workspaceId, workspaceModel.id),
-        )
-        .where(eq(workspaceModel.ownerId, userId)),
+      userQuotaService.countDistinctTeamMembersForOwner(userId),
 
       db
         .select({ count: count() })
@@ -134,7 +126,6 @@ export const reconcileUser = async (userId: string): Promise<void> => {
     ])
 
     const contactsUsed = contactsResult?.count ?? 0
-    const teamMembersUsed = teamMembersResult?.count ?? 0
     const workspacesUsed = workspacesResult?.count ?? 0
     const channelsUsed = channelsResult?.count ?? 0
 

--- a/packages/business/__tests__/live-counter-store-consume.test.ts
+++ b/packages/business/__tests__/live-counter-store-consume.test.ts
@@ -16,16 +16,30 @@ const whereUpdate = vi.fn(async () => undefined)
 const setUpdate = vi.fn(() => ({ where: whereUpdate }))
 const update = vi.fn(() => ({ set: setUpdate }))
 const findFirstQuota = vi.fn(async () => null as unknown)
+const eq = vi.fn()
+const reconcileCounts: number[] = []
+const select = vi.fn(() => {
+  const chain: Record<string, unknown> = {}
+  chain.from = vi.fn(() => chain)
+  chain.innerJoin = vi.fn(() => chain)
+  chain.where = vi.fn(() =>
+    Promise.resolve([{ count: reconcileCounts.shift() ?? 0 }]),
+  )
+  return chain
+})
+const countDistinct = vi.fn((column: unknown) => ({ countDistinct: column }))
 
 vi.mock("@chatbotx.io/database/client", () => ({
   db: {
     query: { userQuotaModel: { findFirst: findFirstQuota } },
     insert,
+    select,
     update,
   },
   and: vi.fn(),
   count: vi.fn(),
-  eq: vi.fn(),
+  countDistinct,
+  eq,
   gt: vi.fn(),
   lte: vi.fn(),
   ne: vi.fn(),
@@ -45,11 +59,23 @@ vi.mock("@chatbotx.io/database/schema", () => ({
     contactsUsed: "contactsUsed",
     macUsed: "macUsed",
   },
-  contactModel: {},
-  inboxModel: {},
-  workspaceMacModel: {},
-  workspaceMemberModel: {},
-  workspaceModel: {},
+  contactModel: { workspaceId: "contact.workspaceId" },
+  inboxModel: { workspaceId: "inbox.workspaceId" },
+  workspaceMacModel: {
+    macCount: "workspaceMac.macCount",
+    periodStart: "workspaceMac.periodStart",
+    periodEnd: "workspaceMac.periodEnd",
+    workspaceId: "workspaceMac.workspaceId",
+  },
+  workspaceMemberModel: {
+    userId: "workspaceMember.userId",
+    workspaceId: "workspaceMember.workspaceId",
+  },
+  workspaceModel: {
+    id: "workspace.id",
+    ownerId: "workspace.ownerId",
+    tenantId: "workspace.tenantId",
+  },
 }))
 
 const redisClient = {
@@ -78,6 +104,8 @@ const USER = "user-1"
 
 beforeEach(() => {
   vi.clearAllMocks()
+  reconcileCounts.length = 0
+  findFirstQuota.mockResolvedValue(null)
   cacheConnections.useExisting.mockResolvedValue(redisClient)
   redisClient.hget.mockResolvedValue("5")
 })
@@ -153,5 +181,81 @@ describe("userQuotaService write-through", () => {
     expect(redisClient.hincrby).not.toHaveBeenCalled()
     expect(update).not.toHaveBeenCalled()
     expect(insert).not.toHaveBeenCalled()
+  })
+})
+
+describe("userQuotaService.reconcileOwnerPoolUsage", () => {
+  test("counts a human shared across tenant workspaces once", async () => {
+    // Two workspaces with an owner and one shared teammate have four member
+    // rows, but only two distinct humans in the owner pool.
+    reconcileCounts.push(0, 2, 2, 0, 0)
+
+    await userQuotaService.reconcileOwnerPoolUsage("owner-1", "tenant-1")
+
+    expect(countDistinct).toHaveBeenCalledWith("workspaceMember.userId")
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "owner-1",
+        teamMembersUsed: 2,
+      }),
+    )
+    expect(onConflictDoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        set: expect.objectContaining({ teamMembersUsed: 2 }),
+      }),
+    )
+    expect(redisClient.hset).toHaveBeenCalledWith(
+      "user-quota-live:owner-1",
+      "contacts",
+      "0",
+      "teamMembers",
+      "2",
+      "workspaces",
+      "2",
+      "channels",
+      "0",
+      "mac",
+      "0",
+    )
+  })
+})
+
+describe("userQuotaService.isTeamMemberLimitReached", () => {
+  test("uses the owner-scoped distinct DB count instead of the stale live counter", async () => {
+    findFirstQuota.mockResolvedValue({
+      planStatus: "active",
+      teamMembersLimit: 2,
+      teamMembersUsed: 0,
+    })
+    reconcileCounts.push(2)
+
+    await expect(
+      userQuotaService.isTeamMemberLimitReached(
+        { ownerId: "owner-1" },
+        "owner-1",
+      ),
+    ).resolves.toBe(true)
+
+    expect(countDistinct).toHaveBeenCalledWith("workspaceMember.userId")
+    expect(eq).toHaveBeenCalledWith("workspace.ownerId", "owner-1")
+  })
+
+  test("uses tenant scope for a reseller pool while retaining the owner quota limit", async () => {
+    findFirstQuota.mockResolvedValue({
+      planStatus: "active",
+      teamMembersLimit: 3,
+      teamMembersUsed: 99,
+    })
+    reconcileCounts.push(2)
+
+    await expect(
+      userQuotaService.isTeamMemberLimitReached(
+        { tenantId: "tenant-1" },
+        "owner-1",
+      ),
+    ).resolves.toBe(false)
+
+    expect(countDistinct).toHaveBeenCalledWith("workspaceMember.userId")
+    expect(eq).toHaveBeenCalledWith("workspace.tenantId", "tenant-1")
   })
 })

--- a/packages/business/__tests__/quota-enforcement.service.test.ts
+++ b/packages/business/__tests__/quota-enforcement.service.test.ts
@@ -49,6 +49,9 @@ const userQuotaService = {
   hasCapacity: vi.fn(async () => true),
   consume: vi.fn(async () => undefined),
   isLimitReached: vi.fn(async () => false),
+  isTeamMemberLimitReached: vi.fn(async () => false),
+  countDistinctTeamMembersForOwner: vi.fn(async () => 0),
+  countDistinctTeamMembersForTenant: vi.fn(async () => 0),
   getRemainingSlots: vi.fn(async () => null as number | null),
   increment: vi.fn(async () => undefined),
   incrementBy: vi.fn(async () => undefined),
@@ -456,7 +459,11 @@ describe("quotaEnforcementService.getUsageSummary", () => {
     const summary = await quotaEnforcementService.getUsageSummary(ROOT_USER)
 
     expect(summary.workspaces).toEqual({ used: 3, limit: 10 })
+    expect(summary.teamMembers).toEqual({ used: 0, limit: 10 })
     expect(userQuotaService.getLiveUsage).toHaveBeenCalledWith(ROOT_USER)
+    expect(
+      userQuotaService.countDistinctTeamMembersForOwner,
+    ).toHaveBeenCalledWith(ROOT_USER)
   })
 
   test("reseller reports the live pooled usage against their plan limit", async () => {
@@ -472,8 +479,12 @@ describe("quotaEnforcementService.getUsageSummary", () => {
     const summary = await quotaEnforcementService.getUsageSummary(RESELLER)
 
     expect(summary.workspaces).toEqual({ used: 8, limit: 10 })
+    expect(summary.teamMembers).toEqual({ used: 0, limit: 10 })
     expect(userQuotaService.getLiveUsage).toHaveBeenCalledWith(RESELLER)
     expect(userQuotaService.getForUser).toHaveBeenCalledWith(RESELLER)
+    expect(
+      userQuotaService.countDistinctTeamMembersForTenant,
+    ).toHaveBeenCalledWith(TENANT)
   })
 
   test("sub-account reports its own live allocation, not the pool", async () => {
@@ -488,5 +499,65 @@ describe("quotaEnforcementService.getUsageSummary", () => {
 
     expect(summary.workspaces).toEqual({ used: 2, limit: 5 })
     expect(userQuotaService.getLiveUsage).toHaveBeenCalledWith(CUSTOMER)
+  })
+})
+
+describe("quotaEnforcementService.hasReachedLimit", () => {
+  test("reads the current owner-scoped distinct count for team members", async () => {
+    asRootUser()
+    userQuotaService.isTeamMemberLimitReached.mockResolvedValue(true)
+
+    await expect(
+      quotaEnforcementService.hasReachedLimit({
+        userId: ROOT_USER,
+        metric: "teamMembers",
+      }),
+    ).resolves.toBe(true)
+
+    expect(userQuotaService.isTeamMemberLimitReached).toHaveBeenCalledWith(
+      { ownerId: ROOT_USER },
+      ROOT_USER,
+    )
+    expect(userQuotaService.isLimitReached).not.toHaveBeenCalled()
+  })
+
+  test("keeps non-team-member metrics on the live-counter path", async () => {
+    asRootUser()
+
+    await quotaEnforcementService.hasReachedLimit({
+      userId: ROOT_USER,
+      metric: "workspaces",
+    })
+
+    expect(userQuotaService.isLimitReached).toHaveBeenCalledWith(
+      ROOT_USER,
+      "workspaces",
+    )
+    expect(userQuotaService.isTeamMemberLimitReached).not.toHaveBeenCalled()
+  })
+
+  test("checks both the sub-account owner scope and reseller tenant pool", async () => {
+    asCustomer()
+    userQuotaService.isTeamMemberLimitReached.mockImplementation(
+      async (_scope: unknown, limitUserId: string) => limitUserId === RESELLER,
+    )
+
+    await expect(
+      quotaEnforcementService.hasReachedLimit({
+        userId: CUSTOMER,
+        metric: "teamMembers",
+      }),
+    ).resolves.toBe(true)
+
+    expect(userQuotaService.isTeamMemberLimitReached).toHaveBeenNthCalledWith(
+      1,
+      { ownerId: CUSTOMER },
+      CUSTOMER,
+    )
+    expect(userQuotaService.isTeamMemberLimitReached).toHaveBeenNthCalledWith(
+      2,
+      { tenantId: TENANT },
+      RESELLER,
+    )
   })
 })

--- a/packages/business/__tests__/workspace.service.test.ts
+++ b/packages/business/__tests__/workspace.service.test.ts
@@ -186,17 +186,14 @@ describe("WorkspaceService.create — MAC pre-provisioning", () => {
 })
 
 describe("WorkspaceService.create — happy path", () => {
-  test("consumes an owner team-member seat before creating the owner member", async () => {
+  test("consumes only a workspace seat and creates the owner member", async () => {
     const result = await workspaceService.create(createInput())
 
     expect(result).toEqual({ id: "ws-1", organizationId: "org-1" })
-    expect(quotaEnforcementService.tryConsume).toHaveBeenNthCalledWith(1, {
+    expect(quotaEnforcementService.tryConsume).toHaveBeenCalledOnce()
+    expect(quotaEnforcementService.tryConsume).toHaveBeenCalledWith({
       userId: "user-1",
       metric: "workspaces",
-    })
-    expect(quotaEnforcementService.tryConsume).toHaveBeenNthCalledWith(2, {
-      userId: "user-1",
-      metric: "teamMembers",
     })
     expect(workspaceMemberService.create).toHaveBeenCalledTimes(1)
     const memberArg = workspaceMemberService.create.mock.calls[0][0]
@@ -204,32 +201,16 @@ describe("WorkspaceService.create — happy path", () => {
     expect(memberArg.data.role).toBe("owner")
   })
 
-  test("blocks before inserting when the owner team-member seat is at its limit", async () => {
-    quotaEnforcementService.tryConsume
-      .mockResolvedValueOnce({ ok: true })
-      .mockResolvedValueOnce({ ok: false, level: "user" })
+  test("does not consume a team-member seat for additional workspaces", async () => {
+    await workspaceService.create(createInput())
+    await workspaceService.create(createInput())
 
-    await expect(workspaceService.create(createInput())).rejects.toThrow(
-      "Team member limit reached for this plan",
-    )
-
-    expect(insert).not.toHaveBeenCalled()
-    expect(workspaceMemberService.create).not.toHaveBeenCalled()
-  })
-
-  test("releases the already-consumed workspaces seat when the team-member seat is at its limit", async () => {
-    quotaEnforcementService.tryConsume
-      .mockResolvedValueOnce({ ok: true })
-      .mockResolvedValueOnce({ ok: false, level: "user" })
-
-    await expect(workspaceService.create(createInput())).rejects.toThrow(
-      "Team member limit reached for this plan",
-    )
-
-    expect(quotaEnforcementService.release).toHaveBeenCalledWith({
+    expect(quotaEnforcementService.tryConsume).toHaveBeenCalledTimes(2)
+    expect(quotaEnforcementService.tryConsume).toHaveBeenNthCalledWith(2, {
       userId: "user-1",
       metric: "workspaces",
     })
+    expect(quotaEnforcementService.release).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/business/src/quota-enforcement/service.ts
+++ b/packages/business/src/quota-enforcement/service.ts
@@ -407,20 +407,27 @@ class QuotaEnforcementService {
     metric: QuotaMetric,
   ): Promise<boolean> {
     const pooled = this.isPooled(ctx)
+    const atLimit = (
+      limitUserId: string,
+      scope: { ownerId: string } | { tenantId: string },
+    ) =>
+      metric === "teamMembers"
+        ? userQuotaService.isTeamMemberLimitReached(scope, limitUserId)
+        : userQuotaService.isLimitReached(limitUserId, metric)
 
     if (pooled && userId === ctx.ownerId) {
       // Reseller acting directly: only the pool (owner row) governs.
-      return userQuotaService.isLimitReached(ctx.ownerId, metric)
+      return atLimit(ctx.ownerId, { tenantId: ctx.tenantId })
     }
 
-    const userFull = await userQuotaService.isLimitReached(userId, metric)
+    const userFull = await atLimit(userId, { ownerId: userId })
     if (!pooled) {
       return userFull
     }
     if (userFull) {
       return true
     }
-    return userQuotaService.isLimitReached(ctx.ownerId as string, metric)
+    return atLimit(ctx.ownerId as string, { tenantId: ctx.tenantId })
   }
 
   /** Tighter of the user and pool remaining slots (`null` = unlimited). */
@@ -465,36 +472,37 @@ class QuotaEnforcementService {
     const ctx = await this.resolveContext(userId)
 
     if (this.isPooled(ctx) && userId === ctx.ownerId) {
-      // Reseller acting directly: the owner's `UserQuota` row IS the pool. `used`
-      // from its live counters (near-real-time), `limit` from the same row —
-      // both from one write-through source, so they cannot disagree.
-      const [liveUsed, ownerQuota] = await Promise.all([
+      // Reseller acting directly: the owner's `UserQuota` row IS the pool. The
+      // `teamMembers` usage is live from its source tables; other metrics use
+      // their near-real-time counters, while all limits come from the owner row.
+      const [liveUsed, ownerQuota, teamMembersUsed] = await Promise.all([
         userQuotaService.getLiveUsage(ctx.ownerId),
         userQuotaService.getForUser(ctx.ownerId),
+        userQuotaService.countDistinctTeamMembersForTenant(ctx.tenantId),
       ])
       return Object.fromEntries(
         ALL_METRICS.map((metric) => [
           metric,
           {
-            used: liveUsed[metric],
+            used: metric === "teamMembers" ? teamMembersUsed : liveUsed[metric],
             limit: userQuotaService.metricValues(ownerQuota, metric).limit,
           },
         ]),
       ) as QuotaUsageSummary
     }
 
-    // `used` from the live per-user counters (near-real-time), `limit` from the
-    // cached quota row — the value the user sees now matches what enforcement
-    // counts, with no wait for the next `sync-user-quota` pass.
-    const [liveUsed, quota] = await Promise.all([
+    // `teamMembers` is read live from its source tables; the other `used` values
+    // come from near-real-time counters. Limits come from the cached quota row.
+    const [liveUsed, quota, teamMembersUsed] = await Promise.all([
       userQuotaService.getLiveUsage(userId),
       userQuotaService.getForUser(userId),
+      userQuotaService.countDistinctTeamMembersForOwner(userId),
     ])
     return Object.fromEntries(
       ALL_METRICS.map((metric) => [
         metric,
         {
-          used: liveUsed[metric],
+          used: metric === "teamMembers" ? teamMembersUsed : liveUsed[metric],
           limit: userQuotaService.metricValues(quota, metric).limit,
         },
       ]),

--- a/packages/business/src/user-quota/service.ts
+++ b/packages/business/src/user-quota/service.ts
@@ -1,6 +1,7 @@
 import {
   and,
   count,
+  countDistinct,
   db,
   eq,
   gt,
@@ -483,6 +484,58 @@ class UserQuotaService extends BaseService {
     return limit !== null && liveCount >= limit
   }
 
+  /**
+   * Current distinct humans across an owner's workspaces or a reseller's
+   * tenant. `teamMembers` is intentionally read from its source tables: its
+   * counter is only a reconcile snapshot and can be stale between syncs.
+   */
+  private async countDistinctTeamMembers(
+    scope: { ownerId: string } | { tenantId: string },
+  ): Promise<number> {
+    const where =
+      "ownerId" in scope
+        ? eq(workspaceModel.ownerId, scope.ownerId)
+        : eq(workspaceModel.tenantId, scope.tenantId)
+    const rows = await db
+      .select({ count: countDistinct(workspaceMemberModel.userId) })
+      .from(workspaceMemberModel)
+      .innerJoin(
+        workspaceModel,
+        eq(workspaceMemberModel.workspaceId, workspaceModel.id),
+      )
+      .where(where)
+    return rows[0]?.count ?? 0
+  }
+
+  /** Source-of-truth team-member count for the per-owner reconcile. */
+  countDistinctTeamMembersForOwner(ownerId: string): Promise<number> {
+    return this.countDistinctTeamMembers({ ownerId })
+  }
+
+  /** Source-of-truth team-member count for a reseller tenant pool. */
+  countDistinctTeamMembersForTenant(tenantId: string): Promise<number> {
+    return this.countDistinctTeamMembers({ tenantId })
+  }
+
+  /**
+   * Live at-limit check for `teamMembers`; the quota row still supplies the
+   * plan limit while the distinct member count comes directly from the DB.
+   */
+  async isTeamMemberLimitReached(
+    scope: { ownerId: string } | { tenantId: string },
+    limitUserId: string,
+  ): Promise<boolean> {
+    const [quota, realCount] = await Promise.all([
+      this.getForUser(limitUserId),
+      this.countDistinctTeamMembers(scope),
+    ])
+    if (!quota) {
+      return false
+    }
+    const { limit } = this.readMetricValues(quota, "teamMembers")
+    return limit !== null && realCount >= limit
+  }
+
   async getRemainingSlots(
     userId: string,
     metric: QuotaMetric,
@@ -590,8 +643,9 @@ class UserQuotaService extends BaseService {
    * counts aggregated across EVERY workspace under their tenant — the owner's row
    * is the pool (owner's own resources carry the reseller tenantId too, so the
    * tenant aggregate already includes them; no separate own-count is added). The
-   * recomputed `COUNT(*)` is authoritative (already reflects deletions) and is
+   * recomputed counts are authoritative (already reflect deletions) and are
    * assigned directly so freeing pooled resources frees pooled quota.
+   * `teamMembers` is `COUNT(DISTINCT userId)`; all other metrics are `COUNT(*)`.
    *
    * `mac` is summed from the `WorkspaceMac` rollup for the CURRENT period only,
    * so it resets naturally at period rollover (mirroring the contacts recount).
@@ -606,7 +660,7 @@ class UserQuotaService extends BaseService {
 
     const [
       [contactsResult],
-      [teamMembersResult],
+      teamMembersUsed,
       [workspacesResult],
       [channelsResult],
       [macResult],
@@ -620,14 +674,7 @@ class UserQuotaService extends BaseService {
         )
         .where(eq(workspaceModel.tenantId, tenantId)),
 
-      db
-        .select({ count: count() })
-        .from(workspaceMemberModel)
-        .innerJoin(
-          workspaceModel,
-          eq(workspaceMemberModel.workspaceId, workspaceModel.id),
-        )
-        .where(eq(workspaceModel.tenantId, tenantId)),
+      this.countDistinctTeamMembers({ tenantId }),
 
       db
         .select({ count: count() })
@@ -660,7 +707,6 @@ class UserQuotaService extends BaseService {
     ])
 
     const contactsUsed = contactsResult?.count ?? 0
-    const teamMembersUsed = teamMembersResult?.count ?? 0
     const workspacesUsed = workspacesResult?.count ?? 0
     const channelsUsed = channelsResult?.count ?? 0
     // `sum()` returns a numeric string (or null when no rows match).

--- a/packages/business/src/workspace/service.ts
+++ b/packages/business/src/workspace/service.ts
@@ -318,31 +318,16 @@ class WorkspaceService extends BaseService {
   }): Promise<WorkspaceModel> {
     const { data, tx = db } = props
 
-    // Both consumes below run against `db`, not `tx`: if a caller wraps
-    // `create` in its own transaction that later rolls back (e.g. a channel
-    // connect action), these seats are not released with it. The scheduled
-    // reconcile is the backstop that re-grounds counts in that case.
+    // This consume runs against `db`, not `tx`: if a caller wraps `create` in
+    // its own transaction that later rolls back (e.g. a channel connect action),
+    // the workspace seat is not released with it. Scheduled reconcile is the
+    // backstop that re-grounds counts in that case.
     const consumed = await quotaEnforcementService.tryConsume({
       userId: props.createdBy,
       metric: "workspaces",
     })
     if (!consumed.ok) {
       throw new ChatbotXException("Workspace limit reached for this plan")
-    }
-
-    const teamMembersConsumed = await quotaEnforcementService.tryConsume({
-      userId: props.createdBy,
-      metric: "teamMembers",
-    })
-    if (!teamMembersConsumed.ok) {
-      // Give back the workspaces seat consumed above so a teamMembers-limit
-      // rejection doesn't permanently strand it on a workspace that is never
-      // created.
-      await quotaEnforcementService.release({
-        userId: props.createdBy,
-        metric: "workspaces",
-      })
-      throw new ChatbotXException("Team member limit reached for this plan")
     }
 
     const tenantId =


### PR DESCRIPTION
## Summary
- `teamMembers` was a raw `COUNT(*)` of membership rows, so a solo owner burned one seat per workspace they created and the same human was double-counted across workspaces. Sub-account own-rows also drifted upward with no reconcile path to correct them.
- Redefine `teamMembers` as **distinct humans** (`COUNT(DISTINCT userId)`) and make the at-limit gate read that count **live from the DB** rather than a ≤60s-stale reconcile snapshot, so bursts of accepts can't overshoot the limit.

## Changes
- **`packages/business/src/workspace/service.ts`** — remove the create-time `teamMembers` consume (and its `workspaces` rollback). Creating additional workspaces no longer burns a seat.
- **`apps/builder/.../accept-invitation.ts`** — accept is now a read-only `hasReachedLimit` gate instead of a `tryConsume`; **`delete-workspace-member.action.ts`** drops the `release` (and now-unused `logger` import).
- **`packages/business/src/user-quota/service.ts`** — new `countDistinctTeamMembers` helper (owner/tenant scopes) + `isTeamMemberLimitReached`; reused by both reconcile paths and `getUsageSummary` (one query definition).
- **`packages/business/src/quota-enforcement/service.ts`** — `atLimitForMetric` routes only the `teamMembers` branch through the live DB check; all other metrics keep the live-counter path. `getUsageSummary` shows the real distinct count.
- **`apps/worker/.../sync-user-quota.ts`** — reconcile uses the shared distinct-count helper; reconcile stays the durable snapshot writer.
- Tests updated across business/worker/builder suites.

## Notes
- No schema migration or backfill: both reconcile paths assign the recomputed value directly, so inflated rows self-heal on the next `sync-user-quota` pass.
- Follow-up (separate PR, needs explicit approval — do not auto-run `db:migrate`): consider indexes on `Workspace.ownerId` and `WorkspaceMember.workspaceId` for the rare gate query.

## Test plan
- [x] `pnpm lint` (touched files clean; only pre-existing generated `next-env.d.ts` noise)
- [x] `pnpm --filter @chatbotx.io/business check-types`
- [x] `pnpm --filter worker check-types`
- [x] `pnpm --filter builder check-types`
- [x] `pnpm --filter @chatbotx.io/business test quota-enforcement user-quota workspace.service live-counter-store-consume` (56 passed)
- [x] `pnpm --filter worker test sync-user-quota-reconcile` (10 passed)
- [x] `pnpm --filter builder test accept-invitation-action workspace-members-actions` (20 passed)
- [ ] Manual: set `teamMembersLimit` to current distinct count → accepting an invite for a NEW human is blocked immediately; adding a workspace as owner leaves `teamMembers` unchanged