### PR TITLE
fix: freeze a workspace while it is waiting to be deleted

### DIFF
--- a/apps/builder/__tests__/accept-invitation-action.test.ts
+++ b/apps/builder/__tests__/accept-invitation-action.test.ts
@@ -34,6 +34,12 @@ vi.mock("@chatbotx.io/database/schema", () => ({
 const hasReachedLimit = vi.fn()
 const workspaceServiceFind = vi.fn()
 vi.mock("@chatbotx.io/business", () => ({
+  isWorkspaceScheduledForDeletion: (
+    workspace:
+      | { scheduledDeletionAt?: Date | string | null }
+      | null
+      | undefined,
+  ) => Boolean(workspace?.scheduledDeletionAt),
   quotaEnforcementService: {
     hasReachedLimit: (...args: unknown[]) => hasReachedLimit(...args),
   },

--- a/apps/builder/__tests__/broadcast-estimated-contacts-display.test.ts
+++ b/apps/builder/__tests__/broadcast-estimated-contacts-display.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest"
+import { getEstimatedContactsDisplayState } from "../src/features/broadcasts/utils/estimated-contacts-display"
+
+describe("getEstimatedContactsDisplayState", () => {
+  test("shows a count when contactCount is available", () => {
+    expect(
+      getEstimatedContactsDisplayState({
+        contactCount: 12,
+        status: "cancelled",
+      }),
+    ).toBe("count")
+  })
+
+  test("keeps loading for active broadcasts without contactCount", () => {
+    expect(
+      getEstimatedContactsDisplayState({
+        contactCount: null,
+        status: "scheduled",
+      }),
+    ).toBe("loading")
+    expect(
+      getEstimatedContactsDisplayState({
+        contactCount: null,
+        status: "sending",
+      }),
+    ).toBe("loading")
+  })
+
+  test("does not keep terminal broadcasts loading without contactCount", () => {
+    expect(
+      getEstimatedContactsDisplayState({
+        contactCount: null,
+        status: "cancelled",
+      }),
+    ).toBe("empty")
+    expect(
+      getEstimatedContactsDisplayState({
+        contactCount: null,
+        status: "sent",
+      }),
+    ).toBe("empty")
+  })
+})

--- a/apps/builder/__tests__/channel-route-guards.test.ts
+++ b/apps/builder/__tests__/channel-route-guards.test.ts
@@ -47,6 +47,12 @@ vi.mock("@chatbotx.io/analytics-nextjs/components/base-dashboard", () => ({
 }))
 
 vi.mock("@chatbotx.io/business", () => ({
+  isWorkspaceScheduledForDeletion: (
+    workspace:
+      | { scheduledDeletionAt?: Date | string | null }
+      | null
+      | undefined,
+  ) => Boolean(workspace?.scheduledDeletionAt),
   platformCredentialService: {
     resolveForOwner: vi.fn(async () => null),
   },

--- a/apps/builder/__tests__/create-webchat-message-action.test.ts
+++ b/apps/builder/__tests__/create-webchat-message-action.test.ts
@@ -113,6 +113,12 @@ vi.mock("@chatbotx.io/automated-response", () => ({
 }))
 
 vi.mock("@chatbotx.io/business", () => ({
+  isWorkspaceScheduledForDeletion: (
+    workspace:
+      | { scheduledDeletionAt?: Date | string | null }
+      | null
+      | undefined,
+  ) => Boolean(workspace?.scheduledDeletionAt),
   contactInboxService: {
     findLatestBySource: mockContactInboxFindLatest,
     updateTracking: mockContactInboxUpdateTracking,

--- a/apps/builder/__tests__/delete-me-data-action.test.ts
+++ b/apps/builder/__tests__/delete-me-data-action.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
 const deleteMeData = vi.fn()
+const loadServableWorkspace = vi.fn()
 
 vi.mock("@chatbotx.io/business/system-field", () => ({
   systemFieldService: {
@@ -17,6 +18,10 @@ vi.mock("@/lib/safe-action", () => ({
   },
 }))
 
+vi.mock("@/lib/workspace/load-servable-workspace", () => ({
+  loadServableWorkspace,
+}))
+
 const { handleDeleteMeData } = await import(
   "../src/features/system-fields/actions/delete-me-data.action"
 )
@@ -24,6 +29,7 @@ const { handleDeleteMeData } = await import(
 describe("delete me data action", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    loadServableWorkspace.mockResolvedValue({ servable: true })
   })
 
   test("maps public link params to the business erasure service", async () => {
@@ -46,5 +52,26 @@ describe("delete me data action", () => {
       formId: "form-1",
       hash: "hash-1",
     })
+  })
+
+  test("rejects without deleting data when the workspace is scheduled for deletion", async () => {
+    loadServableWorkspace.mockResolvedValue({ servable: false })
+
+    await expect(
+      handleDeleteMeData({
+        parsedInput: {
+          w: "workspace-1",
+          u: "source-1",
+          ib: "integration-1",
+          id: "form-1",
+          hash: "hash-1",
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "workspaceScheduledDeletion",
+      httpStatusCode: 403,
+    })
+
+    expect(deleteMeData).not.toHaveBeenCalled()
   })
 })

--- a/apps/builder/__tests__/email-topic-click-route.test.ts
+++ b/apps/builder/__tests__/email-topic-click-route.test.ts
@@ -1,25 +1,42 @@
 // @vitest-environment node
-import { afterEach, expect, test, vi } from "vitest"
+import { beforeEach, expect, test, vi } from "vitest"
 
 const recordClick = vi.fn().mockResolvedValue(undefined)
 const verifyEmailClickToken = vi.fn()
+const findAnalyticsWorkspaceIdByToken = vi.fn()
+const loadServableWorkspace = vi.fn()
 
 vi.mock("@chatbotx.io/analytics", () => ({
   emailTopicAnalyticsService: { recordClick },
 }))
 
 vi.mock("@chatbotx.io/business", () => ({
+  emailTopicService: { findAnalyticsWorkspaceIdByToken },
   verifyEmailClickToken,
 }))
 
-afterEach(() => {
-  vi.clearAllMocks()
+vi.mock("@/lib/workspace/load-servable-workspace", () => ({
+  loadServableWorkspace,
+}))
+
+beforeEach(() => {
+  recordClick.mockReset()
+  recordClick.mockResolvedValue(undefined)
+  verifyEmailClickToken.mockReset()
+  findAnalyticsWorkspaceIdByToken.mockReset()
+  findAnalyticsWorkspaceIdByToken.mockResolvedValue(undefined)
+  loadServableWorkspace.mockReset()
+  loadServableWorkspace.mockResolvedValue({ servable: true })
 })
 
 const { GET } = await import("../src/app/email-topic/click/route")
 
 test("redirects to the verified destination with 302", async () => {
-  verifyEmailClickToken.mockResolvedValueOnce("https://example.com/path")
+  findAnalyticsWorkspaceIdByToken.mockResolvedValue(undefined)
+  verifyEmailClickToken.mockResolvedValueOnce({
+    url: "https://example.com/path",
+    workspaceId: "workspace-1",
+  })
   const req = new Request("http://localhost/email-topic/click?r=tok&u=signed")
   const res = await GET(req)
   expect(res.status).toBe(302)
@@ -28,6 +45,7 @@ test("redirects to the verified destination with 302", async () => {
 })
 
 test("redirects to same-origin when the token is tampered or expired", async () => {
+  findAnalyticsWorkspaceIdByToken.mockResolvedValue("workspace-1")
   verifyEmailClickToken.mockRejectedValueOnce(new Error("invalid token"))
   const req = new Request(
     "http://localhost/email-topic/click?r=tok&u=https%3A%2F%2Fevil.com",
@@ -36,6 +54,7 @@ test("redirects to same-origin when the token is tampered or expired", async () 
   expect(res.status).toBe(302)
   // Open-redirect guard: never forwards to an attacker-supplied target.
   expect(res.headers.get("location")).toBe("http://localhost/")
+  expect(recordClick).not.toHaveBeenCalled()
 })
 
 test("redirects to same-origin when the u param is missing", async () => {
@@ -47,18 +66,99 @@ test("redirects to same-origin when the u param is missing", async () => {
 })
 
 test("calls recordClick with the token from ?r param", async () => {
-  verifyEmailClickToken.mockResolvedValueOnce("https://example.com")
+  findAnalyticsWorkspaceIdByToken.mockResolvedValue("workspace-1")
+  verifyEmailClickToken.mockResolvedValueOnce({
+    url: "https://example.com",
+    workspaceId: "workspace-1",
+  })
   const req = new Request(
     "http://localhost/email-topic/click?r=tok-123&u=signed",
   )
   await GET(req)
   expect(recordClick).toHaveBeenCalledOnce()
   expect(recordClick).toHaveBeenCalledWith("tok-123")
+  expect(loadServableWorkspace).toHaveBeenCalledWith("workspace-1")
+})
+
+test("returns 410 and skips click recording and redirect when the workspace is scheduled for deletion", async () => {
+  findAnalyticsWorkspaceIdByToken.mockResolvedValue("workspace-1")
+  loadServableWorkspace.mockResolvedValue({ servable: false })
+  verifyEmailClickToken.mockResolvedValueOnce({
+    url: "https://example.com",
+    workspaceId: "workspace-1",
+  })
+  const req = new Request(
+    "http://localhost/email-topic/click?r=tok-123&u=signed",
+  )
+
+  const res = await GET(req)
+
+  expect(res.status).toBe(410)
+  expect(recordClick).not.toHaveBeenCalled()
+  expect(verifyEmailClickToken).not.toHaveBeenCalled()
 })
 
 test("does not call recordClick when r param is missing", async () => {
-  verifyEmailClickToken.mockResolvedValueOnce("https://example.com")
+  verifyEmailClickToken.mockResolvedValueOnce({
+    url: "https://example.com",
+    workspaceId: "workspace-1",
+  })
   const req = new Request("http://localhost/email-topic/click?u=signed")
   await GET(req)
   expect(recordClick).not.toHaveBeenCalled()
+})
+
+test("checks signed-token workspace and redirects when r param is missing", async () => {
+  verifyEmailClickToken.mockResolvedValueOnce({
+    url: "https://example.com",
+    workspaceId: "workspace-1",
+  })
+  const req = new Request("http://localhost/email-topic/click?u=signed")
+
+  const res = await GET(req)
+
+  expect(res.status).toBe(302)
+  expect(res.headers.get("location")).toBe("https://example.com/")
+  expect(loadServableWorkspace).toHaveBeenCalledWith("workspace-1")
+})
+
+test("does not redirect u-only tokens without a workspace identity", async () => {
+  verifyEmailClickToken.mockResolvedValueOnce({
+    url: "https://example.com",
+  })
+  const req = new Request("http://localhost/email-topic/click?u=legacy")
+
+  const res = await GET(req)
+
+  expect(res.status).toBe(302)
+  expect(res.headers.get("location")).toBe("http://localhost/")
+  expect(recordClick).not.toHaveBeenCalled()
+})
+
+test("returns 410 for u-only tokens from a scheduled workspace", async () => {
+  verifyEmailClickToken.mockResolvedValueOnce({
+    url: "https://example.com",
+    workspaceId: "workspace-1",
+  })
+  loadServableWorkspace.mockResolvedValue({ servable: false })
+  const req = new Request("http://localhost/email-topic/click?u=signed")
+
+  const res = await GET(req)
+
+  expect(res.status).toBe(410)
+  expect(res.headers.get("location")).toBeNull()
+})
+
+test("does not redirect when tracking token and signed token disagree on workspace", async () => {
+  findAnalyticsWorkspaceIdByToken.mockResolvedValue("workspace-1")
+  verifyEmailClickToken.mockResolvedValueOnce({
+    url: "https://example.com",
+    workspaceId: "workspace-2",
+  })
+  const req = new Request("http://localhost/email-topic/click?r=tok&u=signed")
+
+  const res = await GET(req)
+
+  expect(res.status).toBe(302)
+  expect(res.headers.get("location")).toBe("http://localhost/")
 })

--- a/apps/builder/__tests__/email-topic-open-route.test.ts
+++ b/apps/builder/__tests__/email-topic-open-route.test.ts
@@ -1,14 +1,26 @@
 // @vitest-environment node
-import { afterEach, expect, test, vi } from "vitest"
+import { beforeEach, expect, test, vi } from "vitest"
 
 const recordOpen = vi.fn().mockResolvedValue(undefined)
+const findAnalyticsWorkspaceIdByToken = vi.fn()
+const loadServableWorkspace = vi.fn()
 
 vi.mock("@chatbotx.io/analytics", () => ({
   emailTopicAnalyticsService: { recordOpen },
 }))
 
-afterEach(() => {
+vi.mock("@chatbotx.io/business", () => ({
+  emailTopicService: { findAnalyticsWorkspaceIdByToken },
+}))
+
+vi.mock("@/lib/workspace/load-servable-workspace", () => ({
+  loadServableWorkspace,
+}))
+
+beforeEach(() => {
   vi.clearAllMocks()
+  findAnalyticsWorkspaceIdByToken.mockResolvedValue(undefined)
+  loadServableWorkspace.mockResolvedValue({ servable: true })
 })
 
 const { GET } = await import("../src/app/email-topic/open/route")
@@ -21,10 +33,23 @@ test("returns 1×1 GIF with no-cache headers", async () => {
 })
 
 test("calls recordOpen with the token from ?r param", async () => {
+  findAnalyticsWorkspaceIdByToken.mockResolvedValue("workspace-1")
   const req = new Request("http://localhost/email-topic/open?r=test-token-abc")
   await GET(req)
   expect(recordOpen).toHaveBeenCalledOnce()
   expect(recordOpen).toHaveBeenCalledWith("test-token-abc")
+  expect(loadServableWorkspace).toHaveBeenCalledWith("workspace-1")
+})
+
+test("returns the GIF but skips recordOpen when the workspace is scheduled for deletion", async () => {
+  findAnalyticsWorkspaceIdByToken.mockResolvedValue("workspace-1")
+  loadServableWorkspace.mockResolvedValue({ servable: false })
+
+  const req = new Request("http://localhost/email-topic/open?r=test-token-abc")
+  const res = await GET(req)
+
+  expect(res.headers.get("Content-Type")).toBe("image/gif")
+  expect(recordOpen).not.toHaveBeenCalled()
 })
 
 test("does not call recordOpen when r param is missing", async () => {

--- a/apps/builder/__tests__/integration-webhook-freeze.test.ts
+++ b/apps/builder/__tests__/integration-webhook-freeze.test.ts
@@ -1,0 +1,185 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const getAccessState = vi.fn()
+const workspaceFind = vi.fn()
+const findIntegrationTelegramByBotId = vi.fn()
+const findIntegrationTiktokByOpenId = vi.fn()
+const telegramHandleRequest = vi.fn()
+const tiktokHandleRequest = vi.fn()
+const loggerInfo = vi.fn()
+
+vi.mock("@chatbotx.io/business", async () => {
+  const { resolveWorkspaceFreezeReason } = await import(
+    "@chatbotx.io/business/workspace-lifecycle/predicates"
+  )
+  return {
+    customDomainService: { findActiveByDomain: vi.fn() },
+    platformCredentialService: {
+      findDecryptedPlatform: vi.fn(),
+      findDecryptedForUser: vi.fn(),
+    },
+    resolveWorkspaceFreezeReason,
+    tenantService: { findById: vi.fn() },
+    userQuotaService: { getAccessState },
+    workspaceService: { find: workspaceFind },
+  }
+})
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: { update: vi.fn() },
+  eq: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/database/partials", () => ({
+  inboxStatuses: { enum: { disconnected: "disconnected" } },
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  inboxModel: {},
+}))
+
+vi.mock("@chatbotx.io/worker-config", () => ({
+  integrationQueue: {},
+}))
+
+vi.mock("@/env", () => ({
+  isCloud: () => false,
+}))
+
+vi.mock("@/features/integration-telegram/queries", () => ({
+  findIntegrationTelegramByBotId,
+}))
+
+vi.mock("@/features/integration-tiktok/queries", () => ({
+  findIntegrationTiktokByOpenId,
+}))
+
+vi.mock("@/integration", () => ({
+  integrations: {
+    telegram: { name: "telegram", handleRequest: telegramHandleRequest },
+    tiktok: { name: "tiktok", handleRequest: tiktokHandleRequest },
+  },
+}))
+
+vi.mock("@/lib/log", () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: loggerInfo },
+}))
+
+vi.mock("@/lib/oauth-broker", () => ({
+  isBrokerHost: () => false,
+}))
+
+const { handleWebhook } = await import(
+  "../src/app/integrations/[...integration]/webhook"
+)
+
+const asNextRequest = (url: string, body?: string) => {
+  const request = new Request(url, body ? { method: "POST", body } : undefined)
+  return Object.assign(request, { nextUrl: new URL(url) }) as never
+}
+
+const liveWorkspace = {
+  id: "workspace-1",
+  ownerId: "owner-1",
+  scheduledDeletionAt: null,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getAccessState.mockResolvedValue({ blocked: false })
+  workspaceFind.mockResolvedValue(liveWorkspace)
+  telegramHandleRequest.mockResolvedValue("ok")
+  tiktokHandleRequest.mockResolvedValue("ok")
+  findIntegrationTelegramByBotId.mockResolvedValue({
+    auth: { secretText: "secret", metadata: { webhookSecretToken: "token" } },
+    botId: "bot-1",
+    workspaceId: "workspace-1",
+  })
+  findIntegrationTiktokByOpenId.mockResolvedValue({
+    auth: { clientId: "id", clientSecret: "secret", redirectUrl: "https://x" },
+    inboxId: "inbox-1",
+    openId: "open-1",
+    workspaceId: "workspace-1",
+  })
+})
+
+describe("telegram webhook freeze", () => {
+  const request = () =>
+    asNextRequest("http://localhost/integrations/telegram?botId=bot-1")
+
+  test("forwards the update to the integration for a live workspace", async () => {
+    await handleWebhook("telegram", request())
+
+    expect(telegramHandleRequest).toHaveBeenCalledOnce()
+  })
+
+  test("skips the update when the workspace is scheduled for deletion", async () => {
+    workspaceFind.mockResolvedValue({
+      ...liveWorkspace,
+      scheduledDeletionAt: new Date("2026-01-01T00:00:00Z"),
+    })
+
+    const response = await handleWebhook("telegram", request())
+
+    expect(await response.text()).toBe("ok")
+    expect(telegramHandleRequest).not.toHaveBeenCalled()
+    expect(loggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ freezeReason: "scheduledForDeletion" }),
+      "webhook skipped: frozen workspace",
+    )
+  })
+
+  test("skips the update when the owner entitlement is blocked", async () => {
+    getAccessState.mockResolvedValue({ blocked: true })
+
+    const response = await handleWebhook("telegram", request())
+
+    expect(await response.text()).toBe("ok")
+    expect(telegramHandleRequest).not.toHaveBeenCalled()
+  })
+
+  test("skips the update when the workspace row no longer exists", async () => {
+    workspaceFind.mockResolvedValue(undefined)
+
+    const response = await handleWebhook("telegram", request())
+
+    expect(await response.text()).toBe("ok")
+    expect(telegramHandleRequest).not.toHaveBeenCalled()
+  })
+})
+
+describe("tiktok webhook freeze", () => {
+  const request = () =>
+    asNextRequest(
+      "http://localhost/integrations/tiktok",
+      JSON.stringify({ user_openid: "open-1", event: "comment" }),
+    )
+
+  test("forwards the event to the integration for a live workspace", async () => {
+    await handleWebhook("tiktok", request())
+
+    expect(tiktokHandleRequest).toHaveBeenCalledOnce()
+  })
+
+  test("skips the event when the workspace is scheduled for deletion", async () => {
+    workspaceFind.mockResolvedValue({
+      ...liveWorkspace,
+      scheduledDeletionAt: new Date("2026-01-01T00:00:00Z"),
+    })
+
+    const response = await handleWebhook("tiktok", request())
+
+    expect(await response.text()).toBe("ok")
+    expect(tiktokHandleRequest).not.toHaveBeenCalled()
+  })
+
+  test("skips the event when the workspace row no longer exists", async () => {
+    workspaceFind.mockResolvedValue(undefined)
+
+    const response = await handleWebhook("tiktok", request())
+
+    expect(await response.text()).toBe("ok")
+    expect(tiktokHandleRequest).not.toHaveBeenCalled()
+  })
+})

--- a/apps/builder/__tests__/load-servable-workspace.test.ts
+++ b/apps/builder/__tests__/load-servable-workspace.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockWorkspaceFind } = vi.hoisted(() => ({
+  mockWorkspaceFind: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  isWorkspaceScheduledForDeletion: (workspace: {
+    scheduledDeletionAt?: Date | string | null
+  }) => workspace.scheduledDeletionAt != null,
+  workspaceService: {
+    find: mockWorkspaceFind,
+  },
+}))
+
+const { loadServableWorkspace } = await import(
+  "../src/lib/workspace/load-servable-workspace"
+)
+
+describe("loadServableWorkspace", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("returns servable false when the workspace is scheduled for deletion", async () => {
+    const workspace = {
+      id: "workspace-1",
+      scheduledDeletionAt: new Date("2026-01-01T00:00:00Z"),
+    }
+    mockWorkspaceFind.mockResolvedValue(workspace)
+
+    await expect(loadServableWorkspace("workspace-1")).resolves.toEqual({
+      servable: false,
+      workspace,
+    })
+  })
+
+  test("returns servable true when the workspace is not scheduled for deletion", async () => {
+    const workspace = { id: "workspace-1", scheduledDeletionAt: null }
+    mockWorkspaceFind.mockResolvedValue(workspace)
+
+    await expect(loadServableWorkspace("workspace-1")).resolves.toEqual({
+      servable: true,
+      workspace,
+    })
+  })
+})

--- a/apps/builder/__tests__/load-servable-workspace.test.ts
+++ b/apps/builder/__tests__/load-servable-workspace.test.ts
@@ -5,14 +5,17 @@ const { mockWorkspaceFind } = vi.hoisted(() => ({
   mockWorkspaceFind: vi.fn(),
 }))
 
-vi.mock("@chatbotx.io/business", () => ({
-  isWorkspaceScheduledForDeletion: (workspace: {
-    scheduledDeletionAt?: Date | string | null
-  }) => workspace.scheduledDeletionAt != null,
-  workspaceService: {
-    find: mockWorkspaceFind,
-  },
-}))
+vi.mock("@chatbotx.io/business", async () => {
+  const predicates = await import(
+    "@chatbotx.io/business/workspace-lifecycle/predicates"
+  )
+  return {
+    ...predicates,
+    workspaceService: {
+      find: mockWorkspaceFind,
+    },
+  }
+})
 
 const { loadServableWorkspace } = await import(
   "../src/lib/workspace/load-servable-workspace"
@@ -43,6 +46,15 @@ describe("loadServableWorkspace", () => {
     await expect(loadServableWorkspace("workspace-1")).resolves.toEqual({
       servable: true,
       workspace,
+    })
+  })
+
+  test("returns servable false when the workspace no longer exists", async () => {
+    mockWorkspaceFind.mockResolvedValue(undefined)
+
+    await expect(loadServableWorkspace("workspace-1")).resolves.toEqual({
+      servable: false,
+      workspace: undefined,
     })
   })
 })

--- a/apps/builder/__tests__/me-extension-download-route.test.ts
+++ b/apps/builder/__tests__/me-extension-download-route.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
 const buildMeExport = vi.fn()
+const loadServableWorkspace = vi.fn()
 
 vi.mock("@chatbotx.io/business/system-field", () => ({
   systemFieldService: {
@@ -9,11 +10,16 @@ vi.mock("@chatbotx.io/business/system-field", () => ({
   },
 }))
 
+vi.mock("@/lib/workspace/load-servable-workspace", () => ({
+  loadServableWorkspace,
+}))
+
 const { GET } = await import("../src/app/extensions/me/download/route")
 
 describe("me extension download route", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    loadServableWorkspace.mockResolvedValue({ servable: true })
   })
 
   test("returns export JSON with an attachment filename", async () => {
@@ -83,5 +89,18 @@ describe("me extension download route", () => {
       ),
     )
     expect(invalid.status).toBe(404)
+  })
+
+  test("returns 410 without building export when the workspace is scheduled for deletion", async () => {
+    loadServableWorkspace.mockResolvedValue({ servable: false })
+
+    const res = await GET(
+      new Request(
+        "http://localhost/extensions/me/download?w=workspace-1&u=source-1&ib=integration-1&id=form-1&hash=hash-1",
+      ),
+    )
+
+    expect(res.status).toBe(410)
+    expect(buildMeExport).not.toHaveBeenCalled()
   })
 })

--- a/apps/builder/__tests__/presigned-upload-route.test.ts
+++ b/apps/builder/__tests__/presigned-upload-route.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const loadServableWorkspace = vi.fn()
+const assertCurrentUserCanAccessChatbot = vi.fn()
+const getPresignedUpload = vi.fn()
+const insertValues = vi.fn()
+
+vi.mock("@chatbotx.io/business", () => ({
+  isPlatformAdmin: vi.fn(),
+  resolveTenantSettings: vi.fn(async () => ({
+    storageUrl: "https://cdn.example.com",
+  })),
+  resolveTenantSettingsByDomain: vi.fn(async () => ({
+    storageUrl: "https://cdn.example.com",
+  })),
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: { insert: () => ({ values: insertValues }) },
+}))
+
+vi.mock("@chatbotx.io/database/partials", () => ({
+  fileContextTypes: { enum: { generic: "generic", import: "import" } },
+  fileStatuses: { enum: { pending: "pending" } },
+  importTypes: { options: ["contact"] },
+  uploadTypes: { options: ["import", "generic"] },
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({ fileModel: {} }))
+
+vi.mock("@chatbotx.io/filesystem", () => ({
+  uploader: { getPresignedUpload },
+}))
+
+vi.mock("@chatbotx.io/utils", () => ({ createId: () => "file-1" }))
+
+vi.mock("@/features/import/schemas/presign", () => ({
+  presignImportUploadRequest: {
+    parse: (value: unknown) => value,
+  },
+}))
+
+vi.mock("@/lib/auth/utils", () => ({
+  assertCurrentUserCanAccessChatbot,
+  getCurrentUser: vi.fn(async () => ({ id: "user-1" })),
+  getCurrentUserId: vi.fn(async () => "user-1"),
+}))
+
+vi.mock("@/lib/domain", () => ({ getDomainFromHeader: vi.fn(async () => "") }))
+
+vi.mock("@/lib/errors/server-handler", () => ({
+  serverErrorHandler: (error: unknown) => {
+    throw error
+  },
+}))
+
+vi.mock("@/lib/serialize", () => ({
+  safeJsonParse: (req: Request) => req.json(),
+}))
+
+vi.mock("@/lib/upload/handlers", () => ({
+  getUploadHandler: () => () => ({ ok: true, path: "workspaces/1/logo.png" }),
+}))
+
+vi.mock("@/lib/workspace/load-servable-workspace", () => ({
+  loadServableWorkspace,
+}))
+
+const { POST } = await import("../src/app/api/presigned-upload/route")
+
+const asNextRequest = (body: unknown) => {
+  const request = new Request("http://localhost/api/presigned-upload", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  })
+  return request as never
+}
+
+const validBody = {
+  fileName: "logo.png",
+  mimeType: "image/png",
+  path: "workspaces/1/logo.png",
+  subType: "generic",
+  type: "generic",
+  workspaceId: "1",
+}
+
+describe("POST /api/presigned-upload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    loadServableWorkspace.mockResolvedValue({
+      servable: true,
+      workspace: { id: "1" },
+    })
+    getPresignedUpload.mockResolvedValue("https://upload.example.com/signed")
+    insertValues.mockResolvedValue(undefined)
+  })
+
+  test("mints a presigned url for a servable workspace", async () => {
+    const response = await POST(asNextRequest(validBody))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      fileId: "file-1",
+      presignedPostUrl: "https://upload.example.com/signed",
+      publicUrl: "https://cdn.example.com/workspaces/1/logo.png",
+    })
+  })
+
+  test("rejects the upload when the workspace is frozen", async () => {
+    loadServableWorkspace.mockResolvedValue({
+      servable: false,
+      workspace: { id: "1", scheduledDeletionAt: new Date() },
+    })
+
+    const response = await POST(asNextRequest(validBody))
+
+    expect(response.status).toBe(403)
+    expect(getPresignedUpload).not.toHaveBeenCalled()
+    expect(insertValues).not.toHaveBeenCalled()
+  })
+
+  test("rejects the upload when the workspace row no longer exists", async () => {
+    loadServableWorkspace.mockResolvedValue({
+      servable: false,
+      workspace: undefined,
+    })
+
+    const response = await POST(asNextRequest(validBody))
+
+    expect(response.status).toBe(403)
+    expect(getPresignedUpload).not.toHaveBeenCalled()
+  })
+})

--- a/apps/builder/__tests__/public-scheduled-deletion-routes.test.tsx
+++ b/apps/builder/__tests__/public-scheduled-deletion-routes.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment node
+import type { NextRequest } from "next/server"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+  mockContactUnsubscribeEmail,
+  mockEmit,
+  mockLoadServableWorkspace,
+  mockMagicLinkFindFirst,
+  mockNotFound,
+  mockQrCodeFind,
+  mockResolveTenantSettings,
+  mockSystemGetMePrivacyData,
+  mockVerifyUnsubscribeToken,
+} = vi.hoisted(() => ({
+  mockContactUnsubscribeEmail: vi.fn(),
+  mockEmit: vi.fn(),
+  mockLoadServableWorkspace: vi.fn(),
+  mockMagicLinkFindFirst: vi.fn(),
+  mockNotFound: vi.fn(() => {
+    throw new Error("notFound")
+  }),
+  mockQrCodeFind: vi.fn(),
+  mockResolveTenantSettings: vi.fn(),
+  mockSystemGetMePrivacyData: vi.fn(),
+  mockVerifyUnsubscribeToken: vi.fn(),
+}))
+
+vi.mock("@/lib/workspace/load-servable-workspace", () => ({
+  loadServableWorkspace: mockLoadServableWorkspace,
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      magicLinkModel: { findFirst: mockMagicLinkFindFirst },
+    },
+  },
+}))
+
+vi.mock("@chatbotx.io/event-bus", () => ({
+  emit: mockEmit,
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  contactService: {
+    unsubscribeEmail: mockContactUnsubscribeEmail,
+  },
+  inboxService: {
+    list: vi.fn(),
+  },
+  qrCodeService: {
+    find: mockQrCodeFind,
+  },
+  resolveTenantSettings: mockResolveTenantSettings,
+  verifyUnsubscribeToken: mockVerifyUnsubscribeToken,
+}))
+
+vi.mock("@chatbotx.io/business/system-field", () => ({
+  systemFieldService: {
+    getMePrivacyData: mockSystemGetMePrivacyData,
+  },
+}))
+
+vi.mock("@chatbotx.io/business/utils", () => ({
+  getInboxLinks: vi.fn(() => []),
+}))
+
+vi.mock("@chatbotx.io/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@chatbotx.io/utils")>()
+  return {
+    ...actual,
+    getIdFromParams: (params: Record<string, string>, key: string) =>
+      params[key],
+  }
+})
+
+vi.mock("next/navigation", () => ({
+  notFound: mockNotFound,
+  redirect: vi.fn(),
+}))
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: vi.fn(async () => (key: string) => key),
+}))
+
+vi.mock("next-intl", () => ({
+  NextIntlClientProvider: ({ children }: { children: unknown }) => children,
+}))
+
+vi.mock("@/features/inboxes/components/landing-inbox-list", () => ({
+  InboxListLandingPage: () => null,
+}))
+
+vi.mock("@/features/system-fields/components/me-data-view", () => ({
+  MeDataView: () => null,
+}))
+
+vi.mock("@/i18n/workspace-locale", () => ({
+  loadWorkspaceMessages: vi.fn(async () => ({ locale: "en", messages: {} })),
+}))
+
+const { GET: getMagicLink } = await import(
+  "../src/app/r/[workspaceId]/[name]/route"
+)
+const { default: LandingPage } = await import(
+  "../src/app/l/[workspaceId]/[id]/page"
+)
+const { default: MePage } = await import("../src/app/extensions/me/page")
+const { default: UnsubscribePage } = await import("../src/app/unsubscribe/page")
+
+describe("public scheduled-deletion route guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockLoadServableWorkspace.mockResolvedValue({ servable: true })
+    mockResolveTenantSettings.mockResolvedValue({
+      appUrl: "https://app.example.com",
+    })
+    mockVerifyUnsubscribeToken.mockResolvedValue({
+      cid: "contact-1",
+      wid: "workspace-1",
+    })
+  })
+
+  test("magiclink returns 410 before lookup, emit, or redirect when the workspace is scheduled for deletion", async () => {
+    mockLoadServableWorkspace.mockResolvedValue({ servable: false })
+
+    const response = await getMagicLink(
+      new Request(
+        "http://localhost/r/workspace-1/link",
+      ) as unknown as NextRequest,
+      { params: Promise.resolve({ workspaceId: "workspace-1", name: "link" }) },
+    )
+
+    expect(response.status).toBe(410)
+    expect(mockMagicLinkFindFirst).not.toHaveBeenCalled()
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  test("QR landing returns notFound before resolving channels when the workspace is scheduled for deletion", async () => {
+    mockLoadServableWorkspace.mockResolvedValue({ servable: false })
+
+    await expect(
+      LandingPage({
+        params: Promise.resolve({ workspaceId: "workspace-1", id: "qr-1" }),
+      }),
+    ).rejects.toThrow("notFound")
+
+    expect(mockResolveTenantSettings).not.toHaveBeenCalled()
+    expect(mockQrCodeFind).not.toHaveBeenCalled()
+  })
+
+  test("GDPR me page returns notFound before loading private data when the workspace is scheduled for deletion", async () => {
+    mockLoadServableWorkspace.mockResolvedValue({ servable: false })
+
+    await expect(
+      MePage({
+        searchParams: Promise.resolve({
+          w: "workspace-1",
+          u: "source-1",
+          ib: "integration-1",
+          id: "form-1",
+          hash: "hash-1",
+        }),
+      }),
+    ).rejects.toThrow("notFound")
+
+    expect(mockSystemGetMePrivacyData).not.toHaveBeenCalled()
+  })
+
+  test("unsubscribe renders unavailable and skips mutation when the workspace is scheduled for deletion", async () => {
+    mockLoadServableWorkspace.mockResolvedValue({ servable: false })
+
+    const result = await UnsubscribePage({
+      searchParams: Promise.resolve({ token: "token-1" }),
+    })
+
+    expect(JSON.stringify(result)).toContain("unavailableTitle")
+    expect(mockContactUnsubscribeEmail).not.toHaveBeenCalled()
+  })
+})

--- a/apps/builder/__tests__/schedule-workspace-deletion-action.test.ts
+++ b/apps/builder/__tests__/schedule-workspace-deletion-action.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+
+import { beforeEach, expect, test, vi } from "vitest"
+
+const mockGetCurrentUserAndTargetWorkspace = vi.fn()
+const mockHasWorkspacePermission = vi.fn()
+const mockScheduleDeletion = vi.fn()
+const mockCancelInFlightCampaigns = vi.fn()
+const mockRedirect = vi.fn(() => {
+  throw new Error("redirect")
+})
+
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, unknown> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.action = (fn: unknown) => fn
+  return {
+    workspaceActionClientAllowExpired: chain,
+  }
+})
+
+vi.mock("next/navigation", () => ({
+  redirect: mockRedirect,
+}))
+
+vi.mock("@/lib/auth/utils", () => ({
+  getCurrentUserAndTargetWorkspace: mockGetCurrentUserAndTargetWorkspace,
+}))
+
+vi.mock("@/lib/auth/permission-routes", () => ({
+  hasWorkspacePermission: mockHasWorkspacePermission,
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  workspaceLifecycleService: {
+    cancelInFlightCampaigns: mockCancelInFlightCampaigns,
+  },
+  workspaceService: {
+    scheduleDeletion: mockScheduleDeletion,
+  },
+}))
+
+const { scheduleWorkspaceDeletionAction } = await import(
+  "../src/features/workspaces/actions/schedule-workspace-deletion-action"
+)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
+    targetWorkspaceMember: {
+      permissions: { superAdmin: true },
+    },
+  })
+  mockHasWorkspacePermission.mockReturnValue(true)
+  mockScheduleDeletion.mockResolvedValue(undefined)
+  mockCancelInFlightCampaigns.mockResolvedValue([])
+})
+
+test("schedules deletion then cancels in-flight campaigns before redirecting", async () => {
+  await expect(
+    (scheduleWorkspaceDeletionAction as (props: unknown) => Promise<unknown>)({
+      bindArgsParsedInputs: ["workspace-1"],
+    }),
+  ).rejects.toThrow("redirect")
+
+  expect(mockScheduleDeletion).toHaveBeenCalledWith({ id: "workspace-1" })
+  expect(mockCancelInFlightCampaigns).toHaveBeenCalledWith("workspace-1")
+  expect(mockRedirect).toHaveBeenCalledWith("/")
+})

--- a/apps/builder/__tests__/schedule-workspace-deletion-action.test.ts
+++ b/apps/builder/__tests__/schedule-workspace-deletion-action.test.ts
@@ -65,5 +65,7 @@ test("schedules deletion then freezes the workspace runtime before redirecting",
 
   expect(mockScheduleDeletion).toHaveBeenCalledWith({ id: "workspace-1" })
   expect(mockFreezeWorkspaceRuntime).toHaveBeenCalledWith("workspace-1")
-  expect(mockRedirect).toHaveBeenCalledWith("/")
+  expect(mockRedirect).toHaveBeenCalledWith(
+    "/space/workspace-1/settings/general",
+  )
 })

--- a/apps/builder/__tests__/schedule-workspace-deletion-action.test.ts
+++ b/apps/builder/__tests__/schedule-workspace-deletion-action.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, expect, test, vi } from "vitest"
 const mockGetCurrentUserAndTargetWorkspace = vi.fn()
 const mockHasWorkspacePermission = vi.fn()
 const mockScheduleDeletion = vi.fn()
-const mockCancelInFlightCampaigns = vi.fn()
+const mockFreezeWorkspaceRuntime = vi.fn()
 const mockRedirect = vi.fn(() => {
   throw new Error("redirect")
 })
@@ -33,7 +33,7 @@ vi.mock("@/lib/auth/permission-routes", () => ({
 
 vi.mock("@chatbotx.io/business", () => ({
   workspaceLifecycleService: {
-    cancelInFlightCampaigns: mockCancelInFlightCampaigns,
+    freezeWorkspaceRuntime: mockFreezeWorkspaceRuntime,
   },
   workspaceService: {
     scheduleDeletion: mockScheduleDeletion,
@@ -53,10 +53,10 @@ beforeEach(() => {
   })
   mockHasWorkspacePermission.mockReturnValue(true)
   mockScheduleDeletion.mockResolvedValue(undefined)
-  mockCancelInFlightCampaigns.mockResolvedValue([])
+  mockFreezeWorkspaceRuntime.mockResolvedValue(undefined)
 })
 
-test("schedules deletion then cancels in-flight campaigns before redirecting", async () => {
+test("schedules deletion then freezes the workspace runtime before redirecting", async () => {
   await expect(
     (scheduleWorkspaceDeletionAction as (props: unknown) => Promise<unknown>)({
       bindArgsParsedInputs: ["workspace-1"],
@@ -64,6 +64,6 @@ test("schedules deletion then cancels in-flight campaigns before redirecting", a
   ).rejects.toThrow("redirect")
 
   expect(mockScheduleDeletion).toHaveBeenCalledWith({ id: "workspace-1" })
-  expect(mockCancelInFlightCampaigns).toHaveBeenCalledWith("workspace-1")
+  expect(mockFreezeWorkspaceRuntime).toHaveBeenCalledWith("workspace-1")
   expect(mockRedirect).toHaveBeenCalledWith("/")
 })

--- a/apps/builder/__tests__/webchat-page-guards.test.tsx
+++ b/apps/builder/__tests__/webchat-page-guards.test.tsx
@@ -26,6 +26,12 @@ vi.mock("next/navigation", () => ({
 }))
 
 vi.mock("@chatbotx.io/business", () => ({
+  isWorkspaceScheduledForDeletion: (
+    workspace:
+      | { scheduledDeletionAt?: Date | string | null }
+      | null
+      | undefined,
+  ) => Boolean(workspace?.scheduledDeletionAt),
   workspaceService: { find: mockWorkspaceFind },
 }))
 

--- a/apps/builder/__tests__/workspace-root-page-scheduled-deletion.test.ts
+++ b/apps/builder/__tests__/workspace-root-page-scheduled-deletion.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+  mockEnforceFromRequest,
+  mockGetCurrentUserAndTargetWorkspace,
+  mockNotFound,
+  mockRedirect,
+} = vi.hoisted(() => ({
+  mockEnforceFromRequest: vi.fn(),
+  mockGetCurrentUserAndTargetWorkspace: vi.fn(),
+  mockNotFound: vi.fn(() => {
+    throw new Error("notFound")
+  }),
+  mockRedirect: vi.fn((path: string) => {
+    throw new Error(`NEXT_REDIRECT:${path}`)
+  }),
+}))
+
+vi.mock("next/navigation", () => ({
+  notFound: mockNotFound,
+  redirect: mockRedirect,
+}))
+
+vi.mock("@/lib/auth/utils", () => ({
+  getCurrentUserAndTargetWorkspace: mockGetCurrentUserAndTargetWorkspace,
+}))
+
+vi.mock("@/lib/workspace/require-not-scheduled-for-deletion", () => ({
+  enforceWorkspaceNotScheduledForDeletionFromRequest: mockEnforceFromRequest,
+}))
+
+const WorkspacePage = (await import("@/app/space/[workspaceId]/page")).default
+
+const memberWith = (permissions: Record<string, boolean>) => ({
+  targetWorkspace: {
+    id: "w1",
+    scheduledDeletionAt: new Date("2026-01-02T00:00:00Z"),
+  },
+  targetWorkspaceMember: { permissions },
+})
+
+describe("workspace root page during the deletion grace window", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // clearAllMocks keeps implementations — reset the enforcer to a no-op so a
+    // throwing implementation cannot leak into the next test.
+    mockEnforceFromRequest.mockImplementation(() => Promise.resolve())
+  })
+
+  test("runs the scheduled-deletion enforcer before redirecting to a landing section", async () => {
+    // Layout and page render in the SAME pass, so both redirects race. The page
+    // must reach the identical verdict, otherwise the winner is a coin flip
+    // between settings/general and the landing section.
+    mockGetCurrentUserAndTargetWorkspace.mockResolvedValue(
+      memberWith({ superAdmin: true }),
+    )
+    mockEnforceFromRequest.mockImplementation(() => {
+      throw new Error("NEXT_REDIRECT:/space/w1/settings/general")
+    })
+
+    await expect(
+      WorkspacePage({ params: Promise.resolve({ workspaceId: "w1" }) }),
+    ).rejects.toThrow("NEXT_REDIRECT:/space/w1/settings/general")
+
+    expect(mockEnforceFromRequest).toHaveBeenCalledWith(
+      { id: "w1", scheduledDeletionAt: new Date("2026-01-02T00:00:00Z") },
+      true,
+    )
+    expect(mockRedirect).not.toHaveBeenCalled()
+  })
+
+  test("passes canManageDeletion=false for a member without superAdmin", async () => {
+    mockGetCurrentUserAndTargetWorkspace.mockResolvedValue(
+      memberWith({ analytics: true }),
+    )
+    mockEnforceFromRequest.mockImplementation(() => {
+      throw new Error("NEXT_REDIRECT:/?workspaceDeletionPending=1")
+    })
+
+    await expect(
+      WorkspacePage({ params: Promise.resolve({ workspaceId: "w1" }) }),
+    ).rejects.toThrow("NEXT_REDIRECT:/?workspaceDeletionPending=1")
+
+    expect(mockEnforceFromRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      false,
+    )
+  })
+
+  test("still redirects to the permitted landing section when no deletion is scheduled", async () => {
+    mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
+      targetWorkspace: { id: "w1", scheduledDeletionAt: null },
+      targetWorkspaceMember: { permissions: { analytics: true } },
+    })
+
+    await expect(
+      WorkspacePage({ params: Promise.resolve({ workspaceId: "w1" }) }),
+    ).rejects.toThrow("NEXT_REDIRECT:/space/w1/dashboard")
+
+    expect(mockEnforceFromRequest).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/builder/__tests__/workspace-scheduled-deletion-enforcer.test.ts
+++ b/apps/builder/__tests__/workspace-scheduled-deletion-enforcer.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockRedirect } = vi.hoisted(() => ({
+  mockRedirect: vi.fn((path: string) => {
+    // Mirrors Next.js: redirect() throws so nothing after it runs.
+    const error = new Error(`NEXT_REDIRECT:${path}`)
+    throw error
+  }),
+}))
+
+vi.mock("next/navigation", () => ({
+  redirect: mockRedirect,
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  isWorkspaceScheduledForDeletion: (workspace: {
+    scheduledDeletionAt: Date | string | null
+  }) => workspace.scheduledDeletionAt != null,
+}))
+
+const { enforceWorkspaceNotScheduledForDeletion } = await import(
+  "@/lib/workspace/require-not-scheduled-for-deletion"
+)
+
+const SETTINGS_GENERAL = "/space/w1/settings/general"
+
+const scheduledWorkspace = {
+  id: "w1",
+  scheduledDeletionAt: new Date("2026-01-02T00:00:00Z"),
+}
+
+const activeWorkspace = { id: "w1", scheduledDeletionAt: null }
+
+describe("enforceWorkspaceNotScheduledForDeletion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("does nothing for a workspace that is not scheduled for deletion", () => {
+    expect(() =>
+      enforceWorkspaceNotScheduledForDeletion(
+        activeWorkspace,
+        "/space/w1/broadcasts",
+        true,
+      ),
+    ).not.toThrow()
+
+    expect(mockRedirect).not.toHaveBeenCalled()
+  })
+
+  test("redirects a super admin from another section to settings/general", () => {
+    expect(() =>
+      enforceWorkspaceNotScheduledForDeletion(
+        scheduledWorkspace,
+        "/space/w1/broadcasts",
+        true,
+      ),
+    ).toThrow("NEXT_REDIRECT")
+
+    expect(mockRedirect).toHaveBeenCalledWith(SETTINGS_GENERAL)
+  })
+
+  test("does not redirect when already on settings/general", () => {
+    expect(() =>
+      enforceWorkspaceNotScheduledForDeletion(
+        scheduledWorkspace,
+        SETTINGS_GENERAL,
+        true,
+      ),
+    ).not.toThrow()
+
+    expect(mockRedirect).not.toHaveBeenCalled()
+  })
+
+  test("does not redirect when already on settings/general with a trailing slash", () => {
+    expect(() =>
+      enforceWorkspaceNotScheduledForDeletion(
+        scheduledWorkspace,
+        `${SETTINGS_GENERAL}/`,
+        true,
+      ),
+    ).not.toThrow()
+
+    expect(mockRedirect).not.toHaveBeenCalled()
+  })
+
+  test("does not redirect when the current pathname is unknown, so an unresolvable request cannot bounce a user in a loop", () => {
+    // `x-url` missing or unparseable leaves the pathname empty. Redirecting on
+    // an unknown location can target the page the user is already on, and the
+    // client router turns that into an endless refetch/redirect loop. The
+    // banner plus the action-layer guards still hold the freeze.
+    expect(() =>
+      enforceWorkspaceNotScheduledForDeletion(scheduledWorkspace, "", true),
+    ).not.toThrow()
+
+    expect(mockRedirect).not.toHaveBeenCalled()
+  })
+
+  test("redirects a member without deletion-management permission to the workspace list", () => {
+    expect(() =>
+      enforceWorkspaceNotScheduledForDeletion(
+        scheduledWorkspace,
+        "/space/w1/broadcasts",
+        false,
+      ),
+    ).toThrow("NEXT_REDIRECT")
+
+    expect(mockRedirect).toHaveBeenCalledWith("/?workspaceDeletionPending=1")
+  })
+})

--- a/apps/builder/__tests__/workspace-update-actions-scheduled-deletion-guard.test.ts
+++ b/apps/builder/__tests__/workspace-update-actions-scheduled-deletion-guard.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "vitest"
+
+const actionSource = readFileSync(
+  join(
+    process.cwd(),
+    "src/features/workspaces/actions/update-workspace-action.ts",
+  ),
+  "utf8",
+)
+
+describe("workspace update actions scheduled-deletion guard", () => {
+  test("allows only general settings updates during the deletion grace window", () => {
+    expect(actionSource).toContain(
+      "updateWorkspaceBasicAction =\n  workspaceActionClientAllowScheduledDeletion",
+    )
+    expect(actionSource).toContain(
+      "updateWorkspaceAdvancedAction =\n  workspaceActionClientAllowScheduledDeletion",
+    )
+    expect(actionSource).toContain(
+      "updateSmartResponseDelayAction = workspaceActionClient",
+    )
+  })
+})

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -322,7 +322,8 @@
     "status": {
       "scheduled": "Scheduled",
       "sent": "Sent",
-      "sending": "Sending"
+      "sending": "Sending",
+      "cancelled": "Cancelled"
     },
     "stats": {
       "sent": "Sent",
@@ -3698,7 +3699,9 @@
     "title": "You have been unsubscribed.",
     "description": "You will no longer receive emails from this sender.",
     "invalidTitle": "Invalid unsubscribe link.",
-    "invalidDescription": "This link is invalid or has expired."
+    "invalidDescription": "This link is invalid or has expired.",
+    "unavailableTitle": "Unsubscribe unavailable.",
+    "unavailableDescription": "This workspace is no longer available."
   },
   "extensionsMe": {
     "actions": {

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -323,7 +323,8 @@
     "status": {
       "scheduled": "Đã lên lịch",
       "sent": "Đã gửi",
-      "sending": "Đang gửi"
+      "sending": "Đang gửi",
+      "cancelled": "Đã huỷ"
     },
     "stats": {
       "sent": "Đã gửi",
@@ -3723,7 +3724,9 @@
     "title": "Bạn đã hủy đăng ký.",
     "description": "Bạn sẽ không còn nhận email từ người gửi này nữa.",
     "invalidTitle": "Liên kết hủy đăng ký không hợp lệ.",
-    "invalidDescription": "Liên kết này không hợp lệ hoặc đã hết hạn."
+    "invalidDescription": "Liên kết này không hợp lệ hoặc đã hết hạn.",
+    "unavailableTitle": "Không thể hủy đăng ký.",
+    "unavailableDescription": "Không gian làm việc này không còn khả dụng."
   },
   "extensionsMe": {
     "actions": {

--- a/apps/builder/src/app/(no-sidebar)/webchat/page.tsx
+++ b/apps/builder/src/app/(no-sidebar)/webchat/page.tsx
@@ -1,4 +1,7 @@
-import { workspaceService } from "@chatbotx.io/business"
+import {
+  isWorkspaceScheduledForDeletion,
+  workspaceService,
+} from "@chatbotx.io/business"
 import { db } from "@chatbotx.io/database/client"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import type { SearchParams } from "next/dist/server/request/search-params"
@@ -67,7 +70,7 @@ export default async function WebchatPage(props: WebchatPageProps) {
   const workspace = await workspaceService.find({
     where: { id: data.workspaceId },
   })
-  if (workspace?.scheduledDeletionAt) {
+  if (workspace && isWorkspaceScheduledForDeletion(workspace)) {
     const t = await getTranslations("webchat")
 
     return (

--- a/apps/builder/src/app/api/guest/messages/route.ts
+++ b/apps/builder/src/app/api/guest/messages/route.ts
@@ -1,6 +1,7 @@
 import {
   contactInboxService,
   conversationService,
+  isWorkspaceScheduledForDeletion,
   workspaceService,
 } from "@chatbotx.io/business"
 import { type NextRequest, NextResponse } from "next/server"
@@ -88,7 +89,7 @@ export async function GET(req: NextRequest) {
     const workspace = await workspaceService.find({
       where: { id: data.workspaceId },
     })
-    if (workspace?.scheduledDeletionAt) {
+    if (workspace && isWorkspaceScheduledForDeletion(workspace)) {
       return await forbiddenResponse(corsHeaders(requestOrigin, false))
     }
 

--- a/apps/builder/src/app/api/presigned-upload/route.ts
+++ b/apps/builder/src/app/api/presigned-upload/route.ts
@@ -19,6 +19,7 @@ import { getDomainFromHeader } from "@/lib/domain"
 import { serverErrorHandler } from "@/lib/errors/server-handler"
 import { safeJsonParse } from "@/lib/serialize"
 import { getUploadHandler } from "@/lib/upload/handlers"
+import { loadServableWorkspace } from "@/lib/workspace/load-servable-workspace"
 
 export async function POST(req: NextRequest) {
   try {
@@ -34,6 +35,17 @@ export async function POST(req: NextRequest) {
 
     if (input.workspaceId) {
       await assertCurrentUserCanAccessChatbot(input.workspaceId)
+
+      // Membership alone is not enough: a scheduled-for-deletion (or already
+      // purged) workspace must not accumulate new storage objects and File rows
+      // that the purge cron has no chance of cleaning up.
+      const { servable } = await loadServableWorkspace(input.workspaceId)
+      if (!servable) {
+        return NextResponse.json(
+          { error: "Workspace deletion scheduled" },
+          { status: 403 },
+        )
+      }
       ;({ storageUrl } = await resolveTenantSettings({
         workspaceId: input.workspaceId,
       }))

--- a/apps/builder/src/app/email-topic/click/route.ts
+++ b/apps/builder/src/app/email-topic/click/route.ts
@@ -1,24 +1,83 @@
 import { emailTopicAnalyticsService } from "@chatbotx.io/analytics"
-import { verifyEmailClickToken } from "@chatbotx.io/business"
+import { emailTopicService, verifyEmailClickToken } from "@chatbotx.io/business"
 import { NextResponse } from "next/server"
+import { loadServableWorkspace } from "@/lib/workspace/load-servable-workspace"
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
   const token = searchParams.get("r")
   const signedUrl = searchParams.get("u")
+  let shouldRecordClick = false
+  let trackedWorkspaceId: string | undefined
+  let checkedWorkspaceId: string | undefined
+
+  const isWorkspaceServable = async (workspaceId: string) => {
+    if (checkedWorkspaceId === workspaceId) {
+      return true
+    }
+
+    const { servable } = await loadServableWorkspace(workspaceId)
+    if (servable) {
+      checkedWorkspaceId = workspaceId
+    }
+    return servable
+  }
 
   if (token) {
-    await emailTopicAnalyticsService.recordClick(token)
+    const workspaceId = await emailTopicService.findAnalyticsWorkspaceIdByToken(
+      {
+        token,
+      },
+    )
+    if (workspaceId) {
+      trackedWorkspaceId = workspaceId
+      if (!(await isWorkspaceServable(workspaceId))) {
+        return NextResponse.json(
+          { code: "workspaceScheduledDeletion" },
+          { status: 410 },
+        )
+      }
+    }
+
+    shouldRecordClick = true
   }
 
   if (signedUrl) {
     try {
-      const url = await verifyEmailClickToken(signedUrl)
-      return NextResponse.redirect(url, { status: 302 })
+      const payload = await verifyEmailClickToken(signedUrl)
+      if (
+        payload.workspaceId &&
+        trackedWorkspaceId &&
+        payload.workspaceId !== trackedWorkspaceId
+      ) {
+        return NextResponse.redirect(origin, { status: 302 })
+      }
+
+      const redirectWorkspaceId = payload.workspaceId ?? trackedWorkspaceId
+      if (!redirectWorkspaceId) {
+        return NextResponse.redirect(origin, { status: 302 })
+      }
+
+      if (!(await isWorkspaceServable(redirectWorkspaceId))) {
+        return NextResponse.json(
+          { code: "workspaceScheduledDeletion" },
+          { status: 410 },
+        )
+      }
+
+      if (shouldRecordClick && token) {
+        await emailTopicAnalyticsService.recordClick(token)
+      }
+
+      return NextResponse.redirect(payload.url, { status: 302 })
     } catch {
       // Tampered, malformed, or expired token: never redirect to an
       // attacker-controlled target. Fall through to a safe same-origin redirect.
     }
+  }
+
+  if (shouldRecordClick && !signedUrl && token) {
+    await emailTopicAnalyticsService.recordClick(token)
   }
 
   return NextResponse.redirect(origin, { status: 302 })

--- a/apps/builder/src/app/email-topic/open/route.ts
+++ b/apps/builder/src/app/email-topic/open/route.ts
@@ -1,5 +1,7 @@
 import { emailTopicAnalyticsService } from "@chatbotx.io/analytics"
+import { emailTopicService } from "@chatbotx.io/business"
 import { NextResponse } from "next/server"
+import { loadServableWorkspace } from "@/lib/workspace/load-servable-workspace"
 
 const GIF = Buffer.from(
   "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
@@ -10,7 +12,19 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
   const token = searchParams.get("r")
   if (token) {
-    await emailTopicAnalyticsService.recordOpen(token)
+    const workspaceId = await emailTopicService.findAnalyticsWorkspaceIdByToken(
+      {
+        token,
+      },
+    )
+    if (workspaceId) {
+      const { servable } = await loadServableWorkspace(workspaceId)
+      if (servable) {
+        await emailTopicAnalyticsService.recordOpen(token)
+      }
+    } else {
+      await emailTopicAnalyticsService.recordOpen(token)
+    }
   }
 
   return new NextResponse(GIF, {

--- a/apps/builder/src/app/extensions/me/download/route.ts
+++ b/apps/builder/src/app/extensions/me/download/route.ts
@@ -4,6 +4,7 @@ import {
   parseMeLinkSearchParams,
   toMePrivacyParams,
 } from "@/features/system-fields/lib/me-link-params"
+import { loadServableWorkspace } from "@/lib/workspace/load-servable-workspace"
 
 export const runtime = "nodejs"
 
@@ -11,6 +12,14 @@ export async function GET(request: Request) {
   const input = parseMeLinkSearchParams(new URL(request.url).searchParams)
   if (!input) {
     return new Response(null, { status: 404 })
+  }
+
+  const { servable } = await loadServableWorkspace(input.w)
+  if (!servable) {
+    return NextResponse.json(
+      { code: "workspaceScheduledDeletion" },
+      { status: 410 },
+    )
   }
 
   const data = await systemFieldService.buildMeExport(toMePrivacyParams(input))

--- a/apps/builder/src/app/extensions/me/page.tsx
+++ b/apps/builder/src/app/extensions/me/page.tsx
@@ -1,5 +1,6 @@
 import { systemFieldService } from "@chatbotx.io/business/system-field"
 import type { Metadata } from "next"
+import { notFound } from "next/navigation"
 import { NextIntlClientProvider } from "next-intl"
 import { MeDataView } from "@/features/system-fields/components/me-data-view"
 import {
@@ -7,6 +8,7 @@ import {
   toMePrivacyParams,
 } from "@/features/system-fields/lib/me-link-params"
 import { loadWorkspaceMessages } from "@/i18n/workspace-locale"
+import { loadServableWorkspace } from "@/lib/workspace/load-servable-workspace"
 
 export const metadata: Metadata = {
   title: "Privacy",
@@ -28,6 +30,11 @@ export default async function MePage(props: MePageProps) {
   const input = parseMeLinkInput(await props.searchParams)
   if (!input) {
     return null
+  }
+
+  const { servable } = await loadServableWorkspace(input.w)
+  if (!servable) {
+    return notFound()
   }
 
   const data = await systemFieldService.getMePrivacyData(

--- a/apps/builder/src/app/integrations/[...integration]/webhook.ts
+++ b/apps/builder/src/app/integrations/[...integration]/webhook.ts
@@ -1,6 +1,7 @@
 import {
   customDomainService,
   platformCredentialService,
+  resolveWorkspaceFreezeReason,
   tenantService,
   userQuotaService,
   workspaceService,
@@ -39,8 +40,22 @@ const logWebhookRequestBody = async (
     )
   }
 }
-const isBlockedOwner = async (ownerId: string | undefined) =>
-  ownerId ? (await userQuotaService.getAccessState(ownerId)).blocked : false
+/**
+ * Per-bot/per-account channels (telegram, tiktok) reach their integration
+ * handler before any queue consumer runs, so they need the freeze verdict
+ * in-request. Delegating to the shared resolver keeps them aligned with the
+ * worker-side guard instead of re-implementing a weaker owner-only check.
+ */
+const resolveWebhookFreezeReason = async (
+  workspaceId: string,
+): Promise<ReturnType<typeof resolveWorkspaceFreezeReason>> => {
+  const workspace = await workspaceService.find({ where: { id: workspaceId } })
+  const accessState = workspace
+    ? await userQuotaService.getAccessState(workspace.ownerId)
+    : null
+
+  return resolveWorkspaceFreezeReason({ accessState, workspace })
+}
 
 export const handleWebhook = async (
   integrationType: string,
@@ -197,14 +212,19 @@ const handleTelegramWebhook = async (req: NextRequest) => {
     })
   }
 
-  const telegramWorkspace = await workspaceService.find({
-    where: { id: integrationTelegram.workspaceId },
-  })
-  if (await isBlockedOwner(telegramWorkspace?.ownerId)) {
+  const telegramFreezeReason = await resolveWebhookFreezeReason(
+    integrationTelegram.workspaceId,
+  )
+  if (telegramFreezeReason) {
     logger.info(
-      { ownerId: telegramWorkspace?.ownerId, integrationType: "telegram" },
-      "webhook skipped: blocked owner",
+      {
+        freezeReason: telegramFreezeReason,
+        integrationType: "telegram",
+        workspaceId: integrationTelegram.workspaceId,
+      },
+      "webhook skipped: frozen workspace",
     )
+    // 200 so Telegram does not retry or disable the webhook while frozen.
     return new Response("ok")
   }
 
@@ -283,14 +303,19 @@ const handleTiktokWebhook = async (req: NextRequest) => {
     )
   }
 
-  const tiktokWorkspace = await workspaceService.find({
-    where: { id: integrationTiktok.workspaceId },
-  })
-  if (await isBlockedOwner(tiktokWorkspace?.ownerId)) {
+  const tiktokFreezeReason = await resolveWebhookFreezeReason(
+    integrationTiktok.workspaceId,
+  )
+  if (tiktokFreezeReason) {
     logger.info(
-      { ownerId: tiktokWorkspace?.ownerId, integrationType: "tiktok" },
-      "webhook skipped: blocked owner",
+      {
+        freezeReason: tiktokFreezeReason,
+        integrationType: "tiktok",
+        workspaceId: integrationTiktok.workspaceId,
+      },
+      "webhook skipped: frozen workspace",
     )
+    // 200 so TikTok does not retry or revoke the subscription while frozen.
     return new Response("ok")
   }
 

--- a/apps/builder/src/app/l/[workspaceId]/[id]/page.tsx
+++ b/apps/builder/src/app/l/[workspaceId]/[id]/page.tsx
@@ -9,6 +9,7 @@ import { getIdFromParams } from "@chatbotx.io/utils"
 import { notFound, redirect } from "next/navigation"
 import { InboxListLandingPage } from "@/features/inboxes/components/landing-inbox-list"
 import { maxPerPage } from "@/lib/shared-request"
+import { loadServableWorkspace } from "@/lib/workspace/load-servable-workspace"
 
 export default async function LandingPage({
   params,
@@ -20,6 +21,11 @@ export default async function LandingPage({
   const id = getIdFromParams(resolvedParams, "id")
 
   if (!(workspaceId && id)) {
+    return notFound()
+  }
+
+  const { servable } = await loadServableWorkspace(workspaceId)
+  if (!servable) {
     return notFound()
   }
 

--- a/apps/builder/src/app/r/[workspaceId]/[name]/route.ts
+++ b/apps/builder/src/app/r/[workspaceId]/[name]/route.ts
@@ -9,6 +9,7 @@ import {
 } from "@chatbotx.io/flow-config"
 import { interpolate } from "@chatbotx.io/variables"
 import { type NextRequest, NextResponse } from "next/server"
+import { loadServableWorkspace } from "@/lib/workspace/load-servable-workspace"
 
 export const GET = async (
   request: NextRequest,
@@ -16,6 +17,13 @@ export const GET = async (
 ) => {
   const { workspaceId, name: nameParam } = await context.params
   const name = decodeURIComponent(nameParam)
+  const { servable } = await loadServableWorkspace(workspaceId)
+  if (!servable) {
+    return NextResponse.json(
+      { code: "workspaceScheduledDeletion" },
+      { status: 410 },
+    )
+  }
 
   const row = await db.query.magicLinkModel.findFirst({
     where: {

--- a/apps/builder/src/app/space/[workspaceId]/(settings)/settings/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(settings)/settings/layout.tsx
@@ -1,3 +1,4 @@
+import { isWorkspaceScheduledForDeletion } from "@chatbotx.io/business"
 import type { ReactNode } from "react"
 import { resolveGuardedWorkspaceId } from "@/lib/auth/require-workspace-permission"
 import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
@@ -14,9 +15,9 @@ export default async function SettingLayout({
 }: LayoutSettingProps) {
   const workspaceId = await resolveGuardedWorkspaceId(params, "superAdmin")
   const result = await getCurrentUserAndTargetWorkspace(workspaceId)
-  const scheduledForDeletion = Boolean(
-    result?.targetWorkspace.scheduledDeletionAt,
-  )
+  const scheduledForDeletion = result?.targetWorkspace
+    ? isWorkspaceScheduledForDeletion(result.targetWorkspace)
+    : false
 
   return (
     <>

--- a/apps/builder/src/app/space/[workspaceId]/(settings)/settings/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(settings)/settings/page.tsx
@@ -1,5 +1,13 @@
 import { redirect } from "next/navigation"
+import { workspaceSettingsGeneralPath } from "@/lib/workspace/require-not-scheduled-for-deletion"
 
-export default function SettingPage() {
-  return redirect("settings/general")
+type SettingPageProps = {
+  params: Promise<{ workspaceId: string }>
+}
+
+// Absolute on purpose. A relative target resolves against the current URL, so
+// a trailing slash or a soft navigation lands on `/settings/settings/general`.
+export default async function SettingPage({ params }: SettingPageProps) {
+  const { workspaceId } = await params
+  return redirect(workspaceSettingsGeneralPath(workspaceId))
 }

--- a/apps/builder/src/app/space/[workspaceId]/(settings)/settings/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(settings)/settings/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation"
-import { workspaceSettingsGeneralPath } from "@/lib/workspace/require-not-scheduled-for-deletion"
+import { workspaceSettingsGeneralPath } from "@/lib/workspace/settings-paths"
 
 type SettingPageProps = {
   params: Promise<{ workspaceId: string }>

--- a/apps/builder/src/app/space/[workspaceId]/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/layout.tsx
@@ -1,6 +1,7 @@
 import {
   isPlatformAdmin,
   isSuperAdmin,
+  isWorkspaceScheduledForDeletion,
   quotaEnforcementService,
   userQuotaService,
   workspaceMemberService,
@@ -94,8 +95,8 @@ export default async function WorkspaceLayout({
   const cookieStore = await cookies()
   const defaultOpen = cookieStore.get("sidebar_state")?.value === "true"
 
-  const scheduledForDeletion = Boolean(
-    targetWorkspaceMember.workspace.scheduledDeletionAt,
+  const scheduledForDeletion = isWorkspaceScheduledForDeletion(
+    targetWorkspaceMember.workspace,
   )
 
   return (

--- a/apps/builder/src/app/space/[workspaceId]/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/layout.tsx
@@ -19,6 +19,7 @@ import { ExpiredBanner } from "@/components/expired-banner"
 import type { QuotaSummary } from "@/components/nav-usage"
 import { RefreshOnNavigation } from "@/components/refresh-on-navigation"
 import { ScheduledDeletionBanner } from "@/components/scheduled-deletion-banner"
+import { WorkspaceDeletionTabSync } from "@/components/workspace-deletion-tab-sync"
 import { isCloud } from "@/env"
 import { getTenantSettings } from "@/features/tenant/utils"
 import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
@@ -112,8 +113,14 @@ export default async function WorkspaceLayout({
       />
       <SidebarInset>
         <main className="flex min-w-0 flex-1 flex-col gap-4 p-6">
+          <WorkspaceDeletionTabSync
+            scheduledForDeletion={scheduledForDeletion}
+            workspaceId={workspaceId}
+          />
           <ScheduledDeletionBanner scheduled={scheduledForDeletion} />
-          {!scheduledForDeletion && <RefreshOnNavigation />}
+          {!scheduledForDeletion && (
+            <RefreshOnNavigation workspaceId={workspaceId} />
+          )}
           <ExpiredBanner blocked={cloud && blocked} />
           {children}
         </main>

--- a/apps/builder/src/app/space/[workspaceId]/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/page.tsx
@@ -1,6 +1,10 @@
 import { notFound, redirect } from "next/navigation"
-import { resolveWorkspaceLandingSegment } from "@/lib/auth/permission-routes"
+import {
+  hasWorkspacePermission,
+  resolveWorkspaceLandingSegment,
+} from "@/lib/auth/permission-routes"
 import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
+import { enforceWorkspaceNotScheduledForDeletionFromRequest } from "@/lib/workspace/require-not-scheduled-for-deletion"
 
 type WorkspacePageProps = {
   params: Promise<{ workspaceId: string }>
@@ -15,6 +19,18 @@ export default async function WorkspacePage(props: WorkspacePageProps) {
   if (!userAndWorkspace) {
     return notFound()
   }
+
+  // Must run BEFORE the landing redirect. This page and the workspace layout
+  // render in the same pass, so their two redirects race; reaching the same
+  // verdict here keeps the destination deterministic instead of a coin flip
+  // between settings/general and the landing section.
+  await enforceWorkspaceNotScheduledForDeletionFromRequest(
+    userAndWorkspace.targetWorkspace,
+    hasWorkspacePermission(
+      userAndWorkspace.targetWorkspaceMember.permissions,
+      "superAdmin",
+    ),
+  )
 
   const segment = resolveWorkspaceLandingSegment(
     userAndWorkspace.targetWorkspaceMember.permissions,

--- a/apps/builder/src/app/unsubscribe/page.tsx
+++ b/apps/builder/src/app/unsubscribe/page.tsx
@@ -1,6 +1,7 @@
 import { contactService, verifyUnsubscribeToken } from "@chatbotx.io/business"
 import type { Metadata } from "next"
 import { getTranslations } from "next-intl/server"
+import { loadServableWorkspace } from "@/lib/workspace/load-servable-workspace"
 
 export const metadata: Metadata = {
   title: "Unsubscribe",
@@ -25,6 +26,16 @@ export default async function UnsubscribePage(props: UnsubscribePageProps) {
 
   try {
     const payload = await verifyUnsubscribeToken(token)
+    const { servable } = await loadServableWorkspace(payload.wid)
+    if (!servable) {
+      return (
+        <UnsubscribeMessage
+          description={t("unavailableDescription")}
+          title={t("unavailableTitle")}
+        />
+      )
+    }
+
     await contactService.unsubscribeEmail(payload.cid)
   } catch {
     return (

--- a/apps/builder/src/components/refresh-on-navigation.tsx
+++ b/apps/builder/src/components/refresh-on-navigation.tsx
@@ -2,13 +2,25 @@
 
 import { useRouter } from "next/navigation"
 import { useEffect } from "react"
+import { readWorkspaceDeletionSync } from "@/lib/workspace/deletion-tab-sync"
+import { workspaceSettingsGeneralPath } from "@/lib/workspace/settings-paths"
 
-export function RefreshOnNavigation() {
+export function RefreshOnNavigation({ workspaceId }: { workspaceId: string }) {
   const router = useRouter()
 
   useEffect(() => {
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
+        const deletionSync = readWorkspaceDeletionSync()
+        const targetPath = workspaceSettingsGeneralPath(workspaceId)
+        if (
+          deletionSync?.workspaceId === workspaceId &&
+          !window.location.pathname.startsWith(targetPath)
+        ) {
+          window.location.assign(targetPath)
+          return
+        }
+
         router.refresh()
       }
     }
@@ -16,7 +28,7 @@ export function RefreshOnNavigation() {
     document.addEventListener("visibilitychange", handleVisibilityChange)
     return () =>
       document.removeEventListener("visibilitychange", handleVisibilityChange)
-  }, [router])
+  }, [router, workspaceId])
 
   return null
 }

--- a/apps/builder/src/components/workspace-deletion-tab-sync.tsx
+++ b/apps/builder/src/components/workspace-deletion-tab-sync.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { usePathname } from "next/navigation"
+import { useEffect } from "react"
+import {
+  clearWorkspaceDeletionSync,
+  parseWorkspaceDeletionPayload,
+  WORKSPACE_DELETION_SYNC_KEY,
+  writeWorkspaceDeletionSync,
+} from "@/lib/workspace/deletion-tab-sync"
+import { workspaceSettingsGeneralPath } from "@/lib/workspace/settings-paths"
+
+export function WorkspaceDeletionTabSync({
+  workspaceId,
+  scheduledForDeletion,
+}: {
+  workspaceId: string
+  scheduledForDeletion: boolean
+}) {
+  const pathname = usePathname()
+
+  useEffect(() => {
+    const targetPath = workspaceSettingsGeneralPath(workspaceId)
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== WORKSPACE_DELETION_SYNC_KEY) {
+        return
+      }
+
+      const payload = parseWorkspaceDeletionPayload(event.newValue)
+      if (payload?.workspaceId !== workspaceId) {
+        return
+      }
+
+      if (window.location.pathname.startsWith(targetPath)) {
+        return
+      }
+
+      window.location.assign(targetPath)
+    }
+
+    window.addEventListener("storage", handleStorage)
+    return () => window.removeEventListener("storage", handleStorage)
+  }, [workspaceId])
+
+  useEffect(() => {
+    if (scheduledForDeletion) {
+      writeWorkspaceDeletionSync(workspaceId)
+    } else {
+      clearWorkspaceDeletionSync(workspaceId)
+    }
+  }, [workspaceId, scheduledForDeletion])
+
+  useEffect(() => {
+    if (!scheduledForDeletion) {
+      return
+    }
+
+    const targetPath = workspaceSettingsGeneralPath(workspaceId)
+    if (!pathname.startsWith(targetPath)) {
+      window.location.assign(targetPath)
+    }
+  }, [pathname, scheduledForDeletion, workspaceId])
+
+  return null
+}

--- a/apps/builder/src/features/broadcasts/broadcast-detail-dialog.tsx
+++ b/apps/builder/src/features/broadcasts/broadcast-detail-dialog.tsx
@@ -31,6 +31,15 @@ import { useWorkspaceId } from "@/hooks/routing"
 import { client } from "@/lib/orpc/orpc"
 import type { BroadcastResourceWithRelations } from "./schemas/resource"
 
+type BroadcastStatusBadgeVariant = "default" | "outline" | "secondary"
+
+const BROADCAST_STATUS_VARIANTS: Partial<
+  Record<string, BroadcastStatusBadgeVariant>
+> = {
+  cancelled: "secondary",
+  scheduled: "outline",
+}
+
 type BroadcastDetailDialogProps = {
   broadcast: BroadcastResourceWithRelations | null
   open: boolean
@@ -147,7 +156,7 @@ export function BroadcastDetailDialog({
               value={
                 <Badge
                   variant={
-                    broadcast.status === "scheduled" ? "outline" : "default"
+                    BROADCAST_STATUS_VARIANTS[broadcast.status] ?? "default"
                   }
                 >
                   {t(`broadcasts.status.${broadcast.status}`)}

--- a/apps/builder/src/features/broadcasts/broadcasts-table.tsx
+++ b/apps/builder/src/features/broadcasts/broadcasts-table.tsx
@@ -40,6 +40,7 @@ import { BroadcastStatsStoreProvider } from "./provider/broadcast-stats-store-co
 import { RenameBroadcastDialog } from "./rename-broadcast-dialog"
 import { ResendBroadcastDialog } from "./resend-broadcast-dialog"
 import type { BroadcastResourceWithRelations } from "./schemas/resource"
+import { getEstimatedContactsDisplayState } from "./utils/estimated-contacts-display"
 
 type BroadcastStatusBadgeVariant = "default" | "outline" | "secondary"
 
@@ -147,8 +148,17 @@ export function BroadcastsTable({ promises }: BroadcastsTableProps) {
           />
         ),
         cell: ({ row }) => {
-          if (row.original.contactCount === null) {
+          const displayState = getEstimatedContactsDisplayState({
+            contactCount: row.original.contactCount,
+            status: row.original.status,
+          })
+
+          if (displayState === "loading") {
             return <Loader2Icon className="h-4 w-4 animate-spin" />
+          }
+
+          if (displayState === "empty") {
+            return <span className="text-muted-foreground">-</span>
           }
 
           return <div>{row.original.contactCount}</div>

--- a/apps/builder/src/features/broadcasts/broadcasts-table.tsx
+++ b/apps/builder/src/features/broadcasts/broadcasts-table.tsx
@@ -41,6 +41,15 @@ import { RenameBroadcastDialog } from "./rename-broadcast-dialog"
 import { ResendBroadcastDialog } from "./resend-broadcast-dialog"
 import type { BroadcastResourceWithRelations } from "./schemas/resource"
 
+type BroadcastStatusBadgeVariant = "default" | "outline" | "secondary"
+
+const BROADCAST_STATUS_VARIANTS: Partial<
+  Record<string, BroadcastStatusBadgeVariant>
+> = {
+  cancelled: "secondary",
+  scheduled: "outline",
+}
+
 type BroadcastsTableProps = {
   promises: Promise<[Awaited<ReturnType<typeof listBroadcasts>>]>
 }
@@ -114,16 +123,15 @@ export function BroadcastsTable({ promises }: BroadcastsTableProps) {
             title={t("fields.status.label")}
           />
         ),
-        cell: ({ row }) =>
-          row.original.status === "scheduled" ? (
-            <Badge variant="outline">
-              {t(`broadcasts.status.${row.original.status}`)}
-            </Badge>
-          ) : (
-            <Badge variant="default">
-              {t(`broadcasts.status.${row.original.status}`)}
-            </Badge>
-          ),
+        cell: ({ row }) => (
+          <Badge
+            variant={
+              BROADCAST_STATUS_VARIANTS[row.original.status] ?? "default"
+            }
+          >
+            {t(`broadcasts.status.${row.original.status}`)}
+          </Badge>
+        ),
         enableSorting: false,
         enableHiding: false,
         meta: {

--- a/apps/builder/src/features/broadcasts/utils/estimated-contacts-display.ts
+++ b/apps/builder/src/features/broadcasts/utils/estimated-contacts-display.ts
@@ -1,0 +1,14 @@
+export type EstimatedContactsDisplayState = "count" | "empty" | "loading"
+
+const ESTIMATING_BROADCAST_STATUSES = new Set<string>(["scheduled", "sending"])
+
+export function getEstimatedContactsDisplayState(props: {
+  contactCount: number | null
+  status: string
+}): EstimatedContactsDisplayState {
+  if (props.contactCount !== null) {
+    return "count"
+  }
+
+  return ESTIMATING_BROADCAST_STATUSES.has(props.status) ? "loading" : "empty"
+}

--- a/apps/builder/src/features/integration-messenger/actions/__tests__/toggle-tag-sync.action.test.ts
+++ b/apps/builder/src/features/integration-messenger/actions/__tests__/toggle-tag-sync.action.test.ts
@@ -76,10 +76,18 @@ vi.mock("@chatbotx.io/database/schema", () => ({
 }))
 
 // ---------------------------------------------------------------------------
-// 6. Mock @chatbotx.io/business (isPlatformAdmin used by safe-action)
+// 6. Mock @chatbotx.io/business (symbols used by safe-action)
+//
+// This factory mock enumerates exports, so it must cover everything
+// `workspaceActionClient` reaches — not just what this action calls directly.
+// A missing symbol becomes `undefined`, the middleware throws a TypeError, and
+// next-safe-action swallows it into a generic `serverError`, which reads like an
+// unrelated failure. `isWorkspaceScheduledForDeletion` is the deletion gate in
+// `lib/safe-action.ts`; `false` = an active workspace, this action's precondition.
 // ---------------------------------------------------------------------------
 vi.mock("@chatbotx.io/business", () => ({
   isPlatformAdmin: vi.fn(async () => false),
+  isWorkspaceScheduledForDeletion: vi.fn(() => false),
 }))
 
 // ---------------------------------------------------------------------------

--- a/apps/builder/src/features/integration-messenger/actions/__tests__/toggle-tag-sync.test.ts
+++ b/apps/builder/src/features/integration-messenger/actions/__tests__/toggle-tag-sync.test.ts
@@ -70,9 +70,17 @@ vi.mock("@chatbotx.io/database/schema", () => ({
 
 // ---------------------------------------------------------------------------
 // Mock @chatbotx.io/business (isPlatformAdmin) and errors
+//
+// This factory mock enumerates exports, so it must cover everything
+// `workspaceActionClient` reaches — not just what this action calls directly.
+// A missing symbol becomes `undefined`, the middleware throws a TypeError, and
+// next-safe-action swallows it into a generic `serverError`, which reads like an
+// unrelated failure. `isWorkspaceScheduledForDeletion` is the deletion gate in
+// `lib/safe-action.ts`; `false` = an active workspace, this action's precondition.
 // ---------------------------------------------------------------------------
 vi.mock("@chatbotx.io/business", () => ({
   isPlatformAdmin: vi.fn(async () => false),
+  isWorkspaceScheduledForDeletion: vi.fn(() => false),
 }))
 
 vi.mock("@chatbotx.io/business/errors", () => ({

--- a/apps/builder/src/features/integration-zalo/actions/__tests__/toggle-tag-sync.test.ts
+++ b/apps/builder/src/features/integration-zalo/actions/__tests__/toggle-tag-sync.test.ts
@@ -66,9 +66,17 @@ vi.mock("@chatbotx.io/database/schema", () => ({
 
 // ---------------------------------------------------------------------------
 // Mock @chatbotx.io/business (isPlatformAdmin) and errors
+//
+// This factory mock enumerates exports, so it must cover everything
+// `workspaceActionClient` reaches — not just what this action calls directly.
+// A missing symbol becomes `undefined`, the middleware throws a TypeError, and
+// next-safe-action swallows it into a generic `serverError`, which reads like an
+// unrelated failure. `isWorkspaceScheduledForDeletion` is the deletion gate in
+// `lib/safe-action.ts`; `false` = an active workspace, this action's precondition.
 // ---------------------------------------------------------------------------
 vi.mock("@chatbotx.io/business", () => ({
   isPlatformAdmin: vi.fn(async () => false),
+  isWorkspaceScheduledForDeletion: vi.fn(() => false),
 }))
 
 vi.mock("@chatbotx.io/business/errors", () => ({

--- a/apps/builder/src/features/invitations/actions/accept-invitation.ts
+++ b/apps/builder/src/features/invitations/actions/accept-invitation.ts
@@ -1,6 +1,7 @@
 "use server"
 
 import {
+  isWorkspaceScheduledForDeletion,
   quotaEnforcementService,
   workspaceService,
 } from "@chatbotx.io/business"
@@ -56,7 +57,7 @@ export const acceptInvitationAction = authActionClient
     const workspace = await workspaceService.find({
       where: { id: invitation.workspaceId },
     })
-    if (workspace?.scheduledDeletionAt) {
+    if (workspace && isWorkspaceScheduledForDeletion(workspace)) {
       const t = await getTranslations("invitation")
       throw new ChatbotXException(
         t("workspaceUnavailable"),

--- a/apps/builder/src/features/invitations/invitatation-card.tsx
+++ b/apps/builder/src/features/invitations/invitatation-card.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { isWorkspaceScheduledForDeletion } from "@chatbotx.io/business/workspace-lifecycle/predicates"
 import type {
   InvitationModel,
   UserModel,
@@ -30,7 +31,9 @@ export function InvitationCard({
 }) {
   const router = useRouter()
   const t = useTranslations()
-  const canJoin = Boolean(workspace) && !workspace?.scheduledDeletionAt
+  const canJoin = workspace
+    ? !isWorkspaceScheduledForDeletion(workspace)
+    : false
 
   const { execute, isPending } = useAction(acceptInvitationAction, {
     onSuccess: () => {
@@ -50,7 +53,7 @@ export function InvitationCard({
           <WorkspaceInvitationCard user={user} workspace={workspace} />
         ) : (
           <p className="text-muted-foreground">
-            {workspace?.scheduledDeletionAt
+            {workspace && isWorkspaceScheduledForDeletion(workspace)
               ? t("invitation.workspaceUnavailable")
               : t("invitation.invalidInvitation")}
           </p>

--- a/apps/builder/src/features/messages/actions/create-webchat-message.action.ts
+++ b/apps/builder/src/features/messages/actions/create-webchat-message.action.ts
@@ -5,6 +5,7 @@ import {
   contactInboxService,
   contactService,
   conversationService,
+  isWorkspaceScheduledForDeletion,
   messageCleanupService,
   quotaEnforcementService,
   resolveTenantSettings,
@@ -80,7 +81,7 @@ export async function handleCreateWebchatMessage({
   const workspace = await workspaceService.find({
     where: { id: parsedInput.workspaceId },
   })
-  if (workspace?.scheduledDeletionAt) {
+  if (workspace && isWorkspaceScheduledForDeletion(workspace)) {
     const t = await getTranslations("webchat")
     throw new ChatbotXException(
       t("workspaceUnavailable"),

--- a/apps/builder/src/features/system-fields/actions/delete-me-data.action.ts
+++ b/apps/builder/src/features/system-fields/actions/delete-me-data.action.ts
@@ -1,7 +1,9 @@
 "use server"
 
+import { ChatbotXException } from "@chatbotx.io/business/errors"
 import { systemFieldService } from "@chatbotx.io/business/system-field"
 import { actionClient } from "@/lib/safe-action"
+import { loadServableWorkspace } from "@/lib/workspace/load-servable-workspace"
 import {
   type MeLinkInput,
   meLinkInputSchema,
@@ -17,6 +19,15 @@ export async function handleDeleteMeData({
 }: {
   parsedInput: MeLinkInput
 }) {
+  const { servable } = await loadServableWorkspace(parsedInput.w)
+  if (!servable) {
+    throw new ChatbotXException(
+      "workspaceScheduledDeletion",
+      "workspaceScheduledDeletion",
+      403,
+    )
+  }
+
   await systemFieldService.deleteMeData(toMePrivacyParams(parsedInput))
   return null
 }

--- a/apps/builder/src/features/workspaces/actions/schedule-workspace-deletion-action.ts
+++ b/apps/builder/src/features/workspaces/actions/schedule-workspace-deletion-action.ts
@@ -1,6 +1,9 @@
 "use server"
 
-import { workspaceService } from "@chatbotx.io/business"
+import {
+  workspaceLifecycleService,
+  workspaceService,
+} from "@chatbotx.io/business"
 import { ChatbotXException } from "@chatbotx.io/business/errors"
 import { redirect } from "next/navigation"
 import {
@@ -38,6 +41,8 @@ export const scheduleWorkspaceDeletionAction = workspaceActionClientAllowExpired
       await workspaceService.scheduleDeletion({
         id: workspaceId,
       })
+
+      await workspaceLifecycleService.cancelInFlightCampaigns(workspaceId)
 
       redirect("/")
     },

--- a/apps/builder/src/features/workspaces/actions/schedule-workspace-deletion-action.ts
+++ b/apps/builder/src/features/workspaces/actions/schedule-workspace-deletion-action.ts
@@ -13,6 +13,7 @@ import {
 import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
 import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
 import { workspaceActionClientAllowExpired } from "@/lib/safe-action"
+import { workspaceSettingsGeneralPath } from "@/lib/workspace/settings-paths"
 
 export const scheduleWorkspaceDeletionAction = workspaceActionClientAllowExpired
   .bindArgsSchemas(workspaceIdrequestParams)
@@ -44,6 +45,6 @@ export const scheduleWorkspaceDeletionAction = workspaceActionClientAllowExpired
 
       await workspaceLifecycleService.freezeWorkspaceRuntime(workspaceId)
 
-      redirect("/")
+      redirect(workspaceSettingsGeneralPath(workspaceId))
     },
   )

--- a/apps/builder/src/features/workspaces/actions/schedule-workspace-deletion-action.ts
+++ b/apps/builder/src/features/workspaces/actions/schedule-workspace-deletion-action.ts
@@ -42,7 +42,7 @@ export const scheduleWorkspaceDeletionAction = workspaceActionClientAllowExpired
         id: workspaceId,
       })
 
-      await workspaceLifecycleService.cancelInFlightCampaigns(workspaceId)
+      await workspaceLifecycleService.freezeWorkspaceRuntime(workspaceId)
 
       redirect("/")
     },

--- a/apps/builder/src/features/workspaces/actions/update-workspace-action.ts
+++ b/apps/builder/src/features/workspaces/actions/update-workspace-action.ts
@@ -5,7 +5,10 @@ import {
   type WorkspaceIdRequestParams,
   workspaceIdrequestParams,
 } from "@/features/common/schemas"
-import { workspaceActionClient } from "@/lib/safe-action"
+import {
+  workspaceActionClient,
+  workspaceActionClientAllowScheduledDeletion,
+} from "@/lib/safe-action"
 import {
   type UpdateSmartResponseDelayRequest,
   type UpdateWorkspaceAdvancedRequest,
@@ -15,35 +18,37 @@ import {
   updateWorkspaceBasicRequest,
 } from "../schema/update-workspace-schema"
 
-export const updateWorkspaceBasicAction = workspaceActionClient
-  .bindArgsSchemas(workspaceIdrequestParams)
-  .inputSchema(updateWorkspaceBasicRequest)
-  .action(
-    async ({
-      bindArgsParsedInputs: [workspaceId],
-      parsedInput,
-    }: {
-      bindArgsParsedInputs: WorkspaceIdRequestParams
-      parsedInput: UpdateWorkspaceBasicRequest
-    }) => {
-      await workspaceService.update({ id: workspaceId, data: parsedInput })
-    },
-  )
+export const updateWorkspaceBasicAction =
+  workspaceActionClientAllowScheduledDeletion
+    .bindArgsSchemas(workspaceIdrequestParams)
+    .inputSchema(updateWorkspaceBasicRequest)
+    .action(
+      async ({
+        bindArgsParsedInputs: [workspaceId],
+        parsedInput,
+      }: {
+        bindArgsParsedInputs: WorkspaceIdRequestParams
+        parsedInput: UpdateWorkspaceBasicRequest
+      }) => {
+        await workspaceService.update({ id: workspaceId, data: parsedInput })
+      },
+    )
 
-export const updateWorkspaceAdvancedAction = workspaceActionClient
-  .bindArgsSchemas(workspaceIdrequestParams)
-  .inputSchema(updateWorkspaceAdvancedRequest)
-  .action(
-    async ({
-      bindArgsParsedInputs: [workspaceId],
-      parsedInput,
-    }: {
-      bindArgsParsedInputs: WorkspaceIdRequestParams
-      parsedInput: UpdateWorkspaceAdvancedRequest
-    }) => {
-      await workspaceService.update({ id: workspaceId, data: parsedInput })
-    },
-  )
+export const updateWorkspaceAdvancedAction =
+  workspaceActionClientAllowScheduledDeletion
+    .bindArgsSchemas(workspaceIdrequestParams)
+    .inputSchema(updateWorkspaceAdvancedRequest)
+    .action(
+      async ({
+        bindArgsParsedInputs: [workspaceId],
+        parsedInput,
+      }: {
+        bindArgsParsedInputs: WorkspaceIdRequestParams
+        parsedInput: UpdateWorkspaceAdvancedRequest
+      }) => {
+        await workspaceService.update({ id: workspaceId, data: parsedInput })
+      },
+    )
 
 export const updateSmartResponseDelayAction = workspaceActionClient
   .bindArgsSchemas(workspaceIdrequestParams)

--- a/apps/builder/src/features/workspaces/components/workspace-status-switch.tsx
+++ b/apps/builder/src/features/workspaces/components/workspace-status-switch.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { isWorkspaceScheduledForDeletion } from "@chatbotx.io/business/workspace-lifecycle/predicates"
 import { Switch } from "@chatbotx.io/ui/components/ui/switch"
 import {
   Tooltip,
@@ -30,7 +31,7 @@ export function WorkspaceStatusSwitch({
 }) {
   const t = useTranslations()
   const router = useRouter()
-  const scheduledForDeletion = Boolean(workspace.scheduledDeletionAt)
+  const scheduledForDeletion = isWorkspaceScheduledForDeletion(workspace)
   const [isActive, setIsActive] = useState(workspace.isActive)
   const [schedule, setSchedule] = useState<Schedule>({
     startTime: workspace.startTime,

--- a/apps/builder/src/features/workspaces/components/workspaces-list.tsx
+++ b/apps/builder/src/features/workspaces/components/workspaces-list.tsx
@@ -1,3 +1,4 @@
+import { isWorkspaceScheduledForDeletion } from "@chatbotx.io/business"
 import {
   Avatar,
   AvatarFallback,
@@ -120,7 +121,7 @@ const WorkspaceCard = ({
   const firstLetter = workspace.name?.[0]?.toUpperCase() ?? ""
   const name = workspace.name ?? ""
   const href = `/space/${workspace.id}`
-  const isScheduledForDeletion = Boolean(workspace.scheduledDeletionAt)
+  const isScheduledForDeletion = isWorkspaceScheduledForDeletion(workspace)
   const activeHours =
     workspace.isActive && workspace.startTime && workspace.endTime
       ? t("workspace.schedule.activeHours", {

--- a/apps/builder/src/lib/safe-action.ts
+++ b/apps/builder/src/lib/safe-action.ts
@@ -127,3 +127,17 @@ export const workspaceActionClient = workspaceActionClientAllowExpired.use(
     return next({ ctx })
   },
 )
+
+// Settings/general remains editable during the deletion grace window so admins
+// can correct workspace metadata before undoing or before the purge deadline.
+export const workspaceActionClientAllowScheduledDeletion =
+  workspaceActionClientAllowExpired.use(async ({ ctx, next }) => {
+    if (isCloud()) {
+      const { blocked } = await userQuotaService.getAccessState(ctx.user.id)
+      if (blocked) {
+        throw new ChatbotXException("Trial expired", "trialExpired", 403)
+      }
+    }
+
+    return next({ ctx })
+  })

--- a/apps/builder/src/lib/safe-action.ts
+++ b/apps/builder/src/lib/safe-action.ts
@@ -1,6 +1,7 @@
 import {
   isPlatformAdmin,
   isSuperAdmin,
+  isWorkspaceScheduledForDeletion,
   userQuotaService,
 } from "@chatbotx.io/business"
 import { ChatbotXException } from "@chatbotx.io/business/errors"
@@ -103,7 +104,7 @@ export const workspaceActionClient = workspaceActionClientAllowExpired.use(
     // Server-side deletion gate: a workspace pending deletion must block every
     // mutation regardless of trial status, so this runs before the trial check
     // below. Mirrors the RSC-side redirect in enforceWorkspaceNotScheduledForDeletion.
-    if (ctx.workspace.scheduledDeletionAt) {
+    if (isWorkspaceScheduledForDeletion(ctx.workspace)) {
       throw new ChatbotXException(
         "Workspace deletion scheduled",
         "workspaceScheduledDeletion",

--- a/apps/builder/src/lib/workspace/deletion-tab-sync.ts
+++ b/apps/builder/src/lib/workspace/deletion-tab-sync.ts
@@ -1,0 +1,65 @@
+const WORKSPACE_DELETION_SYNC_KEY = "chatbotx:workspace-deletion-scheduled"
+
+export type WorkspaceDeletionSyncPayload = {
+  workspaceId: string
+  scheduledAt: number
+}
+
+export function parseWorkspaceDeletionPayload(
+  value: string | null,
+): WorkspaceDeletionSyncPayload | null {
+  if (!value) {
+    return null
+  }
+
+  try {
+    const payload = JSON.parse(value) as Partial<WorkspaceDeletionSyncPayload>
+    if (typeof payload.workspaceId !== "string") {
+      return null
+    }
+    return {
+      workspaceId: payload.workspaceId,
+      scheduledAt:
+        typeof payload.scheduledAt === "number" ? payload.scheduledAt : 0,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function readWorkspaceDeletionSync(): WorkspaceDeletionSyncPayload | null {
+  try {
+    return parseWorkspaceDeletionPayload(
+      window.localStorage.getItem(WORKSPACE_DELETION_SYNC_KEY),
+    )
+  } catch {
+    return null
+  }
+}
+
+export function writeWorkspaceDeletionSync(workspaceId: string): void {
+  try {
+    window.localStorage.setItem(
+      WORKSPACE_DELETION_SYNC_KEY,
+      JSON.stringify({
+        workspaceId,
+        scheduledAt: Date.now(),
+      } satisfies WorkspaceDeletionSyncPayload),
+    )
+  } catch {
+    // Best-effort cross-tab navigation; server guards remain authoritative.
+  }
+}
+
+export function clearWorkspaceDeletionSync(workspaceId: string): void {
+  try {
+    const payload = readWorkspaceDeletionSync()
+    if (payload?.workspaceId === workspaceId) {
+      window.localStorage.removeItem(WORKSPACE_DELETION_SYNC_KEY)
+    }
+  } catch {
+    // Best-effort cross-tab state cleanup; server guards remain authoritative.
+  }
+}
+
+export { WORKSPACE_DELETION_SYNC_KEY }

--- a/apps/builder/src/lib/workspace/load-servable-workspace.ts
+++ b/apps/builder/src/lib/workspace/load-servable-workspace.ts
@@ -1,11 +1,28 @@
 import {
-  isWorkspaceScheduledForDeletion,
+  resolveWorkspaceFreezeReason,
   workspaceService,
 } from "@chatbotx.io/business"
+import type { WorkspaceModel } from "@chatbotx.io/database/types"
 
-export const loadServableWorkspace = async (workspaceId: string) => {
+type ServableWorkspace = {
+  servable: boolean
+  workspace: WorkspaceModel | undefined
+}
+
+/**
+ * Freeze gate for in-request public surfaces (reflinks, entrypoint links,
+ * unsubscribe, email-topic pixels, /extensions/me). Fail-closed on a missing
+ * row: after the purge cron runs, a still-circulating public link must 404/410
+ * rather than serve a workspace that no longer exists.
+ *
+ * The owner entitlement is deliberately NOT consulted here — a trial-expired
+ * workspace keeps serving its already-published public links.
+ */
+export const loadServableWorkspace = async (
+  workspaceId: string,
+): Promise<ServableWorkspace> => {
   const workspace = await workspaceService.find({ where: { id: workspaceId } })
-  const servable = !(workspace && isWorkspaceScheduledForDeletion(workspace))
+  const servable = resolveWorkspaceFreezeReason({ workspace }) === null
 
   return { servable, workspace }
 }

--- a/apps/builder/src/lib/workspace/load-servable-workspace.ts
+++ b/apps/builder/src/lib/workspace/load-servable-workspace.ts
@@ -1,0 +1,11 @@
+import {
+  isWorkspaceScheduledForDeletion,
+  workspaceService,
+} from "@chatbotx.io/business"
+
+export const loadServableWorkspace = async (workspaceId: string) => {
+  const workspace = await workspaceService.find({ where: { id: workspaceId } })
+  const servable = !(workspace && isWorkspaceScheduledForDeletion(workspace))
+
+  return { servable, workspace }
+}

--- a/apps/builder/src/lib/workspace/require-not-scheduled-for-deletion.ts
+++ b/apps/builder/src/lib/workspace/require-not-scheduled-for-deletion.ts
@@ -2,14 +2,7 @@ import { isWorkspaceScheduledForDeletion } from "@chatbotx.io/business"
 import { redirect } from "next/navigation"
 import { getOriginUrlFromHeader } from "@/lib/domain"
 import { WORKSPACE_DELETION_PENDING_PARAM } from "./deletion-pending-param"
-
-/**
- * The one page a workspace stays reachable on during the deletion grace
- * window. Shared so the redirect target and the exemption check can never
- * drift apart — a mismatch between those two IS a redirect loop.
- */
-export const workspaceSettingsGeneralPath = (workspaceId: string): string =>
-  `/space/${workspaceId}/settings/general`
+import { workspaceSettingsGeneralPath } from "./settings-paths"
 
 const safePathname = (originUrl: string): string => {
   if (!originUrl) {

--- a/apps/builder/src/lib/workspace/require-not-scheduled-for-deletion.ts
+++ b/apps/builder/src/lib/workspace/require-not-scheduled-for-deletion.ts
@@ -3,6 +3,27 @@ import { redirect } from "next/navigation"
 import { getOriginUrlFromHeader } from "@/lib/domain"
 import { WORKSPACE_DELETION_PENDING_PARAM } from "./deletion-pending-param"
 
+/**
+ * The one page a workspace stays reachable on during the deletion grace
+ * window. Shared so the redirect target and the exemption check can never
+ * drift apart — a mismatch between those two IS a redirect loop.
+ */
+export const workspaceSettingsGeneralPath = (workspaceId: string): string =>
+  `/space/${workspaceId}/settings/general`
+
+const safePathname = (originUrl: string): string => {
+  if (!originUrl) {
+    return ""
+  }
+  try {
+    return new URL(originUrl).pathname
+  } catch {
+    // A malformed `x-url` must not throw inside a layout. An unknown path is
+    // treated as "don't redirect" below.
+    return ""
+  }
+}
+
 export function enforceWorkspaceNotScheduledForDeletion(
   workspace: { id: string; scheduledDeletionAt: Date | string | null },
   pathname: string,
@@ -12,11 +33,22 @@ export function enforceWorkspaceNotScheduledForDeletion(
     return
   }
 
+  // No self-redirect risk here: `/` never runs this enforcer, so a member who
+  // cannot manage the deletion always leaves the workspace for good.
   if (!canManageDeletion) {
     redirect(`/?${WORKSPACE_DELETION_PENDING_PARAM}=1`)
   }
 
-  const settingsGeneralPath = `/space/${workspace.id}/settings/general`
+  // An unknown current path (missing or unparseable `x-url`) means we cannot
+  // tell whether the redirect target IS the page being rendered. Redirecting
+  // blind sends the client router into a refetch/redirect loop, so stay put —
+  // the banner and the action-layer guards still hold the freeze, this hop is
+  // only navigation UX.
+  if (!pathname) {
+    return
+  }
+
+  const settingsGeneralPath = workspaceSettingsGeneralPath(workspace.id)
   if (pathname.startsWith(settingsGeneralPath)) {
     return
   }
@@ -29,10 +61,9 @@ export async function enforceWorkspaceNotScheduledForDeletionFromRequest(
   canManageDeletion: boolean,
 ): Promise<void> {
   const originUrl = await getOriginUrlFromHeader()
-  const pathname = originUrl ? new URL(originUrl).pathname : ""
   enforceWorkspaceNotScheduledForDeletion(
     workspace,
-    pathname,
+    safePathname(originUrl),
     canManageDeletion,
   )
 }

--- a/apps/builder/src/lib/workspace/require-not-scheduled-for-deletion.ts
+++ b/apps/builder/src/lib/workspace/require-not-scheduled-for-deletion.ts
@@ -1,3 +1,4 @@
+import { isWorkspaceScheduledForDeletion } from "@chatbotx.io/business"
 import { redirect } from "next/navigation"
 import { getOriginUrlFromHeader } from "@/lib/domain"
 import { WORKSPACE_DELETION_PENDING_PARAM } from "./deletion-pending-param"
@@ -7,7 +8,7 @@ export function enforceWorkspaceNotScheduledForDeletion(
   pathname: string,
   canManageDeletion: boolean,
 ): void {
-  if (!workspace.scheduledDeletionAt) {
+  if (!isWorkspaceScheduledForDeletion(workspace)) {
     return
   }
 

--- a/apps/builder/src/lib/workspace/settings-paths.ts
+++ b/apps/builder/src/lib/workspace/settings-paths.ts
@@ -1,0 +1,6 @@
+/**
+ * The one page a workspace stays reachable on during the deletion grace
+ * window. Shared so redirect targets and exemption checks cannot drift apart.
+ */
+export const workspaceSettingsGeneralPath = (workspaceId: string): string =>
+  `/space/${workspaceId}/settings/general`

--- a/apps/builder/src/middlewares/auth.ts
+++ b/apps/builder/src/middlewares/auth.ts
@@ -1,4 +1,7 @@
-import { workspaceMemberService } from "@chatbotx.io/business"
+import {
+  isWorkspaceScheduledForDeletion,
+  workspaceMemberService,
+} from "@chatbotx.io/business"
 import { ORPCError } from "@orpc/server"
 import { auth } from "@/lib/auth/auth"
 import { base } from "./context"
@@ -52,7 +55,7 @@ export const workspaceAuthorizedMidddleware = base.middleware(
       throw new ORPCError("UNAUTHORIZED")
     }
 
-    if (workspaceMember.workspace.scheduledDeletionAt) {
+    if (isWorkspaceScheduledForDeletion(workspaceMember.workspace)) {
       throw new ORPCError("FORBIDDEN", {
         message: "Workspace deletion scheduled",
       })

--- a/apps/builder/src/middlewares/workspace-token-auth.ts
+++ b/apps/builder/src/middlewares/workspace-token-auth.ts
@@ -1,4 +1,7 @@
-import { workspaceService } from "@chatbotx.io/business"
+import {
+  isWorkspaceScheduledForDeletion,
+  workspaceService,
+} from "@chatbotx.io/business"
 import { ORPCError } from "@orpc/server"
 import { base } from "./context"
 
@@ -21,7 +24,7 @@ export const workspaceTokenAuthMidddleware = base.middleware(
       throw new ORPCError("INVALID_CHATBOT_TOKEN")
     }
 
-    if (workspace.scheduledDeletionAt) {
+    if (isWorkspaceScheduledForDeletion(workspace)) {
       throw new ORPCError("FORBIDDEN", {
         message: "Workspace deletion scheduled",
       })

--- a/apps/worker/__tests__/default-worker.test.ts
+++ b/apps/worker/__tests__/default-worker.test.ts
@@ -1,0 +1,180 @@
+import type { DefaultJobData } from "@chatbotx.io/worker-config"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+type DefaultWorkerJob = {
+  attemptsMade: number
+  data: DefaultJobData
+  id: string
+  name: string
+}
+
+type DefaultWorkerProcessor = (job: DefaultWorkerJob) => Promise<void>
+
+const workerState = vi.hoisted(() => ({
+  defaultQueueAdd: vi.fn(),
+  handleBulkTagContacts: vi.fn(),
+  isBlockedWorkspace: vi.fn(),
+  loggerError: vi.fn(),
+  loggerInfo: vi.fn(),
+  loggerWarn: vi.fn(),
+  processor: undefined as DefaultWorkerProcessor | undefined,
+  resolveWorkspaceId: vi.fn(),
+  workerClose: vi.fn(async () => undefined),
+  workerOn: vi.fn(),
+}))
+
+vi.mock("bullmq", () => {
+  class WorkerMock {
+    close = workerState.workerClose
+    on = workerState.workerOn
+
+    constructor(
+      _queueName: unknown,
+      processor: DefaultWorkerProcessor,
+      _options: unknown,
+    ) {
+      workerState.processor = processor
+    }
+  }
+
+  return {
+    Worker: WorkerMock,
+  }
+})
+
+vi.mock("@chatbotx.io/worker-config", () => ({
+  DefaultJobAction: {
+    bulkTagContacts: "bulkTagContacts",
+    exportContacts: "exportContacts",
+    runImport: "runImport",
+    sendAuditLog: "sendAuditLog",
+    sendErrorLog: "sendErrorLog",
+    syncChannelLabels: "syncChannelLabels",
+    syncTag: "syncTag",
+  },
+  defaultQueue: {
+    add: (...args: unknown[]) => workerState.defaultQueueAdd(...args),
+  },
+  defaultWorkerOptions: {},
+  getRedisConnection: () => ({}),
+  queueNames: {
+    enum: {
+      default: "default",
+    },
+  },
+}))
+
+vi.mock("../src/lib/is-blocked-workspace", () => ({
+  isBlockedWorkspace: (workspaceId: string | undefined) =>
+    workerState.isBlockedWorkspace(workspaceId),
+}))
+
+vi.mock("../src/lib/resolve-workspace-id", () => ({
+  resolveWorkspaceId: (data: unknown) => workerState.resolveWorkspaceId(data),
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: {
+    error: (...args: unknown[]) => workerState.loggerError(...args),
+    info: (...args: unknown[]) => workerState.loggerInfo(...args),
+    warn: (...args: unknown[]) => workerState.loggerWarn(...args),
+  },
+}))
+
+vi.mock("../src/default/handlers/bulk-tag-contacts", () => ({
+  handleBulkTagContacts: (...args: unknown[]) =>
+    workerState.handleBulkTagContacts(...args),
+}))
+
+vi.mock("../src/default/handlers/export-contacts", () => ({
+  loopableExportContacts: vi.fn(),
+}))
+
+vi.mock("../src/default/handlers/run-import", () => ({
+  runImport: vi.fn(),
+}))
+
+vi.mock("../src/default/handlers/send-audit-log", () => ({
+  sendAuditLog: vi.fn(),
+}))
+
+vi.mock("../src/default/handlers/send-error-log", () => ({
+  sendErrorLog: vi.fn(),
+}))
+
+vi.mock("../src/default/handlers/sync-channel-labels", () => ({
+  handleSyncChannelLabels: vi.fn(),
+}))
+
+vi.mock("../src/default/handlers/sync-tag", () => ({
+  handleSyncTag: vi.fn(),
+}))
+
+await import("../src/default/worker")
+
+const buildBulkTagContactsJob = (): DefaultJobData => ({
+  type: "bulkTagContacts",
+  data: {
+    broadcastId: "broadcast-1",
+    eventType: "message:sent",
+    excludedContactIds: [],
+    requestedUserId: "user-1",
+    source: "broadcast",
+    tagIds: ["tag-1"],
+    workspaceId: "workspace-1",
+  },
+})
+
+const processDefaultJob = async (
+  data: DefaultJobData,
+  attemptsMade = 0,
+): Promise<void> => {
+  if (!workerState.processor) {
+    throw new Error("Default worker processor was not captured")
+  }
+
+  await workerState.processor({
+    attemptsMade,
+    data,
+    id: "job-1",
+    name: data.type,
+  })
+}
+
+beforeEach(() => {
+  workerState.defaultQueueAdd.mockReset()
+  workerState.handleBulkTagContacts.mockReset()
+  workerState.isBlockedWorkspace.mockReset()
+  workerState.loggerError.mockReset()
+  workerState.loggerInfo.mockReset()
+  workerState.loggerWarn.mockReset()
+  workerState.resolveWorkspaceId.mockReset()
+  workerState.resolveWorkspaceId.mockResolvedValue("workspace-1")
+  workerState.isBlockedWorkspace.mockResolvedValue(false)
+})
+
+describe("default worker", () => {
+  test("skips bulk tag contact jobs for frozen workspaces", async () => {
+    workerState.isBlockedWorkspace.mockResolvedValue(true)
+
+    const jobData = buildBulkTagContactsJob()
+    await processDefaultJob(jobData)
+
+    expect(workerState.resolveWorkspaceId).toHaveBeenCalledWith(jobData.data)
+    expect(workerState.isBlockedWorkspace).toHaveBeenCalledWith("workspace-1")
+    expect(workerState.handleBulkTagContacts).not.toHaveBeenCalled()
+  })
+
+  test("runs bulk tag contact jobs for active workspaces", async () => {
+    const jobData = buildBulkTagContactsJob()
+
+    await processDefaultJob(jobData, 2)
+
+    expect(workerState.resolveWorkspaceId).toHaveBeenCalledWith(jobData.data)
+    expect(workerState.isBlockedWorkspace).toHaveBeenCalledWith("workspace-1")
+    expect(workerState.handleBulkTagContacts).toHaveBeenCalledWith(
+      jobData.data,
+      { attemptsMade: 2 },
+    )
+  })
+})

--- a/apps/worker/__tests__/enqueue-broadcast.test.ts
+++ b/apps/worker/__tests__/enqueue-broadcast.test.ts
@@ -106,6 +106,27 @@ describe("enqueueBroadcast", () => {
       expect(job.opts.jobId).toBe("schedule-prepare-broadcast-broadcast-1")
     })
 
+    test("clears the dedup jobId on completion and on failure so a terminal job cannot wedge the broadcast forever", async () => {
+      findManyBroadcast.mockResolvedValue(makeBroadcasts(1))
+
+      await enqueueBroadcast()
+
+      const [jobs] = addBulkSpy.mock.calls[0] as [
+        Array<{
+          opts: {
+            jobId: string
+            removeOnComplete?: boolean | number
+            removeOnFail?: boolean | number
+          }
+        }>,
+      ]
+      // A deterministic jobId is a Redis dedup key that survives any terminal
+      // state. Left behind after a failure it silently swallows every later
+      // addBulk for the same broadcast.
+      expect(jobs[0].opts.removeOnComplete).toBe(true)
+      expect(jobs[0].opts.removeOnFail).toBe(true)
+    })
+
     test("queries broadcastModel with status 'scheduled' and schedulesAt lte startTime", async () => {
       findManyBroadcast.mockResolvedValue(makeBroadcasts(1))
 

--- a/apps/worker/__tests__/prepare-broadcast.test.ts
+++ b/apps/worker/__tests__/prepare-broadcast.test.ts
@@ -7,6 +7,7 @@ const forEachAudienceChunk = vi.fn()
 const scheduleAddSpy = vi.fn()
 const loggerInfoSpy = vi.fn()
 const loggerWarnSpy = vi.fn()
+const blockedWorkspaceIds = new Set<string>()
 
 type UpdateCall = {
   table: unknown
@@ -22,9 +23,9 @@ const onConflictSpy = vi.fn()
 
 vi.mock("@chatbotx.io/business", () => ({
   withBlockedOwnerGuard: async (
-    _workspaceId: unknown,
+    workspaceId: unknown,
     fn: () => Promise<unknown>,
-  ) => fn(),
+  ) => (blockedWorkspaceIds.has(String(workspaceId)) ? undefined : fn()),
   broadcastService: {
     forEachAudienceChunk: (...args: unknown[]) => forEachAudienceChunk(...args),
   },
@@ -125,11 +126,24 @@ beforeEach(() => {
   loggerInfoSpy.mockReset()
   loggerWarnSpy.mockReset()
   onConflictSpy.mockReset()
+  blockedWorkspaceIds.clear()
 })
 
 describe("prepareBroadcast", () => {
   test("returns without db writes or queue enqueues when the broadcast is missing", async () => {
     findFirstBroadcast.mockResolvedValue(undefined)
+
+    await prepareBroadcast(BROADCAST_ID)
+
+    expect(updateCalls).toHaveLength(0)
+    expect(insertCalls).toHaveLength(0)
+    expect(forEachAudienceChunk).not.toHaveBeenCalled()
+    expect(scheduleAddSpy).not.toHaveBeenCalled()
+  })
+
+  test("returns without db writes or queue enqueues when the workspace is frozen", async () => {
+    findFirstBroadcast.mockResolvedValue(baseBroadcast())
+    blockedWorkspaceIds.add(WORKSPACE_ID)
 
     await prepareBroadcast(BROADCAST_ID)
 

--- a/apps/worker/__tests__/resolve-workspace-id.test.ts
+++ b/apps/worker/__tests__/resolve-workspace-id.test.ts
@@ -4,12 +4,16 @@ const findBy = vi.fn()
 const findFirst = vi.fn()
 const identify = vi.fn()
 const smartDelayFindById = vi.fn()
+const findWorkspaceId = vi.fn()
 
 vi.mock("@chatbotx.io/business", () => ({
   conversationService: { findBy },
 }))
 vi.mock("@chatbotx.io/database/client", () => ({
   db: { query: { importModel: { findFirst } } },
+}))
+vi.mock("@chatbotx.io/database/repositories", () => ({
+  createAiWorkspaceScopeRepository: () => ({ findWorkspaceId }),
 }))
 vi.mock("@chatbotx.io/business/smart-delay", () => ({
   smartDelayService: { findById: smartDelayFindById },
@@ -27,6 +31,7 @@ beforeEach(() => {
   findFirst.mockReset()
   identify.mockReset()
   smartDelayFindById.mockReset()
+  findWorkspaceId.mockReset()
 })
 
 describe("resolveWorkspaceId", () => {
@@ -81,9 +86,43 @@ describe("resolveWorkspaceId", () => {
     ).resolves.toBe("workspace-from-smart-delay")
   })
 
+  // The scope assertion is the point: one shared repository method means a
+  // mis-wired row in the resolver table would still return a workspace id and
+  // silently attribute an AI job to the wrong record kind.
+  test.each([
+    { field: "aiFileId", id: "ai-file-1", scope: "aiFile" },
+    { field: "aiEmbeddingId", id: "ai-embedding-1", scope: "aiEmbedding" },
+    { field: "sourceId", id: "source-1", scope: "conversationSource" },
+    {
+      field: "conversationEmbeddingId",
+      id: "embedding-1",
+      scope: "conversationEmbedding",
+    },
+  ])("resolves $field through the $scope scope", async ({
+    field,
+    id,
+    scope,
+  }) => {
+    findWorkspaceId.mockResolvedValue("workspace-from-ai-record")
+
+    await expect(resolveWorkspaceId({ [field]: id })).resolves.toBe(
+      "workspace-from-ai-record",
+    )
+    expect(findWorkspaceId).toHaveBeenCalledWith({ id, scope })
+  })
+
+  test("prefers the earlier resolver when a payload carries several ids", async () => {
+    findBy.mockResolvedValue({ workspaceId: "workspace-from-conversation" })
+
+    await expect(
+      resolveWorkspaceId({ aiFileId: "ai-file-1", conversationId: "conv-1" }),
+    ).resolves.toBe("workspace-from-conversation")
+    expect(findWorkspaceId).not.toHaveBeenCalled()
+  })
+
   test("fails open when no workspace identity is available", async () => {
     await expect(
-      resolveWorkspaceId({ type: "embedding" }),
+      resolveWorkspaceId({ type: "unknown" }),
     ).resolves.toBeUndefined()
   })
 })

--- a/apps/worker/__tests__/webhook-executor-payloads.test.ts
+++ b/apps/worker/__tests__/webhook-executor-payloads.test.ts
@@ -3,13 +3,18 @@ import type { MatchableEventType } from "@chatbotx.io/events"
 import { beforeEach, describe, expect, test, vi } from "vitest"
 import type { WebhookWithConditions } from "../src/webhook/types"
 
-const { assertPublicUrl, tagFindFirst } = vi.hoisted(() => ({
-  assertPublicUrl: vi.fn().mockResolvedValue(undefined),
-  tagFindFirst: vi.fn(),
-}))
+const { assertPublicUrl, contactFindById, listCustomFields, tagFindFirst } =
+  vi.hoisted(() => ({
+    assertPublicUrl: vi.fn().mockResolvedValue(undefined),
+    contactFindById: vi.fn(),
+    listCustomFields: vi.fn(),
+    tagFindFirst: vi.fn(),
+  }))
 
 vi.mock("@chatbotx.io/business", () => ({
   assertPublicUrl,
+  contactCustomFieldService: { listWithDefinitions: listCustomFields },
+  contactService: { findById: contactFindById },
 }))
 
 vi.mock("@chatbotx.io/database/client", () => ({
@@ -97,16 +102,21 @@ const payloadCases = [
     },
   },
   {
+    // The contact row is committed before `emitContactCreated` fires, so the
+    // stored record — not the event metadata — is the source of truth here.
+    // `customFields` is never populated by any emitter; only the database read
+    // can fill `custom_fields`.
     eventType: triggerEventTypes.enum.newContact,
     metadata: {
       name: "Ada",
-      phone: "+15551234567",
-      email: "ada@example.com",
-      customFields: { plan: "Pro" },
+      phone: "+15550000000",
+      email: "stale@example.com",
     },
     expectedPayload: {
       ...basePayload("new_contact"),
-      name: "Ada",
+      name: "Ada Lovelace",
+      first_name: "Ada",
+      last_name: "Lovelace",
       phone: "+15551234567",
       email: "ada@example.com",
       custom_fields: { plan: "Pro" },
@@ -211,6 +221,15 @@ describe("WebhookExecutor payloads", () => {
     vi.clearAllMocks()
     fetchMock.mockResolvedValue(new Response(null, { status: 200 }))
     tagFindFirst.mockResolvedValue({ name: "VIP" })
+    contactFindById.mockResolvedValue({
+      id: "contact-1",
+      fullName: "Ada Lovelace",
+      firstName: "Ada",
+      lastName: "Lovelace",
+      phoneNumber: "+15551234567",
+      email: "ada@example.com",
+    })
+    listCustomFields.mockResolvedValue([{ name: "plan", value: "Pro" }])
     vi.stubGlobal("fetch", fetchMock)
   })
 
@@ -234,5 +253,36 @@ describe("WebhookExecutor payloads", () => {
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(JSON.parse(String(init.body))).toEqual(expectedPayload)
+  })
+
+  // A contact deleted between the event and the delivery attempt must still
+  // produce a well-formed payload: the subscriber's parser would break on
+  // missing keys, so every field falls back to the metadata or to null.
+  test("falls back to event metadata when the contact no longer exists", async () => {
+    contactFindById.mockResolvedValue(undefined)
+    const executor = new WebhookExecutor()
+
+    await executor.execute({
+      webhook,
+      eventData: {
+        workspaceId: "workspace-1",
+        contactId: "contact-1",
+        eventType: triggerEventTypes.enum.newContact,
+        eventData: { name: "Ada", phone: "+15550000000" },
+        timestamp,
+      },
+    })
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(JSON.parse(String(init.body))).toEqual({
+      ...basePayload("new_contact"),
+      name: "Ada",
+      first_name: null,
+      last_name: null,
+      phone: "+15550000000",
+      email: null,
+      custom_fields: {},
+    })
+    expect(listCustomFields).not.toHaveBeenCalled()
   })
 })

--- a/apps/worker/__tests__/webhook-executor-payloads.test.ts
+++ b/apps/worker/__tests__/webhook-executor-payloads.test.ts
@@ -37,12 +37,29 @@ vi.mock("../src/lib/logger", () => ({
 const { WebhookExecutor } = await import(
   "../src/webhook/services/webhook-executor.service"
 )
+const { buildWebhookPayload } = await import(
+  "../src/webhook/services/webhook-payload.builder"
+)
 
 const timestamp = new Date("2026-07-11T10:00:00.000Z")
 const webhook = {
   id: "webhook-1",
   url: "https://example.com/webhook",
 } as WebhookWithConditions
+
+type TagQuery = { where: { id: string; workspaceId?: string } }
+
+// Tag ids are globally unique, so an id-only lookup resolves a row from any
+// workspace. These rows let the mock mimic SQL semantics — a `where` without
+// `workspaceId` matches across workspaces — instead of hiding the difference.
+const tagRows = [
+  { id: "tag-1", workspaceId: "workspace-1", name: "VIP" },
+  {
+    id: "tag-foreign",
+    workspaceId: "workspace-2",
+    name: "Other workspace tag",
+  },
+]
 
 type PayloadCase = {
   eventType: MatchableEventType
@@ -240,19 +257,50 @@ describe("WebhookExecutor payloads", () => {
   }) => {
     const executor = new WebhookExecutor()
 
-    await executor.execute({
-      webhook,
-      eventData: {
-        workspaceId: "workspace-1",
-        contactId: "contact-1",
-        eventType,
-        eventData: metadata,
-        timestamp,
-      },
+    const payload = await buildWebhookPayload({
+      workspaceId: "workspace-1",
+      contactId: "contact-1",
+      eventType,
+      eventData: metadata,
+      timestamp,
     })
+    await executor.execute({ webhook, payload })
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(JSON.parse(String(init.body))).toEqual(expectedPayload)
+  })
+
+  // The tag id arrives as event metadata, so it must never be trusted to belong
+  // to the workspace the webhook is registered under. An id-only lookup would
+  // put another tenant's tag name in this workspace's outbound payload.
+  test("does not leak a tag that belongs to another workspace", async () => {
+    tagFindFirst.mockImplementation((query: TagQuery) =>
+      Promise.resolve(
+        tagRows.find(
+          (row) =>
+            row.id === query.where.id &&
+            (query.where.workspaceId === undefined ||
+              row.workspaceId === query.where.workspaceId),
+        ),
+      ),
+    )
+
+    const payload = await buildWebhookPayload({
+      workspaceId: "workspace-1",
+      contactId: "contact-1",
+      eventType: triggerEventTypes.enum.tagApplied,
+      eventData: { tagId: "tag-foreign" },
+      timestamp,
+    })
+
+    // Asserted on the raw payload, so `timestamp` is still a Date here — the
+    // other cases assert the serialized request body instead.
+    expect(payload).toEqual({
+      event: "tag_applied",
+      contact_id: "contact-1",
+      timestamp,
+      tag: "",
+    })
   })
 
   // A contact deleted between the event and the delivery attempt must still
@@ -262,16 +310,14 @@ describe("WebhookExecutor payloads", () => {
     contactFindById.mockResolvedValue(undefined)
     const executor = new WebhookExecutor()
 
-    await executor.execute({
-      webhook,
-      eventData: {
-        workspaceId: "workspace-1",
-        contactId: "contact-1",
-        eventType: triggerEventTypes.enum.newContact,
-        eventData: { name: "Ada", phone: "+15550000000" },
-        timestamp,
-      },
+    const payload = await buildWebhookPayload({
+      workspaceId: "workspace-1",
+      contactId: "contact-1",
+      eventType: triggerEventTypes.enum.newContact,
+      eventData: { name: "Ada", phone: "+15550000000" },
+      timestamp,
     })
+    await executor.execute({ webhook, payload })
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(JSON.parse(String(init.body))).toEqual({

--- a/apps/worker/__tests__/webhook-matcher-datetime.test.ts
+++ b/apps/worker/__tests__/webhook-matcher-datetime.test.ts
@@ -2,13 +2,17 @@ import { triggerEventTypes } from "@chatbotx.io/database/partials"
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
 const {
+  buildPayload,
   contactCustomFieldFindFirst,
   executeWebhook,
+  loggerError,
   webhookFindMany,
   workspaceFind,
 } = vi.hoisted(() => ({
+  buildPayload: vi.fn(),
   contactCustomFieldFindFirst: vi.fn(),
   executeWebhook: vi.fn(),
+  loggerError: vi.fn(),
   webhookFindMany: vi.fn(),
   workspaceFind: vi.fn(),
 }))
@@ -38,9 +42,13 @@ vi.mock("../src/webhook/services/webhook-executor.service", () => ({
   },
 }))
 
+vi.mock("../src/webhook/services/webhook-payload.builder", () => ({
+  buildWebhookPayload: buildPayload,
+}))
+
 vi.mock("../src/lib/logger", () => ({
   logger: {
-    error: vi.fn(),
+    error: loggerError,
   },
 }))
 
@@ -73,12 +81,40 @@ const secondWebhook = {
   conditions: [datetimeCondition],
 }
 
+// Custom-field conditions are re-evaluated against the database, so this is the
+// fixture that can make condition evaluation itself fail.
+const customFieldWebhook = {
+  id: "webhook-cf",
+  workspaceId: "workspace-1",
+  active: true,
+  conditions: [
+    {
+      id: "condition-cf",
+      type: triggerEventTypes.enum.customFieldValueChanged,
+      sourceId: "cf-1",
+      operator: "is",
+      value: "Pro",
+    },
+  ],
+}
+
+const datetimeEvent = {
+  workspaceId: "workspace-1",
+  contactId: "contact-1",
+  eventType: triggerEventTypes.enum.dateTimeBasedTrigger,
+  eventData: { sourceId: "cf-1" },
+  timestamp: new Date("2026-07-11T00:00:00.000Z"),
+}
+
+const datetimePayload = { event: "datetime_based_trigger", sourceId: "cf-1" }
+
 describe("WebhookMatcherService datetime events", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     contactCustomFieldFindFirst.mockRejectedValue(
       new Error("datetime should not be re-evaluated by webhook matcher"),
     )
+    buildPayload.mockResolvedValue(datetimePayload)
     executeWebhook.mockResolvedValue(undefined)
     webhookFindMany.mockResolvedValue([webhook])
     workspaceFind.mockResolvedValue({ id: "workspace-1", timezone: "UTC" })
@@ -87,21 +123,18 @@ describe("WebhookMatcherService datetime events", () => {
   test("executes datetime webhook when scanner already matched the source id", async () => {
     const matcher = new WebhookMatcherService()
 
-    await matcher.findAndExecuteWebhooks({
-      workspaceId: "workspace-1",
-      contactId: "contact-1",
-      eventType: triggerEventTypes.enum.dateTimeBasedTrigger,
-      eventData: { sourceId: "cf-1" },
-      timestamp: new Date("2026-07-11T00:00:00.000Z"),
-    })
+    await matcher.findAndExecuteWebhooks(datetimeEvent)
 
     expect(contactCustomFieldFindFirst).not.toHaveBeenCalled()
-    expect(executeWebhook).toHaveBeenCalledWith({
-      webhook,
-      eventData: expect.objectContaining({
+    expect(buildPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
         eventType: triggerEventTypes.enum.dateTimeBasedTrigger,
         eventData: { sourceId: "cf-1" },
       }),
+    )
+    expect(executeWebhook).toHaveBeenCalledWith({
+      webhook,
+      payload: datetimePayload,
     })
   })
 
@@ -109,14 +142,12 @@ describe("WebhookMatcherService datetime events", () => {
     const matcher = new WebhookMatcherService()
 
     await matcher.findAndExecuteWebhooks({
-      workspaceId: "workspace-1",
-      contactId: "contact-1",
-      eventType: triggerEventTypes.enum.dateTimeBasedTrigger,
+      ...datetimeEvent,
       eventData: { sourceId: "cf-other" },
-      timestamp: new Date("2026-07-11T00:00:00.000Z"),
     })
 
     expect(contactCustomFieldFindFirst).not.toHaveBeenCalled()
+    expect(buildPayload).not.toHaveBeenCalled()
     expect(executeWebhook).not.toHaveBeenCalled()
   })
 
@@ -128,27 +159,79 @@ describe("WebhookMatcherService datetime events", () => {
     const matcher = new WebhookMatcherService()
 
     await expect(
-      matcher.findAndExecuteWebhooks({
-        workspaceId: "workspace-1",
-        contactId: "contact-1",
-        eventType: triggerEventTypes.enum.dateTimeBasedTrigger,
-        eventData: { sourceId: "cf-1" },
-        timestamp: new Date("2026-07-11T00:00:00.000Z"),
-      }),
+      matcher.findAndExecuteWebhooks(datetimeEvent),
     ).resolves.toBeUndefined()
 
     expect(executeWebhook).toHaveBeenCalledTimes(2)
     expect(executeWebhook).toHaveBeenCalledWith({
       webhook,
-      eventData: expect.objectContaining({
-        eventType: triggerEventTypes.enum.dateTimeBasedTrigger,
-      }),
+      payload: datetimePayload,
     })
     expect(executeWebhook).toHaveBeenCalledWith({
       webhook: secondWebhook,
-      eventData: expect.objectContaining({
-        eventType: triggerEventTypes.enum.dateTimeBasedTrigger,
-      }),
+      payload: datetimePayload,
     })
+  })
+
+  test("builds a matched event payload once for multiple webhook deliveries", async () => {
+    webhookFindMany.mockResolvedValue([webhook, secondWebhook])
+    const matcher = new WebhookMatcherService()
+
+    await matcher.findAndExecuteWebhooks(datetimeEvent)
+
+    expect(buildPayload).toHaveBeenCalledTimes(1)
+    expect(executeWebhook).toHaveBeenCalledTimes(2)
+    expect(executeWebhook).toHaveBeenCalledWith({
+      webhook,
+      payload: datetimePayload,
+    })
+    expect(executeWebhook).toHaveBeenCalledWith({
+      webhook: secondWebhook,
+      payload: datetimePayload,
+    })
+  })
+
+  // One payload feeds the whole fan-out, so swallowing a build failure would
+  // drop every delivery at once with nothing left to retry. Failing the job is
+  // safe here precisely because the build runs before the first delivery:
+  // nothing has been sent yet, so the queue retry cannot duplicate a webhook.
+  test("fails the job without delivering when the payload cannot be built", async () => {
+    buildPayload.mockRejectedValue(new Error("contact lookup failed"))
+    webhookFindMany.mockResolvedValue([webhook, secondWebhook])
+    const matcher = new WebhookMatcherService()
+
+    await expect(matcher.findAndExecuteWebhooks(datetimeEvent)).rejects.toThrow(
+      "contact lookup failed",
+    )
+
+    expect(executeWebhook).not.toHaveBeenCalled()
+  })
+
+  // The opposite call: a condition that cannot be evaluated must NOT fail the
+  // job, because matched webhooks are delivered after this step and a retry
+  // would send them twice. It must still be visible in the logs.
+  test("logs and skips a webhook whose conditions cannot be evaluated", async () => {
+    contactCustomFieldFindFirst.mockRejectedValue(
+      new Error("custom field lookup failed"),
+    )
+    webhookFindMany.mockResolvedValue([customFieldWebhook])
+    const matcher = new WebhookMatcherService()
+
+    await expect(
+      matcher.findAndExecuteWebhooks({
+        workspaceId: "workspace-1",
+        contactId: "contact-1",
+        eventType: triggerEventTypes.enum.customFieldValueChanged,
+        eventData: { customFieldId: "cf-other", newValue: "Pro" },
+        timestamp: new Date("2026-07-11T00:00:00.000Z"),
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(loggerError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.stringContaining("webhook-cf"),
+    )
+    expect(buildPayload).not.toHaveBeenCalled()
+    expect(executeWebhook).not.toHaveBeenCalled()
   })
 })

--- a/apps/worker/src/default/worker.ts
+++ b/apps/worker/src/default/worker.ts
@@ -40,6 +40,9 @@ const worker = new Worker(
         await loopableExportContacts(job.data.data)
         return
       case DefaultJobAction.bulkTagContacts:
+        if (await isBlockedJob(job.data.data)) {
+          return
+        }
         await handleBulkTagContacts(job.data.data, {
           attemptsMade: job.attemptsMade,
         })

--- a/apps/worker/src/integration/handlers/send-email.ts
+++ b/apps/worker/src/integration/handlers/send-email.ts
@@ -37,6 +37,7 @@ async function resolveElements({
   flowId,
   unsubscribeUrl,
   token,
+  workspaceId,
 }: {
   appUrl: string
   rawElements: PageElementSchema[]
@@ -45,6 +46,7 @@ async function resolveElements({
   flowId: string | undefined
   unsubscribeUrl: string
   token?: string
+  workspaceId: string
 }): Promise<MailElementSchema[]> {
   const resolved: MailElementSchema[] = []
 
@@ -90,7 +92,7 @@ async function resolveElements({
           // Seal the destination into an authenticated token so the click
           // route cannot be abused as an open redirect (the raw URL is never
           // trusted from the query string). base64url is URL-safe.
-          const signedUrl = await signEmailClickUrl(url)
+          const signedUrl = await signEmailClickUrl(url, workspaceId)
           url = `${appUrl}/email-topic/click?r=${token}&u=${signedUrl}`
         }
 
@@ -203,6 +205,7 @@ export async function sendEmail({
     flowId: flowVersion.flowId,
     unsubscribeUrl,
     token,
+    workspaceId: conversation.workspaceId,
   })
 
   const props: DynamicEmailProps = {

--- a/apps/worker/src/lib/resolve-workspace-id.ts
+++ b/apps/worker/src/lib/resolve-workspace-id.ts
@@ -2,16 +2,38 @@ import { conversationService } from "@chatbotx.io/business"
 import { smartDelayService } from "@chatbotx.io/business/smart-delay"
 import { db } from "@chatbotx.io/database/client"
 import type { IntegrationType } from "@chatbotx.io/database/partials"
+import { createAiWorkspaceScopeRepository } from "@chatbotx.io/database/repositories"
 import { integrationService } from "../services/integrations"
+
+const aiWorkspaceScopeRepository = createAiWorkspaceScopeRepository()
 
 type JobData = {
   workspaceId?: unknown
+  aiEmbeddingId?: unknown
+  aiFileId?: unknown
   conversation?: { workspaceId?: unknown } | null
+  conversationEmbeddingId?: unknown
   conversationId?: unknown
   importId?: unknown
   smartDelayId?: unknown
+  sourceId?: unknown
   integrationType?: unknown
   integrationIdentifier?: unknown
+}
+
+/** Payload fields that carry a single record id resolvable to one workspace. */
+type RecordIdField =
+  | "aiEmbeddingId"
+  | "aiFileId"
+  | "conversationEmbeddingId"
+  | "conversationId"
+  | "importId"
+  | "smartDelayId"
+  | "sourceId"
+
+type RecordIdResolver = {
+  field: RecordIdField
+  resolve: (id: string) => Promise<string | undefined>
 }
 
 const asString = (value: unknown): string | undefined =>
@@ -22,6 +44,71 @@ const nestedWorkspaceId = (value: unknown): string | undefined =>
     ? asString(value.workspaceId)
     : undefined
 
+/**
+ * Ordered lookup table: the first field present on the payload wins.
+ *
+ * A table rather than a chain of ifs because every entry has the same shape —
+ * one id in, one workspaceId out. Supporting a new job payload means adding a
+ * row, not another branch, and the ordering stays readable in one glance.
+ *
+ * The AI knowledge-base rows resolve rather than fail open: one indexed
+ * single-column read is far cheaper than the embedding API call it gates, and
+ * failing open would let a frozen workspace keep burning embedding credits.
+ */
+const recordIdResolvers: readonly RecordIdResolver[] = [
+  {
+    field: "conversationId",
+    resolve: async (id) =>
+      (await conversationService.findBy({ where: { id } }))?.workspaceId,
+  },
+  {
+    field: "smartDelayId",
+    resolve: async (id) =>
+      (await smartDelayService.findById({ id }))?.workspaceId,
+  },
+  {
+    field: "aiFileId",
+    resolve: (id) =>
+      aiWorkspaceScopeRepository.findWorkspaceId({ id, scope: "aiFile" }),
+  },
+  {
+    field: "aiEmbeddingId",
+    resolve: (id) =>
+      aiWorkspaceScopeRepository.findWorkspaceId({ id, scope: "aiEmbedding" }),
+  },
+  {
+    field: "sourceId",
+    resolve: (id) =>
+      aiWorkspaceScopeRepository.findWorkspaceId({
+        id,
+        scope: "conversationSource",
+      }),
+  },
+  {
+    field: "conversationEmbeddingId",
+    resolve: (id) =>
+      aiWorkspaceScopeRepository.findWorkspaceId({
+        id,
+        scope: "conversationEmbedding",
+      }),
+  },
+  {
+    field: "importId",
+    resolve: async (id) =>
+      (
+        await db.query.importModel.findFirst({
+          where: { id },
+          columns: { workspaceId: true },
+        })
+      )?.workspaceId,
+  },
+]
+
+/**
+ * Best-effort workspace identity for an arbitrary job payload, used by the
+ * freeze guards. Returning `undefined` means "cannot attribute", which callers
+ * treat as fail-open.
+ */
 export async function resolveWorkspaceId(
   data: unknown,
 ): Promise<string | undefined> {
@@ -38,6 +125,7 @@ export async function resolveWorkspaceId(
     return directWorkspaceId
   }
 
+  // Two fields rather than one id, so it stays out of the table above.
   const integrationType = asString(jobData.integrationType)
   const integrationIdentifier = asString(jobData.integrationIdentifier)
   if (integrationType && integrationIdentifier) {
@@ -53,29 +141,10 @@ export async function resolveWorkspaceId(
     }
   }
 
-  const conversationId = asString(jobData.conversationId)
-  if (conversationId) {
-    const conversation = await conversationService.findBy({
-      where: { id: conversationId },
-    })
-    return conversation?.workspaceId
-  }
-
-  const smartDelayId = asString(jobData.smartDelayId)
-  if (smartDelayId) {
-    const row = await smartDelayService.findById({ id: smartDelayId })
-    return row?.workspaceId
-  }
-
-  // AI embedding/file jobs intentionally remain fail-open: their payloads do
-  // not carry a workspace identity and resolving through source/file records
-  // would add unnecessary database work to these background jobs.
-  const importId = asString(jobData.importId)
-  if (importId) {
-    const contactImport = await db.query.importModel.findFirst({
-      where: { id: importId },
-      columns: { workspaceId: true },
-    })
-    return contactImport?.workspaceId
+  for (const resolver of recordIdResolvers) {
+    const id = asString(jobData[resolver.field])
+    if (id) {
+      return await resolver.resolve(id)
+    }
   }
 }

--- a/apps/worker/src/schedule/handlers/enqueue-broadcast.ts
+++ b/apps/worker/src/schedule/handlers/enqueue-broadcast.ts
@@ -35,6 +35,13 @@ export const enqueueBroadcast = async () => {
         opts: {
           // Deduplicate fan-out when the scheduler job retries.
           jobId: `schedule-prepare-broadcast-${broadcast.id}`,
+          // A deterministic jobId is a Redis dedup key that outlives ANY
+          // terminal state, `failed` included. Without these two the first
+          // permanent failure turns the key into a tombstone: every later
+          // tick's addBulk is silently dropped, so the broadcast stays
+          // `scheduled` forever and nothing surfaces the stall.
+          removeOnComplete: true,
+          removeOnFail: true,
         },
       })),
     )

--- a/apps/worker/src/webhook/services/webhook-executor.service.ts
+++ b/apps/worker/src/webhook/services/webhook-executor.service.ts
@@ -1,196 +1,13 @@
-import {
-  assertPublicUrl,
-  contactCustomFieldService,
-  contactService,
-} from "@chatbotx.io/business"
-import { db } from "@chatbotx.io/database/client"
-import { triggerEventTypes } from "@chatbotx.io/database/partials"
-import type { MatchableEventType } from "@chatbotx.io/events"
+import { assertPublicUrl } from "@chatbotx.io/business"
 import { logger } from "../../lib/logger"
-import type { MatchableWebhookEventData, WebhookWithConditions } from "../types"
+import type { WebhookPayload, WebhookWithConditions } from "../types"
 
-type WebhookPayloadBase = {
-  event: string
-  contact_id: string
-  timestamp: Date
-}
-
-type WebhookPayload = Record<string, unknown>
-
-type PayloadBuilder = (
-  basePayload: WebhookPayloadBase,
-  data: Record<string, unknown>,
-  workspaceId: string,
-) => Promise<WebhookPayload> | WebhookPayload
-
-const EVENT_NAMES = {
-  [triggerEventTypes.enum.tagApplied]: "tag_applied",
-  [triggerEventTypes.enum.tagRemoved]: "tag_removed",
-  [triggerEventTypes.enum.customFieldValueChanged]: "custom_field_changed",
-  [triggerEventTypes.enum.contactInfoUpdated]: "contact_info_updated",
-  [triggerEventTypes.enum.conversationTransferredToHuman]:
-    "conversation_transferred_to_human",
-  [triggerEventTypes.enum.conversationTransferredToBot]:
-    "conversation_transferred_to_bot",
-  [triggerEventTypes.enum.newContact]: "new_contact",
-  [triggerEventTypes.enum.contactUnsubscribedFormBroadcast]:
-    "contact_unsubscribed",
-  [triggerEventTypes.enum.archived]: "conversation_archived",
-  [triggerEventTypes.enum.followUp]: "marked_as_follow_up",
-  [triggerEventTypes.enum.conversationAssigned]: "conversation_assigned",
-  [triggerEventTypes.enum.conversationUnassigned]: "conversation_unassigned",
-  [triggerEventTypes.enum.subscribedToSequence]: "subscribed_to_sequence",
-  [triggerEventTypes.enum.unsubscribedFromSequence]:
-    "unsubscribed_from_sequence",
-  [triggerEventTypes.enum.contactReferredANewContact]:
-    "contact_referred_a_new_contact",
-  [triggerEventTypes.enum.contactReferredExistingContact]:
-    "contact_referred_existing_contact",
-  [triggerEventTypes.enum.dateTimeBasedTrigger]: "datetime_based_trigger",
-} satisfies Record<MatchableEventType, string>
-
-async function buildTagPayload(
-  basePayload: WebhookPayloadBase,
-  data: Record<string, unknown>,
-): Promise<WebhookPayload> {
-  const tag = await db.query.tagModel.findFirst({
-    where: {
-      id: data.tagId as string,
-      deletedAt: { isNull: true as const },
-    },
-    columns: { name: true },
-  })
-
-  return {
-    ...basePayload,
-    tag: tag?.name || "",
-  }
-}
-
-function buildCustomFieldPayload(
-  basePayload: WebhookPayloadBase,
-  data: Record<string, unknown>,
-): WebhookPayload {
-  return {
-    ...basePayload,
-    custom_field: {
-      name: data.customFieldName as string,
-      old_value: data.oldValue,
-      new_value: data.newValue,
-    },
-  }
-}
-
-function buildSequencePayload(
-  basePayload: WebhookPayloadBase,
-  data: Record<string, unknown>,
-): WebhookPayload {
-  return {
-    ...basePayload,
-    sequence_id: data.sequenceId as string,
-    sequence_name: data.sequenceName as string,
-  }
-}
-
-function buildReferralPayload(
-  basePayload: WebhookPayloadBase,
-  data: Record<string, unknown>,
-): WebhookPayload {
-  return {
-    ...basePayload,
-    ref_name: data.refName as string,
-    reflink_id: data.reflinkId as string,
-  }
-}
-
-async function buildNewContactPayload(
-  basePayload: WebhookPayloadBase,
-  data: Record<string, unknown>,
-  workspaceId: string,
-): Promise<WebhookPayload> {
-  const contact = await contactService.findById({
-    workspaceId,
-    id: basePayload.contact_id,
-  })
-  const customFields = contact
-    ? await contactCustomFieldService.listWithDefinitions({
-        contactId: contact.id,
-      })
-    : []
-
-  return {
-    ...basePayload,
-    name: contact?.fullName || (data.name as string) || null,
-    first_name: contact?.firstName || null,
-    last_name: contact?.lastName || null,
-    phone: contact?.phoneNumber || (data.phone as string) || null,
-    email: contact?.email || (data.email as string) || null,
-    custom_fields: Object.fromEntries(
-      customFields.map((field) => [field.name, field.value]),
-    ),
-  }
-}
-
-const PAYLOAD_BUILDERS = {
-  [triggerEventTypes.enum.tagApplied]: buildTagPayload,
-  [triggerEventTypes.enum.tagRemoved]: buildTagPayload,
-  [triggerEventTypes.enum.customFieldValueChanged]: buildCustomFieldPayload,
-  [triggerEventTypes.enum.contactInfoUpdated]: (basePayload, data) => ({
-    ...basePayload,
-    info_type: data.infoType as string,
-    old_value: (data.oldValue as string) || null,
-    new_value: data.newValue as string,
-  }),
-  [triggerEventTypes.enum.conversationTransferredToHuman]: (
-    basePayload,
-    data,
-  ) => ({
-    ...basePayload,
-    conversation_id: data.conversationId as string,
-    transferred_by: (data.transferredBy as string) || "bot",
-  }),
-  [triggerEventTypes.enum.conversationTransferredToBot]: (
-    basePayload,
-    data,
-  ) => ({
-    ...basePayload,
-    conversation_id: data.conversationId as string,
-    transferred_by: (data.transferredBy as string) || "system",
-  }),
-  [triggerEventTypes.enum.newContact]: buildNewContactPayload,
-  [triggerEventTypes.enum.contactUnsubscribedFormBroadcast]: (basePayload) =>
-    basePayload,
-  [triggerEventTypes.enum.archived]: (basePayload, data) => ({
-    ...basePayload,
-    conversation_id: data.conversationId as string,
-    archived_by: (data.archivedBy as string) || "system",
-  }),
-  [triggerEventTypes.enum.followUp]: (basePayload, data) => ({
-    ...basePayload,
-    conversation_id: data.conversationId as string,
-    marked_by: (data.markedBy as string) || "system",
-  }),
-  [triggerEventTypes.enum.conversationAssigned]: (basePayload, data) => ({
-    ...basePayload,
-    conversation_id: data.conversationId as string,
-    assigned_to: data.assignedTo as string,
-    assigned_by: (data.assignedBy as string) || "system",
-  }),
-  [triggerEventTypes.enum.conversationUnassigned]: (basePayload, data) => ({
-    ...basePayload,
-    conversation_id: data.conversationId as string,
-    unassigned_by: (data.unassignedBy as string) || "system",
-  }),
-  [triggerEventTypes.enum.subscribedToSequence]: buildSequencePayload,
-  [triggerEventTypes.enum.unsubscribedFromSequence]: buildSequencePayload,
-  [triggerEventTypes.enum.contactReferredANewContact]: buildReferralPayload,
-  [triggerEventTypes.enum.contactReferredExistingContact]: buildReferralPayload,
-  [triggerEventTypes.enum.dateTimeBasedTrigger]: (basePayload, data) => ({
-    ...basePayload,
-    ...data,
-  }),
-} satisfies Record<MatchableEventType, PayloadBuilder>
-
+/**
+ * Delivers an already-built payload to one webhook endpoint, with connection
+ * retries. Building the payload is `buildWebhookPayload`'s job — keeping the two
+ * apart is what lets one payload serve a whole fan-out, and it leaves a single
+ * source of truth for what gets sent.
+ */
 export class WebhookExecutor {
   private readonly MAX_RETRIES = 3
   private readonly RETRY_DELAY_MS = 1000
@@ -216,23 +33,9 @@ export class WebhookExecutor {
     return new Promise((resolve) => setTimeout(resolve, ms))
   }
 
-  private async createPayload(eventData: MatchableWebhookEventData) {
-    const basePayload = {
-      event: EVENT_NAMES[eventData.eventType],
-      contact_id: eventData.contactId,
-      timestamp: eventData.timestamp,
-    }
-
-    return await PAYLOAD_BUILDERS[eventData.eventType](
-      basePayload,
-      eventData.eventData,
-      eventData.workspaceId,
-    )
-  }
-
   private async executeRequest(
     url: string,
-    payload: unknown,
+    payload: WebhookPayload,
   ): Promise<Response> {
     await assertPublicUrl(url, "Webhook URL")
 
@@ -249,7 +52,7 @@ export class WebhookExecutor {
 
   private async attemptRequest(
     webhook: WebhookWithConditions,
-    payload: unknown,
+    payload: WebhookPayload,
     attempt: number,
   ): Promise<boolean> {
     try {
@@ -306,13 +109,11 @@ export class WebhookExecutor {
 
   async execute({
     webhook,
-    eventData,
+    payload,
   }: {
     webhook: WebhookWithConditions
-    eventData: MatchableWebhookEventData
+    payload: WebhookPayload
   }): Promise<void> {
-    const payload = await this.createPayload(eventData)
-
     for (let attempt = 1; attempt <= this.MAX_RETRIES; attempt++) {
       const shouldStop = await this.attemptRequest(webhook, payload, attempt)
 

--- a/apps/worker/src/webhook/services/webhook-matcher.service.ts
+++ b/apps/worker/src/webhook/services/webhook-matcher.service.ts
@@ -15,6 +15,7 @@ import type {
   WebhookWithConditions,
 } from "../types"
 import { WebhookExecutor } from "./webhook-executor.service"
+import { buildWebhookPayload } from "./webhook-payload.builder"
 
 const SCANNER_VERIFIED_EVENT_TYPE_SET: ReadonlySet<string> = new Set(
   SCANNER_VERIFIED_EVENT_TYPES,
@@ -84,23 +85,29 @@ export class WebhookMatcherService {
       return
     }
 
-    await Promise.allSettled(
-      filteredWebhooks.map(async (webhook) => {
-        const isMatch = await this.evaluateWebhookConditions(
-          webhook,
-          matchableEventData,
-          workspace,
-        )
-        if (!isMatch) {
-          return
-        }
+    const matchedWebhooks = await this.selectMatchingWebhooks(
+      filteredWebhooks,
+      matchableEventData,
+      workspace,
+    )
 
+    if (matchedWebhooks.length === 0) {
+      return
+    }
+
+    // Built once for the whole fan-out, and deliberately before the first
+    // delivery. A failure here is allowed to fail the job so the queue retries
+    // the event: nothing has been sent yet, so the retry cannot duplicate a
+    // delivery. Swallowing it instead would drop every webhook at once.
+    const payload = await buildWebhookPayload(matchableEventData)
+
+    await Promise.allSettled(
+      matchedWebhooks.map(async (webhook) => {
         try {
-          await this.webhookExecutor.execute({
-            webhook,
-            eventData: matchableEventData,
-          })
+          await this.webhookExecutor.execute({ webhook, payload })
         } catch (error) {
+          // Past this point deliveries are in flight, so one bad endpoint must
+          // not fail the job and trigger a retry that re-sends the others.
           logger.error(
             error,
             `Failed to execute webhook ${webhook.id} for workspace ${workspaceId}`,
@@ -108,6 +115,41 @@ export class WebhookMatcherService {
         }
       }),
     )
+  }
+
+  /**
+   * Evaluates every candidate concurrently and keeps the matches. A webhook
+   * whose conditions cannot be evaluated is skipped and logged rather than
+   * thrown: the matched webhooks are delivered after this step, so failing the
+   * job here would re-send them on the queue retry.
+   */
+  private async selectMatchingWebhooks(
+    webhooks: WebhookWithConditions[],
+    eventData: MatchableWebhookEventData,
+    workspace: WorkspaceModel,
+  ): Promise<WebhookWithConditions[]> {
+    const evaluated = await Promise.all(
+      webhooks.map(async (webhook) => {
+        try {
+          const isMatch = await this.evaluateWebhookConditions(
+            webhook,
+            eventData,
+            workspace,
+          )
+
+          return isMatch ? [webhook] : []
+        } catch (error) {
+          logger.error(
+            error,
+            `Failed to evaluate conditions for webhook ${webhook.id} in workspace ${eventData.workspaceId}`,
+          )
+
+          return []
+        }
+      }),
+    )
+
+    return evaluated.flat()
   }
 
   private async evaluateWebhookConditions(

--- a/apps/worker/src/webhook/services/webhook-payload.builder.ts
+++ b/apps/worker/src/webhook/services/webhook-payload.builder.ts
@@ -1,0 +1,216 @@
+import {
+  contactCustomFieldService,
+  contactService,
+} from "@chatbotx.io/business"
+import { db } from "@chatbotx.io/database/client"
+import { triggerEventTypes } from "@chatbotx.io/database/partials"
+import type { MatchableEventType } from "@chatbotx.io/events"
+import type { MatchableWebhookEventData, WebhookPayload } from "../types"
+
+type WebhookPayloadBase = {
+  event: string
+  contact_id: string
+  timestamp: Date
+}
+
+type PayloadBuilder = (
+  basePayload: WebhookPayloadBase,
+  data: Record<string, unknown>,
+  workspaceId: string,
+) => Promise<WebhookPayload> | WebhookPayload
+
+const EVENT_NAMES = {
+  [triggerEventTypes.enum.tagApplied]: "tag_applied",
+  [triggerEventTypes.enum.tagRemoved]: "tag_removed",
+  [triggerEventTypes.enum.customFieldValueChanged]: "custom_field_changed",
+  [triggerEventTypes.enum.contactInfoUpdated]: "contact_info_updated",
+  [triggerEventTypes.enum.conversationTransferredToHuman]:
+    "conversation_transferred_to_human",
+  [triggerEventTypes.enum.conversationTransferredToBot]:
+    "conversation_transferred_to_bot",
+  [triggerEventTypes.enum.newContact]: "new_contact",
+  [triggerEventTypes.enum.contactUnsubscribedFormBroadcast]:
+    "contact_unsubscribed",
+  [triggerEventTypes.enum.archived]: "conversation_archived",
+  [triggerEventTypes.enum.followUp]: "marked_as_follow_up",
+  [triggerEventTypes.enum.conversationAssigned]: "conversation_assigned",
+  [triggerEventTypes.enum.conversationUnassigned]: "conversation_unassigned",
+  [triggerEventTypes.enum.subscribedToSequence]: "subscribed_to_sequence",
+  [triggerEventTypes.enum.unsubscribedFromSequence]:
+    "unsubscribed_from_sequence",
+  [triggerEventTypes.enum.contactReferredANewContact]:
+    "contact_referred_a_new_contact",
+  [triggerEventTypes.enum.contactReferredExistingContact]:
+    "contact_referred_existing_contact",
+  [triggerEventTypes.enum.dateTimeBasedTrigger]: "datetime_based_trigger",
+} satisfies Record<MatchableEventType, string>
+
+async function buildTagPayload(
+  basePayload: WebhookPayloadBase,
+  data: Record<string, unknown>,
+  workspaceId: string,
+): Promise<WebhookPayload> {
+  // Scoped by workspace because the tag id comes from event metadata and tag ids
+  // are globally unique: an id-only lookup would resolve another tenant's tag
+  // and put its name in this workspace's outbound payload.
+  const tag = await db.query.tagModel.findFirst({
+    where: {
+      id: data.tagId as string,
+      workspaceId,
+      deletedAt: { isNull: true as const },
+    },
+    columns: { name: true },
+  })
+
+  return {
+    ...basePayload,
+    tag: tag?.name || "",
+  }
+}
+
+function buildCustomFieldPayload(
+  basePayload: WebhookPayloadBase,
+  data: Record<string, unknown>,
+): WebhookPayload {
+  return {
+    ...basePayload,
+    custom_field: {
+      name: data.customFieldName as string,
+      old_value: data.oldValue,
+      new_value: data.newValue,
+    },
+  }
+}
+
+function buildSequencePayload(
+  basePayload: WebhookPayloadBase,
+  data: Record<string, unknown>,
+): WebhookPayload {
+  return {
+    ...basePayload,
+    sequence_id: data.sequenceId as string,
+    sequence_name: data.sequenceName as string,
+  }
+}
+
+function buildReferralPayload(
+  basePayload: WebhookPayloadBase,
+  data: Record<string, unknown>,
+): WebhookPayload {
+  return {
+    ...basePayload,
+    ref_name: data.refName as string,
+    reflink_id: data.reflinkId as string,
+  }
+}
+
+async function buildNewContactPayload(
+  basePayload: WebhookPayloadBase,
+  data: Record<string, unknown>,
+  workspaceId: string,
+): Promise<WebhookPayload> {
+  const contact = await contactService.findById({
+    workspaceId,
+    id: basePayload.contact_id,
+  })
+  const customFields = contact
+    ? await contactCustomFieldService.listWithDefinitions({
+        contactId: contact.id,
+      })
+    : []
+
+  return {
+    ...basePayload,
+    name: contact?.fullName || (data.name as string) || null,
+    first_name: contact?.firstName || null,
+    last_name: contact?.lastName || null,
+    phone: contact?.phoneNumber || (data.phone as string) || null,
+    email: contact?.email || (data.email as string) || null,
+    custom_fields: Object.fromEntries(
+      customFields.map((field) => [field.name, field.value]),
+    ),
+  }
+}
+
+const PAYLOAD_BUILDERS = {
+  [triggerEventTypes.enum.tagApplied]: buildTagPayload,
+  [triggerEventTypes.enum.tagRemoved]: buildTagPayload,
+  [triggerEventTypes.enum.customFieldValueChanged]: buildCustomFieldPayload,
+  [triggerEventTypes.enum.contactInfoUpdated]: (basePayload, data) => ({
+    ...basePayload,
+    info_type: data.infoType as string,
+    old_value: (data.oldValue as string) || null,
+    new_value: data.newValue as string,
+  }),
+  [triggerEventTypes.enum.conversationTransferredToHuman]: (
+    basePayload,
+    data,
+  ) => ({
+    ...basePayload,
+    conversation_id: data.conversationId as string,
+    transferred_by: (data.transferredBy as string) || "bot",
+  }),
+  [triggerEventTypes.enum.conversationTransferredToBot]: (
+    basePayload,
+    data,
+  ) => ({
+    ...basePayload,
+    conversation_id: data.conversationId as string,
+    transferred_by: (data.transferredBy as string) || "system",
+  }),
+  [triggerEventTypes.enum.newContact]: buildNewContactPayload,
+  [triggerEventTypes.enum.contactUnsubscribedFormBroadcast]: (basePayload) =>
+    basePayload,
+  [triggerEventTypes.enum.archived]: (basePayload, data) => ({
+    ...basePayload,
+    conversation_id: data.conversationId as string,
+    archived_by: (data.archivedBy as string) || "system",
+  }),
+  [triggerEventTypes.enum.followUp]: (basePayload, data) => ({
+    ...basePayload,
+    conversation_id: data.conversationId as string,
+    marked_by: (data.markedBy as string) || "system",
+  }),
+  [triggerEventTypes.enum.conversationAssigned]: (basePayload, data) => ({
+    ...basePayload,
+    conversation_id: data.conversationId as string,
+    assigned_to: data.assignedTo as string,
+    assigned_by: (data.assignedBy as string) || "system",
+  }),
+  [triggerEventTypes.enum.conversationUnassigned]: (basePayload, data) => ({
+    ...basePayload,
+    conversation_id: data.conversationId as string,
+    unassigned_by: (data.unassignedBy as string) || "system",
+  }),
+  [triggerEventTypes.enum.subscribedToSequence]: buildSequencePayload,
+  [triggerEventTypes.enum.unsubscribedFromSequence]: buildSequencePayload,
+  [triggerEventTypes.enum.contactReferredANewContact]: buildReferralPayload,
+  [triggerEventTypes.enum.contactReferredExistingContact]: buildReferralPayload,
+  [triggerEventTypes.enum.dateTimeBasedTrigger]: (basePayload, data) => ({
+    ...basePayload,
+    ...data,
+  }),
+} satisfies Record<MatchableEventType, PayloadBuilder>
+
+/**
+ * Builds the request body for one event, independently of how many webhooks it
+ * will be sent to. Payload construction lives apart from delivery on purpose:
+ * it reads the database (a `new_contact` event resolves the stored contact and
+ * its custom fields), so callers build once per event and reuse the result for
+ * the whole fan-out instead of repeating those reads per webhook.
+ */
+export async function buildWebhookPayload(
+  eventData: MatchableWebhookEventData,
+): Promise<WebhookPayload> {
+  const basePayload = {
+    event: EVENT_NAMES[eventData.eventType],
+    contact_id: eventData.contactId,
+    timestamp: eventData.timestamp,
+  }
+
+  return await PAYLOAD_BUILDERS[eventData.eventType](
+    basePayload,
+    eventData.eventData,
+    eventData.workspaceId,
+  )
+}

--- a/apps/worker/src/webhook/types.ts
+++ b/apps/worker/src/webhook/types.ts
@@ -18,3 +18,9 @@ export type WebhookEventData = {
 export type MatchableWebhookEventData = WebhookEventData & {
   eventType: MatchableEventType
 }
+
+/**
+ * Outbound request body. One payload is built per event and shared by every
+ * webhook matched for it, so treat it as read-only once built.
+ */
+export type WebhookPayload = Record<string, unknown>

--- a/integrations/zalo/src/integration.ts
+++ b/integrations/zalo/src/integration.ts
@@ -54,7 +54,12 @@ const config: IntegrationDefinition<ZaloConfig, ZaloAuthValue, ZaloActions> = {
         )
     }
   },
-  disconnect: (_auth: ZaloAuthValue): Promise<void> => Promise.resolve(),
+  disconnect: async (_auth: ZaloAuthValue): Promise<void> => {
+    // Zalo OA webhooks are configured per-app in the Zalo Developer Console —
+    // there is no per-connection API to unsubscribe, so nothing to call here.
+    // Per-workspace teardown removes the local Zalo integration row, after
+    // which inbound events for that OA no longer resolve to a workspace.
+  },
   refreshAuth: async ({ auth }) => {
     if (!auth.tokens.refreshToken) {
       throw new AuthException("Zalo refresh token not available")

--- a/packages/business/__tests__/campaign-cleanup.test.ts
+++ b/packages/business/__tests__/campaign-cleanup.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, expect, test, vi } from "vitest"
+
+const updateReturningMock = vi.fn()
+const updateWhereMock = vi.fn()
+const updateSetMock = vi.fn()
+const updateMock = vi.fn()
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  and: (...conditions: unknown[]) => ({ __and: conditions }),
+  db: {
+    update: (...args: unknown[]) => updateMock(...args),
+  },
+  eq: (column: unknown, value: unknown) => ({ __eq: [column, value] }),
+  inArray: (column: unknown, value: unknown) => ({
+    __inArray: [column, value],
+  }),
+}))
+
+vi.mock("@chatbotx.io/database/partials", () => ({
+  broadcastStatuses: {
+    enum: {
+      cancelled: "cancelled",
+      scheduled: "scheduled",
+      sending: "sending",
+    },
+  },
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  broadcastModel: {
+    id: { __column: "broadcast.id" },
+    status: { __column: "broadcast.status" },
+    workspaceId: { __column: "broadcast.workspaceId" },
+  },
+  contactsOnSequenceModel: {
+    id: { __column: "contactsOnSequence.id" },
+    status: { __column: "contactsOnSequence.status" },
+    workspaceId: { __column: "contactsOnSequence.workspaceId" },
+  },
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  updateReturningMock.mockResolvedValue([{ id: "row-1" }])
+  updateWhereMock.mockReturnValue({ returning: updateReturningMock })
+  updateSetMock.mockReturnValue({ where: updateWhereMock })
+  updateMock.mockReturnValue({ set: updateSetMock })
+})
+
+test("cancelInFlightBroadcastsForWorkspace cancels scheduled and sending broadcasts only", async () => {
+  const { cancelInFlightBroadcastsForWorkspace } = await import(
+    "../src/workspace-lifecycle/campaign-cleanup"
+  )
+
+  const cancelledCount = await cancelInFlightBroadcastsForWorkspace({
+    workspaceId: "workspace-1",
+  })
+
+  expect(cancelledCount).toBe(1)
+  expect(updateMock).toHaveBeenCalledOnce()
+  expect(updateSetMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      status: "cancelled",
+    }),
+  )
+  expect(updateWhereMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      __and: expect.arrayContaining([
+        expect.objectContaining({
+          __eq: [
+            expect.objectContaining({ __column: "broadcast.workspaceId" }),
+            "workspace-1",
+          ],
+        }),
+        expect.objectContaining({
+          __inArray: [
+            expect.objectContaining({ __column: "broadcast.status" }),
+            ["scheduled", "sending"],
+          ],
+        }),
+      ]),
+    }),
+  )
+})
+
+test("completeActiveSequenceEnrollmentsForWorkspace marks active enrollments completed", async () => {
+  const { completeActiveSequenceEnrollmentsForWorkspace } = await import(
+    "../src/workspace-lifecycle/campaign-cleanup"
+  )
+
+  const completedCount = await completeActiveSequenceEnrollmentsForWorkspace({
+    workspaceId: "workspace-1",
+  })
+
+  expect(completedCount).toBe(1)
+  expect(updateMock).toHaveBeenCalledOnce()
+  expect(updateSetMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      status: "completed",
+      nextRunAt: null,
+      nextStepId: null,
+    }),
+  )
+  expect(updateWhereMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      __and: expect.arrayContaining([
+        expect.objectContaining({
+          __eq: [
+            expect.objectContaining({
+              __column: "contactsOnSequence.workspaceId",
+            }),
+            "workspace-1",
+          ],
+        }),
+        expect.objectContaining({
+          __eq: [
+            expect.objectContaining({ __column: "contactsOnSequence.status" }),
+            "active",
+          ],
+        }),
+      ]),
+    }),
+  )
+})

--- a/packages/business/__tests__/edge-safe-import-graph.test.ts
+++ b/packages/business/__tests__/edge-safe-import-graph.test.ts
@@ -1,0 +1,201 @@
+import { readFileSync } from "node:fs"
+import { dirname, join, relative, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, test } from "vitest"
+
+/**
+ * The builder's `instrumentation.ts` is compiled for BOTH the node and the edge
+ * runtime, and Next.js traces its import graph into each bundle. Anything the
+ * `@chatbotx.io/business` barrel reaches statically therefore has to survive the
+ * Edge Runtime, which has no Node built-ins — a single `import "crypto"` deep in
+ * the graph turns into a hard "Ecmascript file had an error" at build time.
+ *
+ * Scope is deliberate: this walks relative imports inside `packages/business`
+ * plus `@chatbotx.io/sequence-scheduler` (resolved through its `exports` map),
+ * because that is the boundary where the barrel drags queue/scheduler internals
+ * in. It is not a whole-monorepo Edge audit.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(HERE, "../../..")
+const BUSINESS_SRC = join(REPO_ROOT, "packages/business/src")
+const SCHEDULER_ROOT = join(REPO_ROOT, "packages/sequence-scheduler")
+
+const NODE_BUILTINS = new Set([
+  "assert",
+  "async_hooks",
+  "buffer",
+  "child_process",
+  "cluster",
+  "crypto",
+  "dgram",
+  "dns",
+  "fs",
+  "http",
+  "http2",
+  "https",
+  "net",
+  "os",
+  "path",
+  "perf_hooks",
+  "process",
+  "readline",
+  "stream",
+  "timers",
+  "tls",
+  "tty",
+  "url",
+  "util",
+  "v8",
+  "vm",
+  "worker_threads",
+  "zlib",
+])
+
+const SCHEDULER_BARREL_IMPORT = /from "@chatbotx\.io\/sequence-scheduler"/
+
+const isNodeBuiltin = (specifier: string): boolean =>
+  specifier.startsWith("node:") || NODE_BUILTINS.has(specifier)
+
+/** Static `from "x"` / `import "x"` specifiers. Dynamic import() is banned repo-wide. */
+const collectSpecifiers = (source: string): string[] => {
+  const specifiers = new Set<string>()
+  const fromPattern = /\bfrom\s+["']([^"']+)["']/g
+  const bareImportPattern = /\bimport\s+["']([^"']+)["']/g
+
+  for (const pattern of [fromPattern, bareImportPattern]) {
+    let match = pattern.exec(source)
+    while (match) {
+      if (match[1]) {
+        specifiers.add(match[1])
+      }
+      match = pattern.exec(source)
+    }
+  }
+
+  return [...specifiers]
+}
+
+const readIfFile = (path: string): string | null => {
+  try {
+    return readFileSync(path, "utf8")
+  } catch {
+    return null
+  }
+}
+
+/** TS path resolution: `./x` may be x.ts, x.tsx, or x/index.ts. */
+const resolveFile = (base: string): string | null => {
+  for (const candidate of [
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    join(base, "index.ts"),
+    join(base, "index.tsx"),
+  ]) {
+    const isTsSource = candidate.endsWith(".ts") || candidate.endsWith(".tsx")
+
+    if (isTsSource && readIfFile(candidate) !== null) {
+      return candidate
+    }
+  }
+
+  return null
+}
+
+const schedulerExports = (): Record<string, string> =>
+  JSON.parse(readFileSync(join(SCHEDULER_ROOT, "package.json"), "utf8")).exports
+
+/**
+ * Resolves only what this audit covers. Returns null for every other package so
+ * the walk stays inside the business ↔ sequence-scheduler boundary.
+ */
+const resolveSpecifier = (
+  specifier: string,
+  importerPath: string,
+): string | null => {
+  if (specifier.startsWith(".")) {
+    return resolveFile(resolve(dirname(importerPath), specifier))
+  }
+
+  if (specifier === "@chatbotx.io/sequence-scheduler") {
+    const target = schedulerExports()["."]
+    return target ? join(SCHEDULER_ROOT, target) : null
+  }
+
+  if (specifier.startsWith("@chatbotx.io/sequence-scheduler/")) {
+    const subpath = `.${specifier.slice("@chatbotx.io/sequence-scheduler".length)}`
+    const target = schedulerExports()[subpath]
+    return target ? join(SCHEDULER_ROOT, target) : null
+  }
+
+  return null
+}
+
+type Violation = { builtin: string; chain: string[] }
+
+const auditFrom = (entry: string): Violation[] => {
+  const parents = new Map<string, string | null>([[entry, null]])
+  const queue = [entry]
+  const violations: Violation[] = []
+
+  const chainTo = (path: string): string[] => {
+    const chain: string[] = []
+    let cursor: string | null | undefined = path
+    while (cursor) {
+      chain.unshift(relative(REPO_ROOT, cursor))
+      cursor = parents.get(cursor)
+    }
+    return chain
+  }
+
+  while (queue.length > 0) {
+    const current = queue.shift() as string
+    const source = readIfFile(current)
+    if (source === null) {
+      continue
+    }
+
+    for (const specifier of collectSpecifiers(source)) {
+      if (isNodeBuiltin(specifier)) {
+        violations.push({ builtin: specifier, chain: chainTo(current) })
+        continue
+      }
+
+      const resolved = resolveSpecifier(specifier, current)
+      if (!resolved || parents.has(resolved)) {
+        continue
+      }
+
+      parents.set(resolved, current)
+      queue.push(resolved)
+    }
+  }
+
+  return violations
+}
+
+describe("@chatbotx.io/business barrel stays Edge-Runtime safe", () => {
+  test("reaches no Node built-in through the sequence-scheduler boundary", () => {
+    const violations = auditFrom(join(BUSINESS_SRC, "index.ts"))
+
+    const report = violations
+      .map((v) => `${v.builtin} via\n    ${v.chain.join("\n    → ")}`)
+      .join("\n\n")
+
+    expect(report).toBe("")
+  })
+
+  test("freezeWorkspaceRuntime keeps cancelling dispatches through a crypto-free module", () => {
+    // Guards the fix's intent, not just its absence of symptoms: the freeze path
+    // must still reach the real cancel + Redis-removal helpers.
+    const service = readFileSync(
+      join(BUSINESS_SRC, "workspace-lifecycle/service.ts"),
+      "utf8",
+    )
+
+    expect(service).toContain("cancelPendingDispatchesForWorkspace")
+    expect(service).toContain("removeDispatchesFromSchedule")
+    expect(service).not.toMatch(SCHEDULER_BARREL_IMPORT)
+  })
+})

--- a/packages/business/__tests__/email-topic-click-url.test.ts
+++ b/packages/business/__tests__/email-topic-click-url.test.ts
@@ -9,17 +9,20 @@ const URL_RE = /^[A-Za-z0-9\-_]+$/ // base64url alphabet, no padding
 describe("email-topic click url signing", () => {
   test("round-trips the destination url", async () => {
     const url = "https://customer.example.com/landing?utm=abc&x=1"
-    const token = await signEmailClickUrl(url)
-    expect(await verifyEmailClickToken(token)).toBe(url)
+    const token = await signEmailClickUrl(url, "workspace-1")
+    await expect(verifyEmailClickToken(token)).resolves.toMatchObject({
+      url,
+      workspaceId: "workspace-1",
+    })
   })
 
   test("produces a URL-safe (base64url) token", async () => {
-    const token = await signEmailClickUrl("https://example.com")
+    const token = await signEmailClickUrl("https://example.com", "workspace-1")
     expect(token).toMatch(URL_RE)
   })
 
   test("rejects a tampered token", async () => {
-    const token = await signEmailClickUrl("https://example.com")
+    const token = await signEmailClickUrl("https://example.com", "workspace-1")
     // Flip a character in the middle of the token to corrupt the ciphertext.
     const mid = Math.floor(token.length / 2)
     const tampered = `${token.slice(0, mid)}${token[mid] === "A" ? "B" : "A"}${token.slice(mid + 1)}`

--- a/packages/business/__tests__/live-counter-store.test.ts
+++ b/packages/business/__tests__/live-counter-store.test.ts
@@ -69,15 +69,7 @@ beforeEach(() => {
 
 describe("LiveCounterStore.getLiveCounts (via getLiveUsage)", () => {
   test("returns parsed live values in one HMGET without touching the DB", async () => {
-    redisClient.hmget.mockResolvedValue([
-      "1",
-      "2",
-      "3",
-      "4",
-      "5",
-      "6",
-      "7",
-    ])
+    redisClient.hmget.mockResolvedValue(["1", "2", "3", "4", "5", "6", "7"])
 
     const usage = await userQuotaService.getLiveUsage(USER)
 
@@ -102,15 +94,7 @@ describe("LiveCounterStore.getLiveCounts (via getLiveUsage)", () => {
 
   test("cold-seeds a missing field from a single DB fetch", async () => {
     // mac field absent (cold start); the rest are live.
-    redisClient.hmget.mockResolvedValue([
-      "1",
-      "2",
-      "3",
-      "4",
-      null,
-      "6",
-      "7",
-    ])
+    redisClient.hmget.mockResolvedValue(["1", "2", "3", "4", null, "6", "7"])
 
     const usage = await userQuotaService.getLiveUsage(USER)
 

--- a/packages/business/__tests__/smart-delay-service.test.ts
+++ b/packages/business/__tests__/smart-delay-service.test.ts
@@ -319,4 +319,30 @@ describe("smartDelayService", () => {
 
     expect(mockDbUpdate).not.toHaveBeenCalled()
   })
+
+  test("cancelActiveForWorkspace cancels a bounded batch of the workspace's live rows", async () => {
+    const canceled = [
+      { id: "row-1", triggerAt: new Date("2026-07-16T00:01:00.000Z") },
+      { id: "row-2", triggerAt: new Date("2026-07-16T00:02:00.000Z") },
+    ]
+    mockDbReturning.mockResolvedValueOnce(canceled)
+
+    await expect(
+      smartDelayService.cancelActiveForWorkspace({
+        limit: 500,
+        workspaceId: "workspace-1",
+      }),
+    ).resolves.toEqual(canceled)
+
+    expect(mockDbSet).toHaveBeenCalledWith({ status: "canceled" })
+    expect(mockEq).toHaveBeenCalledWith(expect.anything(), "workspace-1")
+    // Only rows that can still fire — completed/failed/canceled are left alone.
+    expect(mockInArray).toHaveBeenCalledWith(expect.anything(), [
+      "pending",
+      "scheduled",
+    ])
+    // Bounded claim so a workspace with a huge backlog cannot lock the table.
+    expect(mockDbLimit).toHaveBeenCalledWith(500)
+    expect(mockDbFor).toHaveBeenCalledWith("update", { skipLocked: true })
+  })
 })

--- a/packages/business/__tests__/with-blocked-owner-guard.test.ts
+++ b/packages/business/__tests__/with-blocked-owner-guard.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockLoggerInfo, mockGetAccessState, mockWorkspaceFind } = vi.hoisted(
+  () => ({
+    mockLoggerInfo: vi.fn(),
+    mockGetAccessState: vi.fn(),
+    mockWorkspaceFind: vi.fn(),
+  }),
+)
+
+vi.mock("../src/logger", () => ({
+  logger: {
+    info: mockLoggerInfo,
+  },
+}))
+
+vi.mock("../src/user-quota/service", () => ({
+  userQuotaService: {
+    getAccessState: mockGetAccessState,
+  },
+}))
+
+vi.mock("../src/workspace/service", () => ({
+  workspaceService: {
+    find: mockWorkspaceFind,
+  },
+}))
+
+const { withBlockedOwnerGuard } = await import(
+  "../src/workspace-lifecycle/with-blocked-owner-guard"
+)
+
+const allowedAccessState = {
+  blocked: false,
+  planName: "Trial",
+  status: "trial",
+  trialEndsAt: null,
+}
+
+const blockedAccessState = {
+  ...allowedAccessState,
+  blocked: true,
+}
+
+const workspace = {
+  id: "workspace-1",
+  ownerId: "owner-1",
+  scheduledDeletionAt: null,
+}
+
+describe("withBlockedOwnerGuard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockWorkspaceFind.mockResolvedValue(workspace)
+    mockGetAccessState.mockResolvedValue(allowedAccessState)
+  })
+
+  test("runs the callback when the workspace is not scheduled for deletion and the owner is not blocked", async () => {
+    const fn = vi.fn(async () => "ran")
+
+    await expect(withBlockedOwnerGuard("workspace-1", fn)).resolves.toBe("ran")
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(mockLoggerInfo).not.toHaveBeenCalled()
+  })
+
+  test("skips the callback when the workspace is scheduled for deletion", async () => {
+    mockWorkspaceFind.mockResolvedValue({
+      ...workspace,
+      scheduledDeletionAt: new Date("2026-01-01T00:00:00Z"),
+    })
+    const fn = vi.fn(async () => "ran")
+
+    await expect(withBlockedOwnerGuard("workspace-1", fn)).resolves.toBe(
+      undefined,
+    )
+
+    expect(fn).not.toHaveBeenCalled()
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      {
+        freezeReason: "scheduledForDeletion",
+        ownerId: "owner-1",
+        workspaceId: "workspace-1",
+      },
+      "Skipping workspace job for frozen workspace",
+    )
+  })
+
+  test("skips the callback when the owner is blocked", async () => {
+    mockGetAccessState.mockResolvedValue(blockedAccessState)
+    const fn = vi.fn(async () => "ran")
+
+    await expect(withBlockedOwnerGuard("workspace-1", fn)).resolves.toBe(
+      undefined,
+    )
+
+    expect(fn).not.toHaveBeenCalled()
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      {
+        freezeReason: "ownerBlocked",
+        ownerId: "owner-1",
+        workspaceId: "workspace-1",
+      },
+      "Skipping workspace job for frozen workspace",
+    )
+  })
+
+  test("keeps fail-open behavior when no workspace id is available", async () => {
+    const fn = vi.fn(async () => "ran")
+
+    await expect(withBlockedOwnerGuard(undefined, fn)).resolves.toBe("ran")
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(mockWorkspaceFind).not.toHaveBeenCalled()
+    expect(mockGetAccessState).not.toHaveBeenCalled()
+  })
+})

--- a/packages/business/__tests__/with-blocked-owner-guard.test.ts
+++ b/packages/business/__tests__/with-blocked-owner-guard.test.ts
@@ -1,17 +1,21 @@
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
-const { mockLoggerInfo, mockGetAccessState, mockWorkspaceFind } = vi.hoisted(
-  () => ({
+const { mockLoggerInfo, mockGetAccessState, mockWorkspaceFind, mockIsCloud } =
+  vi.hoisted(() => ({
     mockLoggerInfo: vi.fn(),
     mockGetAccessState: vi.fn(),
     mockWorkspaceFind: vi.fn(),
-  }),
-)
+    mockIsCloud: vi.fn(),
+  }))
 
 vi.mock("../src/logger", () => ({
   logger: {
     info: mockLoggerInfo,
   },
+}))
+
+vi.mock("../src/keys", () => ({
+  isCloud: mockIsCloud,
 }))
 
 vi.mock("../src/user-quota/service", () => ({
@@ -51,6 +55,7 @@ const workspace = {
 describe("withBlockedOwnerGuard", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockIsCloud.mockReturnValue(true)
     mockWorkspaceFind.mockResolvedValue(workspace)
     mockGetAccessState.mockResolvedValue(allowedAccessState)
   })
@@ -103,6 +108,76 @@ describe("withBlockedOwnerGuard", () => {
       },
       "Skipping workspace job for frozen workspace",
     )
+  })
+
+  test("skips the callback when the workspace row no longer exists", async () => {
+    mockWorkspaceFind.mockResolvedValue(undefined)
+    const fn = vi.fn(async () => "ran")
+
+    await expect(withBlockedOwnerGuard("workspace-1", fn)).resolves.toBe(
+      undefined,
+    )
+
+    expect(fn).not.toHaveBeenCalled()
+    expect(mockGetAccessState).not.toHaveBeenCalled()
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      {
+        freezeReason: "missingWorkspace",
+        ownerId: undefined,
+        workspaceId: "workspace-1",
+      },
+      "Skipping workspace job for frozen workspace",
+    )
+  })
+
+  test("never reads owner quota on non-cloud editions, where no owner can be entitlement-blocked", async () => {
+    mockIsCloud.mockReturnValue(false)
+    const fn = vi.fn(async () => "ran")
+
+    await expect(withBlockedOwnerGuard("workspace-1", fn)).resolves.toBe("ran")
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(mockGetAccessState).not.toHaveBeenCalled()
+  })
+
+  test("still skips a workspace scheduled for deletion on non-cloud editions", async () => {
+    mockIsCloud.mockReturnValue(false)
+    mockWorkspaceFind.mockResolvedValue({
+      ...workspace,
+      scheduledDeletionAt: new Date("2026-01-01T00:00:00Z"),
+    })
+    const fn = vi.fn(async () => "ran")
+
+    await expect(withBlockedOwnerGuard("workspace-1", fn)).resolves.toBe(
+      undefined,
+    )
+
+    expect(fn).not.toHaveBeenCalled()
+    expect(mockGetAccessState).not.toHaveBeenCalled()
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      {
+        freezeReason: "scheduledForDeletion",
+        ownerId: "owner-1",
+        workspaceId: "workspace-1",
+      },
+      "Skipping workspace job for frozen workspace",
+    )
+  })
+
+  test("skips a workspace scheduled for deletion without consulting quota, so a quota fault cannot break the deletion freeze", async () => {
+    mockWorkspaceFind.mockResolvedValue({
+      ...workspace,
+      scheduledDeletionAt: new Date("2026-01-01T00:00:00Z"),
+    })
+    mockGetAccessState.mockRejectedValue(new Error("quota read exploded"))
+    const fn = vi.fn(async () => "ran")
+
+    await expect(withBlockedOwnerGuard("workspace-1", fn)).resolves.toBe(
+      undefined,
+    )
+
+    expect(fn).not.toHaveBeenCalled()
+    expect(mockGetAccessState).not.toHaveBeenCalled()
   })
 
   test("keeps fail-open behavior when no workspace id is available", async () => {

--- a/packages/business/__tests__/workspace-lifecycle.predicates.test.ts
+++ b/packages/business/__tests__/workspace-lifecycle.predicates.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest"
-import { isWorkspaceScheduledForDeletion } from "../src/workspace-lifecycle/predicates"
+import {
+  isWorkspaceScheduledForDeletion,
+  resolveWorkspaceFreezeReason,
+} from "../src/workspace-lifecycle/predicates"
 
 describe("isWorkspaceScheduledForDeletion", () => {
   test.each([
@@ -13,5 +16,52 @@ describe("isWorkspaceScheduledForDeletion", () => {
     expect(isWorkspaceScheduledForDeletion({ scheduledDeletionAt })).toBe(
       expected,
     )
+  })
+})
+
+describe("resolveWorkspaceFreezeReason", () => {
+  const liveWorkspace = { scheduledDeletionAt: null }
+  const allowed = { blocked: false }
+
+  test("returns null when the workspace is live and the owner is not blocked", () => {
+    expect(
+      resolveWorkspaceFreezeReason({
+        accessState: allowed,
+        workspace: liveWorkspace,
+      }),
+    ).toBeNull()
+  })
+
+  test("returns missingWorkspace when the workspace row no longer exists", () => {
+    expect(
+      resolveWorkspaceFreezeReason({
+        accessState: allowed,
+        workspace: null,
+      }),
+    ).toBe("missingWorkspace")
+  })
+
+  test("returns scheduledForDeletion before ownerBlocked when both apply", () => {
+    expect(
+      resolveWorkspaceFreezeReason({
+        accessState: { blocked: true },
+        workspace: { scheduledDeletionAt: new Date("2026-01-01T00:00:00Z") },
+      }),
+    ).toBe("scheduledForDeletion")
+  })
+
+  test("returns ownerBlocked when only the owner entitlement is blocked", () => {
+    expect(
+      resolveWorkspaceFreezeReason({
+        accessState: { blocked: true },
+        workspace: liveWorkspace,
+      }),
+    ).toBe("ownerBlocked")
+  })
+
+  test("ignores the owner entitlement when no access state is supplied", () => {
+    expect(
+      resolveWorkspaceFreezeReason({ workspace: liveWorkspace }),
+    ).toBeNull()
   })
 })

--- a/packages/business/__tests__/workspace-lifecycle.predicates.test.ts
+++ b/packages/business/__tests__/workspace-lifecycle.predicates.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest"
+import { isWorkspaceScheduledForDeletion } from "../src/workspace-lifecycle/predicates"
+
+describe("isWorkspaceScheduledForDeletion", () => {
+  test.each([
+    { scheduledDeletionAt: new Date("2026-01-01T00:00:00Z"), expected: true },
+    { scheduledDeletionAt: null, expected: false },
+    { scheduledDeletionAt: undefined, expected: false },
+  ])("returns $expected for $scheduledDeletionAt", ({
+    scheduledDeletionAt,
+    expected,
+  }) => {
+    expect(isWorkspaceScheduledForDeletion({ scheduledDeletionAt })).toBe(
+      expected,
+    )
+  })
+})

--- a/packages/business/__tests__/workspace-lifecycle.service.test.ts
+++ b/packages/business/__tests__/workspace-lifecycle.service.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, expect, test, vi } from "vitest"
+
+const order: string[] = []
+const transactionMock = vi.fn()
+const cancelInFlightBroadcastsForWorkspaceMock = vi.fn()
+const completeActiveSequenceEnrollmentsForWorkspaceMock = vi.fn()
+const cancelPendingDispatchesForWorkspaceMock = vi.fn()
+const removeDispatchesFromScheduleMock = vi.fn()
+const loggerWarnMock = vi.fn()
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    transaction: transactionMock,
+  },
+}))
+
+vi.mock("@chatbotx.io/sequence-scheduler", () => ({
+  cancelPendingDispatchesForWorkspace: cancelPendingDispatchesForWorkspaceMock,
+  removeDispatchesFromSchedule: removeDispatchesFromScheduleMock,
+}))
+
+vi.mock("../src/base.service", () => ({
+  BaseService: class {},
+}))
+
+vi.mock("../src/workspace-lifecycle/campaign-cleanup", () => ({
+  cancelInFlightBroadcastsForWorkspace:
+    cancelInFlightBroadcastsForWorkspaceMock,
+  completeActiveSequenceEnrollmentsForWorkspace:
+    completeActiveSequenceEnrollmentsForWorkspaceMock,
+}))
+
+vi.mock("../src/inbox/service", () => ({
+  inboxService: {
+    listWithIntegrationsByWorkspace: vi.fn(),
+  },
+}))
+
+vi.mock("../src/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: loggerWarnMock,
+  },
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  order.length = 0
+  transactionMock.mockImplementation(
+    async (callback: (tx: unknown) => Promise<unknown>) => {
+      const result = await callback({})
+      order.push("tx-done")
+      return result
+    },
+  )
+  cancelInFlightBroadcastsForWorkspaceMock.mockImplementation(() => {
+    order.push("broadcast")
+    return Promise.resolve(2)
+  })
+  completeActiveSequenceEnrollmentsForWorkspaceMock.mockImplementation(() => {
+    order.push("enrollments")
+    return Promise.resolve(3)
+  })
+  cancelPendingDispatchesForWorkspaceMock.mockImplementation(() => {
+    order.push("dispatches")
+    return Promise.resolve([{ id: "dispatch-1", bucket: 1 }])
+  })
+  removeDispatchesFromScheduleMock.mockImplementation(() => {
+    order.push("remove")
+    return Promise.resolve()
+  })
+})
+
+test("cancelInFlightCampaigns runs cleanup in one transaction and removes Redis entries after commit", async () => {
+  const { workspaceLifecycleService } = await import(
+    "../src/workspace-lifecycle/service"
+  )
+
+  const result =
+    await workspaceLifecycleService.cancelInFlightCampaigns("workspace-1")
+
+  expect(result).toEqual([{ id: "dispatch-1", bucket: 1 }])
+  expect(transactionMock).toHaveBeenCalledOnce()
+  expect(cancelInFlightBroadcastsForWorkspaceMock).toHaveBeenCalledWith({
+    tx: {},
+    workspaceId: "workspace-1",
+  })
+  expect(
+    completeActiveSequenceEnrollmentsForWorkspaceMock,
+  ).toHaveBeenCalledWith({
+    tx: {},
+    workspaceId: "workspace-1",
+  })
+  expect(cancelPendingDispatchesForWorkspaceMock).toHaveBeenCalledWith({
+    client: {},
+    removeFromSchedule: false,
+    workspaceId: "workspace-1",
+  })
+  expect(removeDispatchesFromScheduleMock).toHaveBeenCalledWith([
+    { id: "dispatch-1", bucket: 1 },
+  ])
+  expect(order).toEqual([
+    "broadcast",
+    "enrollments",
+    "dispatches",
+    "tx-done",
+    "remove",
+  ])
+})

--- a/packages/business/__tests__/workspace-lifecycle.service.test.ts
+++ b/packages/business/__tests__/workspace-lifecycle.service.test.ts
@@ -6,6 +6,7 @@ const cancelInFlightBroadcastsForWorkspaceMock = vi.fn()
 const completeActiveSequenceEnrollmentsForWorkspaceMock = vi.fn()
 const cancelPendingDispatchesForWorkspaceMock = vi.fn()
 const removeDispatchesFromScheduleMock = vi.fn()
+const cancelSmartDelaysForWorkspaceMock = vi.fn()
 const loggerWarnMock = vi.fn()
 
 vi.mock("@chatbotx.io/database/client", () => ({
@@ -14,7 +15,7 @@ vi.mock("@chatbotx.io/database/client", () => ({
   },
 }))
 
-vi.mock("@chatbotx.io/sequence-scheduler", () => ({
+vi.mock("@chatbotx.io/sequence-scheduler/dispatch-cancel", () => ({
   cancelPendingDispatchesForWorkspace: cancelPendingDispatchesForWorkspaceMock,
   removeDispatchesFromSchedule: removeDispatchesFromScheduleMock,
 }))
@@ -28,6 +29,10 @@ vi.mock("../src/workspace-lifecycle/campaign-cleanup", () => ({
     cancelInFlightBroadcastsForWorkspaceMock,
   completeActiveSequenceEnrollmentsForWorkspace:
     completeActiveSequenceEnrollmentsForWorkspaceMock,
+}))
+
+vi.mock("../src/workspace-lifecycle/smart-delay-cleanup", () => ({
+  cancelSmartDelaysForWorkspace: cancelSmartDelaysForWorkspaceMock,
 }))
 
 vi.mock("../src/inbox/service", () => ({
@@ -70,17 +75,19 @@ beforeEach(() => {
     order.push("remove")
     return Promise.resolve()
   })
+  cancelSmartDelaysForWorkspaceMock.mockImplementation(() => {
+    order.push("smart-delays")
+    return Promise.resolve(7)
+  })
 })
 
-test("cancelInFlightCampaigns runs cleanup in one transaction and removes Redis entries after commit", async () => {
+test("freezeWorkspaceRuntime runs cleanup in one transaction and removes Redis entries after commit", async () => {
   const { workspaceLifecycleService } = await import(
     "../src/workspace-lifecycle/service"
   )
 
-  const result =
-    await workspaceLifecycleService.cancelInFlightCampaigns("workspace-1")
+  await workspaceLifecycleService.freezeWorkspaceRuntime("workspace-1")
 
-  expect(result).toEqual([{ id: "dispatch-1", bucket: 1 }])
   expect(transactionMock).toHaveBeenCalledOnce()
   expect(cancelInFlightBroadcastsForWorkspaceMock).toHaveBeenCalledWith({
     tx: {},
@@ -100,11 +107,49 @@ test("cancelInFlightCampaigns runs cleanup in one transaction and removes Redis 
   expect(removeDispatchesFromScheduleMock).toHaveBeenCalledWith([
     { id: "dispatch-1", bucket: 1 },
   ])
+  expect(cancelSmartDelaysForWorkspaceMock).toHaveBeenCalledWith({
+    workspaceId: "workspace-1",
+  })
   expect(order).toEqual([
     "broadcast",
     "enrollments",
     "dispatches",
     "tx-done",
     "remove",
+    "smart-delays",
   ])
+})
+
+test("freezeWorkspaceRuntime still cancels smart delays when dispatch cleanup fails", async () => {
+  // Broadcasts/sequences and wait steps are independent runtime sources: a
+  // Redis failure on one must not leave the other armed.
+  removeDispatchesFromScheduleMock.mockRejectedValueOnce(
+    new Error("redis down"),
+  )
+
+  const { workspaceLifecycleService } = await import(
+    "../src/workspace-lifecycle/service"
+  )
+
+  await workspaceLifecycleService.freezeWorkspaceRuntime("workspace-1")
+
+  expect(loggerWarnMock).toHaveBeenCalledOnce()
+  expect(cancelSmartDelaysForWorkspaceMock).toHaveBeenCalledWith({
+    workspaceId: "workspace-1",
+  })
+})
+
+test("freezeWorkspaceRuntime does not throw when smart-delay cancellation fails", async () => {
+  cancelSmartDelaysForWorkspaceMock.mockRejectedValueOnce(
+    new Error("redis down"),
+  )
+
+  const { workspaceLifecycleService } = await import(
+    "../src/workspace-lifecycle/service"
+  )
+
+  await expect(
+    workspaceLifecycleService.freezeWorkspaceRuntime("workspace-1"),
+  ).resolves.toBeUndefined()
+  expect(loggerWarnMock).toHaveBeenCalledOnce()
 })

--- a/packages/business/__tests__/workspace-lifecycle.smart-delay-cleanup.test.ts
+++ b/packages/business/__tests__/workspace-lifecycle.smart-delay-cleanup.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const cancelActiveForWorkspace = vi.fn()
+const queueRemove = vi.fn()
+const loggerWarn = vi.fn()
+
+vi.mock("@chatbotx.io/worker-config", () => ({
+  integrationQueue: { remove: queueRemove },
+}))
+
+vi.mock("../src/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: loggerWarn },
+}))
+
+vi.mock("../src/smart-delay/service", () => ({
+  smartDelayService: { cancelActiveForWorkspace },
+}))
+
+const { cancelSmartDelaysForWorkspace, SMART_DELAY_CANCEL_BATCH_SIZE } =
+  await import("../src/workspace-lifecycle/smart-delay-cleanup")
+
+const rowsOfSize = (size: number, offset = 0) =>
+  Array.from({ length: size }, (_, index) => ({
+    id: `row-${offset + index}`,
+    triggerAt: new Date(`2026-07-16T00:0${(index % 9) + 1}:00.000Z`),
+  }))
+
+describe("cancelSmartDelaysForWorkspace", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queueRemove.mockResolvedValue(undefined)
+  })
+
+  test("cancels nothing and touches no queue when the workspace has no live rows", async () => {
+    cancelActiveForWorkspace.mockResolvedValueOnce([])
+
+    await expect(
+      cancelSmartDelaysForWorkspace({ workspaceId: "workspace-1" }),
+    ).resolves.toBe(0)
+
+    expect(cancelActiveForWorkspace).toHaveBeenCalledOnce()
+    expect(queueRemove).not.toHaveBeenCalled()
+  })
+
+  test("removes the deterministic delayed job for every canceled row", async () => {
+    cancelActiveForWorkspace.mockResolvedValueOnce([
+      { id: "row-1", triggerAt: new Date("2026-07-16T00:01:00.000Z") },
+    ])
+
+    await expect(
+      cancelSmartDelaysForWorkspace({ workspaceId: "workspace-1" }),
+    ).resolves.toBe(1)
+
+    expect(queueRemove).toHaveBeenCalledWith(
+      `smart-delay-row-1-${new Date("2026-07-16T00:01:00.000Z").getTime()}`,
+    )
+  })
+
+  test("keeps draining while batches come back full", async () => {
+    cancelActiveForWorkspace
+      .mockResolvedValueOnce(rowsOfSize(SMART_DELAY_CANCEL_BATCH_SIZE))
+      .mockResolvedValueOnce(rowsOfSize(3, SMART_DELAY_CANCEL_BATCH_SIZE))
+
+    await expect(
+      cancelSmartDelaysForWorkspace({ workspaceId: "workspace-1" }),
+    ).resolves.toBe(SMART_DELAY_CANCEL_BATCH_SIZE + 3)
+
+    expect(cancelActiveForWorkspace).toHaveBeenCalledTimes(2)
+    expect(cancelActiveForWorkspace).toHaveBeenLastCalledWith({
+      limit: SMART_DELAY_CANCEL_BATCH_SIZE,
+      workspaceId: "workspace-1",
+    })
+  })
+
+  test("still reports the cancellation when removing the delayed job fails", async () => {
+    cancelActiveForWorkspace.mockResolvedValueOnce([
+      { id: "row-1", triggerAt: new Date("2026-07-16T00:01:00.000Z") },
+    ])
+    queueRemove.mockRejectedValueOnce(new Error("redis down"))
+
+    // The row is already canceled, so a surviving job is a no-op when it wakes:
+    // removal is cleanup, never correctness.
+    await expect(
+      cancelSmartDelaysForWorkspace({ workspaceId: "workspace-1" }),
+    ).resolves.toBe(1)
+  })
+})

--- a/packages/business/package.json
+++ b/packages/business/package.json
@@ -15,7 +15,8 @@
     "./errors": "./src/errors.ts",
     "./referral": "./src/referral/index.ts",
     "./system-field": "./src/system-field/index.ts",
-    "./utils": "./src/utils.ts"
+    "./utils": "./src/utils.ts",
+    "./workspace-lifecycle/predicates": "./src/workspace-lifecycle/predicates.ts"
   },
   "dependencies": {
     "@chatbotx.io/analytics": "workspace:*",

--- a/packages/business/src/email-topic/click-url.ts
+++ b/packages/business/src/email-topic/click-url.ts
@@ -8,7 +8,9 @@ const TOKEN_TTL_MS = 365 * 24 * 60 * 60 * 1000 // 1 year
 const encryptedClickPayloadSchema = z.object({
   url: z.string(),
   exp: z.number(),
+  workspaceId: z.string().optional(),
 })
+type EmailClickPayload = z.infer<typeof encryptedClickPayloadSchema>
 
 /**
  * Seal a redirect destination into an authenticated token.
@@ -18,10 +20,14 @@ const encryptedClickPayloadSchema = z.object({
  * redirect. The token is URL-safe (base64url) and can be passed as a query
  * param without further encoding.
  */
-export async function signEmailClickUrl(url: string): Promise<string> {
+export async function signEmailClickUrl(
+  url: string,
+  workspaceId: string,
+): Promise<string> {
   const encrypted = await encryptUtils.encryptObject({
     url,
     exp: Date.now() + TOKEN_TTL_MS,
+    workspaceId,
   })
   return Buffer.from(JSON.stringify(encrypted)).toString("base64url")
 }
@@ -32,15 +38,17 @@ export async function signEmailClickUrl(url: string): Promise<string> {
  * Throws if the token is malformed, fails authentication (tampered), or has
  * expired. Callers must treat any throw as "do not trust this destination".
  */
-export async function verifyEmailClickToken(token: string): Promise<string> {
+export async function verifyEmailClickToken(
+  token: string,
+): Promise<EmailClickPayload> {
   const json = Buffer.from(token, "base64url").toString("utf8")
   const encrypted = encryptedDataSchema.parse(JSON.parse(json))
-  const { url, exp } = await encryptUtils.decryptObject(
+  const payload = await encryptUtils.decryptObject(
     encrypted,
     encryptedClickPayloadSchema,
   )
-  if (exp < Date.now()) {
+  if (payload.exp < Date.now()) {
     throw new Error("Email click token has expired")
   }
-  return url
+  return payload
 }

--- a/packages/business/src/email-topic/service.ts
+++ b/packages/business/src/email-topic/service.ts
@@ -38,6 +38,19 @@ type UpdateEmailTopicData = {
 }
 
 class EmailTopicService {
+  async findAnalyticsWorkspaceIdByToken(props: {
+    token: string
+    tx?: DatabaseClient
+  }): Promise<string | undefined> {
+    const { token, tx = db } = props
+    const row = await tx.query.analyticsEmailTopicModel.findFirst({
+      columns: { workspaceId: true },
+      where: { token },
+    })
+
+    return row?.workspaceId
+  }
+
   async list(
     input: ListEmailTopicsInput,
   ): Promise<PaginatedResult<EmailTopicModel>> {

--- a/packages/business/src/smart-delay/service.ts
+++ b/packages/business/src/smart-delay/service.ts
@@ -290,6 +290,52 @@ class SmartDelayService extends BaseService {
     return rows.length
   }
 
+  /**
+   * Cancels one bounded batch of a workspace's still-firable rows (freeze /
+   * teardown path) and returns `id` + `triggerAt` so the caller can rebuild the
+   * deterministic jobId and drop the matching delayed BullMQ job.
+   *
+   * Cancelling the ROW is what actually stops the work: removing only the job
+   * leaves the row `scheduled`, and the scanner's stuck-row sweeper would reset
+   * it to `pending` and re-enqueue it on the next tick. `resetToPending` uses a
+   * `status = 'scheduled'` CAS, so a `canceled` row can never be resurrected.
+   *
+   * Bounded + SKIP LOCKED for the same reason as `claimDueRows`: this table can
+   * hold hundreds of thousands of rows per workspace, and a concurrent scanner
+   * run must not be blocked by the teardown.
+   */
+  async cancelActiveForWorkspace(props: {
+    tx?: DatabaseClient
+    workspaceId: string
+    limit: number
+  }): Promise<Pick<SmartDelayRow, "id" | "triggerAt">[]> {
+    const { tx = db, workspaceId, limit } = props
+    const activeRowIds = tx
+      .select({ id: contactOnSmartDelayModel.id })
+      .from(contactOnSmartDelayModel)
+      .where(
+        and(
+          eq(contactOnSmartDelayModel.workspaceId, workspaceId),
+          inArray(contactOnSmartDelayModel.status, [
+            smartDelayStatuses.enum.pending,
+            smartDelayStatuses.enum.scheduled,
+          ]),
+        ),
+      )
+      .orderBy(contactOnSmartDelayModel.triggerAt)
+      .limit(limit)
+      .for("update", { skipLocked: true })
+
+    return await tx
+      .update(contactOnSmartDelayModel)
+      .set({ status: smartDelayStatuses.enum.canceled })
+      .where(inArray(contactOnSmartDelayModel.id, activeRowIds))
+      .returning({
+        id: contactOnSmartDelayModel.id,
+        triggerAt: contactOnSmartDelayModel.triggerAt,
+      })
+  }
+
   private async markStatus(props: {
     tx?: DatabaseClient
     id: string

--- a/packages/business/src/user-quota/service.ts
+++ b/packages/business/src/user-quota/service.ts
@@ -61,10 +61,10 @@ const BOOTSTRAP_TRIAL_FALLBACK = {
 
 interface DefaultPlanSnapshot {
   botMessagesLimit: number | null
-  monthlyBotMessagesLimit: number | null
   channelsLimit: number | null
   contactsLimit: number | null
   macLimit: number | null
+  monthlyBotMessagesLimit: number | null
   planName: string
   saasMode: boolean
   ssoSaml: boolean

--- a/packages/business/src/workspace-lifecycle/campaign-cleanup.ts
+++ b/packages/business/src/workspace-lifecycle/campaign-cleanup.ts
@@ -1,0 +1,64 @@
+import {
+  and,
+  type DatabaseClient,
+  db,
+  eq,
+  inArray,
+} from "@chatbotx.io/database/client"
+import { broadcastStatuses } from "@chatbotx.io/database/partials"
+import {
+  broadcastModel,
+  contactsOnSequenceModel,
+} from "@chatbotx.io/database/schema"
+
+export async function cancelInFlightBroadcastsForWorkspace(props: {
+  tx?: DatabaseClient
+  workspaceId: string
+}): Promise<number> {
+  const { tx = db, workspaceId } = props
+
+  const cancelledBroadcasts = await tx
+    .update(broadcastModel)
+    .set({
+      status: broadcastStatuses.enum.cancelled,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(broadcastModel.workspaceId, workspaceId),
+        inArray(broadcastModel.status, [
+          broadcastStatuses.enum.scheduled,
+          broadcastStatuses.enum.sending,
+        ]),
+      ),
+    )
+    .returning({ id: broadcastModel.id })
+
+  return cancelledBroadcasts.length
+}
+
+export async function completeActiveSequenceEnrollmentsForWorkspace(props: {
+  tx?: DatabaseClient
+  workspaceId: string
+}): Promise<number> {
+  const { tx = db, workspaceId } = props
+
+  const completedEnrollments = await tx
+    .update(contactsOnSequenceModel)
+    .set({
+      status: "completed",
+      completedAt: new Date(),
+      nextRunAt: null,
+      nextStepId: null,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(contactsOnSequenceModel.workspaceId, workspaceId),
+        eq(contactsOnSequenceModel.status, "active"),
+      ),
+    )
+    .returning({ id: contactsOnSequenceModel.id })
+
+  return completedEnrollments.length
+}

--- a/packages/business/src/workspace-lifecycle/index.ts
+++ b/packages/business/src/workspace-lifecycle/index.ts
@@ -1,1 +1,2 @@
+export * from "./predicates"
 export * from "./service"

--- a/packages/business/src/workspace-lifecycle/predicates.ts
+++ b/packages/business/src/workspace-lifecycle/predicates.ts
@@ -2,6 +2,50 @@ type WorkspaceScheduledDeletionState = {
   scheduledDeletionAt?: Date | string | null
 }
 
+type OwnerAccessState = {
+  blocked: boolean
+}
+
+export type WorkspaceFreezeReason =
+  | "missingWorkspace"
+  | "ownerBlocked"
+  | "scheduledForDeletion"
+
 export const isWorkspaceScheduledForDeletion = (
   workspace: WorkspaceScheduledDeletionState,
 ): boolean => workspace.scheduledDeletionAt != null
+
+/**
+ * Single source of truth for "must this workspace's work be frozen right now".
+ *
+ * Every freeze layer (worker consumers, in-request webhook receivers, public
+ * routes) resolves the reason here so the concept cannot drift into three
+ * subtly different checks. Ordered most-terminal first: a purged row and a
+ * pending deletion both outrank an entitlement block, because they are not
+ * recoverable by paying.
+ *
+ * A missing workspace is FROZEN, not allowed: the row is only absent after the
+ * purge cron hard-deleted it, so any work still referencing it belongs to a
+ * workspace that no longer exists.
+ *
+ * `accessState` is optional so callers that have no owner entitlement in hand
+ * (public routes) can reuse the deletion half of the check.
+ */
+export const resolveWorkspaceFreezeReason = (props: {
+  accessState?: OwnerAccessState | null
+  workspace?: WorkspaceScheduledDeletionState | null
+}): WorkspaceFreezeReason | null => {
+  if (!props.workspace) {
+    return "missingWorkspace"
+  }
+
+  if (isWorkspaceScheduledForDeletion(props.workspace)) {
+    return "scheduledForDeletion"
+  }
+
+  if (props.accessState?.blocked) {
+    return "ownerBlocked"
+  }
+
+  return null
+}

--- a/packages/business/src/workspace-lifecycle/predicates.ts
+++ b/packages/business/src/workspace-lifecycle/predicates.ts
@@ -1,0 +1,7 @@
+type WorkspaceScheduledDeletionState = {
+  scheduledDeletionAt?: Date | string | null
+}
+
+export const isWorkspaceScheduledForDeletion = (
+  workspace: WorkspaceScheduledDeletionState,
+): boolean => workspace.scheduledDeletionAt != null

--- a/packages/business/src/workspace-lifecycle/service.ts
+++ b/packages/business/src/workspace-lifecycle/service.ts
@@ -26,10 +26,14 @@ import {
   whatsappCoexistStagingModel,
 } from "@chatbotx.io/database/schema"
 import type { InboxWithIntegrations } from "@chatbotx.io/database/types"
+// Subpath, not the barrel: the barrel re-exports `dispatch-manager`, whose
+// bucket hashing imports Node's `crypto`. This module ends up in the builder's
+// Edge bundle (instrumentation → oRPC → workspace token auth → workspace
+// service), where a Node built-in is a hard compile error.
 import {
   cancelPendingDispatchesForWorkspace,
   removeDispatchesFromSchedule,
-} from "@chatbotx.io/sequence-scheduler"
+} from "@chatbotx.io/sequence-scheduler/dispatch-cancel"
 import { BaseService } from "../base.service"
 import { inboxService } from "../inbox/service"
 import { integrationActiveCampaignService } from "../integration-active-campaign/service"
@@ -51,6 +55,7 @@ import {
   cancelInFlightBroadcastsForWorkspace,
   completeActiveSequenceEnrollmentsForWorkspace,
 } from "./campaign-cleanup"
+import { cancelSmartDelaysForWorkspace } from "./smart-delay-cleanup"
 
 type WorkspaceTeardownIntegration = {
   disconnect(auth: unknown): Promise<void>
@@ -172,26 +177,40 @@ class WorkspaceLifecycleService extends BaseService {
     })
   }
 
-  async cancelInFlightCampaigns(
-    workspaceId: string,
-  ): Promise<DispatchToRemove[]> {
-    const dispatchesToRemove = await db.transaction(async (tx) => {
-      await cancelInFlightBroadcastsForWorkspace({
-        tx,
-        workspaceId,
-      })
+  /**
+   * Disarms everything a workspace has scheduled to fire on its own: in-flight
+   * broadcasts, active sequence enrollments and their queued dispatches, plus
+   * pending/scheduled smart delays (wait steps and follow-ups).
+   *
+   * Called when deletion is scheduled and when the owner's entitlement is torn
+   * down. The runtime guards (`withBlockedOwnerGuard`) would no-op these jobs
+   * anyway, but they would keep waking for the whole grace window — and the
+   * smart-delay scanner would churn them through claim → drop → reset every
+   * tick. Cancelling the rows is what makes the freeze quiet as well as safe.
+   *
+   * Each source is independent and best-effort: a Redis failure on one must not
+   * leave the others armed.
+   */
+  async freezeWorkspaceRuntime(workspaceId: string): Promise<void> {
+    const dispatchesToRemove: DispatchToRemove[] = await db.transaction(
+      async (tx) => {
+        await cancelInFlightBroadcastsForWorkspace({
+          tx,
+          workspaceId,
+        })
 
-      await completeActiveSequenceEnrollmentsForWorkspace({
-        tx,
-        workspaceId,
-      })
+        await completeActiveSequenceEnrollmentsForWorkspace({
+          tx,
+          workspaceId,
+        })
 
-      return await cancelPendingDispatchesForWorkspace({
-        client: tx,
-        removeFromSchedule: false,
-        workspaceId,
-      })
-    })
+        return await cancelPendingDispatchesForWorkspace({
+          client: tx,
+          removeFromSchedule: false,
+          workspaceId,
+        })
+      },
+    )
 
     try {
       await removeDispatchesFromSchedule(dispatchesToRemove)
@@ -202,7 +221,20 @@ class WorkspaceLifecycleService extends BaseService {
       )
     }
 
-    return dispatchesToRemove
+    try {
+      const canceledSmartDelays = await cancelSmartDelaysForWorkspace({
+        workspaceId,
+      })
+      logger.info(
+        { canceledSmartDelays, workspaceId },
+        "workspace-freeze: canceled smart delays",
+      )
+    } catch (err) {
+      logger.warn(
+        { err, workspaceId },
+        "workspace-freeze: failed to cancel smart delays",
+      )
+    }
   }
 
   /**

--- a/packages/business/src/workspace-lifecycle/service.ts
+++ b/packages/business/src/workspace-lifecycle/service.ts
@@ -26,6 +26,10 @@ import {
   whatsappCoexistStagingModel,
 } from "@chatbotx.io/database/schema"
 import type { InboxWithIntegrations } from "@chatbotx.io/database/types"
+import {
+  cancelPendingDispatchesForWorkspace,
+  removeDispatchesFromSchedule,
+} from "@chatbotx.io/sequence-scheduler"
 import { BaseService } from "../base.service"
 import { inboxService } from "../inbox/service"
 import { integrationActiveCampaignService } from "../integration-active-campaign/service"
@@ -43,6 +47,10 @@ import { integrationOpenRouterService } from "../integration-openrouter/service"
 import { integrationSendGridService } from "../integration-sendgrid/service"
 import { logger } from "../logger"
 import { userQuotaService } from "../user-quota/service"
+import {
+  cancelInFlightBroadcastsForWorkspace,
+  completeActiveSequenceEnrollmentsForWorkspace,
+} from "./campaign-cleanup"
 
 type WorkspaceTeardownIntegration = {
   disconnect(auth: unknown): Promise<void>
@@ -51,6 +59,11 @@ type WorkspaceTeardownIntegration = {
 
 type DisconnectService = {
   disconnect(workspaceId: string): Promise<void>
+}
+
+type DispatchToRemove = {
+  bucket: number
+  id: string
 }
 
 export type WorkspaceTeardownIntegrations = Record<
@@ -157,6 +170,39 @@ class WorkspaceLifecycleService extends BaseService {
         )
       }
     })
+  }
+
+  async cancelInFlightCampaigns(
+    workspaceId: string,
+  ): Promise<DispatchToRemove[]> {
+    const dispatchesToRemove = await db.transaction(async (tx) => {
+      await cancelInFlightBroadcastsForWorkspace({
+        tx,
+        workspaceId,
+      })
+
+      await completeActiveSequenceEnrollmentsForWorkspace({
+        tx,
+        workspaceId,
+      })
+
+      return await cancelPendingDispatchesForWorkspace({
+        client: tx,
+        removeFromSchedule: false,
+        workspaceId,
+      })
+    })
+
+    try {
+      await removeDispatchesFromSchedule(dispatchesToRemove)
+    } catch (err) {
+      logger.warn(
+        { err, dispatchCount: dispatchesToRemove.length, workspaceId },
+        "workspace-teardown: failed to remove dispatches from schedule",
+      )
+    }
+
+    return dispatchesToRemove
   }
 
   /**

--- a/packages/business/src/workspace-lifecycle/smart-delay-cleanup.ts
+++ b/packages/business/src/workspace-lifecycle/smart-delay-cleanup.ts
@@ -1,0 +1,62 @@
+import { buildJobId } from "@chatbotx.io/flow-config"
+import { integrationQueue } from "@chatbotx.io/worker-config"
+import { logger } from "../logger"
+import { smartDelayService } from "../smart-delay/service"
+
+export const SMART_DELAY_CANCEL_BATCH_SIZE = 500
+// Backstop so one workspace with a runaway backlog cannot spin the freeze call
+// forever: 500 * 400 = 200k rows per call. Whatever is left is harmless — the
+// worker-side guard no-ops those wake-ups, and the purge cascade removes the
+// rows when the grace window expires.
+const MAX_CANCEL_BATCHES = 400
+
+/**
+ * Cancels every still-firable smart-delay row of a workspace (wait steps,
+ * follow-ups) and drops their delayed BullMQ jobs.
+ *
+ * Cancelling the row is the part that matters. A wake-up job for a `canceled`
+ * row is already a no-op (`wait-resume` requires `status === 'scheduled'` and
+ * `claimForRun` CASes on it), and — more importantly — the scanner's
+ * stuck-scheduled sweeper can only reset rows that are still `scheduled`, so a
+ * canceled row stops churning through claim → drop → reset for the rest of the
+ * 24-hour grace window.
+ */
+export async function cancelSmartDelaysForWorkspace(props: {
+  workspaceId: string
+}): Promise<number> {
+  let canceled = 0
+
+  for (let batch = 0; batch < MAX_CANCEL_BATCHES; batch += 1) {
+    const rows = await smartDelayService.cancelActiveForWorkspace({
+      limit: SMART_DELAY_CANCEL_BATCH_SIZE,
+      workspaceId: props.workspaceId,
+    })
+
+    if (rows.length === 0) {
+      break
+    }
+
+    canceled += rows.length
+
+    // Best-effort: the rows are already canceled, so a job that survives is
+    // inert. Never let a Redis hiccup abort the cancellation loop.
+    const removals = await Promise.allSettled(
+      rows.map((row) =>
+        integrationQueue.remove(buildJobId(row.id, row.triggerAt)),
+      ),
+    )
+    const failed = removals.filter((result) => result.status === "rejected")
+    if (failed.length > 0) {
+      logger.warn(
+        { failedCount: failed.length, workspaceId: props.workspaceId },
+        "workspace-freeze: failed to remove smart-delay jobs",
+      )
+    }
+
+    if (rows.length < SMART_DELAY_CANCEL_BATCH_SIZE) {
+      break
+    }
+  }
+
+  return canceled
+}

--- a/packages/business/src/workspace-lifecycle/with-blocked-owner-guard.ts
+++ b/packages/business/src/workspace-lifecycle/with-blocked-owner-guard.ts
@@ -1,6 +1,29 @@
+import type { WorkspaceModel } from "@chatbotx.io/database/types"
 import { logger } from "../logger"
-import { userQuotaService } from "../user-quota/service"
+import { type AccessState, userQuotaService } from "../user-quota/service"
 import { workspaceService } from "../workspace/service"
+import { isWorkspaceScheduledForDeletion } from "./predicates"
+
+type WorkspaceFreezeReason = "ownerBlocked" | "scheduledForDeletion"
+
+type WorkspaceFreezeContext = {
+  accessState: AccessState
+  workspace: WorkspaceModel
+}
+
+const FREEZE_CHECKS: ReadonlyArray<{
+  isFrozen: (context: WorkspaceFreezeContext) => boolean
+  reason: WorkspaceFreezeReason
+}> = [
+  {
+    reason: "scheduledForDeletion",
+    isFrozen: ({ workspace }) => isWorkspaceScheduledForDeletion(workspace),
+  },
+  {
+    reason: "ownerBlocked",
+    isFrozen: ({ accessState }) => accessState.blocked,
+  },
+]
 
 /**
  * No-op workspace work for owners whose cloud entitlement has expired.
@@ -20,11 +43,18 @@ export async function withBlockedOwnerGuard<T>(
     return await fn()
   }
   const accessState = await userQuotaService.getAccessState(workspace.ownerId)
+  const freezeCheck = FREEZE_CHECKS.find((check) =>
+    check.isFrozen({ accessState, workspace }),
+  )
 
-  if (accessState.blocked) {
+  if (freezeCheck) {
     logger.info(
-      { workspaceId, ownerId: workspace.ownerId },
-      "Skipping workspace job for blocked owner",
+      {
+        freezeReason: freezeCheck.reason,
+        ownerId: workspace.ownerId,
+        workspaceId,
+      },
+      "Skipping workspace job for frozen workspace",
     )
     return
   }

--- a/packages/business/src/workspace-lifecycle/with-blocked-owner-guard.ts
+++ b/packages/business/src/workspace-lifecycle/with-blocked-owner-guard.ts
@@ -1,34 +1,18 @@
-import type { WorkspaceModel } from "@chatbotx.io/database/types"
+import { isCloud } from "../keys"
 import { logger } from "../logger"
-import { type AccessState, userQuotaService } from "../user-quota/service"
+import { userQuotaService } from "../user-quota/service"
 import { workspaceService } from "../workspace/service"
-import { isWorkspaceScheduledForDeletion } from "./predicates"
-
-type WorkspaceFreezeReason = "ownerBlocked" | "scheduledForDeletion"
-
-type WorkspaceFreezeContext = {
-  accessState: AccessState
-  workspace: WorkspaceModel
-}
-
-const FREEZE_CHECKS: ReadonlyArray<{
-  isFrozen: (context: WorkspaceFreezeContext) => boolean
-  reason: WorkspaceFreezeReason
-}> = [
-  {
-    reason: "scheduledForDeletion",
-    isFrozen: ({ workspace }) => isWorkspaceScheduledForDeletion(workspace),
-  },
-  {
-    reason: "ownerBlocked",
-    isFrozen: ({ accessState }) => accessState.blocked,
-  },
-]
+import { resolveWorkspaceFreezeReason } from "./predicates"
 
 /**
- * No-op workspace work for owners whose cloud entitlement has expired.
+ * No-op workspace work for frozen workspaces (owner entitlement expired,
+ * deletion scheduled, or the workspace row already purged).
+ *
  * Jobs without a workspace identity remain fail-open because they cannot be
- * safely attributed to a tenant here.
+ * safely attributed to a tenant here. Once an id IS present the guard is
+ * fail-CLOSED: a vanished workspace row means the purge cron already ran, so
+ * leftover delayed jobs (smart-delay resumes, wait/follow-up wake-ups) must not
+ * execute against a tenant that no longer exists.
  */
 export async function withBlockedOwnerGuard<T>(
   workspaceId: string | undefined,
@@ -39,19 +23,27 @@ export async function withBlockedOwnerGuard<T>(
   }
 
   const workspace = await workspaceService.find({ where: { id: workspaceId } })
-  if (!workspace) {
-    return await fn()
-  }
-  const accessState = await userQuotaService.getAccessState(workspace.ownerId)
-  const freezeCheck = FREEZE_CHECKS.find((check) =>
-    check.isFrozen({ accessState, workspace }),
-  )
 
-  if (freezeCheck) {
+  // Resolved in two passes on purpose. The Workspace row ALONE decides
+  // `missingWorkspace` and `scheduledForDeletion`, so those verdicts never
+  // depend on — and can never be broken by — an owner quota read. Only
+  // `ownerBlocked` needs entitlements, and only the cloud edition can produce
+  // it, so self-hosted installs skip the lookup entirely.
+  const rowReason = resolveWorkspaceFreezeReason({ workspace })
+  const ownerReason =
+    rowReason || !isCloud() || !workspace
+      ? null
+      : resolveWorkspaceFreezeReason({
+          accessState: await userQuotaService.getAccessState(workspace.ownerId),
+          workspace,
+        })
+  const freezeReason = rowReason ?? ownerReason
+
+  if (freezeReason) {
     logger.info(
       {
-        freezeReason: freezeCheck.reason,
-        ownerId: workspace.ownerId,
+        freezeReason,
+        ownerId: workspace?.ownerId,
         workspaceId,
       },
       "Skipping workspace job for frozen workspace",

--- a/packages/business/src/workspace/service.ts
+++ b/packages/business/src/workspace/service.ts
@@ -214,7 +214,7 @@ class WorkspaceService extends BaseService {
       }
 
       for (const workspace of claimed.rows) {
-        await workspaceLifecycleService.cancelInFlightCampaigns(workspace.id)
+        await workspaceLifecycleService.freezeWorkspaceRuntime(workspace.id)
 
         await workspaceLifecycleService
           .disconnectWorkspaceIntegrations(workspace.id)

--- a/packages/business/src/workspace/service.ts
+++ b/packages/business/src/workspace/service.ts
@@ -214,6 +214,8 @@ class WorkspaceService extends BaseService {
       }
 
       for (const workspace of claimed.rows) {
+        await workspaceLifecycleService.cancelInFlightCampaigns(workspace.id)
+
         await workspaceLifecycleService
           .disconnectWorkspaceIntegrations(workspace.id)
           .catch((err) => {

--- a/packages/database/__tests__/ai-workspace-scope-repository.test.ts
+++ b/packages/database/__tests__/ai-workspace-scope-repository.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test, vi } from "vitest"
+import {
+  AI_WORKSPACE_SCOPES,
+  type AiWorkspaceScope,
+  AiWorkspaceScopeRepository,
+} from "../src/repositories/ai-workspace-scope"
+
+/** The Drizzle model each scope must read, mirrored here so a re-point is caught. */
+const modelByScope: Record<AiWorkspaceScope, string> = {
+  aiEmbedding: "aiEmbeddingModel",
+  aiFile: "aiFileModel",
+  conversationEmbedding: "aiConversationEmbeddingModel",
+  conversationSource: "aiConversationSourceModel",
+}
+
+const clientReading = (model: string, findFirst: ReturnType<typeof vi.fn>) =>
+  ({ query: { [model]: { findFirst } } }) as never
+
+describe("AiWorkspaceScopeRepository", () => {
+  test.each(
+    AI_WORKSPACE_SCOPES,
+  )("resolves the owning workspace for the %s scope", async (scope) => {
+    const findFirst = vi.fn().mockResolvedValue({ workspaceId: "ws-1" })
+    const repository = new AiWorkspaceScopeRepository(
+      clientReading(modelByScope[scope], findFirst),
+    )
+
+    await expect(
+      repository.findWorkspaceId({ id: "record-1", scope }),
+    ).resolves.toBe("ws-1")
+
+    // Only the tenant column: these lookups sit in front of every AI job, so
+    // they must never widen into a full row read.
+    expect(findFirst).toHaveBeenCalledWith({
+      columns: { workspaceId: true },
+      where: { id: "record-1" },
+    })
+  })
+
+  test("returns undefined when the record no longer exists", async () => {
+    const findFirst = vi.fn().mockResolvedValue(undefined)
+    const repository = new AiWorkspaceScopeRepository(
+      clientReading("aiFileModel", findFirst),
+    )
+
+    await expect(
+      repository.findWorkspaceId({ id: "purged", scope: "aiFile" }),
+    ).resolves.toBeUndefined()
+  })
+
+  test("declares a model for every scope it exposes", () => {
+    // Completeness guard: adding a scope without a reader (or without a case in
+    // the table above) fails here instead of silently resolving to undefined.
+    expect(Object.keys(modelByScope).sort()).toEqual(
+      [...AI_WORKSPACE_SCOPES].sort(),
+    )
+  })
+})

--- a/packages/database/drizzle/20260723002157_add_broadcast_cancelled_status/migration.sql
+++ b/packages/database/drizzle/20260723002157_add_broadcast_cancelled_status/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "broadcastStatus" ADD VALUE 'cancelled';--> statement-breakpoint

--- a/packages/database/src/partials/broadcast.ts
+++ b/packages/database/src/partials/broadcast.ts
@@ -4,7 +4,12 @@ import type { ChannelType } from "./channel"
 export const broadcastScheduleTypes = z.enum(["now", "future"])
 export type BroadcastScheduleType = z.infer<typeof broadcastScheduleTypes>
 
-export const broadcastStatuses = z.enum(["scheduled", "sent", "sending"])
+export const broadcastStatuses = z.enum([
+  "scheduled",
+  "sent",
+  "sending",
+  "cancelled",
+])
 export type BroadcastStatus = z.infer<typeof broadcastStatuses>
 
 export const broadcastSubactions = z.enum([

--- a/packages/database/src/repositories/ai-workspace-scope/index.ts
+++ b/packages/database/src/repositories/ai-workspace-scope/index.ts
@@ -1,0 +1,15 @@
+import type { DatabaseClient } from "../../client"
+import { db } from "../../client"
+import { AiWorkspaceScopeRepository } from "./repository"
+
+export function createAiWorkspaceScopeRepository(
+  client: DatabaseClient = db,
+): AiWorkspaceScopeRepository {
+  return new AiWorkspaceScopeRepository(client)
+}
+
+export {
+  AI_WORKSPACE_SCOPES,
+  type AiWorkspaceScope,
+  AiWorkspaceScopeRepository,
+} from "./repository"

--- a/packages/database/src/repositories/ai-workspace-scope/repository.ts
+++ b/packages/database/src/repositories/ai-workspace-scope/repository.ts
@@ -1,0 +1,76 @@
+import type { DatabaseClient } from "../../client"
+
+/**
+ * The AI record kinds whose owning workspace can be resolved from a bare id.
+ *
+ * Adding a kind here is a compile-time obligation: `workspaceIdReaders` is typed
+ * `Record<AiWorkspaceScope, …>`, so the build fails until the reader exists.
+ */
+export const AI_WORKSPACE_SCOPES = [
+  "aiEmbedding",
+  "aiFile",
+  "conversationEmbedding",
+  "conversationSource",
+] as const
+
+export type AiWorkspaceScope = (typeof AI_WORKSPACE_SCOPES)[number]
+
+type WorkspaceIdRow = { workspaceId: string }
+
+type WorkspaceIdReader = (
+  client: DatabaseClient,
+  id: string,
+) => Promise<undefined | WorkspaceIdRow>
+
+/**
+ * One reader per scope. The query shape is identical everywhere — a primary-key
+ * read projecting only `workspaceId` — so only the model varies. Keeping them in
+ * a table instead of one method each is what stops this from becoming four
+ * copies of the same body.
+ */
+const workspaceIdReaders: Record<AiWorkspaceScope, WorkspaceIdReader> = {
+  aiEmbedding: (client, id) =>
+    client.query.aiEmbeddingModel.findFirst({
+      columns: { workspaceId: true },
+      where: { id },
+    }),
+  aiFile: (client, id) =>
+    client.query.aiFileModel.findFirst({
+      columns: { workspaceId: true },
+      where: { id },
+    }),
+  conversationEmbedding: (client, id) =>
+    client.query.aiConversationEmbeddingModel.findFirst({
+      columns: { workspaceId: true },
+      where: { id },
+    }),
+  conversationSource: (client, id) =>
+    client.query.aiConversationSourceModel.findFirst({
+      columns: { workspaceId: true },
+      where: { id },
+    }),
+}
+
+/**
+ * Resolves the owning workspace for AI knowledge-base records.
+ *
+ * AI job payloads carry only a record id (`aiFileId`, `sourceId`, …), so the
+ * worker cannot decide whether a job belongs to a frozen workspace without one
+ * of these lookups. Each is a single indexed primary-key read returning just the
+ * `workspaceId` column — cheap next to the embedding API call it gates.
+ */
+export class AiWorkspaceScopeRepository {
+  private readonly client: DatabaseClient
+
+  constructor(client: DatabaseClient) {
+    this.client = client
+  }
+
+  async findWorkspaceId(params: {
+    id: string
+    scope: AiWorkspaceScope
+  }): Promise<string | undefined> {
+    const row = await workspaceIdReaders[params.scope](this.client, params.id)
+    return row?.workspaceId
+  }
+}

--- a/packages/database/src/repositories/index.ts
+++ b/packages/database/src/repositories/index.ts
@@ -1,5 +1,6 @@
 export * from "./ai-conversation-embedding"
 export * from "./ai-conversation-source"
+export * from "./ai-workspace-scope"
 export * from "./contact-custom-field"
 export * from "./conversation-ai-context"
 export * from "./message"

--- a/packages/events/src/base-emitter.ts
+++ b/packages/events/src/base-emitter.ts
@@ -153,7 +153,6 @@ export abstract class BaseEventEmitter {
     name?: string,
     phone?: string,
     email?: string,
-    customFields?: Record<string, unknown>,
   ): Promise<void> {
     await this.emit(triggerEventTypes.enum.newContact, {
       workspaceId,
@@ -162,7 +161,6 @@ export abstract class BaseEventEmitter {
         name,
         phone,
         email,
-        customFields,
       },
     })
   }

--- a/packages/events/src/event-dispatcher.ts
+++ b/packages/events/src/event-dispatcher.ts
@@ -46,7 +46,6 @@ export const emitContactCreated = async (
   name?: string,
   phone?: string,
   email?: string,
-  customFields?: Record<string, unknown>,
 ) =>
   await emitToAllEmitters(
     "contactCreated",
@@ -55,7 +54,6 @@ export const emitContactCreated = async (
     name,
     phone,
     email,
-    customFields,
   )
 
 export const emitContactReferredANewContact = async (

--- a/packages/sequence-scheduler/__tests__/cancel-pending-dispatches.test.ts
+++ b/packages/sequence-scheduler/__tests__/cancel-pending-dispatches.test.ts
@@ -59,7 +59,7 @@ beforeEach(() => {
 describe("cancelPendingDispatches", () => {
   test("SELECT filters enrollmentId + workspaceId + status=pending", async () => {
     findManySpy.mockResolvedValue([])
-    const { cancelPendingDispatches } = await import("../src/dispatch-manager")
+    const { cancelPendingDispatches } = await import("../src/dispatch-cancel")
 
     await cancelPendingDispatches({
       enrollmentId: "e1",
@@ -77,7 +77,7 @@ describe("cancelPendingDispatches", () => {
 
   test("empty result skips UPDATE and Redis", async () => {
     findManySpy.mockResolvedValue([])
-    const { cancelPendingDispatches } = await import("../src/dispatch-manager")
+    const { cancelPendingDispatches } = await import("../src/dispatch-cancel")
 
     const res = await cancelPendingDispatches({
       enrollmentId: "e1",
@@ -95,7 +95,7 @@ describe("cancelPendingDispatches", () => {
       { id: "d1", bucket: 1 },
       { id: "d2", bucket: 2 },
     ])
-    const { cancelPendingDispatches } = await import("../src/dispatch-manager")
+    const { cancelPendingDispatches } = await import("../src/dispatch-cancel")
 
     await cancelPendingDispatches({
       enrollmentId: "e1",
@@ -113,7 +113,7 @@ describe("cancelPendingDispatches", () => {
       { id: "d1", bucket: 1 },
       { id: "d2", bucket: 2 },
     ])
-    const { cancelPendingDispatches } = await import("../src/dispatch-manager")
+    const { cancelPendingDispatches } = await import("../src/dispatch-cancel")
 
     const res = await cancelPendingDispatches({
       enrollmentId: "e1",
@@ -132,7 +132,7 @@ describe("cancelPendingDispatches", () => {
 
   test("removeDispatchesFromSchedule removes each dispatch from Redis", async () => {
     const { removeDispatchesFromSchedule } = await import(
-      "../src/dispatch-manager"
+      "../src/dispatch-cancel"
     )
 
     await removeDispatchesFromSchedule([
@@ -150,7 +150,7 @@ describe("cancelPendingDispatches", () => {
       .mockRejectedValueOnce(new Error("redis down"))
       .mockResolvedValueOnce(undefined)
     const { removeDispatchesFromSchedule } = await import(
-      "../src/dispatch-manager"
+      "../src/dispatch-cancel"
     )
 
     await expect(
@@ -170,7 +170,7 @@ describe("cancelPendingDispatches", () => {
       .mockRejectedValueOnce(new Error("redis down"))
       .mockResolvedValueOnce(undefined)
     const { removeDispatchesFromSchedule } = await import(
-      "../src/dispatch-manager"
+      "../src/dispatch-cancel"
     )
 
     await expect(

--- a/packages/sequence-scheduler/__tests__/dispatch-manager.test.ts
+++ b/packages/sequence-scheduler/__tests__/dispatch-manager.test.ts
@@ -324,4 +324,33 @@ describe("cancelPendingDispatches", () => {
     expect(customFindManyMock).toHaveBeenCalledTimes(1)
     expect(findManyMock).not.toHaveBeenCalled()
   })
+
+  test("cancels all pending dispatches for a workspace without enrollmentId", async () => {
+    const { cancelPendingDispatchesForWorkspace } = await import(
+      "../src/dispatch-manager"
+    )
+    findManyMock.mockResolvedValue([
+      {
+        id: "d-1",
+        bucket: 9,
+        sequenceId: "seq-1",
+        contactId: "c-1",
+        stepId: "s-1",
+      },
+    ])
+
+    const result = await cancelPendingDispatchesForWorkspace({
+      workspaceId: "ws-2",
+    })
+
+    expect(result).toEqual([{ id: "d-1", bucket: 9 }])
+    expect(findManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          workspaceId: "ws-2",
+          status: "pending",
+        }),
+      }),
+    )
+  })
 })

--- a/packages/sequence-scheduler/__tests__/dispatch-manager.test.ts
+++ b/packages/sequence-scheduler/__tests__/dispatch-manager.test.ts
@@ -235,7 +235,7 @@ describe("cancelPendingDispatches", () => {
   })
 
   test("returns empty array and skips update when no pending dispatches exist", async () => {
-    const { cancelPendingDispatches } = await import("../src/dispatch-manager")
+    const { cancelPendingDispatches } = await import("../src/dispatch-cancel")
     findManyMock.mockResolvedValue([])
 
     const result = await cancelPendingDispatches({
@@ -249,7 +249,7 @@ describe("cancelPendingDispatches", () => {
   })
 
   test("cancels pending dispatches, calls removeFromSchedule for each, and returns id+bucket", async () => {
-    const { cancelPendingDispatches } = await import("../src/dispatch-manager")
+    const { cancelPendingDispatches } = await import("../src/dispatch-cancel")
     const pendingDispatches = [
       {
         id: "d-1",
@@ -284,7 +284,7 @@ describe("cancelPendingDispatches", () => {
   })
 
   test("calls useExisting to obtain the redis client before scheduling removal", async () => {
-    const { cancelPendingDispatches } = await import("../src/dispatch-manager")
+    const { cancelPendingDispatches } = await import("../src/dispatch-cancel")
     findManyMock.mockResolvedValue([
       {
         id: "d-1",
@@ -304,7 +304,7 @@ describe("cancelPendingDispatches", () => {
   })
 
   test("uses provided client instead of default db for the query", async () => {
-    const { cancelPendingDispatches } = await import("../src/dispatch-manager")
+    const { cancelPendingDispatches } = await import("../src/dispatch-cancel")
     const customFindManyMock = vi.fn().mockResolvedValue([])
     const customClient = {
       query: {
@@ -327,7 +327,7 @@ describe("cancelPendingDispatches", () => {
 
   test("cancels all pending dispatches for a workspace without enrollmentId", async () => {
     const { cancelPendingDispatchesForWorkspace } = await import(
-      "../src/dispatch-manager"
+      "../src/dispatch-cancel"
     )
     findManyMock.mockResolvedValue([
       {

--- a/packages/sequence-scheduler/package.json
+++ b/packages/sequence-scheduler/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./dispatch-cancel": "./src/dispatch-cancel.ts"
   },
   "dependencies": {
     "@chatbotx.io/database": "workspace:*",

--- a/packages/sequence-scheduler/src/dispatch-cancel.ts
+++ b/packages/sequence-scheduler/src/dispatch-cancel.ts
@@ -1,0 +1,176 @@
+import {
+  and,
+  type DatabaseClient,
+  db,
+  eq,
+  inArray,
+  type Transaction,
+} from "@chatbotx.io/database/client"
+import { sequenceDispatchModel } from "@chatbotx.io/database/schema"
+import { sequenceConnections } from "@chatbotx.io/redis"
+import { SchedulerClient } from "@chatbotx.io/scheduler"
+
+/**
+ * Cancellation lives apart from `dispatch-manager` on purpose. Creating a
+ * dispatch needs `calculateBucket`, which hashes with Node's `crypto`; cancelling
+ * one never does. Keeping them in one module meant every consumer of the cancel
+ * path — including `@chatbotx.io/business`, which the builder loads into the Edge
+ * Runtime — dragged `crypto` along and failed to compile. Import this module (or
+ * the `@chatbotx.io/sequence-scheduler/dispatch-cancel` subpath) from anywhere
+ * that must stay Edge-safe.
+ */
+
+type DrizzleClient = typeof db | Transaction
+type ScheduledDispatch = { id: string; bucket: number }
+type PendingDispatch = {
+  bucket: number
+  contactId: string
+  id: string
+  sequenceId: string
+  stepId: string
+}
+
+type PendingDispatchWhere = {
+  enrollmentId?: string
+  status: "pending"
+  workspaceId: string
+}
+
+type CancelPendingDispatchesOptions = {
+  client?: DrizzleClient
+  removeFromSchedule?: boolean
+  where: PendingDispatchWhere
+}
+
+const pendingDispatchColumns = {
+  id: true,
+  bucket: true,
+  sequenceId: true,
+  contactId: true,
+  stepId: true,
+} as const
+
+export interface CancelPendingDispatchesParams {
+  client?: DatabaseClient | Transaction
+  enrollmentId: string
+  reason?: string
+  /**
+   * Set to false only when the caller removes scheduler entries after its
+   * surrounding database transaction has committed.
+   */
+  removeFromSchedule?: boolean
+  workspaceId: string
+}
+
+async function cancelPendingDispatchesByWhere(
+  options: CancelPendingDispatchesOptions,
+): Promise<ScheduledDispatch[]> {
+  const { client = db, removeFromSchedule = true, where } = options
+  const pendingDispatches = (await client.query.sequenceDispatchModel.findMany({
+    where,
+    columns: pendingDispatchColumns,
+  })) as PendingDispatch[]
+
+  if (pendingDispatches.length === 0) {
+    return []
+  }
+
+  const dispatchIds = pendingDispatches.map((dispatch) => dispatch.id)
+  await client
+    .update(sequenceDispatchModel)
+    .set({
+      status: "canceled",
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        inArray(sequenceDispatchModel.id, dispatchIds),
+        eq(sequenceDispatchModel.workspaceId, where.workspaceId),
+        eq(sequenceDispatchModel.status, "pending"),
+      ),
+    )
+
+  if (removeFromSchedule) {
+    await removeDispatchesFromSchedule(pendingDispatches)
+  }
+
+  return pendingDispatches.map((dispatch) => ({
+    id: dispatch.id,
+    bucket: dispatch.bucket,
+  }))
+}
+
+export async function cancelPendingDispatches(
+  params: CancelPendingDispatchesParams,
+): Promise<ScheduledDispatch[]> {
+  return await cancelPendingDispatchesByWhere({
+    client: params.client,
+    removeFromSchedule: params.removeFromSchedule,
+    where: {
+      enrollmentId: params.enrollmentId,
+      status: "pending",
+      workspaceId: params.workspaceId,
+    },
+  })
+}
+
+export async function cancelPendingDispatchesForWorkspace(params: {
+  client?: DatabaseClient | Transaction
+  removeFromSchedule?: boolean
+  workspaceId: string
+}): Promise<ScheduledDispatch[]> {
+  return await cancelPendingDispatchesByWhere({
+    client: params.client,
+    removeFromSchedule: params.removeFromSchedule,
+    where: {
+      status: "pending",
+      workspaceId: params.workspaceId,
+    },
+  })
+}
+
+export async function removeDispatchesFromSchedule(
+  dispatches: ScheduledDispatch[],
+): Promise<void> {
+  if (dispatches.length === 0) {
+    return
+  }
+
+  const redisClient = await sequenceConnections.useExisting()
+  const scheduler = new SchedulerClient(redisClient)
+
+  const results = await Promise.allSettled(
+    dispatches.map((dispatch) =>
+      scheduler.removeFromSchedule(dispatch.bucket, dispatch.id),
+    ),
+  )
+  const failures = results.flatMap((result, index) => {
+    if (result.status !== "rejected") {
+      return []
+    }
+
+    const dispatch = dispatches[index]
+    if (!dispatch) {
+      return []
+    }
+
+    return [{ dispatch, reason: result.reason }]
+  })
+
+  if (failures.length > 0) {
+    const failedDispatches = failures
+      .map(({ dispatch }) => `${dispatch.id} bucket=${dispatch.bucket}`)
+      .join(", ")
+
+    throw new AggregateError(
+      failures.map(({ dispatch, reason }) => {
+        const reasonMessage =
+          reason instanceof Error ? reason.message : String(reason)
+        return new Error(
+          `Failed to remove ${dispatch.id} bucket=${dispatch.bucket}: ${reasonMessage}`,
+        )
+      }),
+      `Failed to remove sequence dispatches from schedule: ${failedDispatches}`,
+    )
+  }
+}

--- a/packages/sequence-scheduler/src/dispatch-manager.ts
+++ b/packages/sequence-scheduler/src/dispatch-manager.ts
@@ -1,46 +1,16 @@
-import {
-  and,
-  type DatabaseClient,
-  db,
-  eq,
-  inArray,
-  type Transaction,
-} from "@chatbotx.io/database/client"
+import { db, type Transaction } from "@chatbotx.io/database/client"
 import { sequenceDispatchModel } from "@chatbotx.io/database/schema"
-import { sequenceConnections } from "@chatbotx.io/redis"
-import { SchedulerClient } from "@chatbotx.io/scheduler"
 import { createId } from "@chatbotx.io/utils"
 import { createHash } from "crypto"
 
+/**
+ * The dispatch *creation* path. It hashes with Node's `crypto` to pick a bucket,
+ * so this module can only run in a Node process. Cancellation deliberately lives
+ * in `./dispatch-cancel` — it needs no hashing, and Edge-Runtime consumers import
+ * it directly instead of paying for `crypto` here.
+ */
+
 type DrizzleClient = typeof db | Transaction
-type ScheduledDispatch = { id: string; bucket: number }
-type PendingDispatch = {
-  bucket: number
-  contactId: string
-  id: string
-  sequenceId: string
-  stepId: string
-}
-
-type PendingDispatchWhere = {
-  enrollmentId?: string
-  status: "pending"
-  workspaceId: string
-}
-
-type CancelPendingDispatchesOptions = {
-  client?: DrizzleClient
-  removeFromSchedule?: boolean
-  where: PendingDispatchWhere
-}
-
-const pendingDispatchColumns = {
-  id: true,
-  bucket: true,
-  sequenceId: true,
-  contactId: true,
-  stepId: true,
-} as const
 
 export function calculateBucket(
   workspaceId: string,
@@ -127,127 +97,4 @@ export async function createDispatch(
   }
 
   return await insertDispatch(db)
-}
-export interface CancelPendingDispatchesParams {
-  client?: DatabaseClient | Transaction
-  enrollmentId: string
-  reason?: string
-  /**
-   * Set to false only when the caller removes scheduler entries after its
-   * surrounding database transaction has committed.
-   */
-  removeFromSchedule?: boolean
-  workspaceId: string
-}
-async function cancelPendingDispatchesByWhere(
-  options: CancelPendingDispatchesOptions,
-): Promise<ScheduledDispatch[]> {
-  const { client = db, removeFromSchedule = true, where } = options
-  const pendingDispatches = (await client.query.sequenceDispatchModel.findMany({
-    where,
-    columns: pendingDispatchColumns,
-  })) as PendingDispatch[]
-
-  if (pendingDispatches.length === 0) {
-    return []
-  }
-
-  const dispatchIds = pendingDispatches.map((dispatch) => dispatch.id)
-  await client
-    .update(sequenceDispatchModel)
-    .set({
-      status: "canceled",
-      updatedAt: new Date(),
-    })
-    .where(
-      and(
-        inArray(sequenceDispatchModel.id, dispatchIds),
-        eq(sequenceDispatchModel.workspaceId, where.workspaceId),
-        eq(sequenceDispatchModel.status, "pending"),
-      ),
-    )
-
-  if (removeFromSchedule) {
-    await removeDispatchesFromSchedule(pendingDispatches)
-  }
-
-  return pendingDispatches.map((dispatch) => ({
-    id: dispatch.id,
-    bucket: dispatch.bucket,
-  }))
-}
-
-export async function cancelPendingDispatches(
-  params: CancelPendingDispatchesParams,
-): Promise<ScheduledDispatch[]> {
-  return await cancelPendingDispatchesByWhere({
-    client: params.client,
-    removeFromSchedule: params.removeFromSchedule,
-    where: {
-      enrollmentId: params.enrollmentId,
-      status: "pending",
-      workspaceId: params.workspaceId,
-    },
-  })
-}
-
-export async function cancelPendingDispatchesForWorkspace(params: {
-  client?: DatabaseClient | Transaction
-  removeFromSchedule?: boolean
-  workspaceId: string
-}): Promise<ScheduledDispatch[]> {
-  return await cancelPendingDispatchesByWhere({
-    client: params.client,
-    removeFromSchedule: params.removeFromSchedule,
-    where: {
-      status: "pending",
-      workspaceId: params.workspaceId,
-    },
-  })
-}
-
-export async function removeDispatchesFromSchedule(
-  dispatches: ScheduledDispatch[],
-) {
-  if (dispatches.length === 0) {
-    return
-  }
-
-  const redisClient = await sequenceConnections.useExisting()
-  const scheduler = new SchedulerClient(redisClient)
-
-  const results = await Promise.allSettled(
-    dispatches.map((dispatch) =>
-      scheduler.removeFromSchedule(dispatch.bucket, dispatch.id),
-    ),
-  )
-  const failures = results.flatMap((result, index) => {
-    if (result.status !== "rejected") {
-      return []
-    }
-
-    const dispatch = dispatches[index]
-    if (!dispatch) {
-      return []
-    }
-
-    return [{ dispatch, reason: result.reason }]
-  })
-
-  if (failures.length > 0) {
-    const failedDispatches = failures
-      .map(({ dispatch }) => `${dispatch.id} bucket=${dispatch.bucket}`)
-      .join(", ")
-
-    throw new AggregateError(
-      failures.map(({ dispatch, reason }) => {
-        const reasonMessage =
-          reason instanceof Error ? reason.message : String(reason)
-        return new Error(
-          `Failed to remove ${dispatch.id} bucket=${dispatch.bucket}: ${reasonMessage}`,
-        )
-      }),
-      `Failed to remove sequence dispatches from schedule: ${failedDispatches}`,
-    )
-  }
 }

--- a/packages/sequence-scheduler/src/dispatch-manager.ts
+++ b/packages/sequence-scheduler/src/dispatch-manager.ts
@@ -14,6 +14,33 @@ import { createHash } from "crypto"
 
 type DrizzleClient = typeof db | Transaction
 type ScheduledDispatch = { id: string; bucket: number }
+type PendingDispatch = {
+  bucket: number
+  contactId: string
+  id: string
+  sequenceId: string
+  stepId: string
+}
+
+type PendingDispatchWhere = {
+  enrollmentId?: string
+  status: "pending"
+  workspaceId: string
+}
+
+type CancelPendingDispatchesOptions = {
+  client?: DrizzleClient
+  removeFromSchedule?: boolean
+  where: PendingDispatchWhere
+}
+
+const pendingDispatchColumns = {
+  id: true,
+  bucket: true,
+  sequenceId: true,
+  contactId: true,
+  stepId: true,
+} as const
 
 export function calculateBucket(
   workspaceId: string,
@@ -112,36 +139,20 @@ export interface CancelPendingDispatchesParams {
   removeFromSchedule?: boolean
   workspaceId: string
 }
-export async function cancelPendingDispatches(
-  params: CancelPendingDispatchesParams,
+async function cancelPendingDispatchesByWhere(
+  options: CancelPendingDispatchesOptions,
 ): Promise<ScheduledDispatch[]> {
-  const {
-    enrollmentId,
-    workspaceId,
-    client = db,
-    removeFromSchedule = true,
-  } = params
-
-  const pendingDispatches = await client.query.sequenceDispatchModel.findMany({
-    where: {
-      enrollmentId,
-      workspaceId,
-      status: "pending",
-    },
-    columns: {
-      id: true,
-      bucket: true,
-      sequenceId: true,
-      contactId: true,
-      stepId: true,
-    },
-  })
+  const { client = db, removeFromSchedule = true, where } = options
+  const pendingDispatches = (await client.query.sequenceDispatchModel.findMany({
+    where,
+    columns: pendingDispatchColumns,
+  })) as PendingDispatch[]
 
   if (pendingDispatches.length === 0) {
     return []
   }
 
-  const dispatchIds = pendingDispatches.map((d) => d.id)
+  const dispatchIds = pendingDispatches.map((dispatch) => dispatch.id)
   await client
     .update(sequenceDispatchModel)
     .set({
@@ -151,7 +162,7 @@ export async function cancelPendingDispatches(
     .where(
       and(
         inArray(sequenceDispatchModel.id, dispatchIds),
-        eq(sequenceDispatchModel.workspaceId, workspaceId),
+        eq(sequenceDispatchModel.workspaceId, where.workspaceId),
         eq(sequenceDispatchModel.status, "pending"),
       ),
     )
@@ -160,10 +171,39 @@ export async function cancelPendingDispatches(
     await removeDispatchesFromSchedule(pendingDispatches)
   }
 
-  return pendingDispatches.map((d) => ({
-    id: d.id,
-    bucket: d.bucket,
+  return pendingDispatches.map((dispatch) => ({
+    id: dispatch.id,
+    bucket: dispatch.bucket,
   }))
+}
+
+export async function cancelPendingDispatches(
+  params: CancelPendingDispatchesParams,
+): Promise<ScheduledDispatch[]> {
+  return await cancelPendingDispatchesByWhere({
+    client: params.client,
+    removeFromSchedule: params.removeFromSchedule,
+    where: {
+      enrollmentId: params.enrollmentId,
+      status: "pending",
+      workspaceId: params.workspaceId,
+    },
+  })
+}
+
+export async function cancelPendingDispatchesForWorkspace(params: {
+  client?: DatabaseClient | Transaction
+  removeFromSchedule?: boolean
+  workspaceId: string
+}): Promise<ScheduledDispatch[]> {
+  return await cancelPendingDispatchesByWhere({
+    client: params.client,
+    removeFromSchedule: params.removeFromSchedule,
+    where: {
+      status: "pending",
+      workspaceId: params.workspaceId,
+    },
+  })
 }
 
 export async function removeDispatchesFromSchedule(

--- a/packages/sequence-scheduler/src/index.ts
+++ b/packages/sequence-scheduler/src/index.ts
@@ -2,6 +2,7 @@ export * from "./advance-enrollment"
 export * from "./calculate-next-run-at"
 // new imports
 export * from "./contacts-on-sequences"
+export * from "./dispatch-cancel"
 export * from "./dispatch-manager"
 export * from "./enroll-contact"
 export * from "./send-time-validator"

--- a/packages/variables/__tests__/system-fields.test.ts
+++ b/packages/variables/__tests__/system-fields.test.ts
@@ -920,6 +920,24 @@ describe("getSystemFieldValue", () => {
     })
   })
 
+  test("me returns null without creating a link when workspace is scheduled for deletion", async () => {
+    const scheduledWorkspace = {
+      ...workspace,
+      scheduledDeletionAt: new Date("2026-07-23T00:00:00.000Z"),
+    } as WorkspaceModel
+
+    const value = await getSystemFieldValue(
+      createContext({ workspace: scheduledWorkspace }),
+      systemFieldTypes.enum.me,
+    )
+
+    expect(value).toBeNull()
+    expect(mockFindWithIntegrationsById).not.toHaveBeenCalled()
+    expect(mockResolveWorkspaceAppUrl).not.toHaveBeenCalled()
+    expect(mockSystemFieldCreate).not.toHaveBeenCalled()
+    expect(mockSignMeLink).not.toHaveBeenCalled()
+  })
+
   test("location and flow step fields resolve from persisted contact state", async () => {
     mockFindDMByContact.mockResolvedValue({
       lastStep: "step-1",

--- a/packages/variables/src/utils.ts
+++ b/packages/variables/src/utils.ts
@@ -5,6 +5,7 @@ import {
   offsetFromStoredTimezone,
 } from "@chatbotx.io/business/contact-locale"
 import { resolveGenderLabel } from "@chatbotx.io/business/system-field"
+import { isWorkspaceScheduledForDeletion } from "@chatbotx.io/business/workspace-lifecycle/predicates"
 import {
   type ContactSource,
   contactSources,
@@ -326,9 +327,18 @@ export const getSystemFieldValue = async (
     case systemFieldTypes.enum.ig_business_follow_user:
     case systemFieldTypes.enum.timezone_name:
     case systemFieldTypes.enum.fb_chat_link:
-    case systemFieldTypes.enum.me:
     case systemFieldTypes.enum.user_code:
     case systemFieldTypes.enum.webchat:
+      return await getIntegrationField(
+        contact,
+        key,
+        contactInbox,
+        context.conversation?.id,
+      )
+    case systemFieldTypes.enum.me:
+      if (workspace && isWorkspaceScheduledForDeletion(workspace)) {
+        return null
+      }
       return await getIntegrationField(
         contact,
         key,


### PR DESCRIPTION
## What this does

When someone schedules a workspace for deletion, there is a 24-hour waiting period before it is actually removed. Until now the workspace kept working during that wait — the bot still replied, the inbox still sent messages, and scheduled broadcasts and follow-up messages still went out.

This change makes a workspace go quiet the moment deletion is scheduled. During the waiting period it stops serving people entirely.

## What changes for a workspace that is waiting to be deleted

- The bot no longer replies to anyone, on any channel or on webchat.
- No messages are received, processed, or sent.
- Links and tools stop working: magic links, QR codes, entry-point links, the privacy / "my data" pages, email open and click tracking, and unsubscribe. Anyone who opens one of these links sees a short "this workspace is no longer available" message instead of a broken page.
- API access using an API key stops working.
- Any broadcast or sequence that was scheduled or partway through sending is marked as **Cancelled**, so nothing goes out.
- When the wait ends and the workspace is deleted, all connected pages are disconnected so no more messages can arrive.

The owner keeps access to the workspace's Settings → General page, so they can still review the deletion, cancel it, or update the workspace's basic details while they decide.

## Open tabs stay in sync

If the same workspace is open in several browser tabs, scheduling the deletion in one tab now moves the other tabs to Settings → General too, instead of leaving them on a page that no longer works. Coming back to an old tab later does the same thing.

Opening Settings also lands on the right page now. Previously, in some cases it could end up on a broken address instead of Settings → General.

## Broadcasts

- Broadcasts now have a **Cancelled** status, shown with its own badge in the list and in the detail view.
- The estimated-contacts column only shows the loading spinner while a broadcast is still scheduled or sending. For broadcasts that will never be counted it now shows "-" instead of spinning forever.

## Webhook fixes

This branch also fixes three problems with outgoing webhooks:

- Every destination subscribed to the same event now receives exactly the same information. Previously the information sent could include tag names taken from a different workspace.
- If the information for an event cannot be prepared, the event is retried later instead of being dropped for every destination at once.
- A single destination that fails no longer stops the others from receiving the event. Destinations that have to be skipped are recorded in the logs.

## Before deploying

This change adds the new "Cancelled" status for broadcasts, which needs a small database update. Please apply the database migration before deploying this change.
