### PR TITLE
docs(git): require branching off main before committing

### DIFF
--- a/.agents/rules/git.md
+++ b/.agents/rules/git.md
@@ -36,6 +36,12 @@ Examples: `feat/instagram-channel`, `fix/whatsapp-webhook`, `bugfix/webhook-time
 
 Bot-generated branches (`dependabot/*`, `renovate/*`) are exempt from this convention and are skipped by the `post-checkout` hook.
 
+## Working Branch
+
+- **Never commit directly to `main` or `master`.** These branches only advance through merged PRs.
+- If the current branch is `main` (or `master`) when you are about to commit, **create a new feature branch first** (`git checkout -b <type>/<description>`, following the naming convention above), then commit onto that branch.
+- **Never** push to `main`/`master` directly and **never** force-push shared branches.
+
 ## Staging Rules
 
 - **Never** use `git add -A` or `git add .` — stage specific files only

--- a/.devin/rules/git.md
+++ b/.devin/rules/git.md
@@ -43,6 +43,12 @@ Examples: `feat/instagram-channel`, `fix/whatsapp-webhook`, `bugfix/webhook-time
 
 Bot-generated branches (`dependabot/*`, `renovate/*`) are exempt from this convention and are skipped by the `post-checkout` hook.
 
+## Working Branch
+
+- **Never commit directly to `main` or `master`.** These branches only advance through merged PRs.
+- If the current branch is `main` (or `master`) when you are about to commit, **create a new feature branch first** (`git checkout -b <type>/<description>`, following the naming convention above), then commit onto that branch.
+- **Never** push to `main`/`master` directly and **never** force-push shared branches.
+
 ## Staging Rules
 
 - **Never** use `git add -A` or `git add .` — stage specific files only


### PR DESCRIPTION
## Summary
- Codify the working-branch rule so agents never commit directly to `main`/`master` and always branch off first.
- Prevents accidental direct commits to the protected default branch during automated commit/PR flows.

## Changes
- `.agents/rules/git.md` — new **Working Branch** section: never commit to `main`/`master`, create a feature branch first when currently on `main`, never push/force-push shared branches directly.
- `.devin/rules/git.md` — regenerated mirror via `pnpm sync:agent-instructions` (canonical source is `.agents/rules/git.md`).

## Test plan
- [x] `pnpm sync:agent-instructions` runs clean and updates the `.devin` mirror
- [x] commit-msg hook accepts the conventional commit message
- [ ] Reviewer confirms wording matches intended branch policy