### PR TITLE
fix(worker): type condition-evaluator operator as OperatorType

### DIFF
--- a/apps/worker/src/trigger/services/condition-evaluator.ts
+++ b/apps/worker/src/trigger/services/condition-evaluator.ts
@@ -1,5 +1,8 @@
 import { db } from "@chatbotx.io/database/client"
-import { triggerEventTypes } from "@chatbotx.io/database/partials"
+import {
+  type OperatorType,
+  triggerEventTypes,
+} from "@chatbotx.io/database/partials"
 import type { WorkspaceModel } from "@chatbotx.io/database/types"
 import { toZonedWallClock } from "@chatbotx.io/utils/datetime"
 import type { ConditionEvaluationContext } from "../types"
@@ -27,7 +30,7 @@ export class ConditionEvaluator {
       case triggerEventTypes.enum.customFieldValueChanged:
         return await this.evaluateCustomFieldCondition(
           sourceId,
-          operator,
+          operator as OperatorType | null,
           value,
           eventData.eventData,
           contactId,
@@ -75,7 +78,7 @@ export class ConditionEvaluator {
 
   private async evaluateCustomFieldCondition(
     customFieldId: string | null,
-    operator: string | null,
+    operator: OperatorType | null,
     expectedValue: unknown,
     metadata: Record<string, unknown>,
     contactId: string,
@@ -146,7 +149,7 @@ export class ConditionEvaluator {
    * `default: return false` and silently drop a matching condition. Legacy
    * values pass through unchanged, keeping any old stored conditions working.
    */
-  private normalizeOperator(operator: string): string {
+  private normalizeOperator(operator: OperatorType): string {
     const aliases: Record<string, string> = {
       eq: "is",
       ne: "isNot",
@@ -160,7 +163,7 @@ export class ConditionEvaluator {
   }
 
   private evaluateOperator(
-    operator: string,
+    operator: OperatorType,
     actualValue: unknown,
     expectedValue: unknown,
     customFieldType?: string,


### PR DESCRIPTION
## Summary
- The trigger condition evaluator's `operator` boundary was typed as plain `string`, so a future rename/addition to the canonical `operatorTypes` enum (`packages/database/src/partials/custom-field.ts`) could silently drift again with no compiler error — this is the same class of bug already fixed once in `normalizeOperator`'s alias mapping
- Retypes the DB-facing boundary (`evaluateCustomFieldCondition`, `normalizeOperator`, `evaluateOperator`) to `OperatorType`
- The internal legacy-spelling functions (`evaluateStandardOperator`, `evaluateDateOperator`, `evaluateIntervalOperator`) keep plain `string` since they operate on the post-normalization internal vocabulary (`is`, `isNot`, `hasNoValue`, …), not the canonical enum — type-only change, no behavior change

## Test plan
- [x] `pnpm --filter worker check-types`
- [x] `pnpm --filter worker test __tests__/condition-evaluator.test.ts` (17/17 passing)
- [x] `pnpm lint`