### PR TITLE
feat(worker): propagate channel origin through trigger execution

### DIFF
--- a/apps/builder/src/features/messages/actions/create-webchat-message.action.ts
+++ b/apps/builder/src/features/messages/actions/create-webchat-message.action.ts
@@ -31,6 +31,7 @@ import {
 import type { WorkspaceModel } from "@chatbotx.io/database/types"
 import { emit } from "@chatbotx.io/event-bus"
 import { emitContactCreated } from "@chatbotx.io/events"
+import { setWebhookExecutionContext } from "@chatbotx.io/events/context"
 import { type UploadedFile, uploadMultipleFiles } from "@chatbotx.io/filesystem"
 import { messageEventTypeSchema } from "@chatbotx.io/flow-config"
 import { RealtimeEventType } from "@chatbotx.io/partysocket-config"
@@ -74,6 +75,8 @@ export async function handleCreateWebchatMessage({
 }: {
   parsedInput: CreateWebchatMessageRequest
 }) {
+  setWebhookExecutionContext({ source: "webhook" })
+
   const workspace = await workspaceService.find({
     where: { id: parsedInput.workspaceId },
   })

--- a/apps/worker/src/integration/job-context.ts
+++ b/apps/worker/src/integration/job-context.ts
@@ -16,7 +16,8 @@ export async function runIntegrationJobWithWebhookContext<T>(
   jobData: IntegrationJobData,
   callback: () => Promise<T>,
 ): Promise<T> {
-  const webhookExecutionContext = isChannelOriginatedJob(jobData)
+  const isChannelOriginated = isChannelOriginatedJob(jobData)
+  const webhookExecutionContext = isChannelOriginated
     ? { source: "webhook" as const }
     : {}
 

--- a/apps/worker/src/trigger/services/action-executor.ts
+++ b/apps/worker/src/trigger/services/action-executor.ts
@@ -6,6 +6,7 @@ import {
 import { and, db, eq, inArray } from "@chatbotx.io/database/client"
 import { triggerActions } from "@chatbotx.io/database/partials"
 import { contactsToTagsModel } from "@chatbotx.io/database/schema"
+import { webhookChannelOrigin } from "@chatbotx.io/events/context"
 import {
   errorStateDefaultFn,
   FieldOperationType,
@@ -176,6 +177,7 @@ export class ActionExecutor {
             conversationId: conversation,
             contactInboxId: recentContactInbox,
             flowId,
+            origin: webhookChannelOrigin(),
           },
         })
         break

--- a/apps/worker/src/trigger/types.ts
+++ b/apps/worker/src/trigger/types.ts
@@ -17,6 +17,7 @@ export type TriggerEventData = {
   eventData: Record<string, unknown>
   timestamp: Date
   source?: string
+  channelOriginated?: boolean
 }
 
 export type ConditionEvaluationContext = {

--- a/apps/worker/src/trigger/worker.ts
+++ b/apps/worker/src/trigger/worker.ts
@@ -1,3 +1,4 @@
+import { runWithWebhookExecutionContext } from "@chatbotx.io/events/context"
 import { SdkException } from "@chatbotx.io/sdk"
 import {
   defaultWorkerOptions,
@@ -45,10 +46,14 @@ const worker = new Worker(
           `Found ${matchedTriggers.length} triggers for event type ${eventData.eventType}`,
         )
 
-        await Promise.allSettled(
-          matchedTriggers.map((trigger) =>
-            triggerExecutor.execute(trigger, eventData.contactId),
-          ),
+        await runWithWebhookExecutionContext(
+          eventData.channelOriginated ? { source: "webhook" } : {},
+          () =>
+            Promise.allSettled(
+              matchedTriggers.map((trigger) =>
+                triggerExecutor.execute(trigger, eventData.contactId),
+              ),
+            ),
         )
         return
       }

--- a/packages/events/src/trigger/emitter.ts
+++ b/packages/events/src/trigger/emitter.ts
@@ -2,6 +2,7 @@ import type { TriggerEventType } from "@chatbotx.io/database/partials"
 import { triggerQueue } from "@chatbotx.io/worker-config"
 import { BaseEventEmitter } from "../base-emitter"
 import { EMITTED_EVENT_TYPE_SET } from "../event-type-registry"
+import { webhookChannelOrigin } from "../webhook/context"
 import { hasActiveTriggers } from "./cache"
 import { isWorkerContext } from "./context"
 
@@ -39,6 +40,7 @@ class TriggerEventEmitterImpl extends BaseEventEmitter {
           eventType,
           eventData: data.metadata || {},
           timestamp: new Date(),
+          channelOriginated: webhookChannelOrigin() === "channel",
         },
       },
       {

--- a/packages/events/src/webhook/context.ts
+++ b/packages/events/src/webhook/context.ts
@@ -1,35 +1,12 @@
+import { AsyncLocalStorage } from "node:async_hooks"
+
 type ExecutionContext = {
   source?: "webhook"
 }
 
-type AsyncLocalStorageType = {
-  enterWith: (context: ExecutionContext) => void
-  getStore: () => ExecutionContext | undefined
-  run: <T>(context: ExecutionContext, callback: () => T) => T
-}
-
-let asyncLocalStorage: AsyncLocalStorageType | null = null
-
-// Try to load AsyncLocalStorage - will fail in Edge Runtime
-async function initAsyncLocalStorage() {
-  try {
-    const asyncHooks = await import("node:async_hooks")
-    return new asyncHooks.AsyncLocalStorage()
-  } catch (e) {
-    console.error("Failed to load AsyncLocalStorage:", e)
-    return null
-  }
-}
-
-// Initialize async - will be null initially, then populated
-initAsyncLocalStorage().then((storage) => {
-  asyncLocalStorage = storage as AsyncLocalStorageType | null
-})
+const asyncLocalStorage = new AsyncLocalStorage<ExecutionContext>()
 
 export function setWebhookExecutionContext(context: ExecutionContext) {
-  if (!asyncLocalStorage) {
-    return
-  }
   return asyncLocalStorage.enterWith(context)
 }
 
@@ -37,23 +14,14 @@ export function runWithWebhookExecutionContext<T>(
   context: ExecutionContext,
   callback: () => T,
 ): T {
-  if (!asyncLocalStorage) {
-    return callback()
-  }
   return asyncLocalStorage.run(context, callback)
 }
 
 export function getWebhookExecutionContext(): ExecutionContext | undefined {
-  if (!asyncLocalStorage) {
-    return
-  }
   return asyncLocalStorage.getStore()
 }
 
 export function isWebhookContext(): boolean {
-  if (!asyncLocalStorage) {
-    return false
-  }
   const context = asyncLocalStorage.getStore()
   return context?.source === "webhook"
 }

--- a/packages/events/src/webhook/emitter.ts
+++ b/packages/events/src/webhook/emitter.ts
@@ -14,7 +14,9 @@ class WebhookEventEmitterImpl extends BaseEventEmitter {
     workspaceId: string,
     sourceId?: string,
   ): Promise<boolean> {
-    if (!isWebhookContext()) {
+    const inWebhookContext = isWebhookContext()
+
+    if (!inWebhookContext) {
       logger.debug(
         { eventType, workspaceId, sourceId },
         "Skipping webhook event outside channel-originated context",

--- a/packages/worker-config/src/queues/trigger/index.ts
+++ b/packages/worker-config/src/queues/trigger/index.ts
@@ -19,6 +19,7 @@ export type TriggerEvent = {
   eventData: Record<string, unknown>
   timestamp: Date
   source?: string
+  channelOriginated?: boolean
 }
 
 export type TriggerJobExecute = {


### PR DESCRIPTION
## Summary
- Stamps a `channelOriginated` flag on trigger events and dispatched jobs when they were caused by an incoming webhook (e.g. a webchat message), via an `AsyncLocalStorage`-based execution context, so downstream actions (like `startAnotherFlow`) can carry the same origin
- Fixes `packages/events/src/webhook/context.ts` to use a static `node:async_hooks` import instead of a dynamic `import()`, which the project's tsdown build cannot bundle (see `.agents/rules/no-dynamic-import.md`) — the old lazy-load fallback for Edge Runtime relied on the dynamic import, so it had to go regardless of the Edge concern

## Test plan
- [x] `pnpm --filter worker check-types` / `pnpm --filter builder check-types` / `pnpm --filter @chatbotx.io/events check-types` / `pnpm --filter @chatbotx.io/worker-config check-types`
- [x] `pnpm lint`