### PR TITLE
fix: unrelated contact and webhook payload fixes

### DIFF
--- a/apps/builder/src/features/contacts/actions/create-contact.action.ts
+++ b/apps/builder/src/features/contacts/actions/create-contact.action.ts
@@ -68,7 +68,7 @@ const resolveContactSourceId = ({
     return parsedInput.email ?? ""
   }
   if (channel === channelTypes.enum.webchat) {
-    return `${randomString()}${createId()}`
+    return `${randomString(10)}${createId()}`
   }
   return parsedInput.contactId ?? ""
 }

--- a/apps/builder/src/features/contacts/queries/public-find-contact.ts
+++ b/apps/builder/src/features/contacts/queries/public-find-contact.ts
@@ -101,7 +101,7 @@ export const publicListContactsByCustomField = async (
     where.phoneNumber = value
   } else {
     where.contactCustomFields = {
-      id: customFieldId,
+      customFieldId,
       value,
     }
   }

--- a/apps/worker/src/webhook/services/webhook-executor.service.ts
+++ b/apps/worker/src/webhook/services/webhook-executor.service.ts
@@ -1,4 +1,8 @@
-import { assertPublicUrl } from "@chatbotx.io/business"
+import {
+  assertPublicUrl,
+  contactCustomFieldService,
+  contactService,
+} from "@chatbotx.io/business"
 import { db } from "@chatbotx.io/database/client"
 import { triggerEventTypes } from "@chatbotx.io/database/partials"
 import type { MatchableEventType } from "@chatbotx.io/events"
@@ -16,6 +20,7 @@ type WebhookPayload = Record<string, unknown>
 type PayloadBuilder = (
   basePayload: WebhookPayloadBase,
   data: Record<string, unknown>,
+  workspaceId: string,
 ) => Promise<WebhookPayload> | WebhookPayload
 
 const EVENT_NAMES = {
@@ -98,16 +103,31 @@ function buildReferralPayload(
   }
 }
 
-function buildNewContactPayload(
+async function buildNewContactPayload(
   basePayload: WebhookPayloadBase,
   data: Record<string, unknown>,
-): WebhookPayload {
+  workspaceId: string,
+): Promise<WebhookPayload> {
+  const contact = await contactService.findById({
+    workspaceId,
+    id: basePayload.contact_id,
+  })
+  const customFields = contact
+    ? await contactCustomFieldService.listWithDefinitions({
+        contactId: contact.id,
+      })
+    : []
+
   return {
     ...basePayload,
-    name: data.name as string,
-    phone: data.phone as string,
-    email: data.email as string,
-    custom_fields: (data.customFields as Record<string, unknown>) || {},
+    name: contact?.fullName || (data.name as string) || null,
+    first_name: contact?.firstName || null,
+    last_name: contact?.lastName || null,
+    phone: contact?.phoneNumber || (data.phone as string) || null,
+    email: contact?.email || (data.email as string) || null,
+    custom_fields: Object.fromEntries(
+      customFields.map((field) => [field.name, field.value]),
+    ),
   }
 }
 
@@ -206,6 +226,7 @@ export class WebhookExecutor {
     return await PAYLOAD_BUILDERS[eventData.eventType](
       basePayload,
       eventData.eventData,
+      eventData.workspaceId,
     )
   }
 


### PR DESCRIPTION
## Summary
- `create-contact.action.ts`: pass a length to `randomString()` instead of calling it with no arguments
- `public-find-contact.ts`: filter contact custom fields by `customFieldId` instead of the wrong `id` column
- `webhook-executor.service.ts`: enrich the native outgoing-webhook "new contact" payload with real contact/custom-field data

These three were bundled in with a larger in-progress changeset and have no dependency on it or on each other, so they're split out as their own small PR.

## Test plan
- [x] `pnpm --filter builder check-types` / `pnpm --filter worker check-types`
- [x] `pnpm lint`