### PR TITLE
fix(comment-automation): deliver flow-type private replies via comment-anchored send

### DIFF
--- a/apps/worker/__tests__/comment-automation.test.ts
+++ b/apps/worker/__tests__/comment-automation.test.ts
@@ -446,6 +446,47 @@ describe("processCommentAutomation AIAgent reply", () => {
   })
 })
 
+describe("processCommentAutomation flow private reply", () => {
+  test("messenger: enqueues a sendFlow job carrying commentAnchor with the triggering commentId", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({ privateReply: { type: "flow", value: "flow-1" } }),
+    ])
+
+    await processCommentAutomation(buildJobData() as any)
+
+    expect(mockIntegrationQueueAdd).toHaveBeenCalledWith(
+      "sendFlow",
+      expect.objectContaining({
+        type: "sendFlow",
+        data: expect.objectContaining({
+          flowId: "flow-1",
+          commentAnchor: { commentId: COMMENT_ID },
+        }),
+      }),
+      expect.anything(),
+    )
+  })
+
+  test("instagram: enqueues sendFlow without a commentAnchor (no private_replies API)", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({ privateReply: { type: "flow", value: "flow-1" } }),
+    ])
+
+    await processCommentAutomation({
+      ...buildJobData(),
+      integrationType: "instagram",
+    } as any)
+
+    expect(mockIntegrationQueueAdd).toHaveBeenCalledWith(
+      "sendFlow",
+      expect.objectContaining({
+        data: expect.not.objectContaining({ commentAnchor: expect.anything() }),
+      }),
+      expect.anything(),
+    )
+  })
+})
+
 describe("processCommentAIReply", () => {
   beforeEach(() => {
     mockAiAgentFindBy.mockResolvedValue({ id: "agent-1", prompt: "hi" })

--- a/apps/worker/__tests__/flow.test.ts
+++ b/apps/worker/__tests__/flow.test.ts
@@ -354,6 +354,27 @@ describe("seekConnectedNode", () => {
   })
 })
 
+describe("MESSAGE_PRODUCING_STEP_TYPES", () => {
+  test("matches exactly the step types mapped to sendFlowMessage in flowStepHandlers", async () => {
+    const { MESSAGE_PRODUCING_STEP_TYPES } = await import(
+      "../src/integration/handlers/flow-utils"
+    )
+    const { flowStepHandlers, sendFlowMessage } = await import(
+      "../src/integration/handlers/step"
+    )
+
+    const actualMessageProducingTypes = new Set(
+      Object.entries(flowStepHandlers)
+        .filter(([, handler]) => handler === sendFlowMessage)
+        .map(([stepType]) => stepType),
+    )
+
+    expect(new Set(MESSAGE_PRODUCING_STEP_TYPES)).toEqual(
+      actualMessageProducingTypes,
+    )
+  })
+})
+
 describe("executeMultipleSteps — void handler normalization", () => {
   beforeEach(() => integrationQueueAdd.mockClear())
 
@@ -1099,6 +1120,210 @@ describe("runStepsAndQuickReplies — per-step re-dispatch", () => {
       { data: { nodeId: string } },
     ]
     expect(job.data.nodeId).toBe("node-2")
+  })
+})
+
+describe("runStepsAndQuickReplies — commentAnchor propagation", () => {
+  beforeEach(() => {
+    integrationQueueAdd.mockClear()
+    chatQueueAdd.mockClear()
+  })
+
+  const commentAnchor = { commentId: "comment-1" }
+
+  test("forwards commentAnchor into the first message-producing step, and drops it from the next-step re-dispatch", async () => {
+    const step1 = { ...makeStep("sendText"), id: "step-1" }
+    const step2 = { ...makeStep("sendText"), id: "step-2" }
+    const props = {
+      ...makeBaseProps(),
+      details: { steps: [step1, step2] },
+      triggerNextNode: false,
+      commentAnchor,
+    }
+
+    await runStepsAndQuickReplies(props)
+
+    expect(chatQueueAdd).toHaveBeenCalledOnce()
+    const [, chatJob] = chatQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { commentAnchor?: typeof commentAnchor } },
+    ]
+    expect(chatJob.data.commentAnchor).toEqual(commentAnchor)
+
+    expect(integrationQueueAdd).toHaveBeenCalledOnce()
+    const [, nextJob] = integrationQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { commentAnchor?: typeof commentAnchor } },
+    ]
+    expect(nextJob.data.commentAnchor).toBeUndefined()
+  })
+
+  test("forwards commentAnchor through a non-message step to the next-step re-dispatch", async () => {
+    const step1 = { ...makeStep("landingPage"), id: "step-1" }
+    const step2 = { ...makeStep("sendText"), id: "step-2" }
+    const props = {
+      ...makeBaseProps(),
+      details: { steps: [step1, step2] },
+      triggerNextNode: false,
+      commentAnchor,
+    }
+
+    await runStepsAndQuickReplies(props)
+
+    expect(chatQueueAdd).not.toHaveBeenCalled()
+    expect(integrationQueueAdd).toHaveBeenCalledOnce()
+    const [, nextJob] = integrationQueueAdd.mock.calls[0] as unknown as [
+      string,
+      {
+        data: { startFromStepId: string; commentAnchor?: typeof commentAnchor }
+      },
+    ]
+    expect(nextJob.data.startFromStepId).toBe("step-2")
+    expect(nextJob.data.commentAnchor).toEqual(commentAnchor)
+  })
+
+  test("consumes commentAnchor when resuming at the message step via startFromStepId", async () => {
+    const step1 = { ...makeStep("landingPage"), id: "step-1" }
+    const step2 = { ...makeStep("sendText"), id: "step-2" }
+    const props = {
+      ...makeBaseProps(),
+      details: { steps: [step1, step2] },
+      startFromStepId: "step-2",
+      triggerNextNode: false,
+      commentAnchor,
+    }
+
+    await runStepsAndQuickReplies(props)
+
+    expect(chatQueueAdd).toHaveBeenCalledOnce()
+    const [, chatJob] = chatQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { commentAnchor?: typeof commentAnchor } },
+    ]
+    expect(chatJob.data.commentAnchor).toEqual(commentAnchor)
+    expect(integrationQueueAdd).not.toHaveBeenCalled()
+  })
+
+  test("does not forward commentAnchor to the next-node dispatch once a message step consumed it", async () => {
+    const nextNode: FlowNode = {
+      id: "node-2",
+      position: { x: 0, y: 0 },
+      measured: { width: 100, height: 100 },
+      data: { name: "Next", isStartNode: false, details: { steps: [] } },
+    }
+    const edges: EdgeSchema[] = [
+      {
+        id: "e1",
+        source: "node-1",
+        sourceHandle: "node-1",
+        target: "node-2",
+        targetHandle: "input",
+      },
+    ]
+    const flowVersion = makeFlowVersion([nextNode], edges)
+    const step1 = { ...makeStep("sendText"), id: "step-1" }
+    const props = {
+      ...makeBaseProps(flowVersion),
+      details: { steps: [step1] },
+      triggerNextNode: true,
+      commentAnchor,
+    }
+
+    await runStepsAndQuickReplies(props)
+
+    expect(chatQueueAdd).toHaveBeenCalledOnce()
+    const [, chatJob] = chatQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { commentAnchor?: typeof commentAnchor } },
+    ]
+    expect(chatJob.data.commentAnchor).toEqual(commentAnchor)
+
+    expect(integrationQueueAdd).toHaveBeenCalledOnce()
+    const [, nextNodeJob] = integrationQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { nodeId: string; commentAnchor?: typeof commentAnchor } },
+    ]
+    expect(nextNodeJob.data.nodeId).toBe("node-2")
+    expect(nextNodeJob.data.commentAnchor).toBeUndefined()
+  })
+
+  test("forwards commentAnchor to the next-node dispatch when no step consumed it", async () => {
+    const nextNode: FlowNode = {
+      id: "node-2",
+      position: { x: 0, y: 0 },
+      measured: { width: 100, height: 100 },
+      data: { name: "Next", isStartNode: false, details: { steps: [] } },
+    }
+    const edges: EdgeSchema[] = [
+      {
+        id: "e1",
+        source: "node-1",
+        sourceHandle: "node-1",
+        target: "node-2",
+        targetHandle: "input",
+      },
+    ]
+    const flowVersion = makeFlowVersion([nextNode], edges)
+    const step1 = { ...makeStep("landingPage"), id: "step-1" }
+    const props = {
+      ...makeBaseProps(flowVersion),
+      details: { steps: [step1] },
+      triggerNextNode: true,
+      commentAnchor,
+    }
+
+    await runStepsAndQuickReplies(props)
+
+    expect(chatQueueAdd).not.toHaveBeenCalled()
+    expect(integrationQueueAdd).toHaveBeenCalledOnce()
+    const [, nextNodeJob] = integrationQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { nodeId: string; commentAnchor?: typeof commentAnchor } },
+    ]
+    expect(nextNodeJob.data.nodeId).toBe("node-2")
+    expect(nextNodeJob.data.commentAnchor).toEqual(commentAnchor)
+  })
+
+  test("branch routing (step states) does not carry commentAnchor once the branching step consumed it", async () => {
+    const stateId = "state-success"
+    const step = {
+      ...makeStep("sendText", [{ id: stateId, stateType: "success" as const }]),
+      id: "step-1",
+    }
+    const flowVersion = makeFlowVersion(
+      [],
+      [
+        {
+          id: "e1",
+          source: "n1",
+          sourceHandle: stateId,
+          target: "node-next",
+          targetHandle: "input",
+        },
+      ],
+    )
+    const props = {
+      ...makeBaseProps(flowVersion),
+      steps: [step],
+      commentAnchor,
+    }
+
+    await executeMultipleSteps(props)
+
+    expect(chatQueueAdd).toHaveBeenCalledOnce()
+    const [, chatJob] = chatQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { commentAnchor?: typeof commentAnchor } },
+    ]
+    expect(chatJob.data.commentAnchor).toEqual(commentAnchor)
+
+    expect(integrationQueueAdd).toHaveBeenCalledOnce()
+    const [, branchJob] = integrationQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { nodeId: string; commentAnchor?: typeof commentAnchor } },
+    ]
+    expect(branchJob.data.nodeId).toBe("node-next")
+    expect(branchJob.data.commentAnchor).toBeUndefined()
   })
 })
 

--- a/apps/worker/__tests__/send-flow-step.test.ts
+++ b/apps/worker/__tests__/send-flow-step.test.ts
@@ -708,6 +708,36 @@ describe("sendFlowStep", () => {
     expect(mockProcessMessengerTemplate).toHaveBeenCalled()
     expect(mockCreateMessageRepository).not.toHaveBeenCalled()
   })
+
+  test("forwards commentAnchor to sendFlowStepToChannel when the resolved contactInbox is messenger", async () => {
+    await sendFlowStep({
+      ...baseParams,
+      commentAnchor: { commentId: "comment-1" },
+    })
+
+    expect(mockSendFlowStepToChannel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commentAnchor: { commentId: "comment-1" },
+      }),
+    )
+  })
+
+  test("suppresses commentAnchor when the resolved contactInbox is not messenger", async () => {
+    const instagramContactInbox = {
+      ...fakeContactInbox,
+      channel: "instagram",
+    } as unknown as typeof fakeContactInbox
+    mockFindContactInbox.mockResolvedValue(instagramContactInbox)
+
+    await sendFlowStep({
+      ...baseParams,
+      commentAnchor: { commentId: "comment-1" },
+    })
+
+    expect(mockSendFlowStepToChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ commentAnchor: undefined }),
+    )
+  })
 })
 
 describe("sendChatMessage", () => {

--- a/apps/worker/src/chat/handlers/send-flow-step.ts
+++ b/apps/worker/src/chat/handlers/send-flow-step.ts
@@ -190,6 +190,7 @@ export async function sendFlowStep({
   richResponse,
   quickReplies,
   sendFrom,
+  commentAnchor,
 }: ChatJobSendFlowStep["data"]) {
   const conversation = await db.query.conversationModel.findFirst({
     where: { id: conversationId },
@@ -485,6 +486,13 @@ export async function sendFlowStep({
       messageId: message?.id,
       messageCreatedAt: message?.createdAt,
       sendFrom,
+      // Comment-anchored private replies are Messenger-only (no Instagram
+      // private_replies equivalent) — defensive re-check in case a resolved
+      // contactInboxId ever points at a different channel than the job intended.
+      commentAnchor:
+        targetContactInbox.channel === channelTypes.enum.messenger
+          ? commentAnchor
+          : undefined,
     })
 
     const promises: Promise<unknown>[] = [

--- a/apps/worker/src/chat/handlers/send-message.ts
+++ b/apps/worker/src/chat/handlers/send-message.ts
@@ -14,6 +14,7 @@ import {
 } from "@chatbotx.io/flow-config"
 import { RealtimeEventType } from "@chatbotx.io/partysocket-config"
 import {
+  type CommentAnchor,
   type MessageButtonTemplate,
   parseSdkError,
   type SendFlowStepData,
@@ -394,6 +395,7 @@ export async function sendFlowStepToChannel({
   messageId,
   messageCreatedAt,
   sendFrom,
+  commentAnchor,
 }: {
   conversation: ConversationModel
   contactInbox: ContactInboxModel
@@ -406,6 +408,7 @@ export async function sendFlowStepToChannel({
   messageId?: string
   messageCreatedAt?: Date
   sendFrom?: "inbox"
+  commentAnchor?: CommentAnchor
 }): Promise<{ messageIds: string[] }> {
   const { integration, ctx } = await resolveIntegrationContextFromContactInbox({
     workspaceId: conversation.workspaceId,
@@ -450,6 +453,7 @@ export async function sendFlowStepToChannel({
         metadata,
         richResponse,
         sendFrom,
+        commentAnchor,
       },
     },
   )

--- a/apps/worker/src/integration/handlers/comment-automation/index.ts
+++ b/apps/worker/src/integration/handlers/comment-automation/index.ts
@@ -336,6 +336,9 @@ async function executePrivateReply(
           contactInboxId: ctx.contactInboxId,
           flowId: privateReply.value,
           origin: webhookChannelOrigin(),
+          ...(ctx.channelType === "messenger"
+            ? { commentAnchor: { commentId: ctx.commentId } }
+            : {}),
         },
       },
       { delay: ctx.delay },

--- a/apps/worker/src/integration/handlers/condition.ts
+++ b/apps/worker/src/integration/handlers/condition.ts
@@ -22,6 +22,7 @@ export async function handleCondition(
     nodeVisits,
     metadata,
     trackingContext,
+    commentAnchor,
   } = props
 
   const resolveMatchedHandleId = async (): Promise<string> => {
@@ -77,6 +78,7 @@ export async function handleCondition(
       trackingContext,
       sendFrom,
       nodeVisits,
+      commentAnchor,
       origin: webhookChannelOrigin(),
     },
   })

--- a/apps/worker/src/integration/handlers/flow-utils.ts
+++ b/apps/worker/src/integration/handlers/flow-utils.ts
@@ -4,13 +4,15 @@ import type {
   FlowVersionModel,
 } from "@chatbotx.io/database/types"
 import { webhookChannelOrigin } from "@chatbotx.io/events/context"
-import type {
-  BaseStepSchema,
-  ButtonStepProps,
-  EdgeSchema,
-  MetadataPayload,
+import {
+  type BaseStepSchema,
+  type ButtonStepProps,
+  type EdgeSchema,
+  type MetadataPayload,
+  type StepType,
+  stepTypes,
 } from "@chatbotx.io/flow-config"
-import type { Variables } from "@chatbotx.io/sdk"
+import type { CommentAnchor, Variables } from "@chatbotx.io/sdk"
 import {
   type BotResponseTrackingContext,
   ChatJobAction,
@@ -41,11 +43,35 @@ export type ExecuteMultipleStepsProps = {
   nodeVisits?: NodeVisits
   triggerMessageId?: string
   triggerMessageCreatedAt?: Date
+  commentAnchor?: CommentAnchor
 }
 
 export type ExecuteStepProps<T> = Omit<ExecuteMultipleStepsProps, "steps"> & {
   step: T
 }
+
+/**
+ * Step types that actually send an outgoing message via `sendFlowMessage`
+ * (see the `flowStepHandlers` map in `./step.ts` — keep this set in sync with
+ * every entry mapped to `sendFlowMessage` there). Used to decide which step
+ * "claims" a pending `commentAnchor` (comment-triggered private-reply flow) as
+ * its first outgoing message.
+ */
+export const MESSAGE_PRODUCING_STEP_TYPES = new Set<StepType>([
+  stepTypes.enum.sendText,
+  stepTypes.enum.sendImage,
+  stepTypes.enum.sendGif,
+  stepTypes.enum.sendFile,
+  stepTypes.enum.sendVideo,
+  stepTypes.enum.sendAudio,
+  stepTypes.enum.sendCard,
+  stepTypes.enum.sendCarousel,
+  stepTypes.enum.sendQuickReply,
+  stepTypes.enum.sendWaTemplateMessage,
+  stepTypes.enum.sendMessengerTemplateMessage,
+  stepTypes.enum.whatsappOptionList,
+  stepTypes.enum.whatsappFlow,
+])
 
 export type SuccessErrorStepSchema = BaseStepSchema & {
   successNodeId?: string
@@ -92,6 +118,7 @@ export async function sendFlow(
         metadata: props.metadata,
         sendFrom: props.sendFrom,
         nodeVisits: props.nodeVisits,
+        commentAnchor: props.commentAnchor,
         origin: webhookChannelOrigin(),
       },
     })

--- a/apps/worker/src/integration/handlers/flow.ts
+++ b/apps/worker/src/integration/handlers/flow.ts
@@ -24,7 +24,12 @@ import {
   type StepType,
   stepTypes,
 } from "@chatbotx.io/flow-config"
-import { initVariables, SdkException, type Variables } from "@chatbotx.io/sdk"
+import {
+  type CommentAnchor,
+  initVariables,
+  SdkException,
+  type Variables,
+} from "@chatbotx.io/sdk"
 import {
   type BotResponseTrackingContext,
   IntegrationJobAction,
@@ -39,7 +44,11 @@ import {
   detectFlowVersion,
 } from "../../lib/db"
 import { logger } from "../../lib/logger"
-import { type ExecuteMultipleStepsProps, seekConnectedNode } from "./flow-utils"
+import {
+  type ExecuteMultipleStepsProps,
+  MESSAGE_PRODUCING_STEP_TYPES,
+  seekConnectedNode,
+} from "./flow-utils"
 import { executeRichActions } from "./rich-response/action-executor"
 import { richButtonPayloadSchema } from "./rich-response/button-payload"
 import {
@@ -107,6 +116,7 @@ type ExecuteStepsAndQuickRepliesProps = {
   nodeVisits?: NodeVisits
   triggerMessageId?: string
   triggerMessageCreatedAt?: Date
+  commentAnchor?: CommentAnchor
 }
 
 type FlowActionTarget =
@@ -132,7 +142,7 @@ export const runFlowNode = async (props: IntegrationJobRunFlowNode["data"]) => {
     return
   }
 
-  const { trackingContext, metadata, sendFrom } = props
+  const { trackingContext, metadata, sendFrom, commentAnchor } = props
   const { conversation, contactInbox } =
     await detectConversationAndContactInbox({
       conversationId: props.conversationId,
@@ -177,6 +187,7 @@ export const runFlowNode = async (props: IntegrationJobRunFlowNode["data"]) => {
       metadata,
       sendFrom,
       nodeVisits: props.nodeVisits,
+      commentAnchor,
     })
   } catch (error) {
     if (props.metadata?.type === BROADCAST_PAYLOAD_TYPE) {
@@ -275,12 +286,20 @@ export async function runStepsAndQuickReplies(
     (targetType === "button" || targetType === "quickReply") &&
     details.beforeStep?.stepType === stepTypes.enum.startAnotherNode
 
+  // Tracks whether the comment-anchored private-reply send is still available
+  // to be claimed by the first message-producing step. Forwarded across every
+  // re-enqueued sendFlow job below until a step consumes it (see
+  // `executeMultipleStepsGenerator`'s `MESSAGE_PRODUCING_STEP_TYPES` check).
+  let remainingAnchor = props.commentAnchor
+
   if (details.beforeStep && !props.startFromStepId && !skipBeforeStep) {
-    await executeMultipleSteps({
+    const beforeResult = await executeMultipleSteps({
       ...props,
       nodeVisits,
+      commentAnchor: remainingAnchor,
       steps: [details.beforeStep],
     })
+    remainingAnchor = beforeResult?.commentAnchor
   }
 
   // run steps — one per BullMQ job, re-dispatching for subsequent steps
@@ -304,10 +323,12 @@ export async function runStepsAndQuickReplies(
     const result = await executeMultipleSteps({
       ...props,
       nodeVisits,
+      commentAnchor: remainingAnchor,
       quickReplies:
         quickReplyCarrier?.id === currentStep.id ? quickReplies : undefined,
       steps: [currentStep],
     })
+    remainingAnchor = result?.commentAnchor
 
     if (result?.status === "wait" || result?.status === "retry") {
       return result
@@ -335,6 +356,7 @@ export async function runStepsAndQuickReplies(
           trackingContext: props.trackingContext,
           sendFrom: props.sendFrom,
           nodeVisits,
+          commentAnchor: remainingAnchor,
           origin: webhookChannelOrigin(),
         },
       })
@@ -378,6 +400,7 @@ export async function runStepsAndQuickReplies(
         trackingContext: props.trackingContext,
         sendFrom: props.sendFrom,
         nodeVisits,
+        commentAnchor: remainingAnchor,
         origin: webhookChannelOrigin(),
       },
     })
@@ -386,7 +409,12 @@ export async function runStepsAndQuickReplies(
 
 export async function executeMultipleSteps(props: ExecuteMultipleStepsProps) {
   const gen = executeMultipleStepsGenerator(props)
-  let lastResult: (ExecuteStepResult & { branched: boolean }) | undefined
+  let lastResult:
+    | (ExecuteStepResult & {
+        branched: boolean
+        commentAnchor?: CommentAnchor
+      })
+    | undefined
 
   for await (const result of gen) {
     logger.debug({ result }, "execute multiple steps result")
@@ -401,7 +429,10 @@ export async function executeMultipleSteps(props: ExecuteMultipleStepsProps) {
 async function* executeMultipleStepsGenerator(
   props: ExecuteMultipleStepsProps,
 ) {
-  const { steps, ...rest } = props
+  const { steps, commentAnchor, ...rest } = props
+  // Consumed by the first message-producing step in this run (however many
+  // jobs/nodes it takes to reach one) — see MESSAGE_PRODUCING_STEP_TYPES.
+  let anchorAvailable = commentAnchor
 
   for (const step of steps) {
     // `nodeId` is overloaded: startAnotherNode/startExternalNode store their own jump
@@ -414,8 +445,17 @@ async function* executeMultipleStepsGenerator(
       nodeId: step.nodeId ?? props.targetNodeId ?? "",
     }
 
+    const isMessageProducingStep = MESSAGE_PRODUCING_STEP_TYPES.has(
+      step.stepType as StepType,
+    )
+    const stepAnchor = isMessageProducingStep ? anchorAvailable : undefined
+    if (isMessageProducingStep) {
+      anchorAvailable = undefined
+    }
+
     const rawResult = await flowStepHandlers[step.stepType as StepType]?.({
       ...rest,
+      commentAnchor: stepAnchor,
       step: stepWithNodeId,
     })
 
@@ -452,6 +492,7 @@ async function* executeMultipleStepsGenerator(
               trackingContext: props.trackingContext,
               sendFrom: props.sendFrom,
               nodeVisits: props.nodeVisits,
+              commentAnchor: anchorAvailable,
               origin: webhookChannelOrigin(),
             },
           })
@@ -460,7 +501,7 @@ async function* executeMultipleStepsGenerator(
       }
     }
 
-    yield { ...result, branched }
+    yield { ...result, branched, commentAnchor: anchorAvailable }
   }
 }
 

--- a/apps/worker/src/integration/handlers/follow-up.ts
+++ b/apps/worker/src/integration/handlers/follow-up.ts
@@ -21,6 +21,11 @@ type FollowUpStepResult = {
   result: null
 }
 
+// Known gap: like `handleWait` in step.ts, `commentAnchor` is not threaded
+// into `scheduleSmartDelayResume` — a comment-triggered private-reply flow
+// with a followUp step before its first message step loses the anchor across
+// the delay. Fixing this needs a `ContactOnSmartDelay` schema change; out of
+// scope for now.
 export async function handleFollowUp({
   conversation,
   flowVersion,

--- a/apps/worker/src/integration/handlers/step.ts
+++ b/apps/worker/src/integration/handlers/step.ts
@@ -110,6 +110,7 @@ export async function sendFlowMessage(
     metadata,
     quickReplies,
     sendFrom,
+    commentAnchor,
   } = props
   await enqueueFlowStepMessage({
     conversationId: conversation.id,
@@ -121,6 +122,7 @@ export async function sendFlowMessage(
     metadata,
     quickReplies,
     sendFrom,
+    commentAnchor,
   })
 }
 
@@ -133,6 +135,7 @@ async function splitTraffic({
   useLatestFlowVersion,
   sendFrom,
   nodeVisits,
+  commentAnchor,
 }: ExecuteStepProps<SplitTrafficStepSchema>) {
   if (!(targetId && step.cases.length)) {
     return
@@ -165,12 +168,20 @@ async function splitTraffic({
         nodeId: connectedEdge.target,
         sendFrom,
         nodeVisits,
+        commentAnchor,
         origin: webhookChannelOrigin(),
       },
     })
   }
 }
 
+// Known gap: `commentAnchor` (comment-triggered private-reply flows, see
+// `flow-utils.ts`) is not threaded into `scheduleSmartDelayResume` —
+// `ContactOnSmartDelay` has no column for it, and the resumed `sendFlow` job
+// is rebuilt from that DB row alone (`buildSendFlowResumeJob`). A private
+// reply flow with a "wait" step before its first message step loses the
+// anchor and falls back to the normal (messaging-window-gated) send once the
+// delay elapses. Fixing this needs a schema change; out of scope for now.
 async function handleWait({
   conversation,
   flowVersion,
@@ -251,6 +262,7 @@ async function startAnotherNode(
       metadata: props.metadata,
       sendFrom: props.sendFrom,
       nodeVisits: props.nodeVisits,
+      commentAnchor: props.commentAnchor,
       origin: webhookChannelOrigin(),
     },
   })
@@ -263,6 +275,7 @@ async function startExternalFlow({
   metadata,
   sendFrom,
   nodeVisits,
+  commentAnchor,
 }: ExecuteStepProps<StartExternalFlowStepSchema>) {
   await integrationQueue.add(IntegrationJobAction.sendFlow, {
     type: IntegrationJobAction.sendFlow,
@@ -273,6 +286,7 @@ async function startExternalFlow({
       metadata,
       sendFrom,
       nodeVisits,
+      commentAnchor,
       origin: webhookChannelOrigin(),
     },
   })
@@ -285,6 +299,7 @@ async function startExternalNode({
   metadata,
   sendFrom,
   nodeVisits,
+  commentAnchor,
 }: ExecuteStepProps<StartExternalNodeStepSchema>) {
   await integrationQueue.add(IntegrationJobAction.sendFlow, {
     type: IntegrationJobAction.sendFlow,
@@ -296,6 +311,7 @@ async function startExternalNode({
       metadata,
       sendFrom,
       nodeVisits,
+      commentAnchor,
       origin: webhookChannelOrigin(),
     },
   })

--- a/apps/worker/src/questionnaires/services/engine.ts
+++ b/apps/worker/src/questionnaires/services/engine.ts
@@ -83,6 +83,11 @@ const questionQuickReplies = (
 
 const QUESTIONNAIRE_MESSAGE_LOOKBACK_MS = 365 * 24 * 60 * 60 * 1000
 
+// Known gap: does not forward `props.commentAnchor` — moot in practice today
+// since a questionnaire always waits for the user's answer between
+// questions, which already drops the anchor before completion (same
+// wait-boundary semantics as `handleWait`/`handleFollowUp`). Revisit if a
+// questionnaire step is ever made to complete without any wait.
 async function startTriggerFlow(
   props: ExecuteStepProps<QuestionnairesStepSchema>,
   flowId: string | null | undefined,

--- a/integrations/messenger/__tests__/send-flow-step-comment-anchor.test.ts
+++ b/integrations/messenger/__tests__/send-flow-step-comment-anchor.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockSendPageMessage, mockSendPrivateReplyMessage } = vi.hoisted(() => ({
+  mockSendPageMessage: vi.fn(),
+  mockSendPrivateReplyMessage: vi.fn(),
+}))
+
+vi.mock("../src/apis/message", () => ({
+  sendPageMessage: mockSendPageMessage,
+}))
+
+vi.mock("../src/apis/comment", () => ({
+  sendPrivateReplyMessage: mockSendPrivateReplyMessage,
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+const { sendFlowStep } = await import(
+  "../src/handlers/message/outgoing-message"
+)
+
+const ctx = {
+  auth: {
+    tokens: { accessToken: "tok" },
+    version: "v20.0",
+    metadata: { pageId: "page-1" },
+  },
+  integrationDetail: { personaId: undefined },
+} as never
+
+const contact = {
+  id: "contact-1",
+  sourceId: "psid-1",
+  lastIncomingMessageAt: new Date("2026-06-23T09:00:00.000Z"),
+} as never
+
+describe("messenger sendFlowStep — comment-anchored private reply", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSendPageMessage.mockResolvedValue({
+      recipient_id: "psid-1",
+      message_id: "m_normal-1",
+    })
+    mockSendPrivateReplyMessage.mockResolvedValue({
+      recipient_id: "psid-1",
+      message_id: "m_anchored-1",
+    })
+  })
+
+  test("uses the comment_id-anchored Send API when commentAnchor is present", async () => {
+    const result = await sendFlowStep({
+      ctx,
+      data: {
+        contact,
+        commentAnchor: { commentId: "comment-1" },
+        step: {
+          id: "step-1",
+          nodeId: "node-1",
+          stepType: "sendText",
+          text: "private reply via flow",
+          buttons: [],
+        },
+      },
+    } as never)
+
+    expect(mockSendPrivateReplyMessage).toHaveBeenCalledTimes(1)
+    expect(mockSendPrivateReplyMessage).toHaveBeenCalledWith(
+      ctx.auth,
+      "comment-1",
+      expect.objectContaining({ text: "private reply via flow" }),
+      undefined,
+    )
+    expect(mockSendPageMessage).not.toHaveBeenCalled()
+    expect(result).toEqual({ messageIds: ["m_anchored-1"] })
+  })
+
+  test("uses the normal Send API when commentAnchor is absent (regression guard)", async () => {
+    const result = await sendFlowStep({
+      ctx,
+      data: {
+        contact,
+        step: {
+          id: "step-1",
+          nodeId: "node-1",
+          stepType: "sendText",
+          text: "normal flow reply",
+          buttons: [],
+        },
+      },
+    } as never)
+
+    expect(mockSendPageMessage).toHaveBeenCalledTimes(1)
+    expect(mockSendPrivateReplyMessage).not.toHaveBeenCalled()
+    expect(result).toEqual({ messageIds: ["m_normal-1"] })
+  })
+
+  test("only the first Facebook message of a multi-message step uses the comment anchor", async () => {
+    const cards = Array.from({ length: 11 }, (_, i) => ({
+      title: `Card ${i}`,
+      buttons: [],
+    }))
+
+    const result = await sendFlowStep({
+      ctx,
+      data: {
+        contact,
+        commentAnchor: { commentId: "comment-1" },
+        step: {
+          id: "step-1",
+          nodeId: "node-1",
+          stepType: "sendCarousel",
+          cards,
+        },
+      },
+    } as never)
+
+    // 11 cards chunked by 10 → 2 Facebook messages for this single step
+    expect(mockSendPrivateReplyMessage).toHaveBeenCalledTimes(1)
+    expect(mockSendPrivateReplyMessage).toHaveBeenCalledWith(
+      ctx.auth,
+      "comment-1",
+      expect.anything(),
+      undefined,
+    )
+    expect(mockSendPageMessage).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ messageIds: ["m_anchored-1", "m_normal-1"] })
+  })
+})

--- a/integrations/messenger/__tests__/send-private-reply.test.ts
+++ b/integrations/messenger/__tests__/send-private-reply.test.ts
@@ -1,0 +1,80 @@
+import { HttpResponse, http, server } from "@chatbotx.io/vitest-config/msw"
+import { describe, expect, test } from "vitest"
+import { sendPrivateReply, sendPrivateReplyMessage } from "../src/apis/comment"
+import { DEFAULT_API_VERSION } from "../src/constants"
+import {
+  MESSENGER_MESSAGE_METADATA,
+  type MessengerAuthValue,
+} from "../src/schema"
+
+const PAGE_ID = "page-1"
+const COMMENT_ID = "comment-123"
+const BASE = "https://graph.facebook.com"
+
+const auth = {
+  tokens: { accessToken: "PAGE_TOKEN" },
+  metadata: { pageId: PAGE_ID },
+} as unknown as MessengerAuthValue
+
+function captureRequestBody(): { body: () => unknown } {
+  let body: unknown = null
+  server.use(
+    http.post(
+      `${BASE}/${DEFAULT_API_VERSION}/${PAGE_ID}/messages`,
+      async ({ request }) => {
+        body = await request.json()
+        return HttpResponse.json({
+          recipient_id: "psid-1",
+          message_id: "m_1",
+        })
+      },
+    ),
+  )
+  return { body: () => body }
+}
+
+describe("sendPrivateReply", () => {
+  test("stamps message.metadata so the message_echo webhook recognizes and skips it", async () => {
+    const captured = captureRequestBody()
+
+    await sendPrivateReply(auth, COMMENT_ID, "hello")
+
+    expect(captured.body()).toEqual({
+      recipient: { comment_id: COMMENT_ID },
+      message: { text: "hello", metadata: MESSENGER_MESSAGE_METADATA },
+      persona_id: undefined,
+    })
+  })
+})
+
+describe("sendPrivateReplyMessage", () => {
+  test("posts an arbitrary message payload with recipient.comment_id, stamped metadata, and persona_id", async () => {
+    const captured = captureRequestBody()
+
+    await sendPrivateReplyMessage(
+      auth,
+      COMMENT_ID,
+      {
+        attachment: { type: "image", payload: { url: "https://x.com/a.jpg" } },
+      },
+      "persona-1",
+    )
+
+    expect(captured.body()).toEqual({
+      recipient: { comment_id: COMMENT_ID },
+      message: {
+        attachment: { type: "image", payload: { url: "https://x.com/a.jpg" } },
+        metadata: MESSENGER_MESSAGE_METADATA,
+      },
+      persona_id: "persona-1",
+    })
+  })
+
+  test("omits persona_id when not provided", async () => {
+    const captured = captureRequestBody()
+
+    await sendPrivateReplyMessage(auth, COMMENT_ID, { text: "hi" })
+
+    expect(captured.body()).not.toHaveProperty("persona_id")
+  })
+})

--- a/integrations/messenger/src/apis/comment.ts
+++ b/integrations/messenger/src/apis/comment.ts
@@ -3,7 +3,13 @@ import { DEFAULT_API_VERSION } from "../constants"
 import { rescue } from "../exception"
 import { facebookGraphClient } from "../lib/http-client"
 import { logger } from "../lib/logger"
-import type { MessengerAuthValue } from "../schema"
+import {
+  type FacebookMessage,
+  type FacebookMessageAttachmentPayload,
+  type FacebookSendMessageResponse,
+  MESSENGER_MESSAGE_METADATA,
+  type MessengerAuthValue,
+} from "../schema"
 import { getMessageAttachmentEntity } from "./attachment"
 
 export const sendComment = (
@@ -105,32 +111,50 @@ export const likeComment = (
   )
 }
 
-export const sendPrivateReply = (
+/**
+ * Sends a private reply anchored to a comment (Facebook's comment_id-anchored
+ * Send API, which bypasses the normal messaging-window requirement) with an
+ * arbitrary message payload (text, image, attachment, quick replies, …) —
+ * used by flow-based private replies to deliver the *first* outgoing message
+ * of the run. `FacebookSendMessageRequest["recipient"]` has no `comment_id`
+ * variant, so this posts a raw payload rather than reusing `sendPageMessage`.
+ *
+ * Stamps `message.metadata` like every other Messenger send path so the
+ * message_echo webhook (`handlers/webhook.ts`) recognizes and skips our own
+ * echo instead of re-ingesting it as an incoming message.
+ */
+export const sendPrivateReplyMessage = (
   auth: MessengerAuthValue,
   commentId: string,
-  message: string,
-): Promise<{ message_id: string; recipient_id: string }> => {
+  message: FacebookMessage | FacebookMessageAttachmentPayload,
+  personaId?: string,
+): Promise<FacebookSendMessageResponse> => {
   const { version = DEFAULT_API_VERSION } = auth
   const pageId = auth.metadata.pageId
   const endpoint = `${version}/${pageId}/messages`
 
   return rescue(endpoint, () =>
-    facebookGraphClient.post<{ message_id: string; recipient_id: string }>(
-      endpoint,
-      {
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${auth.tokens.accessToken}`,
-        },
-        json: {
-          recipient: { comment_id: commentId },
-          message: { text: message },
-        },
-        retry: 0,
+    facebookGraphClient.post<FacebookSendMessageResponse>(endpoint, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${auth.tokens.accessToken}`,
       },
-    ),
+      json: {
+        recipient: { comment_id: commentId },
+        message: { ...message, metadata: MESSENGER_MESSAGE_METADATA },
+        persona_id: personaId,
+      },
+      retry: 0,
+    }),
   )
 }
+
+export const sendPrivateReply = (
+  auth: MessengerAuthValue,
+  commentId: string,
+  message: string,
+): Promise<FacebookSendMessageResponse> =>
+  sendPrivateReplyMessage(auth, commentId, { text: message })
 
 /**
  * Fetches the attachment type of a comment (e.g. "photo", "video_inline",

--- a/integrations/messenger/src/handlers/message/outgoing-message/index.ts
+++ b/integrations/messenger/src/handlers/message/outgoing-message/index.ts
@@ -21,6 +21,7 @@ import {
   type OutgoingMessage,
   type SendFlowStepProps,
 } from "@chatbotx.io/sdk"
+import { sendPrivateReplyMessage } from "../../../apis/comment"
 import { sendPageMessage } from "../../../apis/message"
 import { mapToChannelError } from "../../../lib/error-mapper"
 import { logger } from "../../../lib/logger"
@@ -97,13 +98,16 @@ export const sendFlowStep: MessageHandlers<MessengerAuthValue>["sendFlowStep"] =
   async (props: SendFlowStepProps<MessengerAuthValue>) => {
     const {
       ctx,
-      data: { contact, sendFrom, step },
+      data: { contact, sendFrom, step, commentAnchor },
     } = props
     const messageIds: string[] = []
     try {
       // Messenger utility templates must be sent as a complete Send API request
       // using message.template (name/language/components) — they cannot go through
       // the generic buildMessagePayload spread, which is for plain messages.
+      // Known gap: a comment-anchored private reply whose first flow step is a
+      // Messenger template is not covered — it falls back to the normal
+      // (messaging-window-gated) send below, same as before this fix.
       if (step.stepType === stepTypes.enum.sendMessengerTemplateMessage) {
         const payload = buildMessengerTemplateSendRequest(
           props as SendFlowStepProps<
@@ -119,21 +123,36 @@ export const sendFlowStep: MessageHandlers<MessengerAuthValue>["sendFlowStep"] =
       }
 
       const policy = resolveMessengerMessagingPolicy({ contact, sendFrom })
+      // Consumed by the first Facebook message yielded below, if a comment
+      // anchor is present — a single flow step can yield more than one
+      // Facebook message (e.g. text + attachments), so only the very first
+      // send uses the comment_id-anchored API; the rest use the normal path
+      // (the private reply already opened a standard messaging window).
+      let anchorCommentId = commentAnchor?.commentId
       for await (const facebookMessage of convertFlowStepToFacebookMessage(
         props,
       )) {
-        const response = await sendPageMessage(
-          ctx.auth,
-          buildMessagePayload({
-            contact,
-            message: facebookMessage,
-            ...policy,
-            personaId: resolveMessengerPersonaId(
-              ctx.integrationDetail as MessengerIntegrationDetail,
-              contact,
-            ),
-          }),
+        const personaId = resolveMessengerPersonaId(
+          ctx.integrationDetail as MessengerIntegrationDetail,
+          contact,
         )
+        const response = anchorCommentId
+          ? await sendPrivateReplyMessage(
+              ctx.auth,
+              anchorCommentId,
+              facebookMessage,
+              personaId,
+            )
+          : await sendPageMessage(
+              ctx.auth,
+              buildMessagePayload({
+                contact,
+                message: facebookMessage,
+                ...policy,
+                personaId,
+              }),
+            )
+        anchorCommentId = undefined
         if (response.message_id) {
           messageIds.push(response.message_id)
         }

--- a/packages/sdk/src/lib/integration.ts
+++ b/packages/sdk/src/lib/integration.ts
@@ -9,6 +9,7 @@ import {
 import type { SendFlowStepData } from "./flow-step-data"
 import type {
   BaseConfig,
+  CommentAnchor,
   Context,
   HandleRequestProps,
   Handler,
@@ -69,6 +70,8 @@ export type ChannelSendFlowStepProps<IAuth extends AuthValue> = {
     metadata?: MetadataPayload
     richResponse?: RichResponseContentAttributes
     sendFrom?: "inbox"
+    /** See {@link CommentAnchor}. Channels other than Messenger ignore it. */
+    commentAnchor?: CommentAnchor
   }
 }
 
@@ -114,6 +117,8 @@ export type MessageHandlers<
         metadata?: MetadataPayload
         richResponse?: RichResponseContentAttributes
         sendFrom?: "inbox"
+        /** See {@link ChannelSendFlowStepProps}. */
+        commentAnchor?: CommentAnchor
       }
     },
     {

--- a/packages/sdk/src/lib/shared/index.ts
+++ b/packages/sdk/src/lib/shared/index.ts
@@ -56,3 +56,14 @@ export type ReceivedMessageResult = {
   referral?: MessageReferral | null
   buttonTitle?: string | null
 }
+
+/**
+ * Present only for a flow run triggered by a Messenger comment-automation
+ * private reply. Carries the triggering comment's id so the first outgoing
+ * message of the run can use Facebook's comment_id-anchored Send API
+ * (bypasses the normal messaging-window rule) instead of the standard
+ * PSID-based send, which Facebook rejects for users who only commented and
+ * never messaged the Page. Forwarded across every re-enqueued sendFlow job
+ * until consumed by the first message-producing step, then dropped.
+ */
+export type CommentAnchor = { commentId: string }

--- a/packages/worker-config/src/queues/chat/index.ts
+++ b/packages/worker-config/src/queues/chat/index.ts
@@ -21,7 +21,7 @@ import type {
   SendWaTemplateMessageStepSchema,
   WaTemplateParams,
 } from "@chatbotx.io/flow-config"
-import type { MessageButtonTemplate } from "@chatbotx.io/sdk"
+import type { CommentAnchor, MessageButtonTemplate } from "@chatbotx.io/sdk"
 import { Queue } from "bullmq"
 import {
   defaultJobOptions,
@@ -89,6 +89,8 @@ export type ChatJobSendFlowStep = {
     }
     quickReplies?: ButtonStepProps[]
     sendFrom?: "inbox"
+    /** See {@link CommentAnchor}. */
+    commentAnchor?: CommentAnchor
   }
 }
 

--- a/packages/worker-config/src/queues/integration/index.ts
+++ b/packages/worker-config/src/queues/integration/index.ts
@@ -3,7 +3,7 @@ import type {
   ConversationModel,
 } from "@chatbotx.io/database/types"
 import type { MetadataPayload } from "@chatbotx.io/flow-config"
-import type { OutgoingMessage } from "@chatbotx.io/sdk"
+import type { CommentAnchor, OutgoingMessage } from "@chatbotx.io/sdk"
 import { Queue } from "bullmq"
 import {
   defaultJobOptions,
@@ -125,6 +125,8 @@ export type IntegrationJobRunFlowNode = {
     metadata?: MetadataPayload
     sendFrom?: "inbox"
     origin?: "channel"
+    /** See {@link CommentAnchor}. */
+    commentAnchor?: CommentAnchor
   }
 }
 


### PR DESCRIPTION
## Summary
- Facebook comment automation's private reply configured as "flow" silently failed to deliver: it used the normal PSID-based Send API, which Facebook rejects for contacts who only commented and never messaged the Page. The "text" reply type already worked because it uses the comment_id-anchored Send API (`sendPrivateReply`). The rejection was also swallowed after the outgoing message row was optimistically marked as sent, so the job reported success with nothing delivered.
- Threads an optional `commentAnchor { commentId }` through the flow engine (`flow.ts`, `flow-utils.ts`, `step.ts`, `condition.ts`) and the chat queue plumbing, forwarded across every re-enqueued `sendFlow` job until claimed by the first message-producing step. The Messenger channel handler then sends that first message via the new `sendPrivateReplyMessage` API (comment_id-anchored, any payload type) instead of the normal Send API; later messages in the same flow fall back to the normal path once the private reply has opened a standard messaging window.
- `sendPrivateReplyMessage` also stamps `message.metadata` and `persona_id` so the message_echo webhook recognizes our own sends and persona configuration is respected, matching every other Messenger send path; `sendPrivateReply` now delegates to it to remove duplicated request construction.

## Changes
- `apps/worker/src/integration/handlers/comment-automation/index.ts` — creates `commentAnchor` for messenger flow-type private replies
- `apps/worker/src/integration/handlers/{flow.ts,flow-utils.ts,step.ts,condition.ts}` — propagate + consume-once `commentAnchor` through the flow engine
- `apps/worker/src/chat/handlers/{send-flow-step.ts,send-message.ts}` — forward `commentAnchor` through the chat-queue send path (Messenger-only, defense-in-depth channel check)
- `integrations/messenger/src/apis/comment.ts` — new `sendPrivateReplyMessage` (arbitrary payload, comment_id-anchored, stamps metadata/persona_id); `sendPrivateReply` now delegates to it
- `integrations/messenger/src/handlers/message/outgoing-message/index.ts` — uses the comment-anchored send for the first Facebook message of a run when `commentAnchor` is present
- `packages/sdk/src/lib/shared/index.ts` — new shared `CommentAnchor` type (removes duplicated inline type across sdk/worker-config/worker)
- Tests: extended `comment-automation.test.ts`, `flow.test.ts`, `send-flow-step.test.ts`; new `send-flow-step-comment-anchor.test.ts` and `send-private-reply.test.ts` in `integrations/messenger`

Known gap (documented inline, not fixed here): a private-reply flow with a `wait`/`followUp`/`questionnaire` step before its first message step loses the anchor across the scheduled delay, since `ContactOnSmartDelay` has no column to carry it — would need a schema change.

## Test plan
- [x] `pnpm --filter worker check-types`, `pnpm --filter @chatbotx.io/integration-messenger check-types`, `pnpm --filter @chatbotx.io/sdk check-types`, `pnpm --filter @chatbotx.io/worker-config check-types` — all pass
- [x] `pnpm --filter worker vitest run` — 1098/1098 pass
- [x] `pnpm --filter @chatbotx.io/integration-messenger vitest run` — 177/177 pass
- [x] `pnpm lint` — clean
- [ ] Manual: configure a comment automation with private reply = flow on a real connected Page, comment with an account that has never messaged the Page, confirm the private message actually arrives (not just shown as "sent" in the UI)