### PR TITLE
fix(webhooks): skip unrecognized Instagram/Messenger webhook events instead of throwing

### DIFF
--- a/integrations/instagram/src/handlers/webhook.ts
+++ b/integrations/instagram/src/handlers/webhook.ts
@@ -56,11 +56,25 @@ const handleWebhookEvent = async (
       throw new InstagramWebhookException("Invalid webhook signature")
     }
 
-    const webhookData = instagramWebhookEventSchema.parse(JSON.parse(body))
+    const parsedWebhook = instagramWebhookEventSchema.safeParse(
+      JSON.parse(body),
+    )
+    if (!parsedWebhook.success) {
+      logger.warn(
+        {
+          issues: parsedWebhook.error.issues.map(({ code, path }) => ({
+            code,
+            path,
+          })),
+        },
+        "instagram webhook payload unrecognized — skipping",
+      )
+      return
+    }
+    const webhookData = parsedWebhook.data
     if (webhookData.object !== "instagram") {
       throw new InstagramWebhookException(
         `Unsupported webhook object type: ${webhookData.object}`,
-        webhookData,
       )
     }
 
@@ -78,7 +92,12 @@ const handleWebhookEvent = async (
       const parsed = instagramCommentEventValueSchema.safeParse(commentValue)
       if (!parsed.success) {
         logger.warn(
-          { error: parsed.error, value: commentValue },
+          {
+            issues: parsed.error.issues.map(({ code, path }) => ({
+              code,
+              path,
+            })),
+          },
           "comment event parse failed — skipping",
         )
         return
@@ -163,7 +182,6 @@ const handleWebhookEvent = async (
 
     throw new InstagramWebhookException(
       `Failed to process webhook event: ${errorMessage}`,
-      await req.text().catch(() => null),
     )
   }
 }

--- a/integrations/messenger/src/handlers/webhook.ts
+++ b/integrations/messenger/src/handlers/webhook.ts
@@ -56,7 +56,20 @@ const handleWebhookEvent = async (
       throw new MessengerWebhookException("Invalid webhook signature")
     }
 
-    const webhookData = incomingWebhookEventSchema.parse(JSON.parse(body))
+    const parsedWebhook = incomingWebhookEventSchema.safeParse(JSON.parse(body))
+    if (!parsedWebhook.success) {
+      logger.warn(
+        {
+          issues: parsedWebhook.error.issues.map(({ code, path }) => ({
+            code,
+            path,
+          })),
+        },
+        "messenger webhook payload unrecognized — skipping",
+      )
+      return
+    }
+    const webhookData = parsedWebhook.data
     if (webhookData.object !== "page") {
       throw new MessengerWebhookException(
         `Unsupported webhook object type: ${webhookData.object}`,


### PR DESCRIPTION
## What

The Instagram and Messenger webhook handlers parse the top-level webhook envelope with `schema.parse(...)`, which **throws** when Meta delivers an event shape the schema doesn't cover (e.g. some Instagram `messaging` events without `sender`/`recipient`). A single unrecognized event then fails the whole webhook request — filling logs with `Failed to process webhook event` errors and causing Meta to retry.

## Changes

- **Instagram** (`integrations/instagram/src/handlers/webhook.ts`) and **Messenger** (`integrations/messenger/src/handlers/webhook.ts`): parse the top-level webhook with `safeParse` instead of `parse`. On failure, log a concise warning (issue `code`/`path` only) and skip the event instead of throwing.
- Mirrors the pattern already used for comment-value parsing in the same handlers.
- Trims full payloads from webhook exception/log messages — issue codes/paths are enough to debug, and raw payloads can contain user data.

## Why

Webhook endpoints should tolerate unrecognized / new event types; Meta regularly sends fields and event kinds beyond any fixed schema. Skipping what we don't handle keeps the endpoint healthy and avoids unnecessary retries and noisy error logs, without affecting the events we do process (messages, comments).

## Verification

- `check-types` (integration-instagram, integration-messenger) and unit tests pass.
