### PR TITLE
feat(integrations): add Make.com credential settings

### DIFF
--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -1971,6 +1971,10 @@
     },
     "webchatParentUrl": {
       "label": "Webchat Parent URL"
+    },
+    "make": {
+      "inviteUrl": "Invite Link",
+      "inviteUrlHint": "The invite link for your published Make custom app (e.g. https://eu2.make.com/app/invite/...)."
     }
   },
   "flows": {
@@ -2501,6 +2505,15 @@
     "errors": {
       "invalidApiKey": "Invalid API Key. Please check your SendGrid API Key and try again.",
       "missingScopes": "This API key must have Marketing read access. Please ensure your SendGrid API key includes Marketing permissions."
+    }
+  },
+  "make": {
+    "title": "Make",
+    "setting": {
+      "label": "Make",
+      "description": "Connect your Make.com account to send events from your flows and receive contact data through Make scenarios. Your workspace's Developer Access Token is copied to your clipboard when you click Connect — paste it when creating the connection in Make.",
+      "notConfigured": "No Make invite link found. Please add one in Platform Settings.",
+      "noWorkspaceToken": "No Developer Access Token found for this workspace. Generate one in the Workspace token section above, then click Connect again."
     }
   },
   "integrations": {

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -1987,6 +1987,10 @@
     },
     "webchatParentUrl": {
       "label": "URL cha của Webchat"
+    },
+    "make": {
+      "inviteUrl": "Link mời",
+      "inviteUrlHint": "Link mời của Make custom app đã publish (ví dụ: https://eu2.make.com/app/invite/...)."
     }
   },
   "flows": {
@@ -2517,6 +2521,15 @@
     "errors": {
       "invalidApiKey": "API Key không hợp lệ. Vui lòng kiểm tra lại API Key SendGrid và thử lại.",
       "missingScopes": "API key này phải có quyền đọc Marketing. Vui lòng đảm bảo API key SendGrid của bạn bao gồm quyền Marketing."
+    }
+  },
+  "make": {
+    "title": "Make",
+    "setting": {
+      "label": "Make",
+      "description": "Kết nối tài khoản Make.com để gửi sự kiện từ flow của bạn và nhận dữ liệu contact qua scenario của Make. Developer Access Token của workspace sẽ được tự động sao chép vào clipboard khi bạn bấm Connect — dán vào lúc tạo connection trong Make.",
+      "notConfigured": "Chưa tìm thấy link mời Make. Vui lòng thêm trong Cài đặt Nền tảng.",
+      "noWorkspaceToken": "Workspace này chưa có Developer Access Token. Hãy tạo token ở mục Workspace token phía trên rồi bấm Connect lại."
     }
   },
   "integrations": {

--- a/apps/builder/src/app/space/[workspaceId]/(settings)/settings/integrations/@make/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(settings)/settings/integrations/@make/page.tsx
@@ -1,0 +1,31 @@
+import {
+  platformCredentialService,
+  workspaceService,
+} from "@chatbotx.io/business"
+import { getIdFromParams } from "@chatbotx.io/utils"
+import { notFound } from "next/navigation"
+import { ManageMake } from "@/features/integration-make/components/manage-make"
+
+export default async function SettingIntegrationMakePage(props: {
+  params: Promise<{ workspaceId: string }>
+}) {
+  const workspaceId = getIdFromParams(await props.params, "workspaceId")
+  if (!workspaceId) {
+    return notFound()
+  }
+
+  const workspace = await workspaceService.find({ where: { id: workspaceId } })
+  const credential = workspace?.ownerId
+    ? await platformCredentialService.resolveForOwner({
+        ownerId: workspace.ownerId,
+        type: "make",
+      })
+    : undefined
+
+  return (
+    <ManageMake
+      inviteUrl={credential?.config.inviteUrl}
+      workspaceToken={workspace?.token ?? undefined}
+    />
+  )
+}

--- a/apps/builder/src/app/space/[workspaceId]/(settings)/settings/integrations/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(settings)/settings/integrations/layout.tsx
@@ -6,7 +6,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@chatbotx.io/ui/components/ui/accordion"
-import { SiFacebook } from "@icons-pack/react-simple-icons"
+import { SiFacebook, SiMake } from "@icons-pack/react-simple-icons"
 import { BotIcon, CodeIcon, MailIcon, TableIcon } from "lucide-react"
 import { useTranslations } from "next-intl"
 import type { ReactNode } from "react"
@@ -22,6 +22,7 @@ type SettingIntegrationLayoutProps = {
   openaiCompatible?: ReactNode
   googleSheets?: ReactNode
   facebookAds?: ReactNode
+  make?: ReactNode
   activeCampaign?: ReactNode
   getResponse?: ReactNode
   mailchimp?: ReactNode
@@ -42,6 +43,7 @@ export default function SettingIntegrationLayout({
   openaiCompatible,
   googleSheets,
   facebookAds,
+  make,
   activeCampaign,
   getResponse,
   mailchimp,
@@ -98,6 +100,11 @@ export default function SettingIntegrationLayout({
       keyName: t("facebookAds.title"),
       icon: SiFacebook,
       content: facebookAds,
+    },
+    {
+      keyName: t("make.title"),
+      icon: SiMake,
+      content: make,
     },
     {
       keyName: t("activeCampaign.title"),

--- a/apps/builder/src/features/integration-make/components/manage-make.tsx
+++ b/apps/builder/src/features/integration-make/components/manage-make.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { Button } from "@chatbotx.io/ui/components/ui/button"
+import { useTranslations } from "next-intl"
+import { SettingRow } from "@/components/setting-row"
+import { useClipboard } from "@/hooks/use-clipboard"
+
+export function ManageMake({
+  inviteUrl,
+  workspaceToken,
+}: {
+  inviteUrl?: string
+  workspaceToken?: string
+}) {
+  const t = useTranslations()
+  const { handleCopy } = useClipboard()
+
+  return (
+    <SettingRow
+      description={t("make.setting.description")}
+      label={t("make.setting.label")}
+    >
+      {inviteUrl ? (
+        <div className="flex flex-col gap-2">
+          <Button asChild size="sm" variant="secondary">
+            <a
+              href={inviteUrl}
+              onClick={() => {
+                if (workspaceToken) {
+                  handleCopy(workspaceToken)
+                }
+              }}
+              rel="noreferrer"
+              target="_blank"
+            >
+              {t("actions.connect")}
+            </a>
+          </Button>
+          {!workspaceToken && (
+            <p className="text-muted-foreground text-xs">
+              {t("make.setting.noWorkspaceToken")}
+            </p>
+          )}
+        </div>
+      ) : (
+        <p className="text-muted-foreground text-sm">
+          {t("make.setting.notConfigured")}
+        </p>
+      )}
+    </SettingRow>
+  )
+}

--- a/apps/builder/src/features/platform-credentials/make/make-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/make/make-settings.tsx
@@ -1,0 +1,178 @@
+"use client"
+
+import {
+  type MakeCredentialPublic,
+  type MakeCredentialUpdate,
+  makeCredentialUpdateSchema,
+} from "@chatbotx.io/database/partials"
+import { InputField } from "@chatbotx.io/ui/components/form/input-field"
+import { Button } from "@chatbotx.io/ui/components/ui/button"
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@chatbotx.io/ui/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "@chatbotx.io/ui/components/ui/dialog"
+import { Form } from "@chatbotx.io/ui/components/ui/form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { SiMake, SiMakeHex } from "@icons-pack/react-simple-icons"
+import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hooks"
+import { Loader2Icon } from "lucide-react"
+import { useRouter } from "next/navigation"
+import { useTranslations } from "next-intl"
+import { useState } from "react"
+import { toast } from "sonner"
+import { CredentialFallbackNote } from "../credential-fallback-note"
+import { useCredentialScope } from "../provider/credential-scope-context"
+import { updateMakeSettingsAction } from "./update-make-settings.action"
+
+export function MakeSettings({
+  publicConfig,
+  isInherited = false,
+}: {
+  publicConfig: MakeCredentialPublic | null
+  isInherited?: boolean
+}) {
+  const t = useTranslations()
+
+  return (
+    <Card>
+      <CardHeader className="items-center justify-center">
+        <CardTitle className="flex items-center gap-2">
+          <SiMake className="size-6" fill={SiMakeHex} />
+          <span>Make</span>
+        </CardTitle>
+        <CardAction>
+          <EditMakeSettingsDialog publicConfig={publicConfig} />
+        </CardAction>
+      </CardHeader>
+      <CardContent>
+        {publicConfig?.inviteUrl ? (
+          <div className="flex flex-col">
+            <div className="font-bold">{t("fields.make.inviteUrl")}:</div>
+            <a
+              className="truncate text-primary underline"
+              href={publicConfig.inviteUrl}
+              rel="noreferrer"
+              target="_blank"
+            >
+              {publicConfig.inviteUrl}
+            </a>
+          </div>
+        ) : (
+          <CredentialFallbackNote isInherited={isInherited} />
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+export function EditMakeSettingsDialog({
+  publicConfig,
+}: {
+  publicConfig: MakeCredentialPublic | null
+}) {
+  const t = useTranslations()
+  const [open, setOpen] = useState(false)
+  const router = useRouter()
+
+  return (
+    <Dialog onOpenChange={setOpen} open={open}>
+      <DialogTrigger asChild>
+        <Button size="sm" type="button">
+          {t("actions.edit")}
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogTitle>
+          {t("messages.editFeature", { feature: "Make" })}
+        </DialogTitle>
+
+        <EditMakeSettingsForm
+          onClose={() => {
+            setOpen(false)
+            router.refresh()
+          }}
+          publicConfig={publicConfig}
+        />
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function EditMakeSettingsForm({
+  publicConfig,
+  onClose,
+}: {
+  publicConfig: MakeCredentialPublic | null
+  onClose?: () => void
+}) {
+  const t = useTranslations()
+  const scope = useCredentialScope()
+
+  const { form, handleSubmitWithAction, resetFormAndAction } =
+    useHookFormAction(
+      updateMakeSettingsAction.bind(null, scope),
+      zodResolver(makeCredentialUpdateSchema),
+      {
+        actionProps: {
+          onSuccess: () => {
+            onClose?.()
+          },
+          onError: ({ error }) => {
+            if (error.serverError) {
+              toast.error(error.serverError)
+            }
+          },
+        },
+        formProps: {
+          mode: "onChange",
+          defaultValues: {
+            inviteUrl: publicConfig?.inviteUrl ?? "",
+          } satisfies MakeCredentialUpdate,
+        },
+      },
+    )
+
+  return (
+    <Form {...form}>
+      <form className="flex flex-col gap-4" onSubmit={handleSubmitWithAction}>
+        <InputField
+          description={t("fields.make.inviteUrlHint")}
+          label={t("fields.make.inviteUrl")}
+          name="inviteUrl"
+          required
+        />
+
+        <div className="flex justify-end gap-2">
+          <Button
+            onClick={() => {
+              resetFormAndAction()
+              onClose?.()
+            }}
+            type="button"
+            variant="outline"
+          >
+            {t("actions.cancel")}
+          </Button>
+          <Button
+            disabled={!form.formState.isValid || form.formState.isSubmitting}
+            type="submit"
+          >
+            {form.formState.isSubmitting && (
+              <Loader2Icon className="size-4 animate-spin" />
+            )}
+            {t("actions.save")}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  )
+}

--- a/apps/builder/src/features/platform-credentials/make/update-make-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/make/update-make-settings.action.ts
@@ -1,0 +1,25 @@
+"use server"
+
+import { platformCredentialService } from "@chatbotx.io/business"
+import {
+  type MakeCredential,
+  makeCredentialUpdateSchema,
+} from "@chatbotx.io/database/partials"
+
+import { authActionClient } from "@/lib/safe-action"
+import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
+
+export const updateMakeSettingsAction = authActionClient
+  .bindArgsSchemas([credentialScopeSchema])
+  .inputSchema(makeCredentialUpdateSchema)
+  .action(async ({ ctx, bindArgsParsedInputs: [scope], parsedInput }) => {
+    const scopedUserId = resolveCredentialScopedUserId(ctx.user, scope)
+
+    const config: MakeCredential = { inviteUrl: parsedInput.inviteUrl }
+
+    await platformCredentialService.upsert({
+      userId: scopedUserId,
+      type: "make",
+      config,
+    })
+  })

--- a/apps/builder/src/features/platform-credentials/manage-platform-credentials.tsx
+++ b/apps/builder/src/features/platform-credentials/manage-platform-credentials.tsx
@@ -8,6 +8,7 @@ import { GiphySettings } from "./giphy/giphy-settings"
 import { GoogleSettings } from "./google/google-settings"
 import { InstagramSettings } from "./instagram/instagram-settings"
 import { InstagramFacebookSettings } from "./instagram-facebook/instagram-facebook-settings"
+import { MakeSettings } from "./make/make-settings"
 import { MessengerSettings } from "./messenger/messenger-settings"
 import { CredentialScopeProvider } from "./provider/credential-scope-context"
 import type { CredentialScope } from "./scope"
@@ -77,6 +78,7 @@ export async function ManagePlatformCredentials({
     zaloResult,
     giphyResult,
     tiktokResult,
+    makeResult,
   ] = await Promise.allSettled([
     resolveCard(scopedUserId, "whatsapp"),
     resolveCard(scopedUserId, "messenger"),
@@ -86,6 +88,7 @@ export async function ManagePlatformCredentials({
     resolveCard(scopedUserId, "zalo"),
     resolveCard(scopedUserId, "giphy"),
     resolveCard(scopedUserId, "tiktok"),
+    resolveCard(scopedUserId, "make"),
   ])
 
   const emptyCard = { publicConfig: null, isInherited: false } as const
@@ -106,6 +109,7 @@ export async function ManagePlatformCredentials({
     giphyResult.status === "fulfilled" ? giphyResult.value : emptyCard
   const tiktok =
     tiktokResult.status === "fulfilled" ? tiktokResult.value : emptyCard
+  const make = makeResult.status === "fulfilled" ? makeResult.value : emptyCard
 
   return (
     <CredentialScopeProvider scope={scope}>
@@ -141,6 +145,10 @@ export async function ManagePlatformCredentials({
         <GiphySettings
           isConfigured={giphy.publicConfig !== null}
           isInherited={giphy.isInherited}
+        />
+        <MakeSettings
+          isInherited={make.isInherited}
+          publicConfig={make.publicConfig}
         />
       </div>
     </CredentialScopeProvider>

--- a/packages/database/src/partials/credential.ts
+++ b/packages/database/src/partials/credential.ts
@@ -12,6 +12,7 @@ export const credentialTypes = z.enum([
   "smtp",
   "paddle",
   "tiktok",
+  "make",
 ])
 export type CredentialType = z.infer<typeof credentialTypes>
 
@@ -183,6 +184,16 @@ export type TiktokCredentialPublic = z.infer<
   typeof tiktokCredentialPublicSchema
 >
 
+export const makeCredentialSchema = z.object({
+  inviteUrl: z.string().url(),
+})
+export type MakeCredential = z.infer<typeof makeCredentialSchema>
+
+export const makeCredentialPublicSchema = makeCredentialSchema.pick({
+  inviteUrl: true,
+})
+export type MakeCredentialPublic = z.infer<typeof makeCredentialPublicSchema>
+
 export const credentialSchemas = {
   whatsapp: whatsappCredentialSchema,
   messenger: messengerCredentialSchema,
@@ -195,6 +206,7 @@ export const credentialSchemas = {
   smtp: smtpCredentialSchema,
   paddle: paddleCredentialSchema,
   tiktok: tiktokCredentialSchema,
+  make: makeCredentialSchema,
 } as const
 
 export const credentialPublicSchemas = {
@@ -209,6 +221,7 @@ export const credentialPublicSchemas = {
   smtp: smtpCredentialPublicSchema,
   paddle: paddleCredentialPublicSchema,
   tiktok: tiktokCredentialPublicSchema,
+  make: makeCredentialPublicSchema,
 } as const
 
 export type CredentialByType = {
@@ -223,6 +236,7 @@ export type CredentialByType = {
   smtp: SmtpCredential
   paddle: PaddleCredential
   tiktok: TiktokCredential
+  make: MakeCredential
 }
 
 export type CredentialPublicByType = {
@@ -237,6 +251,7 @@ export type CredentialPublicByType = {
   smtp: SmtpCredentialPublic
   paddle: PaddleCredentialPublic
   tiktok: TiktokCredentialPublic
+  make: MakeCredentialPublic
 }
 
 // ─── Update schemas (credential fields required except deliberate optionals) ─
@@ -328,6 +343,11 @@ export const tiktokCredentialUpdateSchema = z.object({
 export type TiktokCredentialUpdate = z.infer<
   typeof tiktokCredentialUpdateSchema
 >
+
+export const makeCredentialUpdateSchema = z.object({
+  inviteUrl: z.string().trim().min(1).url(),
+})
+export type MakeCredentialUpdate = z.infer<typeof makeCredentialUpdateSchema>
 
 // ─── Encrypted blob shape stored in Credential.value ─────────────────────────
 


### PR DESCRIPTION
## Summary
- Add the `make` platform credential type (invite-link based, no OAuth) with encrypted/public/update Zod schemas
- Add the Make settings card (view/edit invite URL) to the platform credentials manager
- Add a `make` slot to the integrations settings layout with the SiMake icon, plus a `@make` parallel route

## Changes
- `packages/database/src/partials/credential.ts` — `make` credential type + schemas
- `apps/builder/src/features/platform-credentials/make/` — settings card, edit dialog, update action
- `apps/builder/src/features/integration-make/components/manage-make.tsx` — Make connection panel
- `apps/builder/src/app/space/[workspaceId]/(settings)/settings/integrations/@make/page.tsx` — parallel route slot
- `apps/builder/src/app/.../integrations/layout.tsx`, `manage-platform-credentials.tsx` — wire up the new panel
- `apps/builder/messages/{en,vi}.json` — new translation keys

## Test plan
- [x] pnpm lint (via pre-commit hook)
- [x] pnpm check-types (via pre-commit hook, all 51 packages)
- [ ] manual verification of the Make settings UI