### PR TITLE
fix(comment-automation): post flow-type public replies as comments, not DMs

### DIFF
--- a/apps/worker/__tests__/comment-automation.test.ts
+++ b/apps/worker/__tests__/comment-automation.test.ts
@@ -460,7 +460,7 @@ describe("processCommentAutomation flow private reply", () => {
         type: "sendFlow",
         data: expect.objectContaining({
           flowId: "flow-1",
-          commentAnchor: { commentId: COMMENT_ID },
+          commentAnchor: { commentId: COMMENT_ID, replyChannel: "private" },
         }),
       }),
       expect.anything(),
@@ -481,6 +481,49 @@ describe("processCommentAutomation flow private reply", () => {
       "sendFlow",
       expect.objectContaining({
         data: expect.not.objectContaining({ commentAnchor: expect.anything() }),
+      }),
+      expect.anything(),
+    )
+  })
+})
+
+describe("processCommentAutomation flow public reply", () => {
+  test("messenger: enqueues a sendFlow job carrying a public commentAnchor with the triggering commentId", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({ publicReply: { type: "flow", value: "flow-1" } }),
+    ])
+
+    await processCommentAutomation(buildJobData() as any)
+
+    expect(mockIntegrationQueueAdd).toHaveBeenCalledWith(
+      "sendFlow",
+      expect.objectContaining({
+        type: "sendFlow",
+        data: expect.objectContaining({
+          flowId: "flow-1",
+          commentAnchor: { commentId: COMMENT_ID, replyChannel: "public" },
+        }),
+      }),
+      expect.anything(),
+    )
+  })
+
+  test("instagram: ALSO enqueues a public commentAnchor (no channelType gate, unlike private)", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({ publicReply: { type: "flow", value: "flow-1" } }),
+    ])
+
+    await processCommentAutomation({
+      ...buildJobData(),
+      integrationType: "instagram",
+    } as any)
+
+    expect(mockIntegrationQueueAdd).toHaveBeenCalledWith(
+      "sendFlow",
+      expect.objectContaining({
+        data: expect.objectContaining({
+          commentAnchor: { commentId: COMMENT_ID, replyChannel: "public" },
+        }),
       }),
       expect.anything(),
     )

--- a/apps/worker/__tests__/flow.test.ts
+++ b/apps/worker/__tests__/flow.test.ts
@@ -1129,7 +1129,10 @@ describe("runStepsAndQuickReplies — commentAnchor propagation", () => {
     chatQueueAdd.mockClear()
   })
 
-  const commentAnchor = { commentId: "comment-1" }
+  const commentAnchor = {
+    commentId: "comment-1",
+    replyChannel: "private" as const,
+  }
 
   test("forwards commentAnchor into the first message-producing step, and drops it from the next-step re-dispatch", async () => {
     const step1 = { ...makeStep("sendText"), id: "step-1" }

--- a/apps/worker/__tests__/send-flow-step.test.ts
+++ b/apps/worker/__tests__/send-flow-step.test.ts
@@ -18,6 +18,7 @@ const {
   mockResolveContactVariables,
   mockUploadFileFromUrl,
   mockSendFlowStepToChannel,
+  mockSendMessageToChannel,
   mockProcessWhatsappTemplate,
   mockProcessMessengerTemplate,
   mockDbSet,
@@ -107,6 +108,9 @@ const {
     mockSendFlowStepToChannel: vi
       .fn()
       .mockResolvedValue({ messageIds: ["provider-1"] }),
+    mockSendMessageToChannel: vi
+      .fn()
+      .mockResolvedValue({ messageIds: ["provider-comment-1"] }),
     mockProcessWhatsappTemplate: vi
       .fn()
       .mockResolvedValue({ messageId: "msg-wa" }),
@@ -236,7 +240,7 @@ vi.mock("../src/lib/logger", () => ({
 
 vi.mock("../src/chat/handlers/send-message", () => ({
   sendFlowStepToChannel: mockSendFlowStepToChannel,
-  sendMessageToChannel: vi.fn().mockResolvedValue(undefined),
+  sendMessageToChannel: mockSendMessageToChannel,
 }))
 
 vi.mock("../src/chat/handlers/send-messenger-template", () => ({
@@ -361,6 +365,9 @@ describe("sendFlowStep", () => {
       fileName: "image.jpg",
     })
     mockSendFlowStepToChannel.mockResolvedValue({ messageIds: ["provider-1"] })
+    mockSendMessageToChannel.mockResolvedValue({
+      messageIds: ["provider-comment-1"],
+    })
     mockEmit.mockResolvedValue(undefined)
   })
 
@@ -709,20 +716,21 @@ describe("sendFlowStep", () => {
     expect(mockCreateMessageRepository).not.toHaveBeenCalled()
   })
 
-  test("forwards commentAnchor to sendFlowStepToChannel when the resolved contactInbox is messenger", async () => {
+  test("forwards a private commentAnchor to sendFlowStepToChannel when the resolved contactInbox is messenger", async () => {
     await sendFlowStep({
       ...baseParams,
-      commentAnchor: { commentId: "comment-1" },
+      commentAnchor: { commentId: "comment-1", replyChannel: "private" },
     })
 
     expect(mockSendFlowStepToChannel).toHaveBeenCalledWith(
       expect.objectContaining({
-        commentAnchor: { commentId: "comment-1" },
+        commentAnchor: { commentId: "comment-1", replyChannel: "private" },
       }),
     )
+    expect(mockSendMessageToChannel).not.toHaveBeenCalled()
   })
 
-  test("suppresses commentAnchor when the resolved contactInbox is not messenger", async () => {
+  test("suppresses a private commentAnchor when the resolved contactInbox is not messenger", async () => {
     const instagramContactInbox = {
       ...fakeContactInbox,
       channel: "instagram",
@@ -731,12 +739,55 @@ describe("sendFlowStep", () => {
 
     await sendFlowStep({
       ...baseParams,
-      commentAnchor: { commentId: "comment-1" },
+      commentAnchor: { commentId: "comment-1", replyChannel: "private" },
     })
 
     expect(mockSendFlowStepToChannel).toHaveBeenCalledWith(
       expect.objectContaining({ commentAnchor: undefined }),
     )
+    expect(mockSendMessageToChannel).not.toHaveBeenCalled()
+  })
+
+  test("routes to sendMessageToChannel with a type:comment message when commentAnchor.replyChannel is public", async () => {
+    await sendFlowStep({
+      ...baseParams,
+      commentAnchor: { commentId: "comment-1", replyChannel: "public" },
+    })
+
+    expect(mockRepositoryCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "comment",
+        contentAttributes: expect.objectContaining({
+          replyToCommentId: "comment-1",
+        }),
+      }),
+    )
+    expect(mockSendMessageToChannel).toHaveBeenCalledOnce()
+    expect(mockSendFlowStepToChannel).not.toHaveBeenCalled()
+  })
+
+  test("routes to sendMessageToChannel for a public commentAnchor even when the contactInbox is instagram", async () => {
+    const instagramContactInbox = {
+      ...fakeContactInbox,
+      channel: "instagram",
+    } as unknown as typeof fakeContactInbox
+    mockFindContactInbox.mockResolvedValue(instagramContactInbox)
+
+    await sendFlowStep({
+      ...baseParams,
+      commentAnchor: { commentId: "comment-1", replyChannel: "public" },
+    })
+
+    expect(mockRepositoryCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "comment",
+        contentAttributes: expect.objectContaining({
+          replyToCommentId: "comment-1",
+        }),
+      }),
+    )
+    expect(mockSendMessageToChannel).toHaveBeenCalledOnce()
+    expect(mockSendFlowStepToChannel).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/worker/__tests__/send-message-handler.test.ts
+++ b/apps/worker/__tests__/send-message-handler.test.ts
@@ -209,7 +209,7 @@ describe("chat send-message handlers", () => {
           createdAt: new Date("2026-07-09T08:37:21.108Z"),
         } as never,
       }),
-    ).resolves.toBeUndefined()
+    ).resolves.toEqual({ messageIds: ["reply-1"] })
 
     expect(mockRunChannelHandler).toHaveBeenCalledTimes(1)
   })
@@ -340,7 +340,7 @@ describe("chat send-message handlers", () => {
           text: "hello",
         } as never,
       }),
-    ).resolves.toBeUndefined()
+    ).resolves.toEqual({ messageIds: [] })
 
     expect(mockEmit).toHaveBeenCalledWith(
       "message:failed",
@@ -376,7 +376,7 @@ describe("chat send-message handlers", () => {
           text: "hello",
         } as never,
       }),
-    ).resolves.toBeUndefined()
+    ).resolves.toEqual({ messageIds: [] })
 
     expect(mockEmit).toHaveBeenCalledWith(
       "message:failed",
@@ -410,7 +410,7 @@ describe("chat send-message handlers", () => {
           text: "hello",
         } as never,
       }),
-    ).resolves.toBeUndefined()
+    ).resolves.toEqual({ messageIds: [] })
   })
 
   test("still throws a retryable ChannelError for channels outside the fix scope", async () => {
@@ -470,7 +470,7 @@ describe("chat send-message handlers", () => {
           text: "hello",
         } as never,
       }),
-    ).resolves.toBeUndefined()
+    ).resolves.toEqual({ messageIds: [] })
 
     expect(mockRunChannelHandler).not.toHaveBeenCalled()
     expect(mockEmit).toHaveBeenCalledWith(

--- a/apps/worker/src/chat/handlers/send-flow-step.ts
+++ b/apps/worker/src/chat/handlers/send-flow-step.ts
@@ -401,6 +401,21 @@ export async function sendFlowStep({
       }
     }
 
+    const isPublicCommentReply = commentAnchor?.replyChannel === "public"
+    if (isPublicCommentReply) {
+      // Mirrors postPublicCommentReply's shape (comment-automation/index.ts) so
+      // this message is recognized as a public comment reply below and routed
+      // through sendMessageToChannel's "comment" channel group instead of a
+      // normal flow DM. sendComment only reads text + the first attachment and
+      // ignores buttons/quick replies/multiple cards — a carousel/button-heavy
+      // first step degrades to best-effort text-and-first-attachment, same
+      // precedent as the private-reply fix's Messenger-template gap.
+      contentAttributes = {
+        ...contentAttributes,
+        replyToCommentId: commentAnchor.commentId,
+      }
+    }
+
     const messageInput = {
       workspaceId: conversation.workspaceId,
       conversationId: conversation.id,
@@ -412,6 +427,7 @@ export async function sendFlowStep({
       text: messageText,
       contentAttributes,
       createdAt: new Date(),
+      ...(isPublicCommentReply ? { type: "comment" as const } : {}),
     }
 
     // Upload file if exists
@@ -474,26 +490,38 @@ export async function sendFlowStep({
       }),
     ])
 
-    const channelSend = sendFlowStepToChannel({
-      conversation,
-      contactInbox: targetContactInbox,
-      flowId,
-      flowVersionId,
-      step: resolvedStep as SendFlowStepData,
-      metadata,
-      richResponse,
-      quickReplies: canonicalQuickReplies,
-      messageId: message?.id,
-      messageCreatedAt: message?.createdAt,
-      sendFrom,
-      // Comment-anchored private replies are Messenger-only (no Instagram
-      // private_replies equivalent) — defensive re-check in case a resolved
-      // contactInboxId ever points at a different channel than the job intended.
-      commentAnchor:
-        targetContactInbox.channel === channelTypes.enum.messenger
-          ? commentAnchor
-          : undefined,
-    })
+    const channelSend = isPublicCommentReply
+      ? sendMessageToChannel({
+          conversation,
+          contactInbox: targetContactInbox,
+          message,
+          quickReplies: canonicalQuickReplies,
+          metadata,
+          sendFrom,
+        })
+      : sendFlowStepToChannel({
+          conversation,
+          contactInbox: targetContactInbox,
+          flowId,
+          flowVersionId,
+          step: resolvedStep as SendFlowStepData,
+          metadata,
+          richResponse,
+          quickReplies: canonicalQuickReplies,
+          messageId: message?.id,
+          messageCreatedAt: message?.createdAt,
+          sendFrom,
+          // Comment-anchored private replies are Messenger-only (no Instagram
+          // private_replies equivalent) — defensive re-check in case a resolved
+          // contactInboxId ever points at a different channel than the job
+          // intended. A "public" anchor never reaches this branch (routed to
+          // sendMessageToChannel above instead).
+          commentAnchor:
+            targetContactInbox.channel === channelTypes.enum.messenger &&
+            commentAnchor?.replyChannel === "private"
+              ? commentAnchor
+              : undefined,
+        })
 
     const promises: Promise<unknown>[] = [
       broadcastToWorkspaceParty(conversation.workspaceId, {

--- a/apps/worker/src/chat/handlers/send-message.ts
+++ b/apps/worker/src/chat/handlers/send-message.ts
@@ -37,7 +37,7 @@ import { shouldSuppressRetryableChannelError } from "../utils/retry"
 
 export async function sendMessageToChannel(
   data: ChatJobSendChannelMessage["data"],
-) {
+): Promise<{ messageIds: string[] }> {
   const {
     conversation,
     contactInbox,
@@ -168,6 +168,8 @@ export async function sendMessageToChannel(
         logger.warn(error, "Auto-unblock on successful send failed")
       }
     }
+
+    return { messageIds: result.messageIds }
   } catch (error) {
     logger.error(error, "An error occurred while sending the message")
     const errorData = await parseSdkError(error)
@@ -187,7 +189,7 @@ export async function sendMessageToChannel(
       metadata,
     })
     if (shouldSuppressRetryableChannelError(error, contactInbox.channel)) {
-      return
+      return { messageIds: [] }
     }
     throw error
   }

--- a/apps/worker/src/integration/handlers/comment-automation/index.ts
+++ b/apps/worker/src/integration/handlers/comment-automation/index.ts
@@ -266,6 +266,7 @@ async function executePublicReply(
           contactInboxId: ctx.contactInboxId,
           flowId: publicReply.value,
           origin: webhookChannelOrigin(),
+          commentAnchor: { commentId: ctx.commentId, replyChannel: "public" },
         },
       },
       { delay: ctx.delay },
@@ -337,7 +338,12 @@ async function executePrivateReply(
           flowId: privateReply.value,
           origin: webhookChannelOrigin(),
           ...(ctx.channelType === "messenger"
-            ? { commentAnchor: { commentId: ctx.commentId } }
+            ? {
+                commentAnchor: {
+                  commentId: ctx.commentId,
+                  replyChannel: "private" as const,
+                },
+              }
             : {}),
         },
       },

--- a/apps/worker/src/integration/handlers/follow-up.ts
+++ b/apps/worker/src/integration/handlers/follow-up.ts
@@ -22,10 +22,10 @@ type FollowUpStepResult = {
 }
 
 // Known gap: like `handleWait` in step.ts, `commentAnchor` is not threaded
-// into `scheduleSmartDelayResume` — a comment-triggered private-reply flow
-// with a followUp step before its first message step loses the anchor across
-// the delay. Fixing this needs a `ContactOnSmartDelay` schema change; out of
-// scope for now.
+// into `scheduleSmartDelayResume` — a comment-triggered public/private-reply
+// flow with a followUp step before its first message step loses the anchor
+// across the delay. Fixing this needs a `ContactOnSmartDelay` schema change;
+// out of scope for now.
 export async function handleFollowUp({
   conversation,
   flowVersion,

--- a/apps/worker/src/integration/handlers/step.ts
+++ b/apps/worker/src/integration/handlers/step.ts
@@ -175,13 +175,14 @@ async function splitTraffic({
   }
 }
 
-// Known gap: `commentAnchor` (comment-triggered private-reply flows, see
-// `flow-utils.ts`) is not threaded into `scheduleSmartDelayResume` —
+// Known gap: `commentAnchor` (comment-triggered public/private-reply flows,
+// see `flow-utils.ts`) is not threaded into `scheduleSmartDelayResume` —
 // `ContactOnSmartDelay` has no column for it, and the resumed `sendFlow` job
-// is rebuilt from that DB row alone (`buildSendFlowResumeJob`). A private
-// reply flow with a "wait" step before its first message step loses the
-// anchor and falls back to the normal (messaging-window-gated) send once the
-// delay elapses. Fixing this needs a schema change; out of scope for now.
+// is rebuilt from that DB row alone (`buildSendFlowResumeJob`). A public or
+// private reply flow with a "wait" step before its first message step loses
+// the anchor: private falls back to the normal (messaging-window-gated) DM
+// send, public falls back to a normal flow DM instead of a comment reply.
+// Fixing this needs a schema change; out of scope for now.
 async function handleWait({
   conversation,
   flowVersion,

--- a/integrations/messenger/__tests__/send-flow-step-comment-anchor.test.ts
+++ b/integrations/messenger/__tests__/send-flow-step-comment-anchor.test.ts
@@ -54,7 +54,7 @@ describe("messenger sendFlowStep — comment-anchored private reply", () => {
       ctx,
       data: {
         contact,
-        commentAnchor: { commentId: "comment-1" },
+        commentAnchor: { commentId: "comment-1", replyChannel: "private" },
         step: {
           id: "step-1",
           nodeId: "node-1",
@@ -74,6 +74,27 @@ describe("messenger sendFlowStep — comment-anchored private reply", () => {
     )
     expect(mockSendPageMessage).not.toHaveBeenCalled()
     expect(result).toEqual({ messageIds: ["m_anchored-1"] })
+  })
+
+  test("uses the normal Send API when commentAnchor.replyChannel is public (defense-in-depth: public replies are never routed here)", async () => {
+    const result = await sendFlowStep({
+      ctx,
+      data: {
+        contact,
+        commentAnchor: { commentId: "comment-1", replyChannel: "public" },
+        step: {
+          id: "step-1",
+          nodeId: "node-1",
+          stepType: "sendText",
+          text: "public reply via flow",
+          buttons: [],
+        },
+      },
+    } as never)
+
+    expect(mockSendPageMessage).toHaveBeenCalledTimes(1)
+    expect(mockSendPrivateReplyMessage).not.toHaveBeenCalled()
+    expect(result).toEqual({ messageIds: ["m_normal-1"] })
   })
 
   test("uses the normal Send API when commentAnchor is absent (regression guard)", async () => {
@@ -106,7 +127,7 @@ describe("messenger sendFlowStep — comment-anchored private reply", () => {
       ctx,
       data: {
         contact,
-        commentAnchor: { commentId: "comment-1" },
+        commentAnchor: { commentId: "comment-1", replyChannel: "private" },
         step: {
           id: "step-1",
           nodeId: "node-1",

--- a/integrations/messenger/src/handlers/message/outgoing-message/index.ts
+++ b/integrations/messenger/src/handlers/message/outgoing-message/index.ts
@@ -123,12 +123,19 @@ export const sendFlowStep: MessageHandlers<MessengerAuthValue>["sendFlowStep"] =
       }
 
       const policy = resolveMessengerMessagingPolicy({ contact, sendFrom })
-      // Consumed by the first Facebook message yielded below, if a comment
-      // anchor is present — a single flow step can yield more than one
-      // Facebook message (e.g. text + attachments), so only the very first
-      // send uses the comment_id-anchored API; the rest use the normal path
-      // (the private reply already opened a standard messaging window).
-      let anchorCommentId = commentAnchor?.commentId
+      // Consumed by the first Facebook message yielded below, if a private
+      // comment anchor is present — a single flow step can yield more than
+      // one Facebook message (e.g. text + attachments), so only the very
+      // first send uses the comment_id-anchored API; the rest use the normal
+      // path (the private reply already opened a standard messaging window).
+      // A "public" anchor is never honored here — it's delivered via the
+      // comment channel's sendComment, not this message channel's
+      // sendFlowStep (see send-flow-step.ts). This check is defense-in-depth
+      // against a public anchor ever reaching this handler by mistake.
+      let anchorCommentId =
+        commentAnchor?.replyChannel === "private"
+          ? commentAnchor.commentId
+          : undefined
       for await (const facebookMessage of convertFlowStepToFacebookMessage(
         props,
       )) {

--- a/packages/sdk/src/lib/shared/index.ts
+++ b/packages/sdk/src/lib/shared/index.ts
@@ -58,12 +58,24 @@ export type ReceivedMessageResult = {
 }
 
 /**
- * Present only for a flow run triggered by a Messenger comment-automation
- * private reply. Carries the triggering comment's id so the first outgoing
- * message of the run can use Facebook's comment_id-anchored Send API
- * (bypasses the normal messaging-window rule) instead of the standard
- * PSID-based send, which Facebook rejects for users who only commented and
- * never messaged the Page. Forwarded across every re-enqueued sendFlow job
- * until consumed by the first message-producing step, then dropped.
+ * Present only for a flow run triggered by a Facebook comment-automation
+ * public or private reply. Carries the triggering comment's id so the first
+ * outgoing message of the run is delivered as a reply to that specific
+ * comment instead of a normal flow message. Forwarded across every
+ * re-enqueued sendFlow job until consumed by the first message-producing
+ * step, then dropped.
+ *
+ * `replyChannel` picks the delivery mechanism for that first message:
+ * - `"public"`: post it as a public comment reply (`comment.sendComment`),
+ *   same as the `text`/`AIAgent` public reply types. Works on any channel
+ *   that implements `sendComment` (Messenger, Instagram).
+ * - `"private"`: send it via Facebook's comment_id-anchored Send API
+ *   (bypasses the normal messaging-window rule) instead of the standard
+ *   PSID-based send, which Facebook rejects for users who only commented and
+ *   never messaged the Page. Messenger-only (no Instagram private_replies
+ *   equivalent).
  */
-export type CommentAnchor = { commentId: string }
+export type CommentAnchor = {
+  commentId: string
+  replyChannel: "public" | "private"
+}


### PR DESCRIPTION
## Summary
- Facebook comment automation's public reply configured as "flow" never posted a public comment reply — it enqueued a generic flow job that always routed outgoing messages through the private DM channel, unlike "text"/"AIAgent" which correctly call `postPublicCommentReply`. Messages either landed silently as an unwanted DM or failed for commenters who'd never messaged the Page (same messaging-window rejection class as the private-reply-flow bug fixed in #831).
- Extends the `CommentAnchor` mechanism shipped in #831 with a `replyChannel: "public" | "private"` discriminant instead of building a parallel mechanism — the propagation plumbing (`flow.ts`, `flow-utils.ts`, `step.ts`, `condition.ts`) already treats the anchor opaquely and needs no changes.
- Public reply is **not** gated to Messenger-only (unlike private reply): both Messenger and Instagram implement `comment.sendComment`.

## Changes
- `packages/sdk/src/lib/shared/index.ts` — `CommentAnchor` now carries `replyChannel: "public" | "private"`
- `apps/worker/src/integration/handlers/comment-automation/index.ts` — `executePublicReply`'s flow branch sets `commentAnchor` with `replyChannel: "public"` (no channelType gate); `executePrivateReply`'s flow branch updated to `replyChannel: "private"`
- `apps/worker/src/chat/handlers/send-flow-step.ts` — branches on `commentAnchor.replyChannel`: `"public"` builds the message row as `type: "comment"` with `contentAttributes.replyToCommentId` and routes through `sendMessageToChannel` (reusing its existing comment-vs-message routing, sourceId persistence, and retry-suppression instead of a new path); `"private"`/absent keeps the existing `sendFlowStepToChannel` behavior
- `apps/worker/src/chat/handlers/send-message.ts` — `sendMessageToChannel` now returns `{ messageIds }` instead of `void` so the flow-step handler's `message:sent` analytics/sourceId tracking works for both branches
- `integrations/messenger/src/handlers/message/outgoing-message/index.ts` — only honors the anchor for `replyChannel === "private"` (defense-in-depth; a public anchor should never reach the DM channel handler)
- Known-gap comments (`step.ts`, `follow-up.ts`) updated to note the wait/followUp anchor-loss gap now applies to both public and private
- Tests: extended `comment-automation.test.ts`, `flow.test.ts`, `send-flow-step.test.ts`, `send-message-handler.test.ts`, `send-flow-step-comment-anchor.test.ts` for the new `replyChannel` field and public-reply routing

## Test plan
- [x] `pnpm --filter worker check-types`, `pnpm --filter @chatbotx.io/sdk check-types`, `pnpm --filter @chatbotx.io/worker-config check-types`, `pnpm --filter @chatbotx.io/integration-messenger check-types`, `pnpm --filter @chatbotx.io/integration-instagram-facebook check-types` — all pass
- [x] `pnpm --filter worker vitest run` — 1171/1172 pass (1 pre-existing unrelated failure in `webhook-executor-payloads.test.ts`, confirmed present on `main` before this change)
- [x] `pnpm --filter @chatbotx.io/integration-messenger vitest run` — 178/178 pass
- [x] `pnpm lint` — clean on all files touched by this change
- [ ] Manual: configure a comment automation with public reply = flow on a real connected Page, comment with an account that has never messaged the Page, confirm the reply actually appears publicly under the comment (not just in the internal inbox)