### PR TITLE
fix(external-webhooks): wire v1/external-webhooks route into main router

### DIFF
--- a/apps/builder/src/features/external-webhooks/api/index.ts
+++ b/apps/builder/src/features/external-webhooks/api/index.ts
@@ -1,0 +1,5 @@
+import externalWebhooksWorkspaceTokenAPIs from "./workspace-token"
+
+export const externalWebhooksAPI = {
+  ...externalWebhooksWorkspaceTokenAPIs,
+}

--- a/apps/builder/src/routers/index.ts
+++ b/apps/builder/src/routers/index.ts
@@ -12,6 +12,7 @@ import { conversationsAPI } from "@/features/conversations/api"
 import { customFieldsAPI } from "@/features/custom-fields/api"
 import { emailTopicsAPI } from "@/features/email-topics/api"
 import { errorLogsAPI } from "@/features/error-logs/api"
+import { externalWebhooksAPI } from "@/features/external-webhooks/api"
 import { fbCommentsAPI } from "@/features/fb-comments/api"
 import { flowsAPI } from "@/features/flows/api"
 import { foldersAPI } from "@/features/folders/api"
@@ -92,6 +93,7 @@ export const router = {
   messagesAPI,
   personasAPIs,
   errorLogsAPI,
+  externalWebhooksAPI,
   workspacesAPI,
   aiFunctionsAPI,
   platformCredentialsAPI,


### PR DESCRIPTION
## Summary
- `GET/POST/DELETE /api/v1/external-webhooks*` returned 404 because the external-webhooks workspace-token API (added in #835 for the Make trigger step) was only registered in `routers/public.ts`, which exists solely to generate the `public-spec.json` OpenAPI doc — it was never wired into `routers/index.ts`, the router that actually backs the `/api` and `/rpc` HTTP handlers.
- Adds the missing `features/external-webhooks/api/index.ts` re-export and registers it in the main router, mirroring the pattern already used by every other feature (workspaces, triggers, webhooks, ...).

## Changes
- `apps/builder/src/features/external-webhooks/api/index.ts` (new) — re-exports `externalWebhooksWorkspaceTokenAPIs`
- `apps/builder/src/routers/index.ts` — imports and registers `externalWebhooksAPI` in the main `router`

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [ ] Manually verify `POST /api/v1/external-webhooks` (with a valid workspace bearer token) now returns 201 instead of 404