### PR TITLE
fix(external-webhooks): drop external-webhooks from public API spec

### DIFF
--- a/apps/builder/src/routers/public.ts
+++ b/apps/builder/src/routers/public.ts
@@ -7,7 +7,6 @@ import contactWorkspaceTokenAPIs from "@/features/contacts/api/workspace-token"
 import conversationWorkspaceTokenAPIs from "@/features/conversations/api/workspace-token"
 import customFieldWorkspaceTokenAPIs from "@/features/custom-fields/api/workspace-token"
 import errorLogWorkspaceTokenAPIs from "@/features/error-logs/api/workspace-token"
-import externalWebhooksWorkspaceTokenAPIs from "@/features/external-webhooks/api/workspace-token"
 import flowWorkspaceTokenAPIs from "@/features/flows/api/workspace-token"
 import inboxWorkspaceTokenAPIs from "@/features/inboxes/api/workspace-token"
 import whatsappMessageTemplateWorkspaceTokenAPIs from "@/features/integration-whatsapp/message-templates/api/workspace-token"
@@ -38,7 +37,6 @@ export const publicRouter = {
   ...whatsappMessageTemplateWorkspaceTokenAPIs,
   ...triggersWorkspaceTokenAPIs,
   ...webhooksWorkspaceTokenAPIs,
-  ...externalWebhooksWorkspaceTokenAPIs,
   ...aiAgentsWorkspaceTokenAPIs,
   ...keywordsWorkspaceTokenAPIs,
   ...integrationsWorkspaceTokenAPIs,


### PR DESCRIPTION
## Summary
- External-webhooks (register/list/delete) exist only to support the Make trigger step's attach/detach flow, not as a documented public API surface
- Removes the `externalWebhooksWorkspaceTokenAPIs` spread from `routers/public.ts` so it no longer appears in `public-spec.json`
- Live `/api` and `/rpc` routes remain wired via `routers/index.ts` (#836) — this is a docs-only change

## Changes
- `apps/builder/src/routers/public.ts` — remove import and spread of `externalWebhooksWorkspaceTokenAPIs`

## Test plan
- [ ] pnpm lint
- [ ] pnpm --filter builder check-types
- [ ] Confirm `/api/public-spec.json` no longer lists `/v1/external-webhooks`
- [ ] Confirm `GET/POST/DELETE /api/v1/external-webhooks` still works via `routers/index.ts`