### PR TITLE
fix(variables): show the gender word in the right language and case

### DIFF
--- a/packages/business/__tests__/system-field-service.test.ts
+++ b/packages/business/__tests__/system-field-service.test.ts
@@ -79,7 +79,9 @@ vi.mock("../src/workspace/service", () => ({
   workspaceService: { findById: mocks.workspaceFindById },
 }))
 
-const { systemFieldService } = await import("../src/system-field/service")
+const { resolveGenderLabel, systemFieldService } = await import(
+  "../src/system-field/service"
+)
 
 const payload = {
   channel: "messenger",
@@ -132,6 +134,32 @@ const conversation = {
   createdAt: new Date("2026-06-05T07:34:29.000Z"),
   id: payload.conversationId,
 }
+
+describe("resolveGenderLabel", () => {
+  test("uses the Vietnamese labels for a Vietnamese workspace", () => {
+    expect(resolveGenderLabel("vi", "male")).toBe("Anh")
+    expect(resolveGenderLabel("vi", "female")).toBe("Chị")
+    expect(resolveGenderLabel("vi", "unknown")).toBe("Anh/Chị")
+  })
+
+  test("falls back to the English labels for every other language", () => {
+    expect(resolveGenderLabel("en", "male")).toBe("Male")
+    expect(resolveGenderLabel("de", "female")).toBe("Female")
+    expect(resolveGenderLabel(null, "male")).toBe("Male")
+    expect(resolveGenderLabel(undefined, null)).toBe("Male/Female")
+  })
+
+  test("matches on the primary subtag so region-tagged languages still localise", () => {
+    expect(resolveGenderLabel("vi-VN", "male")).toBe("Anh")
+    expect(resolveGenderLabel("VI", "female")).toBe("Chị")
+    expect(resolveGenderLabel("vi_VN", null)).toBe("Anh/Chị")
+  })
+
+  test("treats an unrecognised gender as unknown", () => {
+    expect(resolveGenderLabel("vi", "nonbinary")).toBe("Anh/Chị")
+    expect(resolveGenderLabel("vi", "")).toBe("Anh/Chị")
+  })
+})
 
 describe("systemFieldService privacy message window", () => {
   beforeEach(() => {

--- a/packages/business/src/system-field/service.ts
+++ b/packages/business/src/system-field/service.ts
@@ -84,11 +84,14 @@ type VerifiedMeContext = {
 }
 
 const DEFAULT_GENDER_LABEL_LANGUAGE = "en"
+const LANGUAGE_SUBTAG_RE = /[-_]/
 
-const GENDER_LABELS: Record<
-  string,
-  Record<"male" | "female" | "unknown", string>
-> = {
+type GenderKey = "male" | "female" | "unknown"
+
+// Sentence-opening salutation labels for `{{gender}}`. Defined here, not in the
+// builder's messages/*.json, because the worker loads this package without a
+// next-intl runtime. Non-Vietnamese workspaces fall back to English.
+const GENDER_LABELS: Record<string, Record<GenderKey, string>> = {
   en: { female: "Female", male: "Male", unknown: "Male/Female" },
   vi: { female: "Chị", male: "Anh", unknown: "Anh/Chị" },
 }
@@ -97,18 +100,16 @@ export const resolveGenderLabel = (
   language: string | null | undefined,
   gender: string | null,
 ): string => {
-  const normalized = normalizeGender(gender ?? undefined) ?? "unknown"
+  // Primary subtag only, so a legacy "vi-VN" row still localises.
+  const [subtag] = (language || DEFAULT_GENDER_LABEL_LANGUAGE)
+    .toLowerCase()
+    .split(LANGUAGE_SUBTAG_RE)
   const labels =
-    GENDER_LABELS[language ?? DEFAULT_GENDER_LABEL_LANGUAGE] ??
-    GENDER_LABELS[DEFAULT_GENDER_LABEL_LANGUAGE]
-  switch (normalized) {
-    case "male":
-      return labels.male
-    case "female":
-      return labels.female
-    default:
-      return labels.unknown
-  }
+    GENDER_LABELS[subtag] ?? GENDER_LABELS[DEFAULT_GENDER_LABEL_LANGUAGE]
+  const normalized = normalizeGender(gender ?? undefined)
+  return normalized === "male" || normalized === "female"
+    ? labels[normalized]
+    : labels.unknown
 }
 
 const toGeneratedUtc = (): string =>

--- a/packages/variables/__tests__/contact-variable.test.ts
+++ b/packages/variables/__tests__/contact-variable.test.ts
@@ -182,6 +182,68 @@ describe("contactVariableService.replaceAll", () => {
   })
 })
 
+describe("contactVariableService.replaceAll gender casing", () => {
+  const genderVariables = (gender: string | null, language: string) => ({
+    ...createVariables(),
+    contact: { ...contact, gender } as ContactModel,
+    workspace: { ...workspace, language } as WorkspaceModel,
+  })
+
+  test("capitalises {{gender}} when it opens the text", async () => {
+    await expect(
+      contactVariableService.replaceAll({
+        text: "{{gender}} vui lòng xác nhận đơn hàng.",
+        variables: genderVariables("male", "vi"),
+      }),
+    ).resolves.toBe("Anh vui lòng xác nhận đơn hàng.")
+  })
+
+  test("lowercases {{gender}} inside a sentence", async () => {
+    await expect(
+      contactVariableService.replaceAll({
+        text: "Xin chào {{gender}}, đơn hàng đã được giao.",
+        variables: genderVariables("female", "vi"),
+      }),
+    ).resolves.toBe("Xin chào chị, đơn hàng đã được giao.")
+  })
+
+  test("capitalises {{gender}} after a sentence break and after a newline", async () => {
+    await expect(
+      contactVariableService.replaceAll({
+        text: "Cảm ơn. {{gender}} nhé!\n{{gender}} cần hỗ trợ gì thêm không?",
+        variables: genderVariables(null, "vi"),
+      }),
+    ).resolves.toBe("Cảm ơn. Anh/Chị nhé!\nAnh/Chị cần hỗ trợ gì thêm không?")
+  })
+
+  test("keeps the Vietnamese labels for a region-tagged workspace language", async () => {
+    await expect(
+      contactVariableService.replaceAll({
+        text: "Kính gửi {{gender}}",
+        variables: genderVariables("female", "vi-VN"),
+      }),
+    ).resolves.toBe("Kính gửi chị")
+  })
+
+  test("falls back to the English labels for other workspace languages", async () => {
+    await expect(
+      contactVariableService.replaceAll({
+        text: "{{gender}} — hello {{gender}}",
+        variables: genderVariables("male", "de"),
+      }),
+    ).resolves.toBe("Male — hello male")
+  })
+
+  test("leaves other variables untouched by the sentence casing", async () => {
+    await expect(
+      contactVariableService.replaceAll({
+        text: "Hi {{first_name}}, {{gender}}!",
+        variables: genderVariables("male", "vi"),
+      }),
+    ).resolves.toBe("Hi Ada, anh!")
+  })
+})
+
 describe("contactVariableService.getAll", () => {
   test("uses a provided contact inbox object and skips the inbox query", async () => {
     mockContactFindFirst.mockResolvedValue(contact)

--- a/packages/variables/__tests__/contact-variable.test.ts
+++ b/packages/variables/__tests__/contact-variable.test.ts
@@ -244,6 +244,75 @@ describe("contactVariableService.replaceAll gender casing", () => {
   })
 })
 
+describe("contactVariableService.replaceAll gender language", () => {
+  const render = (input: {
+    workspaceLanguage: string
+    contactLocale?: string | null
+    inboxLanguage?: string | null
+  }) =>
+    contactVariableService.replaceAll({
+      text: "{{gender}}",
+      variables: {
+        ...createVariables(),
+        contact: {
+          ...contact,
+          gender: "female",
+          locale: input.contactLocale ?? null,
+        } as ContactModel,
+        contactInbox: {
+          ...contactInbox,
+          language: input.inboxLanguage ?? null,
+        } as ContactInboxModel,
+        workspace: {
+          ...workspace,
+          language: input.workspaceLanguage,
+        } as WorkspaceModel,
+      },
+    })
+
+  test("prefers the contact channel language over the workspace language", async () => {
+    await expect(
+      render({ inboxLanguage: "vi", workspaceLanguage: "en" }),
+    ).resolves.toBe("Chị")
+  })
+
+  test("falls back to the language read from the contact locale", async () => {
+    await expect(
+      render({ contactLocale: "vi_VN", workspaceLanguage: "en" }),
+    ).resolves.toBe("Chị")
+  })
+
+  test("prefers the channel language over the contact locale", async () => {
+    await expect(
+      render({
+        contactLocale: "vi_VN",
+        inboxLanguage: "en",
+        workspaceLanguage: "vi",
+      }),
+    ).resolves.toBe("Female")
+  })
+
+  test("falls back to the workspace language when the contact has none", async () => {
+    await expect(render({ workspaceLanguage: "vi" })).resolves.toBe("Chị")
+  })
+
+  test("treats a blank contact language as unknown so the workspace wins", async () => {
+    await expect(
+      render({
+        contactLocale: "",
+        inboxLanguage: "",
+        workspaceLanguage: "vi",
+      }),
+    ).resolves.toBe("Chị")
+  })
+
+  test("keeps the contact language even when it differs from the workspace", async () => {
+    await expect(
+      render({ contactLocale: "en_US", workspaceLanguage: "vi" }),
+    ).resolves.toBe("Female")
+  })
+})
+
 describe("contactVariableService.getAll", () => {
   test("uses a provided contact inbox object and skips the inbox query", async () => {
     mockContactFindFirst.mockResolvedValue(contact)

--- a/packages/variables/src/contact-variable.ts
+++ b/packages/variables/src/contact-variable.ts
@@ -144,7 +144,8 @@ export const contactVariableService = {
         }
       }
 
-      return interpolate(text, mapping)
+      // Prose: "Anh vui lòng…" opening a sentence, "Xin chào anh" inside one.
+      return interpolate(text, mapping, { sentenceCase: true })
     } catch (error) {
       const message = "Unable to render custom fields to message"
       logger.error(error, message)

--- a/packages/variables/src/utils.ts
+++ b/packages/variables/src/utils.ts
@@ -79,19 +79,43 @@ const capitalizeFirstLetter = (value: string | null): string | null => {
   return value.charAt(0).toUpperCase() + value.slice(1)
 }
 
-export const extractVariables = (text: string): string[] => {
-  const regex = /\{\{([\w.]+)\}\}/g
-  return [...new Set(Array.from(text.matchAll(regex), (match) => match[1]))]
+const VARIABLE_RE = /\{\{([\w.]+)\}\}/g
+
+// `{{gender}}` renders a salutation ("Anh" / "anh"), so its case depends on
+// where the placeholder sits — a call the position-independent mapping can't
+// make. resolveGenderLabel returns the opening form; inside a sentence it is
+// that label lowercased.
+const SENTENCE_CASED_VARIABLES = new Set<string>([systemFieldTypes.enum.gender])
+
+// The text before a placeholder that opens the message, a line, or a sentence.
+const SENTENCE_OPENING_RE = /(?:^|[.!?…\n\r])[\s"'“‘([]*$/
+
+export type InterpolateOptions = {
+  /** Case `{{gender}}` by position. Prose wants it; URLs and JSON must not. */
+  sentenceCase?: boolean
 }
+
+export const extractVariables = (text: string): string[] => [
+  ...new Set(Array.from(text.matchAll(VARIABLE_RE), (match) => match[1])),
+]
 
 export const interpolate = (
   text: string,
   mapping: Record<string, string>,
+  options: InterpolateOptions = {},
 ): string =>
-  text.replace(
-    /\{\{([\w.]+)\}\}/g,
-    (match, variable) => mapping[variable] ?? match,
-  )
+  text.replace(VARIABLE_RE, (match, variable: string, offset: number) => {
+    const value = mapping[variable]
+    if (value === undefined) {
+      return match
+    }
+    if (!(options.sentenceCase && SENTENCE_CASED_VARIABLES.has(variable))) {
+      return value
+    }
+    return SENTENCE_OPENING_RE.test(text.slice(0, offset))
+      ? value
+      : value.toLowerCase()
+  })
 
 const getTimezone = ({
   contact,

--- a/packages/variables/src/utils.ts
+++ b/packages/variables/src/utils.ts
@@ -232,6 +232,16 @@ const getCommentMessagePostId = (
   return typeof postId === "string" ? postId : null
 }
 
+// The contact's own language, in the order the platform learns it: the channel
+// language we recorded, then the locale their profile reports. Undefined when
+// the contact never told us, so the caller picks the fallback. Blank values
+// normalise away here rather than shadowing that fallback.
+const getContactLanguage = (
+  context: ContactVariableContext,
+): string | undefined =>
+  languageFromLocale(context.contactInbox?.language) ??
+  languageFromLocale(context.contact.locale)
+
 export const getSystemFieldValue = async (
   context: ContactVariableContext,
   key: SystemFieldType,
@@ -258,7 +268,10 @@ export const getSystemFieldValue = async (
     case systemFieldTypes.enum.profile_pic:
       return await toPublicStorageUrl(contact.avatar, contact.workspaceId)
     case systemFieldTypes.enum.gender:
-      return resolveGenderLabel(workspace?.language, contact.gender)
+      return resolveGenderLabel(
+        getContactLanguage(context) ?? workspace?.language,
+        contact.gender,
+      )
     case systemFieldTypes.enum.user_country:
       return contact.country
     case systemFieldTypes.enum.user_state:


### PR DESCRIPTION
## What this changes

The `{{gender}}` merge variable did not always read correctly inside a message. Two things are fixed.

### 1. It now follows the reader's language

The label is resolved in this order, first match wins:

1. the language recorded for the contact on their channel
2. the language read from the contact's profile locale
3. the workspace language
4. English

Each supported language has its own set of words; English (`Male` / `Female` / `Male/Female`) is the fallback for anything not covered.

Languages stored with a region are now matched on their primary subtag, so `en-US`, `en_US` and `EN` all resolve the same way as `en`. Previously the lookup required an exact match on the bare code, so any contact whose language was stored with a region silently fell through to the English fallback.

### 2. It is now written with the right capital letter

The label carries a capital only where the sentence needs one:

| Where the placeholder sits | Rendered as |
| --- | --- |
| start of the message | `Male` |
| start of a new line | `Male` |
| after `.`, `!`, `?` or `…` | `Male` |
| middle of a sentence | `male` |

```
{{gender}}, your order is on its way.      ->  Male, your order is on its way.
Hello {{gender}}, your order is on its way. ->  Hello male, your order is on its way.
Thanks. {{gender}}, see you soon.           ->  Thanks. Male, see you soon.
```

Opening quotes and brackets before the placeholder are skipped, so `"{{gender}}` still counts as opening the sentence. The whole label is lowercased rather than just its first character — otherwise `Male/Female` would come out as `male/Female`.

## Scope

Applies to message text only — flows, broadcasts, templates and AI replies. Magic-link URLs and AI tool payloads are byte-identical, because the casing is opt-in per call site rather than applied inside the shared interpolation helper.

The privacy export page is deliberately left on the workspace language, since that page loads its entire UI from the workspace language and a per-contact label there would clash with the surrounding text.

## Trade-off worth reviewing

Because the contact's own language now wins over the workspace language, a contact whose profile reports a different language from the one the workspace writes its templates in will receive the label in their own language. The result is a mixed-language sentence: the template text stays in the workspace language while the label does not. This is intended behaviour for this change; flagging it because it is the case most likely to surprise.

## Test plan

- [x] 16 tests covering both the language chain and the capitalisation, including region-tagged languages, blank language values, and channel-language-over-locale precedence
- [x] Verified the new tests fail without the change (4 fail on the language chain, the fallback cases pass either way since that behaviour is unchanged)
- [x] `@chatbotx.io/variables` — 118 tests pass
- [x] `@chatbotx.io/business` — 584 tests pass
- [x] `worker` — 1198 tests pass
- [x] Lint and type checks pass across all 51 packages