### PR TITLE
fix(tiktok): stop dropping live inbound webhook deliveries

### DIFF
--- a/integrations/tiktok/src/handlers/webhook.ts
+++ b/integrations/tiktok/src/handlers/webhook.ts
@@ -5,8 +5,11 @@ import { hmacSha256Hex, timingSafeStringEqual } from "../lib/webhook"
 import type { TiktokConfig } from "../schema"
 import { tiktokWebhookEventSchema } from "../schema"
 
-// TikTok recommends rejecting events older than 5 seconds
-const WEBHOOK_TIMESTAMP_WINDOW_SECONDS = 5
+// TikTok recommends rejecting events older than 5 seconds, but our webhook
+// route does several DB round-trips (integration lookup, freeze check) before
+// this check runs, so a tight window drops legitimate live deliveries. 300s
+// still blocks replay while giving that request path room to breathe.
+const WEBHOOK_TIMESTAMP_WINDOW_SECONDS = 300
 // Allow 2s of clock skew between TikTok servers and ours
 const WEBHOOK_CLOCK_SKEW_SECONDS = 2
 
@@ -15,7 +18,7 @@ async function verifySignature(
   signature: string,
   body: string,
 ): Promise<boolean> {
-  const parts = signature.split(",")
+  const parts = signature.split(",").map((p) => p.trim())
   const tPart = parts.find((p) => p.startsWith("t="))
   const sPart = parts.find((p) => p.startsWith("s="))
 
@@ -98,17 +101,20 @@ export const webhookHandler = async (
     return "ok"
   }
 
-  await queue?.add("incomingMessage", {
-    type: "incomingMessage",
-    data: {
-      integrationType: "tiktok",
-      integrationIdentifier,
-      payload: event.data,
+  await queue?.add(
+    "incomingMessage",
+    {
+      type: "incomingMessage",
+      data: {
+        integrationType: "tiktok",
+        integrationIdentifier,
+        payload: event.data,
+      },
     },
     // Add delay for echo events to avoid race condition where echo arrives
     // before the send message API response completes
-    opts: event.data.event === "im_send_msg" ? { delay: 2000 } : undefined,
-  })
+    event.data.event === "im_send_msg" ? { delay: 2000 } : undefined,
+  )
 
   return "ok"
 }


### PR DESCRIPTION
## Summary
- TikTok's 5s signature-freshness window was checked *after* several DB round-trips (integration lookup, freeze check) in the builder webhook route, so legitimate live deliveries were routinely rejected as stale and the `incomingMessage` job never got enqueued — the message only appeared once TikTok retried, minutes later. This is why the inbox needed an F5 to show a new TikTok message while every other channel updated live.
- Widened the freshness window to 300s (in line with Stripe/GitHub-style webhook verification) to absorb that request-path latency.
- Fixed two related bugs found in the same handler while tracing this: the signature parser didn't trim `t=`/`s=` parts (would break verification outright if TikTok sends `t=…, s=…` with a space), and the BullMQ delay option for `im_send_msg` echo events was nested inside the job payload instead of passed as `add()`'s third argument, so it was silently ignored.

## Changes
- `integrations/tiktok/src/handlers/webhook.ts`: widen `WEBHOOK_TIMESTAMP_WINDOW_SECONDS` 5s → 300s, trim signature parts before matching, pass BullMQ delay via `add()`'s opts argument.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter @chatbotx.io/integration-tiktok check-types`
- [ ] manual verification: send a TikTok DM to a connected business account and confirm it appears in the inbox live without refreshing