### PR TITLE
fix(builder): resolve workspace quota gates from the owner, not the viewer

### DIFF
--- a/apps/builder/__tests__/workspace-owner-quota.test.ts
+++ b/apps/builder/__tests__/workspace-owner-quota.test.ts
@@ -1,0 +1,187 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import {
+  workspaceActionClient,
+  workspaceActionClientAllowScheduledDeletion,
+} from "@/lib/safe-action"
+import { resolveWorkspaceBlockState } from "@/lib/workspace-quota"
+
+const { getAccessState, getAtLimitMap, getForUser, isAtLimit, isCloud } =
+  vi.hoisted(() => ({
+    getAccessState: vi.fn(),
+    getAtLimitMap: vi.fn(),
+    getForUser: vi.fn(),
+    isAtLimit: vi.fn(),
+    isCloud: vi.fn(),
+  }))
+
+vi.mock("@chatbotx.io/business", () => ({
+  isPlatformAdmin: vi.fn(),
+  isSuperAdmin: vi.fn(),
+  isWorkspaceScheduledForDeletion: vi.fn(() => false),
+  quotaEnforcementService: { getAtLimitMap, isAtLimit },
+  userQuotaService: { getAccessState, getAtLimitMap, getForUser },
+}))
+
+vi.mock("@chatbotx.io/business/errors", () => ({
+  ChatbotXException: class ChatbotXException extends Error {},
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  findOrFail: vi.fn(),
+  isDatabaseError: vi.fn(() => false),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({ userModel: {} }))
+
+vi.mock("@chatbotx.io/sdk", () => ({
+  SdkException: class SdkException extends Error {},
+}))
+
+vi.mock("@chatbotx.io/utils", () => ({
+  zodBigintAsString: () => ({ safeParse: () => ({ data: null }) }),
+}))
+
+vi.mock("@/env", () => ({ isCloud }))
+vi.mock("@/features/workspace-members/queries", () => ({
+  getAllWorkspaceMembers: vi.fn(),
+}))
+vi.mock("@/lib/auth/utils", () => ({ getCurrentUserId: vi.fn() }))
+vi.mock("@/lib/log", () => ({ logger: { error: vi.fn() } }))
+
+function createChain(middlewares: unknown[] = []) {
+  return {
+    middlewares,
+    use(middleware: unknown) {
+      return createChain([...middlewares, middleware])
+    },
+  }
+}
+
+vi.mock("next-safe-action", () => ({
+  DEFAULT_SERVER_ERROR_MESSAGE: "Server error",
+  createSafeActionClient: () => createChain(),
+}))
+
+const activeQuota = {
+  planStatus: "active",
+  periodEnd: null,
+}
+const expiredQuota = {
+  planStatus: "expired",
+  periodEnd: null,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  isCloud.mockReturnValue(true)
+  getAtLimitMap.mockResolvedValue({ mac: false })
+  getForUser.mockResolvedValue(activeQuota)
+  isAtLimit.mockResolvedValue(false)
+})
+
+describe("resolveWorkspaceBlockState", () => {
+  test("uses the active workspace owner quota when a member has an expired personal quota", async () => {
+    const result = await resolveWorkspaceBlockState("owner-active")
+
+    expect(result).toMatchObject({ blocked: false, blockReason: null })
+    expect(getForUser).toHaveBeenCalledWith("owner-active")
+    expect(getAtLimitMap).toHaveBeenCalledWith("owner-active")
+  })
+
+  test("blocks a member when the workspace owner quota is expired", async () => {
+    getForUser.mockResolvedValue(expiredQuota)
+
+    await expect(
+      resolveWorkspaceBlockState("owner-expired"),
+    ).resolves.toMatchObject({
+      blocked: true,
+      blockReason: "status",
+    })
+    expect(getForUser).toHaveBeenCalledWith("owner-expired")
+  })
+
+  test("never blocks a self-hosted workspace", async () => {
+    isCloud.mockReturnValue(false)
+
+    await expect(resolveWorkspaceBlockState("owner-id")).resolves.toEqual({
+      blocked: false,
+      blockReason: null,
+      quota: null,
+      trialEndsAt: null,
+    })
+    expect(getForUser).not.toHaveBeenCalled()
+    expect(getAtLimitMap).not.toHaveBeenCalled()
+  })
+})
+
+describe("workspace action quota gates", () => {
+  const workspace = { id: "workspace-id", ownerId: "owner-id" }
+  const user = { id: "member-with-an-expired-personal-quota" }
+
+  test("allows an action when the owner is active regardless of the member quota", async () => {
+    getAccessState.mockResolvedValue({ blocked: false, reason: null })
+    const next = vi.fn()
+    const actionGate = (
+      workspaceActionClient as unknown as {
+        middlewares: Array<(args: unknown) => Promise<unknown>>
+      }
+    ).middlewares[2]
+
+    await actionGate?.({ ctx: { user, workspace }, next })
+
+    expect(getAccessState).toHaveBeenCalledWith("owner-id")
+    expect(isAtLimit).toHaveBeenCalledWith({
+      userId: "owner-id",
+      metric: "mac",
+    })
+    expect(next).toHaveBeenCalledWith({ ctx: { user, workspace } })
+  })
+
+  test("rejects an action when the owner is expired even if the member is active", async () => {
+    getAccessState.mockResolvedValue({ blocked: true, reason: "status" })
+    const actionGate = (
+      workspaceActionClient as unknown as {
+        middlewares: Array<(args: unknown) => Promise<unknown>>
+      }
+    ).middlewares[2]
+
+    await expect(
+      actionGate?.({ ctx: { user, workspace }, next: vi.fn() }),
+    ).rejects.toThrow("Trial expired")
+    expect(getAccessState).toHaveBeenCalledWith("owner-id")
+  })
+
+  test("rejects a direct action when the owner's reseller pool reaches its MAC limit", async () => {
+    getAccessState.mockResolvedValue({ blocked: false, reason: null })
+    isAtLimit.mockResolvedValue(true)
+    const actionGate = (
+      workspaceActionClient as unknown as {
+        middlewares: Array<(args: unknown) => Promise<unknown>>
+      }
+    ).middlewares[2]
+
+    await expect(
+      actionGate?.({ ctx: { user, workspace }, next: vi.fn() }),
+    ).rejects.toThrow("Monthly active contact limit reached")
+    expect(isAtLimit).toHaveBeenCalledWith({
+      userId: "owner-id",
+      metric: "mac",
+    })
+  })
+
+  test("uses the owner quota for actions allowed during scheduled deletion", async () => {
+    getAccessState.mockResolvedValue({ blocked: false, reason: null })
+    const next = vi.fn()
+    const actionGate = (
+      workspaceActionClientAllowScheduledDeletion as unknown as {
+        middlewares: Array<(args: unknown) => Promise<unknown>>
+      }
+    ).middlewares[2]
+
+    await actionGate?.({ ctx: { user, workspace }, next })
+
+    expect(getAccessState).toHaveBeenCalledWith("owner-id")
+    expect(next).toHaveBeenCalledWith({ ctx: { user, workspace } })
+  })
+})

--- a/apps/builder/src/app/space/[workspaceId]/dashboard/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/dashboard/page.tsx
@@ -1,9 +1,4 @@
 import { BaseDashboard } from "@chatbotx.io/analytics-nextjs/components/base-dashboard"
-import {
-  quotaEnforcementService,
-  userQuotaService,
-  workspaceService,
-} from "@chatbotx.io/business"
 import { getIdFromParams } from "@chatbotx.io/utils"
 import { notFound } from "next/navigation"
 import { isCloud } from "@/env"
@@ -11,7 +6,7 @@ import { InboxCardList } from "@/features/inboxes/components/inbox-card-list"
 import { listInboxes } from "@/features/inboxes/queries"
 import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
 import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
-import { resolveBlockReason, resolveTrialEndsAt } from "@/lib/quota-metrics"
+import { resolveWorkspaceBlockState } from "@/lib/workspace-quota"
 
 export default async function Dashboard({
   params,
@@ -38,23 +33,14 @@ export default async function Dashboard({
 
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
   const cloud = isCloud()
+  const { targetWorkspace } = userAndWorkspace
 
-  const [inboxesResult, workspace, quota, atLimit] = await Promise.all([
+  const [inboxesResult, { blocked, blockReason }] = await Promise.all([
     listInboxes({ workspaceId, includes: ["integration"] }),
-    workspaceService.find({ where: { id: workspaceId } }),
-    cloud ? userQuotaService.getForUser(userAndWorkspace.user.id) : null,
-    cloud
-      ? quotaEnforcementService.getAtLimitMap(userAndWorkspace.user.id)
-      : null,
+    resolveWorkspaceBlockState(targetWorkspace.ownerId),
   ])
 
   const inboxes = inboxesResult.data.filter((inbox) => inbox.channel !== "smtp")
-  const blockReason = resolveBlockReason(
-    quota?.planStatus ?? null,
-    resolveTrialEndsAt(quota),
-    atLimit?.mac ?? false,
-  )
-  const blocked = blockReason !== null
 
   return (
     <div className="flex flex-col gap-4">
@@ -74,7 +60,7 @@ export default async function Dashboard({
           workspaceId,
           timezone,
         }}
-        workspaceCreatedAt={workspace?.createdAt}
+        workspaceCreatedAt={targetWorkspace.createdAt}
       />
     </div>
   )

--- a/apps/builder/src/app/space/[workspaceId]/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/layout.tsx
@@ -3,7 +3,6 @@ import {
   isSuperAdmin,
   isWorkspaceScheduledForDeletion,
   quotaEnforcementService,
-  userQuotaService,
   workspaceMemberService,
 } from "@chatbotx.io/business"
 import {
@@ -25,12 +24,9 @@ import { getTenantSettings } from "@/features/tenant/utils"
 import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
 import { enforcePasswordCurrent } from "@/lib/auth/require-password-current"
 import { getCurrentUser } from "@/lib/auth/utils"
-import {
-  buildWorkspaceQuotaMetrics,
-  resolveBlockReason,
-  resolveTrialEndsAt,
-} from "@/lib/quota-metrics"
+import { buildWorkspaceQuotaMetrics } from "@/lib/quota-metrics"
 import { enforceWorkspaceNotScheduledForDeletionFromRequest } from "@/lib/workspace/require-not-scheduled-for-deletion"
+import { resolveWorkspaceBlockState } from "@/lib/workspace-quota"
 
 export default async function WorkspaceLayout({
   children,
@@ -56,32 +52,29 @@ export default async function WorkspaceLayout({
   const cloud = isCloud()
 
   // Check if user is a member of the workspace
-  const [
-    allWorkspaceMembers,
-    { storageUrl },
-    platformAdmin,
-    quota,
-    usage,
-    atLimit,
-  ] = await Promise.all([
-    workspaceMemberService.listByUserId({ userId: user.id }),
-    getTenantSettings(),
-    isPlatformAdmin(user),
-    cloud ? userQuotaService.getForUser(user.id) : Promise.resolve(null),
-    cloud
-      ? quotaEnforcementService.getWorkspaceUsageSummary({
-          userId: user.id,
-          workspaceId,
-        })
-      : null,
-    cloud ? quotaEnforcementService.getAtLimitMap(user.id) : null,
-  ])
+  const [allWorkspaceMembers, { storageUrl }, platformAdmin] =
+    await Promise.all([
+      workspaceMemberService.listByUserId({ userId: user.id }),
+      getTenantSettings(),
+      isPlatformAdmin(user),
+    ])
   const targetWorkspaceMember = allWorkspaceMembers.find(
     (workspaceMember) => workspaceMember.workspace.id === workspaceId,
   )
   if (!targetWorkspaceMember) {
     return notFound()
   }
+
+  const [{ blocked, blockReason, quota, trialEndsAt }, usage] =
+    await Promise.all([
+      resolveWorkspaceBlockState(targetWorkspaceMember.workspace.ownerId),
+      cloud
+        ? quotaEnforcementService.getWorkspaceUsageSummary({
+            userId: targetWorkspaceMember.workspace.ownerId,
+            workspaceId,
+          })
+        : null,
+    ])
 
   await enforceWorkspaceNotScheduledForDeletionFromRequest(
     targetWorkspaceMember.workspace,
@@ -94,14 +87,6 @@ export default async function WorkspaceLayout({
       ? new URL(workspaceMember.workspace.logo, storageUrl).toString()
       : null,
   }))
-
-  const trialEndsAt = resolveTrialEndsAt(quota)
-  const blockReason = resolveBlockReason(
-    quota?.planStatus ?? null,
-    trialEndsAt,
-    atLimit?.mac ?? false,
-  )
-  const blocked = blockReason !== null
 
   const quotaSummary: QuotaSummary = {
     planName: quota?.planName ?? null,

--- a/apps/builder/src/lib/safe-action.ts
+++ b/apps/builder/src/lib/safe-action.ts
@@ -2,6 +2,7 @@ import {
   isPlatformAdmin,
   isSuperAdmin,
   isWorkspaceScheduledForDeletion,
+  quotaEnforcementService,
   userQuotaService,
 } from "@chatbotx.io/business"
 import { ChatbotXException } from "@chatbotx.io/business/errors"
@@ -99,6 +100,31 @@ export const workspaceActionClientAllowExpired = authActionClient.use(
   },
 )
 
+async function getWorkspaceOwnerAccessState(ownerId: string) {
+  const accessState = await userQuotaService.getAccessState(ownerId)
+  if (accessState.blocked) {
+    return accessState
+  }
+
+  // getAccessState already checks ownerId's own live MAC counter, so this is a
+  // no-op for a reseller acting directly or a root-tenant owner (isAtLimit
+  // reduces to the same isLimitReached(ownerId, "mac") call in both cases). It
+  // only adds new information when ownerId is a sub-account: isAtLimit then
+  // also checks the reseller pool row, closing a pool-level MAC bypass for
+  // workspaces owned by a sub-account. Costs one extra, uncached lookup of the
+  // owner's tenant on every call — see resolveContext in quota-enforcement/service.ts.
+  if (
+    await quotaEnforcementService.isAtLimit({
+      userId: ownerId,
+      metric: "mac",
+    })
+  ) {
+    return { ...accessState, blocked: true, reason: "mac" as const }
+  }
+
+  return accessState
+}
+
 export const workspaceActionClient = workspaceActionClientAllowExpired.use(
   async ({ ctx, next }) => {
     // Server-side deletion gate: a workspace pending deletion must block every
@@ -112,14 +138,17 @@ export const workspaceActionClient = workspaceActionClientAllowExpired.use(
       )
     }
 
-    // Server-side trial gate: the RSC banner shows a blocked user read/delete
-    // mode, but a stale session could still POST a create/change action
-    // directly. Re-check the entitlement here so the paywall holds. Cloud-only;
-    // self-hosted editions have no quota row and stay unrestricted. The quota
-    // read is cached, so this adds no per-action DB round-trip in the hot path.
+    // Server-side owner-quota gate: the RSC banner shows the workspace owner's
+    // blocked read/delete mode, but a stale session could still POST a
+    // create/change action directly. A workspace's owner quota row is the
+    // tenant pool (AGENTS.md invariant #12), so members must never be gated by
+    // their unrelated personal quota. Cloud-only; self-hosted editions have no
+    // quota row and stay unrestricted. getAccessState's quota read is cached,
+    // but getWorkspaceOwnerAccessState's tenant lookup (for the sub-account
+    // pool check) is not — this adds one uncached DB round-trip per action.
     if (isCloud()) {
-      const { blocked, reason } = await userQuotaService.getAccessState(
-        ctx.user.id,
+      const { blocked, reason } = await getWorkspaceOwnerAccessState(
+        ctx.workspace.ownerId,
       )
       if (blocked) {
         throw reason === "mac"
@@ -141,9 +170,17 @@ export const workspaceActionClient = workspaceActionClientAllowExpired.use(
 export const workspaceActionClientAllowScheduledDeletion =
   workspaceActionClientAllowExpired.use(async ({ ctx, next }) => {
     if (isCloud()) {
-      const { blocked } = await userQuotaService.getAccessState(ctx.user.id)
+      const { blocked, reason } = await getWorkspaceOwnerAccessState(
+        ctx.workspace.ownerId,
+      )
       if (blocked) {
-        throw new ChatbotXException("Trial expired", "trialExpired", 403)
+        throw reason === "mac"
+          ? new ChatbotXException(
+              "Monthly active contact limit reached",
+              "macLimitReached",
+              403,
+            )
+          : new ChatbotXException("Trial expired", "trialExpired", 403)
       }
     }
 

--- a/apps/builder/src/lib/workspace-quota.ts
+++ b/apps/builder/src/lib/workspace-quota.ts
@@ -1,0 +1,50 @@
+import {
+  quotaEnforcementService,
+  userQuotaService,
+} from "@chatbotx.io/business"
+import type { UserQuotaModel } from "@chatbotx.io/database/types"
+import { isCloud } from "@/env"
+import { resolveBlockReason, resolveTrialEndsAt } from "./quota-metrics"
+
+export interface WorkspaceBlockState {
+  blocked: boolean
+  blockReason: "status" | "mac" | null
+  quota: UserQuotaModel | null
+  trialEndsAt: string | null
+}
+
+/**
+ * Resolves the entitlement state for a workspace. Quota is owner-anchored: the
+ * workspace owner's UserQuota row is the tenant pool, including for invited
+ * members (AGENTS.md invariant #12).
+ */
+export async function resolveWorkspaceBlockState(
+  ownerId: string,
+): Promise<WorkspaceBlockState> {
+  if (!isCloud()) {
+    return {
+      blocked: false,
+      blockReason: null,
+      quota: null,
+      trialEndsAt: null,
+    }
+  }
+
+  const [quota, atLimit] = await Promise.all([
+    userQuotaService.getForUser(ownerId),
+    quotaEnforcementService.getAtLimitMap(ownerId),
+  ])
+  const trialEndsAt = resolveTrialEndsAt(quota)
+  const blockReason = resolveBlockReason(
+    quota?.planStatus ?? null,
+    trialEndsAt,
+    atLimit.mac,
+  )
+
+  return {
+    blocked: blockReason !== null,
+    blockReason,
+    quota,
+    trialEndsAt,
+  }
+}


### PR DESCRIPTION
## Summary
- Every workspace-scoped quota surface (layout banner, dashboard inbox cards, both workspace action gates) resolved `UserQuota` by the *viewer's* `user.id` instead of the *workspace owner's* `ownerId`, incorrectly blocking invited members with no quota row (or a stale expired personal trial) inside workspaces owned by someone on an active plan.
- Quota is owner-anchored (AGENTS.md invariant #12): the owner's row is the tenant pool. This also closes the opposite bypass, where an active member inside an owner-expired workspace was previously left unblocked.
- Extracts `resolveWorkspaceBlockState()` into a shared helper so the RSC layout banner and dashboard page derive blocked state identically instead of duplicating the same three-call sequence.

## Changes
- `apps/builder/src/lib/workspace-quota.ts` (new) — `resolveWorkspaceBlockState(ownerId)` helper with an explicit `WorkspaceBlockState` return type; short-circuits to unblocked on self-hosted (`isCloud() === false`).
- `apps/builder/src/lib/safe-action.ts` — `workspaceActionClient` and `workspaceActionClientAllowScheduledDeletion` now gate on `ctx.workspace.ownerId` via a new `getWorkspaceOwnerAccessState` helper, which also closes a pool-level MAC bypass for sub-account-owned workspaces.
- `apps/builder/src/app/space/[workspaceId]/layout.tsx` — restructured so `ownerId` is resolved from membership before quota/usage/at-limit are fetched, then keys all three off the owner.
- `apps/builder/src/app/space/[workspaceId]/dashboard/page.tsx` — keys inbox-card blocked state off the owner; reuses the workspace already returned by `getCurrentUserAndTargetWorkspace` instead of a second redundant lookup.
- `apps/builder/__tests__/workspace-owner-quota.test.ts` (new) — covers: member of an owner-active workspace with an expired personal quota (unblocked), member of an owner-expired workspace (blocked, the bypass direction), self-hosted (never blocked), and the action-client gates including the MAC-limit path.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [x] `vitest run apps/builder/__tests__/workspace-owner-quota.test.ts` (7/7 passing)
- [ ] Manual verification: invite a member into a workspace owned by an active-plan user whose own account has an expired trial, confirm no `ExpiredBanner` and mutations succeed
- [ ] Manual verification: member with an active personal plan inside an owner-expired workspace is now correctly blocked