### PR TITLE
feat(usage-ring): show compact usage value alongside limit

### DIFF
--- a/apps/builder/__tests__/usage-number-formatting.test.tsx
+++ b/apps/builder/__tests__/usage-number-formatting.test.tsx
@@ -30,16 +30,40 @@ const renderWithLocale = (locale: string, node: ReactNode) =>
   )
 
 describe("usage number formatting", () => {
-  test("UsageRing renders its label without exposing numeric usage values", () => {
+  test("UsageRing renders label with compact usage value", () => {
     const html = renderWithLocale(
-      "vi",
+      "en",
       <UsageRing label="MAC" limit={10_000} used={1234} workspaceUsed={456} />,
     )
 
     expect(html).toContain("MAC")
-    expect(html).not.toContain("456 / 1.234 / 10.000")
-    expect(html).not.toContain("1.234")
-    expect(html).not.toContain("10.000")
+    expect(html).toContain("456")
+    expect(html).toContain("10K")
+    expect(html).not.toContain("1,234")
+    expect(html).not.toContain("10,000")
+  })
+
+  test("UsageRing formats compact values across boundary cases", () => {
+    const cases: [number, number, string, string][] = [
+      [999, 10_000, "999", "10K"],
+      [1000, 10_000, "1K", "10K"],
+      [1500, 10_000, "1.5K", "10K"],
+      [3_000_000, 5_000_000, "3M", "5M"],
+    ]
+
+    for (const [workspaceUsed, limit, expectedUsed, expectedLimit] of cases) {
+      const html = renderWithLocale(
+        "en",
+        <UsageRing
+          label="MAC"
+          limit={limit}
+          used={workspaceUsed}
+          workspaceUsed={workspaceUsed}
+        />,
+      )
+      expect(html).toContain(expectedUsed)
+      expect(html).toContain(expectedLimit)
+    }
   })
 
   test("UsageRing renders nested workspace and user fill widths", () => {

--- a/apps/builder/src/components/usage-ring.tsx
+++ b/apps/builder/src/components/usage-ring.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@chatbotx.io/ui/lib/utils"
+import { useFormatter } from "next-intl"
 import { quotaUsageState } from "@/lib/quota-metrics"
 
 interface UsageRingProps {
@@ -14,6 +15,8 @@ interface UsageRingProps {
  * Presentational three-tier usage bar for the sidebar footer: workspace usage
  * is green, account-wide usage is amber, and remaining plan capacity is gray.
  * The caller owns label resolution and must supply the workspace contribution.
+ * Numbers are formatted via next-intl so server and client produce identical
+ * text.
  */
 export function UsageRing({
   used,
@@ -22,14 +25,36 @@ export function UsageRing({
   workspaceUsed,
   className,
 }: UsageRingProps) {
+  const formatter = useFormatter()
   const { pct: userPct, isOverLimit } = quotaUsageState(used, limit)
   const { pct: workspacePct } = quotaUsageState(workspaceUsed, limit)
 
   return (
     <div className={cn("flex items-center gap-3", className)}>
       <div className="min-w-0 flex-1">
-        <span className="truncate text-muted-foreground text-xs">{label}</span>
-        {/* Decorative: usage amounts are intentionally not displayed as text. */}
+        <div className="flex items-center justify-between gap-2 text-xs">
+          <span className="min-w-0 truncate text-muted-foreground">
+            {label}
+          </span>
+          <span
+            className={cn(
+              "shrink-0 text-muted-foreground tabular-nums",
+              isOverLimit && "font-medium text-destructive",
+            )}
+          >
+            {formatter.number(workspaceUsed, {
+              notation: "compact",
+              compactDisplay: "short",
+              maximumFractionDigits: 1,
+            })}{" "}
+            /{" "}
+            {formatter.number(limit, {
+              notation: "compact",
+              compactDisplay: "short",
+              maximumFractionDigits: 1,
+            })}
+          </span>
+        </div>
         <div
           aria-hidden
           className="relative mt-1 h-2 overflow-hidden rounded-full bg-muted"


### PR DESCRIPTION
## Summary
- The sidebar usage ring now displays the workspace's compact, locale-aware usage figure (e.g. `456 / 10K`) next to the label instead of hiding all numeric usage.
- Uses next-intl's `useFormatter` with `notation: "compact"` so server-rendered and client-rendered text stay identical (avoids hydration mismatches).
- Displays `workspaceUsed`/`limit` specifically (not the account-wide `used`), matching the ring's existing green/amber tier semantics for workspace vs. account usage.

## Changes
- `apps/builder/src/components/usage-ring.tsx`: render a compact `workspaceUsed / limit` value next to the label; over-limit state is bolded/destructive-colored.
- `apps/builder/__tests__/usage-number-formatting.test.tsx`: updated/added coverage for compact formatting and boundary cases (999 vs 1000, 1.5K, 3M/5M).

## Test plan
- [x] `pnpm --filter builder exec vitest run __tests__/usage-number-formatting.test.tsx` — 4/4 passing
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [ ] Manual verification in the sidebar footer across locales (en/vi)