### PR TITLE
fix(tiktok): read message_id from nested send response, not flat

### DIFF
--- a/integrations/tiktok/src/apis/message.ts
+++ b/integrations/tiktok/src/apis/message.ts
@@ -1,9 +1,16 @@
 import { rescue } from "../exception"
 import { createTiktokBusinessClient } from "../lib/http-client"
+import { logger } from "../lib/logger"
 import type { TiktokApiResponse, TiktokSendMessageRequest } from "../schema"
 
 type SendMessageResult = {
+  // TikTok's business/message/send/ response nests the created message's id
+  // under data.message.message_id, not data.message_id — keep the flat field
+  // as a defensive fallback in case a message_type returns a flatter shape.
   message_id?: string
+  message?: {
+    message_id?: string
+  }
 }
 
 type UploadMediaResult = {
@@ -49,5 +56,13 @@ export const sendTiktokMessage = (
       "business/message/send/",
       { json: payload },
     )
-    return response.data?.message_id
+    const messageId =
+      response.data?.message?.message_id ?? response.data?.message_id
+    if (!messageId) {
+      logger.warn(
+        { data: response.data },
+        "No message_id in TikTok send response — outgoing message row will keep sourceId=null and its echo will be inserted as a new row",
+      )
+    }
+    return messageId
   })


### PR DESCRIPTION
## Summary
- TikTok's `business/message/send/` response nests the created message's id under `data.message.message_id`, not `data.message_id` as the code assumed.
- Because of this, `sendTiktokMessage()` always returned `undefined`, so the outgoing message row's `sourceId` was never persisted — every `im_send_msg` echo webhook then failed to match that row and got inserted as a **duplicate message** in the inbox (this is the bug reported: messages sent to TikTok contacts show up twice, while Messenger doesn't).
- Fix reads the nested shape first, falls back to the flat shape for safety (in case a different `message_type` responds differently), and logs a warning if neither is present so a future regression is visible instead of silent.

## Test plan
- [x] `pnpm --filter @chatbotx.io/integration-tiktok check-types`
- [x] `pnpm lint` (scoped to changed file — clean)
- [x] `integrations/tiktok` vitest suite passes (5/5)
- [ ] Manual verification against a real TikTok Business inbox: send a message from ChatbotX inbox to a TikTok contact and confirm only one message row appears (no duplicate), ideally while logging the raw send response once to fully confirm the nested shape live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)