### PR TITLE
fix(whatsapp): send full card content and continue the flow after a quick reply

### DIFF
--- a/apps/builder/__tests__/magic-link-route.test.ts
+++ b/apps/builder/__tests__/magic-link-route.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment node
+import {
+  buttonStepDefaultFn,
+  encodeButtonPayload,
+  type SendMessageNodeSchema,
+  sendMessageNodeDefaultFn,
+  sendTextStepDefaultFn,
+} from "@chatbotx.io/flow-config"
+import { NextRequest } from "next/server"
+import { beforeEach, expect, test, vi } from "vitest"
+
+const FLOW_ID = "1000000000001"
+const FLOW_VERSION_ID = "1000000000002"
+const CONTACT_INBOX_ID = "1000000000003"
+const WORKSPACE_ID = "1000000000004"
+
+const findMagicLink = vi.fn()
+const findContactInbox = vi.fn()
+const findFlowVersion = vi.fn()
+const emit = vi.fn()
+const loadServableWorkspace = vi.fn()
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      magicLinkModel: { findFirst: findMagicLink },
+      contactInboxModel: { findFirst: findContactInbox },
+      flowVersionModel: { findFirst: findFlowVersion },
+    },
+  },
+}))
+
+vi.mock("@chatbotx.io/event-bus", () => ({ emit }))
+
+vi.mock("@/lib/workspace/load-servable-workspace", () => ({
+  loadServableWorkspace,
+}))
+
+const stepButton = buttonStepDefaultFn({ label: "Buy now" })
+const quickReply = buttonStepDefaultFn({ label: "Yes" })
+
+type NodeDetails = SendMessageNodeSchema["data"]["details"]
+
+const makeNode = (
+  id: string,
+  details: Partial<NodeDetails>,
+): SendMessageNodeSchema => {
+  const node = sendMessageNodeDefaultFn({ nodeProps: { id } })
+  return {
+    ...node,
+    data: { ...node.data, details: { ...node.data.details, ...details } },
+  }
+}
+
+const nodes = [
+  makeNode("node-1", {
+    steps: [sendTextStepDefaultFn({ text: "Hi", buttons: [stepButton] })],
+  }),
+  makeNode("node-2", { quickReplies: [quickReply] }),
+]
+
+beforeEach(() => {
+  emit.mockReset()
+  emit.mockResolvedValue(undefined)
+  loadServableWorkspace.mockReset()
+  loadServableWorkspace.mockResolvedValue({ servable: true })
+  findMagicLink.mockReset()
+  findMagicLink.mockResolvedValue({
+    id: "magic-1",
+    url: "https://example.com/landing",
+  })
+  findContactInbox.mockReset()
+  findContactInbox.mockResolvedValue({
+    contactId: "contact-1",
+    channel: "whatsapp",
+    conversation: { id: "conversation-1" },
+  })
+  findFlowVersion.mockReset()
+  findFlowVersion.mockResolvedValue({ nodes })
+})
+
+const { GET } = await import("../src/app/r/[workspaceId]/[name]/route")
+
+const callRoute = (buttonId: string) => {
+  const code = encodeButtonPayload({
+    flowId: FLOW_ID,
+    flowVersionId: FLOW_VERSION_ID,
+    buttonId,
+    contactInboxId: CONTACT_INBOX_ID,
+  })
+  const request = new NextRequest(
+    `http://localhost/r/${WORKSPACE_ID}/promo?code=${encodeURIComponent(code)}`,
+  )
+  return GET(request, {
+    params: Promise.resolve({ workspaceId: WORKSPACE_ID, name: "promo" }),
+  })
+}
+
+test("redirects a step button magic link and reports its node", async () => {
+  const response = await callRoute(stepButton.id)
+
+  expect(response.status).toBe(302)
+  expect(response.headers.get("location")).toBe("https://example.com/landing")
+  expect(emit).toHaveBeenCalledWith(
+    "flow:clicked",
+    expect.objectContaining({
+      nodeId: "node-1",
+      action: expect.objectContaining({ buttonId: stepButton.id }),
+    }),
+  )
+})
+
+// Quick replies use the same editor as step buttons, so they can carry a
+// website link too. Before they were resolvable, this path returned 404.
+test("redirects a quick reply magic link and reports its node", async () => {
+  const response = await callRoute(quickReply.id)
+
+  expect(response.status).toBe(302)
+  expect(response.headers.get("location")).toBe("https://example.com/landing")
+  expect(emit).toHaveBeenCalledWith(
+    "flow:clicked",
+    expect.objectContaining({
+      nodeId: "node-2",
+      action: expect.objectContaining({ buttonId: quickReply.id }),
+    }),
+  )
+})
+
+test("returns 404 when no node owns the button id", async () => {
+  const response = await callRoute("9999999999999")
+
+  expect(response.status).toBe(404)
+  expect(emit).not.toHaveBeenCalled()
+})

--- a/apps/builder/src/app/r/[workspaceId]/[name]/route.ts
+++ b/apps/builder/src/app/r/[workspaceId]/[name]/route.ts
@@ -5,7 +5,7 @@ import {
   decodeButtonPayload,
   type FlowNode,
   flowEventTypeSchema,
-  getNodeFromButton,
+  resolveFlowActionTarget,
 } from "@chatbotx.io/flow-config"
 import { interpolate } from "@chatbotx.io/variables"
 import { type NextRequest, NextResponse } from "next/server"
@@ -91,20 +91,19 @@ export const GET = async (
 
   const nodes = flowVersion?.nodes as unknown as FlowNode[]
 
-  const { button: foundedButton, nodeId: foundedNodeId } = getNodeFromButton(
-    nodes,
-    decodedButton?.buttonId ?? "",
-  )
+  // Quick replies use the same editor as step buttons, so they can also carry a
+  // website link — resolving both keeps their magic links redirecting.
+  const target = resolveFlowActionTarget(nodes, decodedButton?.buttonId ?? "")
 
-  if (!foundedButton) {
+  if (!target) {
     return NextResponse.json({ message: "Button not found" }, { status: 404 })
   }
-  if (!foundedNodeId) {
+  if (!target.nodeId) {
     return NextResponse.json({ message: "Node ID is missing" }, { status: 400 })
   }
 
   await emit(flowEventTypeSchema.enum["flow:clicked"], {
-    nodeId: foundedNodeId,
+    nodeId: target.nodeId,
     context: {
       workspaceId,
       contactId: contactInbox.contactId,

--- a/apps/worker/__tests__/flow.test.ts
+++ b/apps/worker/__tests__/flow.test.ts
@@ -5,6 +5,7 @@ import type {
   EdgeSchema,
   FlowNode,
 } from "@chatbotx.io/flow-config"
+import { encodeButtonPayload } from "@chatbotx.io/flow-config"
 import { SdkException } from "@chatbotx.io/sdk"
 import { beforeEach, describe, expect, type Mock, test, vi } from "vitest"
 
@@ -30,6 +31,16 @@ vi.mock("@chatbotx.io/worker-config", () => ({
 vi.mock("@chatbotx.io/database/client", () => ({
   db: { query: {}, update: vi.fn(), insert: vi.fn() },
   eq: vi.fn(),
+}))
+
+// Any action carrying a button ID goes through the rich-response fallback
+// before the flow is consulted, so it has to resolve to "no rich response".
+const findRichResponseByButton = vi.fn(async () => null)
+vi.mock("@chatbotx.io/database/repositories", () => ({
+  createMessageRepository: async () => ({ findRichResponseByButton }),
+}))
+vi.mock("@chatbotx.io/automated-response", () => ({
+  automatedResponseService: { enqueue: vi.fn(async () => undefined) },
 }))
 
 // Passthrough the real schema: a transitive dependency imports `createSelectSchema`
@@ -327,6 +338,166 @@ describe("flow action channel gating (bare flow ID)", () => {
         action: BARE_FLOW_ID,
       },
       "runFlowPostback: bare flow ID could not be resolved, skipping",
+    )
+  })
+})
+
+describe("flow action target resolution", () => {
+  const FLOW_ID = "11612473309626368"
+  const FLOW_VERSION_ID = "11612473309626369"
+  const REPLY_ID = "11612473309626370"
+
+  beforeEach(() => {
+    integrationQueueAdd.mockClear()
+    chatQueueAdd.mockClear()
+    vi.mocked(logger.warn).mockClear()
+    findRichResponseByButton.mockClear()
+    detectConversationAndContactInbox.mockReset()
+    detectFlowVersion.mockReset()
+    // WhatsApp, Zalo, Telegram and TikTok all deliver a tapped reply through a
+    // single webhook field, so the channel cannot say whether it was a step
+    // button or a node quick reply.
+    detectConversationAndContactInbox.mockResolvedValue({
+      conversation: makeConversation(),
+      contactInbox: { ...makeContactInbox(), channel: "whatsapp" },
+    })
+  })
+
+  function makeNode(id: string, details: Record<string, unknown>): FlowNode {
+    return {
+      id,
+      position: { x: 0, y: 0 },
+      measured: { width: 100, height: 100 },
+      data: { name: id, isStartNode: false, details },
+    } as FlowNode
+  }
+
+  /** A node holding `details`, wired to node-2 through the tapped reply. */
+  function mockFlowWithReply(details: Record<string, unknown>) {
+    const edges: EdgeSchema[] = [
+      {
+        id: "e1",
+        source: "node-1",
+        sourceHandle: REPLY_ID,
+        target: "node-2",
+        targetHandle: "input",
+      },
+    ]
+    detectFlowVersion.mockResolvedValue({
+      flowVersion: makeFlowVersion(
+        [makeNode("node-1", details), makeNode("node-2", { steps: [] })],
+        edges,
+      ),
+      useLatestFlowVersion: true,
+    })
+  }
+
+  function replyAction() {
+    return encodeButtonPayload({
+      flowId: FLOW_ID,
+      flowVersionId: FLOW_VERSION_ID,
+      buttonId: REPLY_ID,
+    })
+  }
+
+  function expectAdvancedToNextNode() {
+    expect(integrationQueueAdd).toHaveBeenCalled()
+    const [action, job] = integrationQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { nodeId: string } },
+    ]
+    expect(action).toBe("sendFlow")
+    expect(job.data.nodeId).toBe("node-2")
+  }
+
+  test("runFlowPostback advances the flow for a node quick reply", async () => {
+    mockFlowWithReply({
+      steps: [],
+      quickReplies: [makeQuickReply(REPLY_ID, "Yes")],
+    })
+
+    await runFlowPostback({
+      conversationId: "conv-1",
+      contactInboxId: "ci-1",
+      action: replyAction(),
+      ref: null,
+    } as never)
+
+    expectAdvancedToNextNode()
+  })
+
+  test("runFlowPostback still advances the flow for a step button", async () => {
+    mockFlowWithReply({
+      steps: [
+        {
+          id: "step-1",
+          stepType: "sendText",
+          buttons: [makeQuickReply(REPLY_ID, "Buy now")],
+        },
+      ],
+    })
+
+    await runFlowPostback({
+      conversationId: "conv-1",
+      contactInboxId: "ci-1",
+      action: replyAction(),
+      ref: null,
+    } as never)
+
+    expectAdvancedToNextNode()
+  })
+
+  test("runFlowQuickReply advances the flow for a step button", async () => {
+    mockFlowWithReply({
+      steps: [
+        {
+          id: "step-1",
+          stepType: "sendText",
+          buttons: [makeQuickReply(REPLY_ID, "Buy now")],
+        },
+      ],
+    })
+
+    await runFlowQuickReply({
+      conversationId: "conv-1",
+      contactInboxId: "ci-1",
+      action: replyAction(),
+      ref: null,
+    } as never)
+
+    expectAdvancedToNextNode()
+  })
+
+  test("runFlowQuickReply still advances the flow for a node quick reply", async () => {
+    mockFlowWithReply({
+      steps: [],
+      quickReplies: [makeQuickReply(REPLY_ID, "Yes")],
+    })
+
+    await runFlowQuickReply({
+      conversationId: "conv-1",
+      contactInboxId: "ci-1",
+      action: replyAction(),
+      ref: null,
+    } as never)
+
+    expectAdvancedToNextNode()
+  })
+
+  test("an action matching no reply is warned about instead of failing silently", async () => {
+    mockFlowWithReply({ steps: [], quickReplies: [] })
+
+    await runFlowPostback({
+      conversationId: "conv-1",
+      contactInboxId: "ci-1",
+      action: replyAction(),
+      ref: null,
+    } as never)
+
+    expect(integrationQueueAdd).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ buttonId: REPLY_ID, flowId: FLOW_ID }),
+      "runFlowPostback: action matches no button or quick reply, skipping",
     )
   })
 })
@@ -867,6 +1038,43 @@ describe("runStepsAndQuickReplies — per-step re-dispatch", () => {
         channel: "whatsapp",
       },
       details: { steps: [imageStep], quickReplies },
+      triggerNextNode: false,
+    }
+
+    await runStepsAndQuickReplies(props)
+
+    expect(chatQueueAdd).toHaveBeenCalledOnce()
+    const [, job] = chatQueueAdd.mock.calls[0] as unknown as [
+      string,
+      { data: { step: { id: string }; quickReplies?: ButtonStepProps[] } },
+    ]
+    expect(job.data.step.id).toBe("step-1")
+    expect(job.data.quickReplies).toEqual(quickReplies)
+  })
+
+  test("attaches quick replies to a carousel carrier for whatsapp", async () => {
+    const quickReplies = [makeQuickReply()]
+    const carouselStep = {
+      ...makeStep("sendCarousel"),
+      id: "step-1",
+      layout: "horizontal",
+      cards: [
+        {
+          id: "card-1",
+          stepType: "sendCard",
+          title: "Card",
+          subtitle: "",
+          buttons: [],
+        },
+      ],
+    }
+    const props = {
+      ...makeBaseProps(),
+      contactInbox: {
+        ...makeContactInbox(),
+        channel: "whatsapp",
+      },
+      details: { steps: [carouselStep], quickReplies },
       triggerNextNode: false,
     }
 

--- a/apps/worker/src/integration/handlers/flow.ts
+++ b/apps/worker/src/integration/handlers/flow.ts
@@ -16,11 +16,13 @@ import {
   type ButtonStepProps,
   decodeButtonPayload,
   type EdgeSchema,
+  type FlowActionTargetType,
   type FlowNode,
+  flowActionTargetTypes,
   flowEventTypeSchema,
-  getNodeFromButton,
   isQuickReplyCarrierStep,
   type MetadataPayload,
+  resolveFlowActionTarget,
   type StepType,
   stepTypes,
 } from "@chatbotx.io/flow-config"
@@ -119,20 +121,21 @@ type ExecuteStepsAndQuickRepliesProps = {
   commentAnchor?: CommentAnchor
 }
 
-type FlowActionTarget =
+/** A job carries either an entity ID or the already-loaded entity. */
+type FlowJobEntityRef =
   | string
   | Pick<ConversationModel | ContactInboxModel, "id">
 
-const getFlowActionTargetId = (value: FlowActionTarget): string =>
+const getFlowJobEntityId = (value: FlowJobEntityRef): string =>
   typeof value === "string" ? value : value.id
 
 const createFlowActionWarningContext = (data: {
-  conversationId: FlowActionTarget
-  contactInboxId: FlowActionTarget
+  conversationId: FlowJobEntityRef
+  contactInboxId: FlowJobEntityRef
   action: string
 }) => ({
-  conversationId: getFlowActionTargetId(data.conversationId),
-  contactInboxId: getFlowActionTargetId(data.contactInboxId),
+  conversationId: getFlowJobEntityId(data.conversationId),
+  contactInboxId: getFlowJobEntityId(data.contactInboxId),
   action: data.action,
 })
 
@@ -599,8 +602,36 @@ async function tryRunRichButtonFallback(props: {
   return { handled: true, shouldEnqueueAutomatedResponse: false }
 }
 
-export async function runFlowPostback(
+/**
+ * A tapped reply is dispatched to one of two jobs depending on how the channel
+ * reported it, but from there the work is identical — only the wording of the
+ * logs and analytics differs.
+ */
+const flowActionHandlers = {
+  postback: {
+    name: "runFlowPostback",
+    triggerType: "contact_postback",
+    failedTriggerType: "contact_postback_failed",
+  },
+  quickReply: {
+    name: "runFlowQuickReply",
+    triggerType: "contact_quick_reply",
+    failedTriggerType: "contact_quick_reply_failed",
+  },
+} as const
+
+type FlowActionHandler =
+  (typeof flowActionHandlers)[keyof typeof flowActionHandlers]
+
+/** `flow:clicked` reports the reply that was tapped, not the job that ran. */
+const flowActionClickTypes = {
+  [flowActionTargetTypes.button]: "button",
+  [flowActionTargetTypes.quickReply]: "quick_reply",
+} as const satisfies Record<FlowActionTargetType, string>
+
+async function runFlowAction(
   data: IntegrationJobSendFlowPostback["data"],
+  handler: FlowActionHandler,
 ) {
   const { conversation, contactInbox } =
     await detectConversationAndContactInbox({
@@ -618,12 +649,13 @@ export async function runFlowPostback(
   if (!parsedAction) {
     logger.warn(
       createFlowActionWarningContext(data),
-      "runFlowPostback: could not decode action payload, skipping",
+      `${handler.name}: could not decode action payload, skipping`,
     )
     return
   }
 
-  if (!parsedAction.buttonId) {
+  const { buttonId } = parsedAction
+  if (!buttonId) {
     // A bare flow-ID payload (Messenger ad) can point at a since-deleted or
     // unpublished flow. Resolve it first so a missing flow is a graceful skip
     // rather than a thrown job that retries and dead-letters to no effect.
@@ -637,7 +669,7 @@ export async function runFlowPostback(
       if (error instanceof SdkException) {
         logger.warn(
           createFlowActionWarningContext(data),
-          "runFlowPostback: bare flow ID could not be resolved, skipping",
+          `${handler.name}: bare flow ID could not be resolved, skipping`,
         )
         return
       }
@@ -652,25 +684,23 @@ export async function runFlowPostback(
     return
   }
 
-  if (parsedAction.buttonId) {
-    const richButtonResult = await tryRunRichButtonFallback({
-      buttonId: parsedAction.buttonId,
-      contactInbox,
-      conversation,
-      flowContextId: parsedAction.flowId,
-      messageId: data.messageId,
-    })
-    if (richButtonResult.handled) {
-      if (richButtonResult.shouldEnqueueAutomatedResponse && data.messageId) {
-        await automatedResponseService.enqueue({
-          conversationId: conversation.id,
-          contactInboxId: contactInbox.id,
-          messageId: data.messageId,
-          workspaceId: conversation.workspaceId,
-        })
-      }
-      return
+  const richButtonResult = await tryRunRichButtonFallback({
+    buttonId,
+    contactInbox,
+    conversation,
+    flowContextId: parsedAction.flowId,
+    messageId: data.messageId,
+  })
+  if (richButtonResult.handled) {
+    if (richButtonResult.shouldEnqueueAutomatedResponse && data.messageId) {
+      await automatedResponseService.enqueue({
+        conversationId: conversation.id,
+        contactInboxId: contactInbox.id,
+        messageId: data.messageId,
+        workspaceId: conversation.workspaceId,
+      })
     }
+    return
   }
 
   const { flowVersion } = await detectFlowVersion({
@@ -681,25 +711,27 @@ export async function runFlowPostback(
 
   const nodes = flowVersion.nodes as unknown as FlowNode[]
 
-  const { button: foundedButton, nodeId: foundedNodeId } = getNodeFromButton(
-    nodes,
-    parsedAction.buttonId,
-  )
-
-  if (!foundedButton) {
+  // The channel cannot say whether the tap was a step button or a node quick
+  // reply, so the flow decides — and drives the target type from here on.
+  const target = resolveFlowActionTarget(nodes, buttonId)
+  if (!target) {
+    logger.warn(
+      {
+        ...createFlowActionWarningContext(data),
+        buttonId,
+        flowId: parsedAction.flowId,
+        flowVersionId: flowVersion.id,
+      },
+      `${handler.name}: action matches no button or quick reply, skipping`,
+    )
     return
   }
 
+  const targetNodeId = target.nodeId ?? ""
+
   const waFlowResponse = data.payload?.waFlowResponse
-  if (
-    waFlowResponse &&
-    typeof waFlowResponse === "object" &&
-    parsedAction.buttonId
-  ) {
-    const whatsappFlowStep = findWhatsappFlowStepByButtonId(
-      nodes,
-      parsedAction.buttonId,
-    )
+  if (waFlowResponse && typeof waFlowResponse === "object") {
+    const whatsappFlowStep = findWhatsappFlowStepByButtonId(nodes, buttonId)
     if (whatsappFlowStep) {
       await applyWhatsappFlowResponseSideEffects({
         workspaceId: conversation.workspaceId,
@@ -713,7 +745,7 @@ export async function runFlowPostback(
 
   if (data.webhookType !== IntegrationJobAction.messageStatus) {
     await emit(flowEventTypeSchema.enum["flow:clicked"], {
-      nodeId: foundedNodeId ?? "",
+      nodeId: targetNodeId,
       context: {
         workspaceId: conversation.workspaceId,
         contactId: conversation.contactId,
@@ -723,10 +755,10 @@ export async function runFlowPostback(
       },
       action: {
         flowId: parsedAction.flowId,
-        buttonId: parsedAction.buttonId,
+        buttonId,
         broadcastId: parsedAction.broadcastId,
         sequenceStepId: parsedAction.sequenceStepId ?? "",
-        clickType: "button",
+        clickType: flowActionClickTypes[target.targetType],
       },
       occurredAt: new Date(),
     })
@@ -739,10 +771,10 @@ export async function runFlowPostback(
       contactInbox,
       flowVersion,
       useLatestFlowVersion: true,
-      details: foundedButton,
-      targetType: "button",
-      targetId: foundedButton.id,
-      targetNodeId: foundedNodeId ?? "",
+      details: target.details,
+      targetType: target.targetType,
+      targetId: target.details.id,
+      targetNodeId,
       ctx: {
         variables: initVariables(),
       },
@@ -764,8 +796,8 @@ export async function runFlowPostback(
           flowId: parsedAction.flowId,
           triggerContext: {
             triggerSource: "worker",
-            triggerHandler: "runFlowPostback",
-            triggerType: "contact_postback",
+            triggerHandler: handler.name,
+            triggerType: handler.triggerType,
           },
         },
       })
@@ -789,8 +821,8 @@ export async function runFlowPostback(
           fallbackReason: "handler_error_to_fallback",
           triggerContext: {
             triggerSource: "worker",
-            triggerHandler: "runFlowPostback",
-            triggerType: "contact_postback_failed",
+            triggerHandler: handler.name,
+            triggerType: handler.failedTriggerType,
           },
         },
       })
@@ -799,194 +831,12 @@ export async function runFlowPostback(
   }
 }
 
-export async function runFlowQuickReply(
+export function runFlowPostback(data: IntegrationJobSendFlowPostback["data"]) {
+  return runFlowAction(data, flowActionHandlers.postback)
+}
+
+export function runFlowQuickReply(
   data: IntegrationJobSendFlowQuickReply["data"],
 ) {
-  const { conversation, contactInbox } =
-    await detectConversationAndContactInbox({
-      conversationId: data.conversationId,
-      contactInboxId: data.contactInboxId,
-    })
-
-  // Bare flow IDs (Messenger ad payloads) are only honored for Messenger
-  // conversations. The channel is read from the persisted contactInbox, not
-  // from the enqueuer, so no other channel (e.g. webchat) can trigger an
-  // arbitrary flow by posting a bare numeric ID.
-  const parsedAction = decodeButtonPayload(data.action, {
-    allowBareFlowId: contactInbox.channel === "messenger",
-  })
-  if (!parsedAction) {
-    logger.warn(
-      createFlowActionWarningContext(data),
-      "runFlowQuickReply: could not decode action payload, skipping",
-    )
-    return
-  }
-
-  if (!parsedAction.buttonId) {
-    // A bare flow-ID payload (Messenger ad) can point at a since-deleted or
-    // unpublished flow. Resolve it first so a missing flow is a graceful skip
-    // rather than a thrown job that retries and dead-letters to no effect.
-    try {
-      await detectFlowVersion({
-        flowId: parsedAction.flowId,
-        flowVersionId: parsedAction.flowVersionId,
-        workspaceId: conversation.workspaceId,
-      })
-    } catch (error) {
-      if (error instanceof SdkException) {
-        logger.warn(
-          createFlowActionWarningContext(data),
-          "runFlowQuickReply: bare flow ID could not be resolved, skipping",
-        )
-        return
-      }
-      throw error
-    }
-    await runFlowNode({
-      conversationId: data.conversationId,
-      contactInboxId: data.contactInboxId,
-      flowId: parsedAction.flowId,
-      flowVersionId: parsedAction.flowVersionId,
-    })
-    return
-  }
-
-  if (parsedAction.buttonId) {
-    const richButtonResult = await tryRunRichButtonFallback({
-      buttonId: parsedAction.buttonId,
-      contactInbox,
-      conversation,
-      flowContextId: parsedAction.flowId,
-      messageId: data.messageId,
-    })
-    if (richButtonResult.handled) {
-      if (richButtonResult.shouldEnqueueAutomatedResponse && data.messageId) {
-        await automatedResponseService.enqueue({
-          conversationId: conversation.id,
-          contactInboxId: contactInbox.id,
-          messageId: data.messageId,
-          workspaceId: conversation.workspaceId,
-        })
-      }
-      return
-    }
-  }
-
-  const { flowVersion } = await detectFlowVersion({
-    flowId: parsedAction.flowId,
-    flowVersionId: parsedAction.flowVersionId,
-    workspaceId: conversation.workspaceId,
-  })
-
-  const nodes = flowVersion.nodes as unknown as FlowNode[]
-
-  let found: ButtonStepProps | null = null
-  let foundedNodeId: string | null = null
-  for (const node of nodes) {
-    if (
-      !("quickReplies" in node.data.details && node.data.details.quickReplies)
-    ) {
-      continue
-    }
-    const quickReply = node.data.details.quickReplies.find(
-      (qr) => qr.id === parsedAction.buttonId,
-    )
-    if (quickReply) {
-      found = quickReply
-      foundedNodeId = node.id
-      break
-    }
-  }
-
-  if (!found) {
-    return
-  }
-
-  if (data.webhookType !== IntegrationJobAction.messageStatus) {
-    await emit(flowEventTypeSchema.enum["flow:clicked"], {
-      nodeId: foundedNodeId ?? "",
-      context: {
-        workspaceId: conversation.workspaceId,
-        contactId: conversation.contactId,
-        conversationId: conversation.id,
-        channel: contactInbox.channel,
-        contactInboxId: contactInbox.id,
-      },
-      action: {
-        flowId: parsedAction.flowId,
-        buttonId: parsedAction.buttonId,
-        broadcastId: parsedAction.broadcastId,
-        sequenceStepId: parsedAction.sequenceStepId ?? "",
-        clickType: "quick_reply",
-      },
-      occurredAt: new Date(),
-    })
-  }
-
-  const startTime = Date.now()
-  try {
-    await runStepsAndQuickReplies({
-      conversation,
-      contactInbox,
-      flowVersion,
-      useLatestFlowVersion: true,
-      details: found,
-      targetType: "quickReply",
-      targetId: found.id,
-      targetNodeId: foundedNodeId ?? "",
-      ctx: {
-        variables: initVariables(),
-      },
-    })
-    if (data.messageId) {
-      emit("analytics:dashboard", {
-        eventType: "message:bot_received",
-        workspaceId: conversation.workspaceId,
-        conversationId: conversation.id,
-        messageId: data.messageId,
-        occurredAt: new Date(),
-        hasResponse: true,
-        responseType: "flow",
-        routeType: "flow",
-        result: "success",
-        aiProvider: "none",
-        metadata: {
-          latency: Date.now() - startTime,
-          flowId: parsedAction.flowId,
-          triggerContext: {
-            triggerSource: "worker",
-            triggerHandler: "runFlowQuickReply",
-            triggerType: "contact_quick_reply",
-          },
-        },
-      })
-    }
-  } catch (error) {
-    if (data.messageId) {
-      emit("analytics:dashboard", {
-        eventType: "message:bot_received",
-        workspaceId: conversation.workspaceId,
-        conversationId: conversation.id,
-        messageId: data.messageId,
-        occurredAt: new Date(),
-        hasResponse: false,
-        responseType: "flow",
-        routeType: "flow",
-        result: "fallback",
-        aiProvider: "none",
-        metadata: {
-          latency: Date.now() - startTime,
-          flowId: parsedAction.flowId,
-          fallbackReason: "handler_error_to_fallback",
-          triggerContext: {
-            triggerSource: "worker",
-            triggerHandler: "runFlowQuickReply",
-            triggerType: "contact_quick_reply_failed",
-          },
-        },
-      })
-    }
-    throw error
-  }
+  return runFlowAction(data, flowActionHandlers.quickReply)
 }

--- a/integrations/whatsapp/__tests__/outgoing-carousel-card.test.ts
+++ b/integrations/whatsapp/__tests__/outgoing-carousel-card.test.ts
@@ -1,0 +1,488 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockGetWhatsappClient, mockSendMessage, mockLogger } = vi.hoisted(
+  () => {
+    const sendMessage = vi.fn()
+    return {
+      mockGetWhatsappClient: vi.fn(() => ({ sendMessage })),
+      mockSendMessage: sendMessage,
+      mockLogger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    }
+  },
+)
+
+vi.mock("../src/client", () => ({
+  getWhatsappClient: mockGetWhatsappClient,
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: mockLogger,
+}))
+
+const { sendFlowStep } = await import(
+  "../src/handlers/message/outgoing-message"
+)
+
+const FLOW_ID = "1000000000001"
+const FLOW_VERSION_ID = "1000000000002"
+const PHONE_NUMBER_ID = "pn-1"
+const IMAGE_URL = "https://example.com/card.png"
+
+const ctx = {
+  auth: {
+    metadata: {
+      phoneNumber: { id: PHONE_NUMBER_ID },
+    },
+  },
+} as never
+
+const contact = {
+  id: "contact-1",
+  sourceId: "84123456789",
+} as never
+
+type CardOverrides = {
+  id?: string
+  title?: string
+  subtitle?: string
+  imageUrl?: string
+  buttons?: ReturnType<typeof makeButton>[]
+}
+
+/**
+ * Mirrors `sendCardStepDefaultFn()`: the builder always persists an `image`
+ * object, so an un-uploaded picture arrives as `{ url: "" }` rather than
+ * `undefined`.
+ */
+const makeCard = (overrides: CardOverrides = {}) => ({
+  id: overrides.id ?? "card-1",
+  stepType: "sendCard",
+  title: overrides.title ?? "Card title",
+  subtitle: overrides.subtitle ?? "Card subtitle",
+  image: {
+    id: "image-1",
+    stepType: "sendImage",
+    mode: "file",
+    url: overrides.imageUrl ?? "",
+    buttons: [],
+  },
+  buttons: overrides.buttons ?? [],
+})
+
+const makeButton = (id: string, label: string) => ({
+  id,
+  label,
+  buttonType: null,
+  beforeStep: null,
+  steps: [],
+})
+
+const makeQuickReply = (id: string, label: string) => ({
+  id,
+  label,
+  buttonType: "postback",
+  postback: `${FLOW_ID}:${FLOW_VERSION_ID}:${id}`,
+})
+
+const sendCards = (
+  cards: ReturnType<typeof makeCard>[],
+  quickReplies?: ReturnType<typeof makeQuickReply>[],
+) =>
+  sendFlowStep({
+    ctx,
+    data: {
+      contact,
+      flowId: FLOW_ID,
+      flowVersionId: FLOW_VERSION_ID,
+      step: {
+        id: "carousel-1",
+        stepType: "sendCarousel",
+        layout: "horizontal",
+        cards,
+      },
+      quickReplies,
+    },
+  } as never)
+
+const sentMessages = () =>
+  mockSendMessage.mock.calls.map((call) => call[2] as Record<string, unknown>)
+
+describe("whatsapp outgoing card", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSendMessage.mockResolvedValue({
+      messaging_product: "whatsapp",
+      messages: [{ id: "wamid.provider-1" }],
+    })
+  })
+
+  test("renders an image card with buttons as one interactive message", async () => {
+    const result = await sendCards(
+      [
+        makeCard({
+          imageUrl: IMAGE_URL,
+          buttons: [makeButton("1000000000003", "Open")],
+        }),
+      ],
+      [makeQuickReply("1000000000004", "Later")],
+    )
+
+    expect(mockSendMessage).toHaveBeenCalledOnce()
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      PHONE_NUMBER_ID,
+      contact.sourceId,
+      expect.objectContaining({
+        _type: "interactive",
+        type: "button",
+        body: expect.objectContaining({ text: "Card title" }),
+        footer: expect.objectContaining({ text: "Card subtitle" }),
+        header: expect.objectContaining({
+          type: "image",
+          image: expect.objectContaining({ link: IMAGE_URL }),
+        }),
+        action: expect.objectContaining({
+          buttons: [
+            expect.objectContaining({
+              reply: expect.objectContaining({
+                id: `${FLOW_ID}:${FLOW_VERSION_ID}:1000000000003`,
+                title: "Open",
+              }),
+            }),
+            expect.objectContaining({
+              reply: expect.objectContaining({
+                id: `${FLOW_ID}:${FLOW_VERSION_ID}:1000000000004`,
+                title: "Later",
+              }),
+            }),
+          ],
+        }),
+      }),
+    )
+    expect(result).toEqual({ messageIds: ["wamid.provider-1"] })
+  })
+
+  test("omits the header when the card has no uploaded image", async () => {
+    await sendCards([makeCard()], [makeQuickReply("1000000000004", "Later")])
+
+    expect(mockSendMessage).toHaveBeenCalledOnce()
+    const [message] = sentMessages()
+    expect(message).toMatchObject({
+      _type: "interactive",
+      type: "button",
+      body: { text: "Card title" },
+      footer: { text: "Card subtitle" },
+    })
+    expect(message.header).toBeUndefined()
+  })
+
+  test("renders a button-less image card as a single captioned image", async () => {
+    await sendCards([makeCard({ imageUrl: IMAGE_URL })])
+
+    expect(mockSendMessage).toHaveBeenCalledOnce()
+    expect(sentMessages()[0]).toMatchObject({
+      _type: "image",
+      link: IMAGE_URL,
+      caption: "Card title\nCard subtitle",
+    })
+  })
+
+  test("renders a button-less card without an image as a single text message", async () => {
+    await sendCards([makeCard()])
+
+    expect(mockSendMessage).toHaveBeenCalledOnce()
+    expect(sentMessages()[0]).toMatchObject({
+      _type: "text",
+      body: "Card title\nCard subtitle",
+    })
+  })
+
+  test("sends one message per card and attaches quick replies to the last card only", async () => {
+    await sendCards(
+      [
+        makeCard({ id: "card-1", title: "First", imageUrl: IMAGE_URL }),
+        makeCard({ id: "card-2", title: "Second" }),
+      ],
+      [makeQuickReply("1000000000004", "Later")],
+    )
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(2)
+    const [first, second] = sentMessages()
+    expect(first).toMatchObject({ _type: "image", link: IMAGE_URL })
+    expect(second).toMatchObject({
+      _type: "interactive",
+      body: { text: "Second" },
+    })
+    expect(second.action).toMatchObject({
+      buttons: [{ reply: { title: "Later" } }],
+    })
+  })
+
+  test("drops reply buttons that repeat an earlier label", async () => {
+    await sendCards(
+      [makeCard({ buttons: [makeButton("1000000000003", "Yes")] })],
+      [makeQuickReply("1000000000004", "Yes")],
+    )
+
+    expect(mockSendMessage).toHaveBeenCalledOnce()
+    expect(sentMessages()[0].action).toMatchObject({
+      buttons: [
+        { reply: { id: `${FLOW_ID}:${FLOW_VERSION_ID}:1000000000003` } },
+      ],
+    })
+    expect(mockLogger.warn).toHaveBeenCalled()
+  })
+
+  test("keeps the image inline while three replies still fit", async () => {
+    await sendCards(
+      [
+        makeCard({
+          imageUrl: IMAGE_URL,
+          buttons: [
+            makeButton("1000000000003", "One"),
+            makeButton("1000000000005", "Two"),
+          ],
+        }),
+      ],
+      [makeQuickReply("1000000000004", "Three")],
+    )
+
+    expect(mockSendMessage).toHaveBeenCalledOnce()
+    const [message] = sentMessages()
+    expect(message).toMatchObject({
+      type: "button",
+      header: { type: "image", image: { link: IMAGE_URL } },
+    })
+    expect(message.action).toMatchObject({
+      buttons: [
+        { reply: { title: "One" } },
+        { reply: { title: "Two" } },
+        { reply: { title: "Three" } },
+      ],
+    })
+  })
+
+  test("sends the image separately rather than dropping a fourth reply", async () => {
+    await sendCards(
+      [
+        makeCard({
+          imageUrl: IMAGE_URL,
+          buttons: [
+            makeButton("1000000000003", "One"),
+            makeButton("1000000000005", "Two"),
+            makeButton("1000000000006", "Three"),
+          ],
+        }),
+      ],
+      [makeQuickReply("1000000000004", "Four")],
+    )
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(2)
+    const [image, list] = sentMessages()
+    expect(image).toMatchObject({ _type: "image", link: IMAGE_URL })
+    expect(list).toMatchObject({ _type: "interactive", type: "list" })
+    expect(list.action).toMatchObject({
+      sections: [
+        {
+          rows: [
+            { title: "One" },
+            { title: "Two" },
+            { title: "Three" },
+            { title: "Four" },
+          ],
+        },
+      ],
+    })
+  })
+
+  test("spreads more replies than one list holds across extra messages", async () => {
+    await sendCards(
+      [
+        makeCard({
+          buttons: [
+            makeButton("1000000000003", "One"),
+            makeButton("1000000000005", "Two"),
+            makeButton("1000000000006", "Three"),
+          ],
+        }),
+      ],
+      Array.from({ length: 10 }, (_, index) =>
+        makeQuickReply(`${1_000_000_000_020 + index}`, `Quick ${index}`),
+      ),
+    )
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(2)
+    const [first, second] = sentMessages()
+    const rowsOf = (message: Record<string, unknown>) =>
+      (message.action as { sections: { rows: { title: string }[] }[] })
+        .sections[0].rows
+
+    expect(rowsOf(first)).toHaveLength(10)
+    expect(rowsOf(second).map((row) => row.title)).toEqual([
+      "Quick 7",
+      "Quick 8",
+      "Quick 9",
+    ])
+    // Every message keeps the card title so each list stands on its own.
+    expect(second).toMatchObject({ body: { text: "Card title" } })
+  })
+
+  test("falls back to a list layout when an image-less card has more than three replies", async () => {
+    await sendCards(
+      [
+        makeCard({
+          buttons: [
+            makeButton("1000000000003", "One"),
+            makeButton("1000000000005", "Two"),
+            makeButton("1000000000006", "Three"),
+          ],
+        }),
+      ],
+      [makeQuickReply("1000000000004", "Four")],
+    )
+
+    expect(mockSendMessage).toHaveBeenCalledOnce()
+    const [message] = sentMessages()
+    expect(message).toMatchObject({ type: "list" })
+    expect(message.action).toMatchObject({
+      sections: [
+        {
+          rows: [
+            { title: "One" },
+            { title: "Two" },
+            { title: "Three" },
+            { title: "Four" },
+          ],
+        },
+      ],
+    })
+  })
+
+  test("promotes the subtitle to the body when the title resolves empty", async () => {
+    await sendCards(
+      [makeCard({ title: "   ", subtitle: "Only subtitle" })],
+      [makeQuickReply("1000000000004", "Later")],
+    )
+
+    expect(mockSendMessage).toHaveBeenCalledOnce()
+    const [message] = sentMessages()
+    expect(message).toMatchObject({ body: { text: "Only subtitle" } })
+    expect(message.footer).toBeUndefined()
+  })
+
+  test("leads with a text message when the body outgrows one interactive", async () => {
+    await sendCards([
+      makeCard({
+        title: `${"T".repeat(1020)} tail`,
+        subtitle: "S".repeat(120),
+        buttons: [makeButton("1000000000003", "L".repeat(40))],
+      }),
+    ])
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(2)
+    const [overflow, message] = sentMessages()
+
+    expect(overflow).toMatchObject({ _type: "text", body: "T".repeat(1020) })
+    expect(message).toMatchObject({
+      _type: "interactive",
+      body: { text: "tail" },
+    })
+    // A footer and a button title have nowhere to overflow to, so they clamp.
+    expect((message.footer as { text: string }).text).toHaveLength(60)
+    expect(message.action).toMatchObject({
+      buttons: [{ reply: { title: "L".repeat(20) } }],
+    })
+  })
+
+  test("skips a card that has no title, no subtitle and no image", async () => {
+    await sendCards([makeCard({ title: "", subtitle: "" })])
+
+    expect(mockSendMessage).not.toHaveBeenCalled()
+  })
+
+  test("drops a blank-labelled button instead of throwing", async () => {
+    await sendCards([
+      makeCard({
+        buttons: [
+          makeButton("1000000000003", "  "),
+          makeButton("1000000000005", "Keep"),
+        ],
+      }),
+    ])
+
+    expect(mockSendMessage).toHaveBeenCalledOnce()
+    expect(sentMessages()[0].action).toMatchObject({
+      buttons: [{ reply: { title: "Keep" } }],
+    })
+  })
+
+  test("drops a quick reply that repeats a card button id", async () => {
+    await sendCards(
+      [makeCard({ buttons: [makeButton("1000000000003", "Card")] })],
+      [
+        {
+          id: "1000000000003",
+          label: "Quick",
+          buttonType: "postback",
+          postback: `${FLOW_ID}:${FLOW_VERSION_ID}:1000000000003`,
+        },
+      ],
+    )
+
+    expect(mockSendMessage).toHaveBeenCalledOnce()
+    expect(sentMessages()[0].action).toMatchObject({
+      buttons: [{ reply: { title: "Card" } }],
+    })
+  })
+
+  test("falls back to the card text when every reply is unusable", async () => {
+    await sendCards([
+      makeCard({ buttons: [makeButton("1000000000003", "   ")] }),
+    ])
+
+    expect(mockSendMessage).toHaveBeenCalledOnce()
+    expect(sentMessages()[0]).toMatchObject({
+      _type: "text",
+      body: "Card title\nCard subtitle",
+    })
+  })
+
+  test("keeps the image when every reply of an image card is unusable", async () => {
+    await sendCards([
+      makeCard({
+        imageUrl: IMAGE_URL,
+        buttons: [makeButton("1000000000003", "")],
+      }),
+    ])
+
+    expect(mockSendMessage).toHaveBeenCalledOnce()
+    expect(sentMessages()[0]).toMatchObject({
+      _type: "image",
+      link: IMAGE_URL,
+      caption: "Card title\nCard subtitle",
+    })
+  })
+
+  test("trails the image with the caption text that did not fit", async () => {
+    await sendCards([
+      makeCard({
+        imageUrl: IMAGE_URL,
+        title: "T".repeat(700),
+        subtitle: "S".repeat(700),
+      }),
+    ])
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(2)
+    const [image, overflow] = sentMessages()
+    expect(image).toMatchObject({
+      _type: "image",
+      link: IMAGE_URL,
+      caption: "T".repeat(700),
+    })
+    expect(overflow).toMatchObject({ _type: "text", body: "S".repeat(700) })
+  })
+})

--- a/integrations/whatsapp/__tests__/outgoing-reply-buttons.test.ts
+++ b/integrations/whatsapp/__tests__/outgoing-reply-buttons.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockGetWhatsappClient, mockSendMessage, mockLogger } = vi.hoisted(
+  () => {
+    const sendMessage = vi.fn()
+    return {
+      mockGetWhatsappClient: vi.fn(() => ({ sendMessage })),
+      mockSendMessage: sendMessage,
+      mockLogger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    }
+  },
+)
+
+vi.mock("../src/client", () => ({
+  getWhatsappClient: mockGetWhatsappClient,
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: mockLogger,
+}))
+
+const { sendFlowStep } = await import(
+  "../src/handlers/message/outgoing-message"
+)
+
+const FLOW_ID = "1000000000001"
+const FLOW_VERSION_ID = "1000000000002"
+const PHONE_NUMBER_ID = "pn-1"
+const IMAGE_URL = "https://example.com/photo.png"
+
+const ctx = {
+  auth: { metadata: { phoneNumber: { id: PHONE_NUMBER_ID } } },
+} as never
+
+const contact = { id: "contact-1", sourceId: "84123456789" } as never
+
+const makeButton = (index: number, label = `Button ${index}`) => ({
+  id: `${1_000_000_000_010 + index}`,
+  label,
+  buttonType: null,
+  beforeStep: null,
+  steps: [],
+})
+
+const makeButtons = (count: number) =>
+  Array.from({ length: count }, (_, index) => makeButton(index))
+
+const sendStep = (step: Record<string, unknown>) =>
+  sendFlowStep({
+    ctx,
+    data: { contact, flowId: FLOW_ID, flowVersionId: FLOW_VERSION_ID, step },
+  } as never)
+
+const sendTextStep = (buttons: ReturnType<typeof makeButton>[]) =>
+  sendStep({
+    id: "text-1",
+    stepType: "sendText",
+    text: "Pick one",
+    buttons,
+  })
+
+const sendImageStep = (buttons: ReturnType<typeof makeButton>[]) =>
+  sendStep({
+    id: "image-1",
+    stepType: "sendImage",
+    mode: "file",
+    url: IMAGE_URL,
+    buttons,
+  })
+
+const lastMessage = () =>
+  mockSendMessage.mock.lastCall?.[2] as Record<string, unknown>
+
+describe("whatsapp reply button selection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSendMessage.mockResolvedValue({
+      messaging_product: "whatsapp",
+      messages: [{ id: "wamid.provider-1" }],
+    })
+  })
+
+  test("renders up to three buttons of a text step as reply buttons", async () => {
+    await sendTextStep(makeButtons(3))
+
+    expect(lastMessage()).toMatchObject({
+      _type: "interactive",
+      type: "button",
+      body: { text: "Pick one" },
+    })
+  })
+
+  test("switches a text step to a list once it has more than three buttons", async () => {
+    await sendTextStep(makeButtons(4))
+
+    const message = lastMessage()
+    expect(message).toMatchObject({ type: "list" })
+    expect(
+      (message.action as { sections: { rows: unknown[] }[] }).sections[0].rows,
+    ).toHaveLength(4)
+  })
+
+  test("spreads a text step over extra lists instead of dropping buttons", async () => {
+    await sendTextStep(makeButtons(12))
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(2)
+    const rowsOf = (index: number) =>
+      (
+        mockSendMessage.mock.calls[index][2] as {
+          action: { sections: { rows: { title: string }[] }[] }
+        }
+      ).action.sections[0].rows
+
+    expect(rowsOf(0)).toHaveLength(10)
+    expect(rowsOf(1).map((row) => row.title)).toEqual([
+      "Button 10",
+      "Button 11",
+    ])
+    expect(mockLogger.warn).not.toHaveBeenCalled()
+  })
+
+  test("sends an image step's photo separately once buttons need a list", async () => {
+    await sendImageStep(makeButtons(5))
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(2)
+    const [image, list] = mockSendMessage.mock.calls.map(
+      (call) => call[2] as Record<string, unknown>,
+    )
+
+    expect(image).toMatchObject({ _type: "image", link: IMAGE_URL })
+    expect(list).toMatchObject({ type: "list" })
+    expect(
+      (list.action as { sections: { rows: unknown[] }[] }).sections[0].rows,
+    ).toHaveLength(5)
+  })
+
+  test("keeps an image step's photo inline while three buttons still fit", async () => {
+    await sendImageStep(makeButtons(3))
+
+    expect(mockSendMessage).toHaveBeenCalledOnce()
+    expect(lastMessage()).toMatchObject({
+      type: "button",
+      header: { type: "image", image: { link: IMAGE_URL } },
+    })
+  })
+
+  test("sends a bare image when an image step has no buttons", async () => {
+    await sendImageStep([])
+
+    expect(lastMessage()).toMatchObject({ _type: "image", link: IMAGE_URL })
+  })
+
+  test("clamps list row titles to the documented limit", async () => {
+    await sendTextStep([
+      ...makeButtons(3),
+      makeButton(3, `${"R".repeat(30)} tail`),
+    ])
+
+    const rows = (
+      lastMessage().action as { sections: { rows: { title: string }[] }[] }
+    ).sections[0].rows
+
+    expect(rows[3].title).toBe("R".repeat(24))
+  })
+})

--- a/integrations/whatsapp/src/handlers/message/interactive.ts
+++ b/integrations/whatsapp/src/handlers/message/interactive.ts
@@ -1,21 +1,24 @@
-import { Body, Button, Footer } from "whatsapp-api-js/messages"
-
-const ID_MAX_LENGTH = 256
-const TITLE_MAX_LENGTH = 20
-const BODY_MAX_LENGTH = 1024
-const FOOTER_MAX_LENGTH = 60
+import { Body, Button, Footer, Row } from "whatsapp-api-js/messages"
+import { clampText, messageLimits } from "./message-limits"
 
 export function generateButton({ id, title }: { id: string; title: string }) {
   return new Button(
-    id.slice(0, ID_MAX_LENGTH),
-    title.slice(0, TITLE_MAX_LENGTH),
+    clampText(id, messageLimits.buttonId),
+    clampText(title, messageLimits.buttonTitle),
+  )
+}
+
+export function generateRow({ id, title }: { id: string; title: string }) {
+  return new Row(
+    clampText(id, messageLimits.rowId),
+    clampText(title, messageLimits.rowTitle),
   )
 }
 
 export function generateBody(text: string) {
-  return new Body(text.slice(0, BODY_MAX_LENGTH))
+  return new Body(clampText(text, messageLimits.bodyText))
 }
 
 export function generateFooter(text: string) {
-  return new Footer(text.slice(0, FOOTER_MAX_LENGTH))
+  return new Footer(clampText(text, messageLimits.footerText))
 }

--- a/integrations/whatsapp/src/handlers/message/message-limits.ts
+++ b/integrations/whatsapp/src/handlers/message/message-limits.ts
@@ -1,0 +1,62 @@
+/**
+ * Character limits documented by the WhatsApp Cloud API for outgoing message
+ * components.
+ *
+ * `whatsapp-api-js` validates most of these in its constructors and *throws*
+ * when one is exceeded, which aborts the whole flow step rather than degrading
+ * a single field — so every string is clamped before it reaches a builder.
+ *
+ * @see https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages
+ */
+export const messageLimits = {
+  bodyText: 1024,
+  buttonId: 256,
+  buttonTitle: 20,
+  /** Not validated by the library, but rejected by Meta. */
+  caption: 1024,
+  footerText: 60,
+  rowId: 200,
+  rowTitle: 24,
+  text: 4096,
+} as const
+
+/**
+ * Trims both before and after slicing: Meta rejects button ids that have
+ * leading or trailing spaces, and a cut can land mid-word and leave one behind.
+ *
+ * Reserved for values that have nowhere to overflow to — a button title or a
+ * footer cannot be continued in a second message. Anything that can be
+ * continued should use {@link splitText} instead of losing content.
+ */
+export function clampText(value: string, maxLength: number): string {
+  return value.trim().slice(0, maxLength).trim()
+}
+
+/** The whitespace run before the last, possibly truncated, word. */
+const TRAILING_WORD = /\s+\S*$/
+
+/**
+ * Splits text into consecutive chunks that each fit `maxLength`, breaking on
+ * whitespace so words stay intact. Callers send one message per chunk, which
+ * keeps long content whole where WhatsApp's per-message limit would otherwise
+ * force it to be discarded.
+ */
+export function splitText(value: string, maxLength: number): string[] {
+  let rest = value.trim()
+  const chunks: string[] = []
+
+  while (rest.length > maxLength) {
+    const wordBreak = TRAILING_WORD.exec(rest.slice(0, maxLength))?.index ?? -1
+    // A single word longer than the limit has no break to use, so it is cut.
+    const cut = wordBreak > 0 ? wordBreak : maxLength
+
+    chunks.push(rest.slice(0, cut).trim())
+    rest = rest.slice(cut).trim()
+  }
+
+  if (rest) {
+    chunks.push(rest)
+  }
+
+  return chunks
+}

--- a/integrations/whatsapp/src/handlers/message/outgoing-message/index.ts
+++ b/integrations/whatsapp/src/handlers/message/outgoing-message/index.ts
@@ -1,4 +1,5 @@
 import {
+  type SendCarouselStepSchema,
   type SendImageStepSchema,
   type SendTextStepSchema,
   type SendWaTemplateMessageStepSchema,
@@ -22,6 +23,7 @@ import { API_URL, DEFAULT_API_VERSION } from "../../../constants"
 import { mapToChannelError } from "../../../lib/error-mapper"
 import { logger } from "../../../lib/logger"
 import type { TemplateMessage, WhatsappAuthValue } from "../../../schema"
+import { generateOutgoingMessages as convertFlowStepCarousel } from "./send-carousel"
 import { convertFlowStepImage } from "./send-image"
 import { convertFlowStepText } from "./send-text"
 import { convertFlowStepWaTemplate } from "./send-wa-template"
@@ -81,6 +83,25 @@ function* convertFlowStepToWhatsappMessage(
         >[0],
       )
       break
+    case stepTypes.enum.sendCarousel: {
+      const carouselStepProps = props as Parameters<
+        MessageHandlers<
+          WhatsappAuthValue,
+          SendCarouselStepSchema
+        >["sendFlowStep"]
+      >[0]
+
+      yield* convertFlowStepCarousel({
+        flowId: carouselStepProps.data.flowId,
+        flowVersionId: carouselStepProps.data.flowVersionId,
+        metadata: carouselStepProps.data.metadata,
+        quickReplies: carouselStepProps.data.quickReplies,
+        payload: {
+          cards: carouselStepProps.data.step.cards,
+        },
+      })
+      break
+    }
     case stepTypes.enum.sendWaTemplateMessage:
       yield* convertFlowStepWaTemplate(
         props as Parameters<

--- a/integrations/whatsapp/src/handlers/message/outgoing-message/send-card.ts
+++ b/integrations/whatsapp/src/handlers/message/outgoing-message/send-card.ts
@@ -1,65 +1,149 @@
-import { chunkArray } from "@edenchazard/tiny-chunk-array"
-import {
-  ActionButtons,
-  type Button,
-  Header,
-  Image,
-  Interactive,
-  Text,
-} from "whatsapp-api-js/messages"
-import { logger } from "../../../lib/logger"
-import { generateBody, generateButton, generateFooter } from "../interactive"
-
-export const INTERACTIVE_MAX_BUTTONS_COUNT = 3
+import type { ButtonStepProps, MetadataPayload } from "@chatbotx.io/flow-config"
+import type { MessageButtonTemplate } from "@chatbotx.io/sdk"
+import { Image, Text } from "whatsapp-api-js/messages"
+import type { ClientMessage } from "whatsapp-api-js/types"
+import { generateFooter } from "../interactive"
+import { messageLimits, splitText } from "../message-limits"
+import { buildWhatsappButtonMessages } from "./shared"
 
 export type SendCardPayload = {
   title: string
   subtitle?: string
   image?: { url: string }
-  buttons?: { id: string; label: string }[]
+  buttons?: ButtonStepProps[]
+}
+
+export type SendCardProps = {
+  flowId: string
+  flowVersionId?: string
+  metadata?: MetadataPayload
+  quickReplies?: MessageButtonTemplate[]
+  payload: SendCardPayload
+}
+
+/**
+ * WhatsApp has no free-form card message, so a card is rendered as whichever
+ * native message type carries the most of it.
+ */
+const cardLayouts = {
+  /** Replies as buttons, the image as a header, the title as the body. */
+  interactive: "interactive",
+  /** A single media message carrying the card text as its caption. */
+  captionedImage: "captionedImage",
+  /** A single plain text message. */
+  text: "text",
+  /** Nothing worth sending. */
+  empty: "empty",
+} as const
+
+type CardLayout = (typeof cardLayouts)[keyof typeof cardLayouts]
+
+type CardContent = {
+  /** Interactive body — the title, or the subtitle when no title is set. */
+  body: string
+  /** Interactive footer — only set when the body came from the title. */
+  footer?: string
+  /** Absent when the card has no usable image. */
+  imageUrl?: string
+  /** The whole card as one blob, for the non-interactive layouts. */
+  caption: string
+}
+
+function readCardContent(payload: SendCardPayload): CardContent {
+  const title = payload.title.trim()
+  const subtitle = payload.subtitle?.trim() ?? ""
+
+  // `sendCardStepDefaultFn` always stores an `image` object, so a card without
+  // an upload arrives as `{ url: "" }`. Meta rejects a media header whose link
+  // is empty and drops the entire message, so an empty url means "no image".
+  const imageUrl = payload.image?.url.trim()
+
+  return {
+    body: title || subtitle,
+    footer: title ? subtitle || undefined : undefined,
+    imageUrl: imageUrl || undefined,
+    caption: [title, subtitle].filter(Boolean).join("\n"),
+  }
+}
+
+function resolveCardLayout(
+  content: CardContent,
+  hasReplies: boolean,
+): CardLayout {
+  // Meta requires a body on every interactive message, so a card with no text
+  // degrades to a media or text message instead of being rejected outright.
+  if (hasReplies && content.body) {
+    return cardLayouts.interactive
+  }
+  if (content.imageUrl) {
+    return cardLayouts.captionedImage
+  }
+  if (content.caption) {
+    return cardLayouts.text
+  }
+  return cardLayouts.empty
+}
+
+const cardRenderers: Record<
+  CardLayout,
+  (props: SendCardProps, content: CardContent) => ClientMessage[]
+> = {
+  [cardLayouts.interactive]: (props, content) =>
+    buildWhatsappButtonMessages({
+      flowId: props.flowId,
+      flowVersionId: props.flowVersionId,
+      metadata: props.metadata,
+      buttons: props.payload.buttons ?? [],
+      quickReplies: props.quickReplies,
+      bodyText: content.body,
+      media: content.imageUrl ? new Image(content.imageUrl) : undefined,
+      footer: content.footer ? generateFooter(content.footer) : undefined,
+    }),
+
+  [cardLayouts.captionedImage]: (_props, content) => {
+    if (!content.imageUrl) {
+      return []
+    }
+
+    // Text past the caption limit trails the image as its own message rather
+    // than being cut off.
+    const [caption, ...overflow] = splitText(
+      content.caption,
+      messageLimits.caption,
+    )
+
+    return [
+      new Image(content.imageUrl, false, caption),
+      ...overflow.map((chunk) => new Text(chunk)),
+    ]
+  },
+
+  [cardLayouts.text]: (_props, content) =>
+    splitText(content.caption, messageLimits.text).map(
+      (chunk) => new Text(chunk),
+    ),
+
+  [cardLayouts.empty]: () => [],
 }
 
 export function* generateOutgoingMessages(
-  flowVersionId: string,
-  payload: SendCardPayload,
-) {
-  if (payload.buttons?.length) {
-    const chunks = chunkArray(
-      payload.buttons,
-      INTERACTIVE_MAX_BUTTONS_COUNT,
-    ) as { id: string; label: string }[][]
+  props: SendCardProps,
+): Generator<ClientMessage> {
+  const content = readCardContent(props.payload)
+  const hasReplies = Boolean(
+    props.payload.buttons?.length || props.quickReplies?.length,
+  )
 
-    if (payload.buttons.length > INTERACTIVE_MAX_BUTTONS_COUNT) {
-      logger.info(
-        `Splitting ${payload.buttons.length} buttons into groups of ${INTERACTIVE_MAX_BUTTONS_COUNT} buttons each due to a limitation of Whatsapp.`,
-      )
-    }
+  const layout = resolveCardLayout(content, hasReplies)
+  const messages = cardRenderers[layout](props, content)
 
-    for (const chunk of chunks) {
-      const buttons: Button[] = chunk.map((button) =>
-        generateButton({
-          id: `${flowVersionId}-${button.id}`,
-          title: button.label,
-        }),
-      )
-      const [b1, ...rest] = buttons
-
-      yield new Interactive(
-        new ActionButtons(b1, ...rest),
-        generateBody(payload.title),
-        payload.image ? new Header(new Image(payload.image.url)) : undefined,
-        payload.subtitle ? generateFooter(payload.subtitle) : undefined,
-      )
-    }
-  } else {
-    if (payload.image?.url) {
-      yield new Image(payload.image.url)
-    }
-    if (payload.title) {
-      yield new Text(payload.title)
-    }
-    if (payload.subtitle) {
-      yield new Text(payload.subtitle)
-    }
+  // Every reply can still be dropped as blank or duplicated, which would leave
+  // the interactive layout with nothing to send. Fall back to the plain layouts
+  // so the card's own content reaches the contact instead of vanishing.
+  if (messages.length === 0 && layout === cardLayouts.interactive) {
+    yield* cardRenderers[resolveCardLayout(content, false)](props, content)
+    return
   }
+
+  yield* messages
 }

--- a/integrations/whatsapp/src/handlers/message/outgoing-message/send-carousel.ts
+++ b/integrations/whatsapp/src/handlers/message/outgoing-message/send-carousel.ts
@@ -1,15 +1,26 @@
+import type { ClientMessage } from "whatsapp-api-js/types"
 import {
-  generateOutgoingMessages as generateSendCarouselOutgoingMessages,
+  generateOutgoingMessages as generateCardOutgoingMessages,
   type SendCardPayload,
+  type SendCardProps,
 } from "./send-card"
 
 export function* generateOutgoingMessages(
-  flowVersionId: string,
-  payload: { cards: SendCardPayload[] },
-) {
-  for (const card of payload.cards) {
-    for (const m of generateSendCarouselOutgoingMessages(flowVersionId, card)) {
-      yield m
-    }
+  props: Omit<SendCardProps, "payload"> & {
+    payload: { cards: SendCardPayload[] }
+  },
+): Generator<ClientMessage> {
+  for (const [index, card] of props.payload.cards.entries()) {
+    const isLastCard = index === props.payload.cards.length - 1
+
+    // WhatsApp has no carousel, so the cards arrive as separate messages and
+    // the node's quick replies belong to the last one.
+    yield* generateCardOutgoingMessages({
+      flowId: props.flowId,
+      flowVersionId: props.flowVersionId,
+      metadata: props.metadata,
+      quickReplies: isLastCard ? props.quickReplies : undefined,
+      payload: card,
+    })
   }
 }

--- a/integrations/whatsapp/src/handlers/message/outgoing-message/send-image.ts
+++ b/integrations/whatsapp/src/handlers/message/outgoing-message/send-image.ts
@@ -1,9 +1,8 @@
 import type { SendImageStepSchema } from "@chatbotx.io/flow-config"
 import type { MessageHandlers } from "@chatbotx.io/sdk"
-import { Header, Image } from "whatsapp-api-js/messages"
-import { logger } from "../../../lib/logger"
+import { Image } from "whatsapp-api-js/messages"
 import type { WhatsappAuthValue } from "../../../schema"
-import { buildWhatsappButtonMessages, MAX_BUTTONS } from "./shared"
+import { buildWhatsappButtonMessages } from "./shared"
 
 export function* convertFlowStepImage(
   props: Parameters<
@@ -14,34 +13,21 @@ export function* convertFlowStepImage(
     data: { step },
   } = props
   const quickReplies = props.data.quickReplies ?? []
-  const buttonCount = step.buttons.length + quickReplies.length
-  if (buttonCount === 0) {
+  if (step.buttons.length + quickReplies.length === 0) {
     yield new Image(step.url)
     return
   }
 
-  // An image header can only be combined with the 3-button "reply buttons"
-  // layout, not the list layout — so buttons must fit within MAX_BUTTONS to
-  // keep the image attached to the message.
-  const keptButtonCount = Math.min(step.buttons.length, MAX_BUTTONS)
-  const buttons = step.buttons.slice(0, keptButtonCount)
-  const keptQuickReplies = quickReplies.slice(0, MAX_BUTTONS - keptButtonCount)
-
-  if (keptButtonCount + keptQuickReplies.length < buttonCount) {
-    logger.warn(
-      { total: buttonCount, kept: MAX_BUTTONS },
-      "WhatsApp only supports an image header alongside up to 3 buttons; truncating extra buttons to keep the image",
-    )
-  }
-
+  // Past three replies the image can no longer be an inline header, so it is
+  // sent as its own message — `buildWhatsappButtonMessages` owns that split.
   for (const message of buildWhatsappButtonMessages({
     flowId: props.data.flowId,
     flowVersionId: props.data.flowVersionId,
-    buttons,
-    quickReplies: keptQuickReplies,
+    buttons: step.buttons,
+    quickReplies,
     metadata: props.data.metadata,
     bodyText: "",
-    header: new Header(new Image(step.url)),
+    media: new Image(step.url),
   })) {
     yield message
   }

--- a/integrations/whatsapp/src/handlers/message/outgoing-message/shared.ts
+++ b/integrations/whatsapp/src/handlers/message/outgoing-message/shared.ts
@@ -11,20 +11,32 @@ import {
 import {
   ActionButtons,
   ActionList,
-  Body,
-  Button,
-  type Header,
+  type Footer,
+  Header,
+  type Image,
   Interactive,
   ListSection,
-  Row,
+  Text,
 } from "whatsapp-api-js/messages"
+import type { ClientMessage } from "whatsapp-api-js/types"
 import { logger } from "../../../lib/logger"
+import { generateBody, generateButton, generateRow } from "../interactive"
+import { clampText, messageLimits, splitText } from "../message-limits"
 
 export const MAX_BUTTONS = 3
 export const MAX_LIST_ROWS = 10
 export const DEFAULT_LIST_BUTTON_LABEL = "Options"
 
-const ROW_ID_MAX_LENGTH = 200
+/**
+ * A reply is deduplicated on the *strictest* clamp of either layout, because
+ * two labels that only differ past the reply-button limit would collide again
+ * after `generateButton` truncates them.
+ */
+const UNIQUE_ID_LENGTH = Math.min(messageLimits.buttonId, messageLimits.rowId)
+const UNIQUE_LABEL_LENGTH = Math.min(
+  messageLimits.buttonTitle,
+  messageLimits.rowTitle,
+)
 
 type WhatsappReplyButton = {
   id: string
@@ -60,16 +72,42 @@ function normalizeCanonicalQuickReply(
   }
 }
 
-export function buildWhatsappButtonMessages(props: {
+/**
+ * Meta identifies a reply by both its id and its visible title, and
+ * `ActionButtons` throws when either repeats — which would abort the whole flow
+ * step. Step buttons and node quick replies are authored independently, so a
+ * collision between the two lists is expected rather than exceptional.
+ *
+ * Blank labels are dropped for the same reason: `Button` rejects an empty title.
+ */
+function dedupeReplyButtons(
+  buttons: WhatsappReplyButton[],
+): WhatsappReplyButton[] {
+  const seenIds = new Set<string>()
+  const seenLabels = new Set<string>()
+
+  return buttons.filter(({ id, label }) => {
+    const uniqueId = clampText(id, UNIQUE_ID_LENGTH)
+    const uniqueLabel = clampText(label, UNIQUE_LABEL_LENGTH)
+
+    if (!uniqueLabel || seenIds.has(uniqueId) || seenLabels.has(uniqueLabel)) {
+      return false
+    }
+
+    seenIds.add(uniqueId)
+    seenLabels.add(uniqueLabel)
+    return true
+  })
+}
+
+function selectReplyButtons(props: {
   flowId: string
   flowVersionId?: string
   buttons: ButtonStepProps[]
   quickReplies?: MessageButtonTemplate[]
   metadata?: MetadataPayload
-  bodyText: string
-  header?: Header
-}) {
-  const buttons = [
+}): WhatsappReplyButton[] {
+  const selected = dedupeReplyButtons([
     ...props.buttons.map((button) =>
       normalizeRawButton({
         flowId: props.flowId,
@@ -79,47 +117,101 @@ export function buildWhatsappButtonMessages(props: {
       }),
     ),
     ...(props.quickReplies ?? []).map(normalizeCanonicalQuickReply),
-  ]
+  ])
 
-  if (buttons.length === 0) {
+  const requested = props.buttons.length + (props.quickReplies?.length ?? 0)
+
+  if (selected.length < requested) {
+    logger.warn(
+      { requested, sent: selected.length },
+      "Dropped WhatsApp replies that were unlabelled or duplicated",
+    )
+  }
+
+  return selected
+}
+
+function chunkList<T>(items: T[], size: number): T[][] {
+  return Array.from({ length: Math.ceil(items.length / size) }, (_, index) =>
+    items.slice(index * size, index * size + size),
+  )
+}
+
+/**
+ * Builds the message sequence that carries `bodyText`, an optional image and a
+ * set of replies.
+ *
+ * Nothing is discarded to fit a WhatsApp limit: overflowing text and overflowing
+ * replies each become additional messages. Only values with nowhere to overflow
+ * to — a button title, a footer — are clamped.
+ */
+export function buildWhatsappButtonMessages(props: {
+  flowId: string
+  flowVersionId?: string
+  buttons: ButtonStepProps[]
+  quickReplies?: MessageButtonTemplate[]
+  metadata?: MetadataPayload
+  bodyText: string
+  media?: Image
+  footer?: Footer
+}): ClientMessage[] {
+  const replies = selectReplyButtons({
+    flowId: props.flowId,
+    flowVersionId: props.flowVersionId,
+    buttons: props.buttons,
+    quickReplies: props.quickReplies,
+    metadata: props.metadata,
+  })
+
+  if (replies.length === 0) {
     return []
   }
 
-  if (buttons.length <= MAX_BUTTONS) {
-    const actionButtons = buttons.map(
-      (button) => new Button(button.id, button.label),
+  // Only the closing chunk becomes the interactive body; anything before it
+  // leads as plain text so a long message keeps all of its content.
+  const bodyChunks = splitText(props.bodyText, messageLimits.bodyText)
+  const bodyText = bodyChunks.at(-1) ?? ""
+  const leading: ClientMessage[] = bodyChunks
+    .slice(0, -1)
+    .map((chunk) => new Text(chunk))
+
+  // Reply buttons can carry the image inline, which reads best when it all fits.
+  if (replies.length <= MAX_BUTTONS) {
+    const [firstButton, ...restButtons] = replies.map(({ id, label }) =>
+      generateButton({ id, title: label }),
     )
 
     return [
+      ...leading,
       new Interactive(
-        new ActionButtons(...(actionButtons as [Button, ...Button[]])),
-        new Body(props.bodyText),
-        props.header,
+        new ActionButtons(firstButton, ...restButtons),
+        generateBody(bodyText),
+        props.media ? new Header(props.media) : undefined,
+        props.footer,
       ),
     ]
   }
 
-  const listButtons = buttons.slice(0, MAX_LIST_ROWS)
-  if (listButtons.length < buttons.length) {
-    logger.warn(
-      { total: buttons.length, kept: MAX_LIST_ROWS },
-      `WhatsApp interactive lists support at most ${MAX_LIST_ROWS} quick reply rows; truncating extra buttons`,
-    )
-  }
-
-  const rows = listButtons.map(
-    (button) =>
-      new Row(button.id.slice(0, ROW_ID_MAX_LENGTH), button.label.slice(0, 24)),
-  )
-  const [firstRow, ...restRows] = rows
-
+  // `Interactive` throws when a list action carries a non-text header, so past
+  // three replies the image is sent on its own and the replies are spread over
+  // as many lists as they need instead of being cut off.
   return [
-    new Interactive(
-      new ActionList(
-        DEFAULT_LIST_BUTTON_LABEL,
-        new ListSection(undefined, firstRow, ...restRows),
-      ),
-      new Body(props.bodyText),
-    ),
+    ...leading,
+    ...(props.media ? [props.media] : []),
+    ...chunkList(replies, MAX_LIST_ROWS).map((chunk) => {
+      const [firstRow, ...restRows] = chunk.map(({ id, label }) =>
+        generateRow({ id, title: label }),
+      )
+
+      return new Interactive(
+        new ActionList(
+          DEFAULT_LIST_BUTTON_LABEL,
+          new ListSection(undefined, firstRow, ...restRows),
+        ),
+        generateBody(bodyText),
+        undefined,
+        props.footer,
+      )
+    }),
   ]
 }

--- a/packages/flow-config/__tests__/flow-action-target.test.ts
+++ b/packages/flow-config/__tests__/flow-action-target.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "vitest"
+import type { FlowNode } from "../src"
+import {
+  buttonStepDefaultFn,
+  resolveFlowActionTarget,
+  sendCardStepDefaultFn,
+  sendCarouselStepDefaultFn,
+  sendMessageNodeDefaultFn,
+  sendTextStepDefaultFn,
+  whatsappOptionListStepDefaultFn,
+} from "../src"
+
+type NodeDetails = Parameters<typeof sendMessageNodeDefaultFn>[0]["detailProps"]
+
+const makeNode = (id: string, detailProps: NodeDetails): FlowNode =>
+  sendMessageNodeDefaultFn({ nodeProps: { id }, detailProps }) as FlowNode
+
+describe("resolveFlowActionTarget", () => {
+  test("resolves a button owned by a step", () => {
+    const button = buttonStepDefaultFn({ label: "Buy now" })
+    const node = makeNode("node-1", {
+      steps: [sendTextStepDefaultFn({ text: "Hi", buttons: [button] })],
+    })
+
+    expect(resolveFlowActionTarget([node], button.id)).toEqual({
+      details: button,
+      nodeId: "node-1",
+      targetType: "button",
+    })
+  })
+
+  test("resolves a button nested in a carousel card", () => {
+    const button = buttonStepDefaultFn({ label: "Details" })
+    const card = {
+      ...sendCardStepDefaultFn(),
+      title: "Card",
+      buttons: [button],
+    }
+    const node = makeNode("node-1", {
+      steps: [{ ...sendCarouselStepDefaultFn(), cards: [card] }],
+    })
+
+    expect(resolveFlowActionTarget([node], button.id)).toEqual({
+      details: button,
+      nodeId: "node-1",
+      targetType: "button",
+    })
+  })
+
+  test("resolves a WhatsApp option list item as a button target", () => {
+    const step = whatsappOptionListStepDefaultFn({ text: "Pick one" })
+    const option = step.options[0]
+    const node = makeNode("node-1", { steps: [step] })
+
+    expect(resolveFlowActionTarget([node], option.id)).toMatchObject({
+      details: { id: option.id, label: option.title },
+      nodeId: "node-1",
+      targetType: "button",
+    })
+  })
+
+  test("resolves a node-level quick reply as a quickReply target", () => {
+    const quickReply = buttonStepDefaultFn({ label: "Yes" })
+    const node = makeNode("node-1", {
+      steps: [sendTextStepDefaultFn({ text: "Ready?" })],
+      quickReplies: [quickReply],
+    })
+
+    expect(resolveFlowActionTarget([node], quickReply.id)).toEqual({
+      details: quickReply,
+      nodeId: "node-1",
+      targetType: "quickReply",
+    })
+  })
+
+  test("finds a quick reply on a later node", () => {
+    const quickReply = buttonStepDefaultFn({ label: "Yes" })
+    const nodes = [
+      makeNode("node-1", { steps: [sendTextStepDefaultFn({ text: "Hi" })] }),
+      makeNode("node-2", { steps: [], quickReplies: [quickReply] }),
+    ]
+
+    expect(resolveFlowActionTarget(nodes, quickReply.id)).toMatchObject({
+      nodeId: "node-2",
+      targetType: "quickReply",
+    })
+  })
+
+  test("prefers a step button when a quick reply reuses the same id", () => {
+    const button = buttonStepDefaultFn({ label: "Buy now" })
+    const nodes = [
+      makeNode("node-1", {
+        steps: [sendTextStepDefaultFn({ text: "Hi", buttons: [button] })],
+      }),
+      makeNode("node-2", {
+        steps: [],
+        quickReplies: [{ ...button, label: "Yes" }],
+      }),
+    ]
+
+    expect(resolveFlowActionTarget(nodes, button.id)).toMatchObject({
+      nodeId: "node-1",
+      targetType: "button",
+    })
+  })
+
+  test("returns null when no node owns the action id", () => {
+    const node = makeNode("node-1", {
+      steps: [sendTextStepDefaultFn({ text: "Hi" })],
+      quickReplies: [buttonStepDefaultFn({ label: "Yes" })],
+    })
+
+    expect(resolveFlowActionTarget([node], "9999999999999")).toBeNull()
+  })
+})

--- a/packages/flow-config/__tests__/quick-replies-carrier.test.ts
+++ b/packages/flow-config/__tests__/quick-replies-carrier.test.ts
@@ -7,6 +7,7 @@ import {
   isQuickReplyCarrierStep,
   MAX_QUICK_REPLIES,
   sendAudioStepDefaultFn,
+  sendCarouselStepDefaultFn,
   sendFileStepDefaultFn,
   sendGifStepDefaultFn,
   sendImageStepDefaultFn,
@@ -68,6 +69,7 @@ describe("sendMessage quick replies", () => {
       ...sendGifStepDefaultFn(),
       url: "https://example.com/anim.gif",
     }
+    const carouselStep = sendCarouselStepDefaultFn()
 
     expect(isQuickReplyCarrierStep("telegram", textStep)).toBe(true)
     expect(isQuickReplyCarrierStep("telegram", imageStep)).toBe(true)
@@ -77,6 +79,7 @@ describe("sendMessage quick replies", () => {
     expect(isQuickReplyCarrierStep("telegram", gifStep)).toBe(true)
 
     expect(isQuickReplyCarrierStep("whatsapp", imageStep)).toBe(true)
+    expect(isQuickReplyCarrierStep("whatsapp", carouselStep)).toBe(true)
     expect(isQuickReplyCarrierStep("zalo", imageStep)).toBe(true)
     expect(isQuickReplyCarrierStep("messenger", imageStep)).toBe(true)
     expect(isQuickReplyCarrierStep("instagram", imageStep)).toBe(true)

--- a/packages/flow-config/src/nodes/quick-reply-carrier.ts
+++ b/packages/flow-config/src/nodes/quick-reply-carrier.ts
@@ -1,29 +1,41 @@
 import type { BaseStepSchema } from "../steps/base"
-import { stepTypes } from "../steps/step-action"
+import { type StepType, stepTypes } from "../steps/step-action"
+
+const DEFAULT_QUICK_REPLY_CARRIER_STEPS = new Set<StepType>([
+  stepTypes.enum.sendText,
+])
+
+const MEDIA_QUICK_REPLY_CARRIER_STEPS = new Set<StepType>([
+  stepTypes.enum.sendText,
+  stepTypes.enum.sendImage,
+  stepTypes.enum.sendVideo,
+  stepTypes.enum.sendAudio,
+  stepTypes.enum.sendFile,
+  stepTypes.enum.sendGif,
+])
+
+const QUICK_REPLY_CARRIER_STEPS_BY_CHANNEL: Record<
+  string,
+  ReadonlySet<StepType>
+> = {
+  instagram: MEDIA_QUICK_REPLY_CARRIER_STEPS,
+  messenger: MEDIA_QUICK_REPLY_CARRIER_STEPS,
+  telegram: MEDIA_QUICK_REPLY_CARRIER_STEPS,
+  whatsapp: new Set<StepType>([
+    stepTypes.enum.sendText,
+    stepTypes.enum.sendImage,
+    stepTypes.enum.sendCarousel,
+  ]),
+  zalo: new Set<StepType>([stepTypes.enum.sendText, stepTypes.enum.sendImage]),
+}
 
 export function isQuickReplyCarrierStep(
   channel: string | null | undefined,
   step: BaseStepSchema,
 ) {
-  switch (channel) {
-    case "messenger":
-    case "instagram":
-    case "telegram":
-      return (
-        step.stepType === stepTypes.enum.sendText ||
-        step.stepType === stepTypes.enum.sendImage ||
-        step.stepType === stepTypes.enum.sendVideo ||
-        step.stepType === stepTypes.enum.sendAudio ||
-        step.stepType === stepTypes.enum.sendFile ||
-        step.stepType === stepTypes.enum.sendGif
-      )
-    case "whatsapp":
-    case "zalo":
-      return (
-        step.stepType === stepTypes.enum.sendText ||
-        step.stepType === stepTypes.enum.sendImage
-      )
-    default:
-      return step.stepType === stepTypes.enum.sendText
-  }
+  const carrierSteps =
+    QUICK_REPLY_CARRIER_STEPS_BY_CHANNEL[channel ?? ""] ??
+    DEFAULT_QUICK_REPLY_CARRIER_STEPS
+
+  return carrierSteps.has(step.stepType)
 }

--- a/packages/flow-config/src/util.ts
+++ b/packages/flow-config/src/util.ts
@@ -167,3 +167,78 @@ export function getNodeFromButton(nodes: FlowNode[], buttonId: string) {
     nodeId: foundedNodeId,
   }
 }
+
+export function getNodeFromQuickReply(nodes: FlowNode[], quickReplyId: string) {
+  for (const node of nodes) {
+    if (
+      !("quickReplies" in node.data.details && node.data.details.quickReplies)
+    ) {
+      continue
+    }
+
+    const quickReply = node.data.details.quickReplies.find(
+      (reply) => reply.id === quickReplyId,
+    )
+    if (quickReply) {
+      return { quickReply, nodeId: node.id }
+    }
+  }
+
+  return { quickReply: null, nodeId: null }
+}
+
+export const flowActionTargetTypes = {
+  /** A reply owned by a step: step buttons, card buttons, list options. */
+  button: "button",
+  /** A reply owned by the node, shared by every step it renders. */
+  quickReply: "quickReply",
+} as const
+
+export type FlowActionTargetType =
+  (typeof flowActionTargetTypes)[keyof typeof flowActionTargetTypes]
+
+export type FlowActionTarget = {
+  details: ButtonStepProps
+  nodeId: string | null
+  targetType: FlowActionTargetType
+}
+
+/**
+ * Resolves the reply a contact tapped, wherever the builder put it.
+ *
+ * Only Messenger and Instagram tell buttons and quick replies apart on the way
+ * in; WhatsApp, Zalo, Telegram and TikTok deliver both through a single webhook
+ * field. Since the two are encoded with the same payload, the click alone can
+ * never say which one it was — the flow is the only authority. Searching both
+ * places keeps those channels routing to the next node instead of stalling.
+ *
+ * Step buttons win a tie: they were the only resolvable target before quick
+ * replies were searched, so existing flows keep their behavior exactly.
+ */
+export function resolveFlowActionTarget(
+  nodes: FlowNode[],
+  actionId: string,
+): FlowActionTarget | null {
+  const { button, nodeId } = getNodeFromButton(nodes, actionId)
+  if (button) {
+    return {
+      details: button,
+      nodeId,
+      targetType: flowActionTargetTypes.button,
+    }
+  }
+
+  const { quickReply, nodeId: quickReplyNodeId } = getNodeFromQuickReply(
+    nodes,
+    actionId,
+  )
+  if (quickReply) {
+    return {
+      details: quickReply,
+      nodeId: quickReplyNodeId,
+      targetType: flowActionTargetTypes.quickReply,
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary

Fixes two issues that stopped WhatsApp conversations from working properly.

**Cards and carousels**
Only the first card was delivered. When a card had a long text or too many buttons, the rest were dropped silently. Now the content is split across extra messages so nothing is lost.

**Quick replies**
Tapping a quick reply did nothing — the conversation stayed on the same step. Now it moves on to the next step as expected. The same problem affected Zalo, Telegram and TikTok, and is fixed for them too. Messenger and Instagram behave exactly as before.

Magic links attached to a quick reply used to return "not found". They now redirect correctly.

## Test plan

- [x] WhatsApp: send a card with a long text and several buttons — everything arrives, nothing is dropped
- [x] WhatsApp: send a carousel with three cards — all three arrive
- [x] WhatsApp: tap a quick reply — the conversation moves to the next step
- [x] WhatsApp: tap a button — still moves to the next step
- [x] Messenger: tap a quick reply and a button — unchanged
- [x] Open a magic link attached to a quick reply — redirects instead of erroring
- [x] Automated tests: 1211 worker, 138 flow-config, 79 whatsapp, 3 new builder route tests
- [x] Lint and type checks pass

## Notes

- No database migration needed
- Requires redeploying worker, builder and the WhatsApp integration
