### PR TITLE
feat(webhooks): add create/delete to the public webhooks API

### DIFF
--- a/apps/builder/__tests__/webhooks-workspace-token-api.test.ts
+++ b/apps/builder/__tests__/webhooks-workspace-token-api.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+type RouteConfig = {
+  method: string
+  path: string
+  summary: string
+  tags: string[]
+  successStatus?: number
+}
+
+type CapturedProcedure = {
+  route: RouteConfig
+  handler?: (...args: any[]) => any
+}
+
+const { workspaceTokenAuthAPI, capturedProcedures } = vi.hoisted(() => {
+  const capturedProcedures: CapturedProcedure[] = []
+
+  const makeProcedure = (route: RouteConfig) => {
+    const record: CapturedProcedure = { route }
+    capturedProcedures.push(record)
+
+    const chain = {
+      input: vi.fn(() => chain),
+      output: vi.fn(() => chain),
+      errors: vi.fn(() => chain),
+      handler: vi.fn((fn: (...args: any[]) => any) => {
+        record.handler = fn
+        return { handler: fn }
+      }),
+    }
+    return chain
+  }
+
+  return {
+    workspaceTokenAuthAPI: {
+      route: vi.fn((config: RouteConfig) => makeProcedure(config)),
+    },
+    capturedProcedures,
+  }
+})
+
+vi.mock("@/orpc", () => ({ workspaceTokenAuthAPI }))
+
+const webhookService = {
+  listByWorkspaceId: vi.fn(),
+  register: vi.fn(),
+  unregister: vi.fn(),
+}
+vi.mock("@chatbotx.io/business", () => ({ webhookService }))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  createSelectSchema: vi.fn(() => ({})),
+  webhookModel: {},
+}))
+
+await import("@/features/webhooks/api/workspace-token")
+
+const findProcedure = (method: string, path: string) => {
+  const found = capturedProcedures.find(
+    (p) => p.route.method === method && p.route.path === path,
+  )
+  if (!found) {
+    throw new Error(`No procedure registered for ${method} ${path}`)
+  }
+  return found
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("GET /v1/webhooks", () => {
+  const procedure = findProcedure("GET", "/v1/webhooks")
+
+  test("route metadata", () => {
+    expect(procedure.route).toEqual(
+      expect.objectContaining({ method: "GET", path: "/v1/webhooks" }),
+    )
+  })
+
+  test("delegates to webhookService.listByWorkspaceId", async () => {
+    webhookService.listByWorkspaceId.mockResolvedValueOnce([
+      { id: "webhook-1" },
+    ])
+
+    await expect(
+      procedure.handler?.({ context: { workspace: { id: "workspace-1" } } }),
+    ).resolves.toEqual({ data: [{ id: "webhook-1" }] })
+
+    expect(webhookService.listByWorkspaceId).toHaveBeenCalledWith("workspace-1")
+  })
+})
+
+describe("POST /v1/webhooks", () => {
+  const procedure = findProcedure("POST", "/v1/webhooks")
+
+  test("route metadata", () => {
+    expect(procedure.route).toEqual(
+      expect.objectContaining({
+        method: "POST",
+        path: "/v1/webhooks",
+        successStatus: 201,
+      }),
+    )
+  })
+
+  test("maps conditions and delegates to webhookService.register", async () => {
+    webhookService.register.mockResolvedValueOnce({ id: "webhook-1" })
+
+    const result = await procedure.handler?.({
+      context: { workspace: { id: "workspace-1" } },
+      input: {
+        name: "n8n trigger",
+        url: "https://n8n.example.com/webhook/abc",
+        conditions: [
+          { type: "newContact" },
+          { type: "tagApplied", sourceId: "tag-1" },
+        ],
+      },
+    })
+
+    expect(result).toEqual({ id: "webhook-1" })
+    expect(webhookService.register).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      name: "n8n trigger",
+      url: "https://n8n.example.com/webhook/abc",
+      conditions: [
+        { type: "newContact", sourceId: null, operator: null, value: null },
+        {
+          type: "tagApplied",
+          sourceId: "tag-1",
+          operator: null,
+          value: null,
+        },
+      ],
+    })
+  })
+})
+
+describe("DELETE /v1/webhooks/{id}", () => {
+  const procedure = findProcedure("DELETE", "/v1/webhooks/{id}")
+
+  test("route metadata", () => {
+    expect(procedure.route).toEqual(
+      expect.objectContaining({
+        method: "DELETE",
+        path: "/v1/webhooks/{id}",
+        successStatus: 204,
+      }),
+    )
+  })
+
+  test("delegates to webhookService.unregister", async () => {
+    webhookService.unregister.mockResolvedValueOnce(undefined)
+
+    await procedure.handler?.({
+      context: { workspace: { id: "workspace-1" } },
+      input: { id: "webhook-1" },
+    })
+
+    expect(webhookService.unregister).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      id: "webhook-1",
+    })
+  })
+})

--- a/apps/builder/src/features/conditions/schemas/index.ts
+++ b/apps/builder/src/features/conditions/schemas/index.ts
@@ -1,3 +1,4 @@
+import z from "zod"
 import { contactInfoUpdated } from "./contact-info-updated"
 import { customFieldValueChanged } from "./custom-field-value-changed"
 import { dateTimeBasedTrigger } from "./date-time-based-trigger"
@@ -37,3 +38,6 @@ export const allConditions = {
   contactReferredANewContact,
   contactReferredExistingContact,
 }
+
+export const conditionSchema = z.union(Object.values(allConditions))
+export type ConditionInput = z.infer<typeof conditionSchema>

--- a/apps/builder/src/features/conditions/to-condition-columns.ts
+++ b/apps/builder/src/features/conditions/to-condition-columns.ts
@@ -1,0 +1,9 @@
+import type { ConditionInput } from "./schemas"
+
+export const toConditionColumns = (condition: ConditionInput) => ({
+  type: condition.type,
+  sourceId: "sourceId" in condition ? condition.sourceId : null,
+  operator: "operator" in condition ? condition.operator : null,
+  value:
+    "value" in condition && condition.value !== null ? condition.value : null,
+})

--- a/apps/builder/src/features/triggers/actions/update-trigger-action.ts
+++ b/apps/builder/src/features/triggers/actions/update-trigger-action.ts
@@ -4,6 +4,7 @@ import { and, db, eq, inArray } from "@chatbotx.io/database/client"
 import { conditionModel, triggerModel } from "@chatbotx.io/database/schema"
 import { updateTriggerCache } from "@chatbotx.io/events"
 import { createId, zodBigintAsString } from "@chatbotx.io/utils"
+import { toConditionColumns } from "@/features/conditions/to-condition-columns"
 import { workspaceActionClient } from "@/lib/safe-action"
 import { updateTriggerSchema } from "../schema/mutation"
 
@@ -61,15 +62,7 @@ export const updateTriggerAction = workspaceActionClient
       for (const condition of conditionsToUpdate) {
         await tx
           .update(conditionModel)
-          .set({
-            type: condition.type,
-            sourceId: "sourceId" in condition ? condition.sourceId : null,
-            operator: "operator" in condition ? condition.operator : null,
-            value:
-              "value" in condition && condition.value !== null
-                ? condition.value
-                : null,
-          })
+          .set(toConditionColumns(condition))
           .where(eq(conditionModel.id, condition.id ?? ""))
       }
 
@@ -78,10 +71,7 @@ export const updateTriggerAction = workspaceActionClient
           conditionsToCreate.map((c) => ({
             id: createId(),
             triggerId: id,
-            type: c.type,
-            sourceId: "sourceId" in c ? c.sourceId : null,
-            operator: "operator" in c ? c.operator : null,
-            value: "value" in c && c.value !== null ? c.value : null,
+            ...toConditionColumns(c),
           })),
         )
       }

--- a/apps/builder/src/features/webhooks/actions/update-webhook-action.ts
+++ b/apps/builder/src/features/webhooks/actions/update-webhook-action.ts
@@ -4,6 +4,7 @@ import { and, db, eq, inArray } from "@chatbotx.io/database/client"
 import { conditionModel, webhookModel } from "@chatbotx.io/database/schema"
 import { updateWebhookCache } from "@chatbotx.io/events"
 import { createId, zodBigintAsString } from "@chatbotx.io/utils"
+import { toConditionColumns } from "@/features/conditions/to-condition-columns"
 import { workspaceActionClient } from "@/lib/safe-action"
 import { updateWebhookRequest } from "../schemas/update-webhook-schema"
 
@@ -61,15 +62,7 @@ export const updateWebhookAction = workspaceActionClient
       for (const condition of conditionsToUpdate) {
         await tx
           .update(conditionModel)
-          .set({
-            type: condition.type,
-            sourceId: "sourceId" in condition ? condition.sourceId : null,
-            operator: "operator" in condition ? condition.operator : null,
-            value:
-              "value" in condition && condition.value !== null
-                ? condition.value
-                : null,
-          })
+          .set(toConditionColumns(condition))
           .where(eq(conditionModel.id, condition.id as string))
       }
 
@@ -78,10 +71,7 @@ export const updateWebhookAction = workspaceActionClient
           conditionsToCreate.map((c) => ({
             id: createId(),
             webhookId: id,
-            type: c.type,
-            sourceId: "sourceId" in c ? c.sourceId : null,
-            operator: "operator" in c ? c.operator : null,
-            value: "value" in c && c.value !== null ? c.value : null,
+            ...toConditionColumns(c),
           })),
         )
       }

--- a/apps/builder/src/features/webhooks/api/workspace-token.ts
+++ b/apps/builder/src/features/webhooks/api/workspace-token.ts
@@ -1,7 +1,15 @@
 import { webhookService } from "@chatbotx.io/business"
 import { createSelectSchema, webhookModel } from "@chatbotx.io/database/schema"
+import { zodBigintAsString } from "@chatbotx.io/utils"
 import z from "zod"
+import {
+  possibleErrorsOnCreatingResource,
+  possibleErrorsOnDeletingResource,
+  possibleErrorsOnListingResource,
+} from "@/lib/orpc/orpc-error-helper"
 import { workspaceTokenAuthAPI } from "@/orpc"
+import { conditionSchema } from "../../conditions/schemas"
+import { toConditionColumns } from "../../conditions/to-condition-columns"
 
 const webhookResource = createSelectSchema(webhookModel, {
   id: z.string(),
@@ -17,13 +25,63 @@ const listWebhooksWorkspaceTokenAPI = workspaceTokenAuthAPI
     tags: ["Webhooks"],
   })
   .output(z.object({ data: z.array(webhookResource) }))
+  .errors(possibleErrorsOnListingResource)
   .handler(async ({ context }) => {
     const data = await webhookService.listByWorkspaceId(context.workspace.id)
     return { data }
   })
 
+const createWebhookWorkspaceTokenAPI = workspaceTokenAuthAPI
+  .route({
+    method: "POST",
+    path: "/v1/webhooks",
+    summary: "Register a webhook",
+    description:
+      "Registers a URL to receive system events (e.g. new contact, tag applied). Automation platforms (e.g. n8n) can call this to auto-attach a webhook when a workflow is activated.",
+    successStatus: 201,
+    tags: ["Webhooks"],
+  })
+  .input(
+    z.object({
+      name: z.string().trim().min(1).max(255),
+      url: z.string().trim().url().max(1000),
+      conditions: z.array(conditionSchema).min(1),
+    }),
+  )
+  .output(webhookResource)
+  .errors(possibleErrorsOnCreatingResource)
+  .handler(async ({ context, input }) => {
+    const { name, url, conditions } = input
+
+    return await webhookService.register({
+      workspaceId: context.workspace.id,
+      name,
+      url,
+      conditions: conditions.map(toConditionColumns),
+    })
+  })
+
+const deleteWebhookWorkspaceTokenAPI = workspaceTokenAuthAPI
+  .route({
+    method: "DELETE",
+    path: "/v1/webhooks/{id}",
+    summary: "Unregister a webhook",
+    successStatus: 204,
+    tags: ["Webhooks"],
+  })
+  .input(z.object({ id: zodBigintAsString() }))
+  .errors(possibleErrorsOnDeletingResource)
+  .handler(async ({ context, input }) => {
+    await webhookService.unregister({
+      workspaceId: context.workspace.id,
+      id: input.id,
+    })
+  })
+
 export const webhooksWorkspaceTokenAPIs = {
   listWebhooksWorkspaceTokenAPI,
+  createWebhookWorkspaceTokenAPI,
+  deleteWebhookWorkspaceTokenAPI,
 }
 
 export default webhooksWorkspaceTokenAPIs

--- a/apps/builder/src/features/webhooks/constants.ts
+++ b/apps/builder/src/features/webhooks/constants.ts
@@ -1,1 +1,3 @@
-export const MAX_WEBHOOKS_PER_CHATBOT = 10
+import { MAX_WEBHOOKS_PER_WORKSPACE } from "@chatbotx.io/business"
+
+export const MAX_WEBHOOKS_PER_CHATBOT = MAX_WEBHOOKS_PER_WORKSPACE

--- a/packages/business/__tests__/external-webhook.service.test.ts
+++ b/packages/business/__tests__/external-webhook.service.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const mocks = vi.hoisted(() => {
+  const insertBuilder = {
+    values: vi.fn(() => insertBuilder),
+    onConflictDoNothing: vi.fn(() => insertBuilder),
+    returning: vi.fn(async () => [{ id: "external-webhook-1" }]),
+  }
+  const deleteBuilder = {
+    where: vi.fn(() => deleteBuilder),
+    returning: vi.fn(async () => [{ id: "external-webhook-1" }]),
+  }
+
+  return {
+    externalWebhookModel: {
+      id: "id-column",
+      workspaceId: "workspaceId-column",
+    },
+    insertBuilder,
+    deleteBuilder,
+    findFirst: vi.fn(async () => undefined as unknown),
+    count: vi.fn(async () => 0),
+    insertFn: vi.fn(() => insertBuilder),
+    deleteFn: vi.fn(() => deleteBuilder),
+    findOrFail: vi.fn(async () => ({ id: "external-webhook-1" })),
+  }
+})
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: { externalWebhookModel: { findFirst: mocks.findFirst } },
+    $count: mocks.count,
+    insert: mocks.insertFn,
+    delete: mocks.deleteFn,
+  },
+  eq: vi.fn(() => "eq"),
+  and: vi.fn(() => "and"),
+  findOrFail: mocks.findOrFail,
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  externalWebhookModel: mocks.externalWebhookModel,
+}))
+
+let idCounter = 0
+vi.mock("@chatbotx.io/utils", () => ({
+  createId: vi.fn(() => `generated-id-${++idCounter}`),
+}))
+
+const assertPublicUrl = vi.fn(async () => undefined)
+vi.mock("../src/net/ssrf-guard", () => ({ assertPublicUrl }))
+
+const { externalWebhookService } = await import(
+  "../src/external-webhook/service"
+)
+
+// Not exported by the service module; mirrors the private constant there.
+const MAX_WEBHOOKS_PER_WORKSPACE = 50
+const MAX_ITEMS_REACHED_PATTERN = /maximum/i
+
+const REGISTER_INPUT = {
+  workspaceId: "workspace-1",
+  provider: "n8n",
+  event: "newContact",
+  url: "https://n8n.example.com/webhook/abc",
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  idCounter = 0
+  mocks.findFirst.mockResolvedValue(undefined)
+  mocks.count.mockResolvedValue(0)
+  mocks.insertBuilder.returning.mockResolvedValue([
+    { id: "external-webhook-1" },
+  ])
+  mocks.deleteBuilder.returning.mockResolvedValue([
+    { id: "external-webhook-1" },
+  ])
+  assertPublicUrl.mockResolvedValue(undefined)
+})
+
+describe("externalWebhookService.register", () => {
+  test("rejects a non-public URL as a 422 ChatbotXException before touching the DB", async () => {
+    assertPublicUrl.mockRejectedValueOnce(
+      new Error(
+        "[ssrf-guard] Webhook URL is not allowed: http://127.0.0.1/hook",
+      ),
+    )
+
+    await expect(
+      externalWebhookService.register({
+        ...REGISTER_INPUT,
+        url: "http://127.0.0.1/hook",
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining("not allowed"),
+      code: "invalidRequestData",
+      httpStatusCode: 422,
+    })
+
+    expect(mocks.findFirst).not.toHaveBeenCalled()
+    expect(mocks.insertFn).not.toHaveBeenCalled()
+  })
+
+  test("returns the existing row instead of inserting when already registered", async () => {
+    mocks.findFirst.mockResolvedValueOnce({ id: "existing-webhook" })
+
+    const result = await externalWebhookService.register(REGISTER_INPUT)
+
+    expect(result).toEqual({ id: "existing-webhook" })
+    expect(mocks.insertFn).not.toHaveBeenCalled()
+  })
+
+  test("throws once the workspace has reached the cap", async () => {
+    mocks.count.mockResolvedValue(MAX_WEBHOOKS_PER_WORKSPACE)
+
+    await expect(
+      externalWebhookService.register(REGISTER_INPUT),
+    ).rejects.toThrow(MAX_ITEMS_REACHED_PATTERN)
+
+    expect(mocks.insertFn).not.toHaveBeenCalled()
+  })
+
+  test("creates the external webhook when under the cap", async () => {
+    const result = await externalWebhookService.register(REGISTER_INPUT)
+
+    expect(result).toEqual({ id: "external-webhook-1" })
+    expect(mocks.insertBuilder.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "workspace-1",
+        provider: "n8n",
+        event: "newContact",
+        url: "https://n8n.example.com/webhook/abc",
+      }),
+    )
+  })
+})
+
+describe("externalWebhookService.unregister", () => {
+  test("deletes the webhook scoped to the workspace", async () => {
+    await externalWebhookService.unregister({
+      workspaceId: "workspace-1",
+      id: "external-webhook-1",
+    })
+
+    expect(mocks.deleteFn).toHaveBeenCalledWith(mocks.externalWebhookModel)
+  })
+
+  test("throws not-found when no row matches the workspace", async () => {
+    mocks.deleteBuilder.returning.mockResolvedValueOnce([])
+
+    await expect(
+      externalWebhookService.unregister({
+        workspaceId: "workspace-1",
+        id: "missing",
+      }),
+    ).rejects.toThrow("External webhook not found")
+  })
+})

--- a/packages/business/__tests__/webhook.service.test.ts
+++ b/packages/business/__tests__/webhook.service.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const mocks = vi.hoisted(() => {
+  const insertBuilder = {
+    values: vi.fn(() => insertBuilder),
+    returning: vi.fn(async () => [{ id: "webhook-1" }]),
+  }
+  const conditionInsertBuilder = {
+    values: vi.fn(async () => undefined),
+  }
+  const tx = {
+    insert: vi.fn(),
+  }
+  const deleteBuilder = {
+    where: vi.fn(() => deleteBuilder),
+    returning: vi.fn(async () => [{ id: "webhook-1" }]),
+  }
+
+  return {
+    webhookModel: { workspaceId: "workspaceId-column", id: "id-column" },
+    conditionModel: {},
+    insertBuilder,
+    conditionInsertBuilder,
+    deleteBuilder,
+    tx,
+    count: vi.fn(async () => 0),
+    transaction: vi.fn(
+      async (fn: (tx: typeof tx) => Promise<unknown>) => await fn(tx),
+    ),
+    deleteFn: vi.fn(() => deleteBuilder),
+  }
+})
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    $count: mocks.count,
+    transaction: mocks.transaction,
+    delete: mocks.deleteFn,
+  },
+  eq: vi.fn(() => "eq"),
+  and: vi.fn(() => "and"),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  webhookModel: mocks.webhookModel,
+  conditionModel: mocks.conditionModel,
+}))
+
+vi.mock("@chatbotx.io/events", () => ({
+  updateWebhookCache: vi.fn(async () => undefined),
+  removeWebhookCache: vi.fn(async () => undefined),
+}))
+
+const distributedLock = {
+  runExclusive: vi.fn(
+    async ({ fn }: { fn: () => Promise<unknown> }) => await fn(),
+  ),
+}
+vi.mock("@chatbotx.io/redis", () => ({ distributedLock }))
+
+let idCounter = 0
+vi.mock("@chatbotx.io/utils", () => ({
+  createId: vi.fn(() => `generated-id-${++idCounter}`),
+}))
+
+const assertPublicUrl = vi.fn(async () => undefined)
+vi.mock("../src/net/ssrf-guard", () => ({ assertPublicUrl }))
+
+const { updateWebhookCache, removeWebhookCache } = await import(
+  "@chatbotx.io/events"
+)
+const { webhookService, MAX_WEBHOOKS_PER_WORKSPACE } = await import(
+  "../src/webhook/service"
+)
+
+const CONDITIONS = [{ type: "newContact" }]
+const MAX_ITEMS_REACHED_PATTERN = /maximum/i
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  idCounter = 0
+  mocks.count.mockResolvedValue(0)
+  mocks.insertBuilder.returning.mockResolvedValue([{ id: "webhook-1" }])
+  mocks.deleteBuilder.returning.mockResolvedValue([{ id: "webhook-1" }])
+  mocks.tx.insert
+    .mockImplementationOnce(() => mocks.insertBuilder)
+    .mockImplementationOnce(() => mocks.conditionInsertBuilder)
+  assertPublicUrl.mockResolvedValue(undefined)
+  distributedLock.runExclusive.mockImplementation(
+    async ({ fn }: { fn: () => Promise<unknown> }) => await fn(),
+  )
+})
+
+describe("webhookService.register", () => {
+  test("rejects a non-public URL via the SSRF guard before writing anything", async () => {
+    assertPublicUrl.mockRejectedValueOnce(
+      new Error(
+        "[ssrf-guard] Webhook URL is not allowed: http://127.0.0.1/hook",
+      ),
+    )
+
+    await expect(
+      webhookService.register({
+        workspaceId: "workspace-1",
+        name: "n8n trigger",
+        url: "http://127.0.0.1/hook",
+        conditions: CONDITIONS,
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining("not allowed"),
+      code: "invalidRequestData",
+      httpStatusCode: 422,
+    })
+
+    expect(mocks.transaction).not.toHaveBeenCalled()
+  })
+
+  test("throws once the workspace has reached the cap", async () => {
+    mocks.count.mockResolvedValue(MAX_WEBHOOKS_PER_WORKSPACE)
+
+    await expect(
+      webhookService.register({
+        workspaceId: "workspace-1",
+        name: "n8n trigger",
+        url: "https://n8n.example.com/webhook/abc",
+        conditions: CONDITIONS,
+      }),
+    ).rejects.toThrow(MAX_ITEMS_REACHED_PATTERN)
+
+    expect(mocks.transaction).not.toHaveBeenCalled()
+  })
+
+  test("creates the webhook and its conditions, then refreshes the cache", async () => {
+    const result = await webhookService.register({
+      workspaceId: "workspace-1",
+      name: "n8n trigger",
+      url: "https://n8n.example.com/webhook/abc",
+      conditions: [
+        { type: "newContact" },
+        { type: "tagApplied", sourceId: "tag-1" },
+      ],
+    })
+
+    expect(result).toEqual({ id: "webhook-1" })
+    expect(mocks.insertBuilder.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "workspace-1",
+        name: "n8n trigger",
+        url: "https://n8n.example.com/webhook/abc",
+      }),
+    )
+    expect(mocks.conditionInsertBuilder.values).toHaveBeenCalledWith([
+      expect.objectContaining({
+        webhookId: "webhook-1",
+        type: "newContact",
+        sourceId: null,
+        operator: null,
+        value: null,
+      }),
+      expect.objectContaining({
+        webhookId: "webhook-1",
+        type: "tagApplied",
+        sourceId: "tag-1",
+      }),
+    ])
+    expect(updateWebhookCache).toHaveBeenCalledWith("workspace-1")
+  })
+})
+
+describe("webhookService.unregister", () => {
+  test("deletes the webhook scoped to the workspace and refreshes the cache", async () => {
+    await webhookService.unregister({
+      workspaceId: "workspace-1",
+      id: "webhook-1",
+    })
+
+    expect(mocks.deleteFn).toHaveBeenCalledWith(mocks.webhookModel)
+    expect(removeWebhookCache).toHaveBeenCalledWith("workspace-1")
+  })
+
+  test("throws not-found when no row matches the workspace", async () => {
+    mocks.deleteBuilder.returning.mockResolvedValueOnce([])
+
+    await expect(
+      webhookService.unregister({ workspaceId: "workspace-1", id: "missing" }),
+    ).rejects.toThrow("Webhook not found")
+
+    expect(removeWebhookCache).not.toHaveBeenCalled()
+  })
+})

--- a/packages/business/src/external-webhook/service.ts
+++ b/packages/business/src/external-webhook/service.ts
@@ -22,7 +22,15 @@ class ExternalWebhookService extends BaseService {
   }): Promise<ExternalWebhookModel> {
     const { workspaceId, provider, event, url } = props
 
-    await assertPublicUrl(url, "Webhook URL")
+    try {
+      await assertPublicUrl(url, "Webhook URL")
+    } catch (error) {
+      throw new ChatbotXException(
+        error instanceof Error ? error.message : "Invalid webhook URL",
+        "invalidRequestData",
+        422,
+      )
+    }
 
     const existing = await db.query.externalWebhookModel.findFirst({
       where: { workspaceId, event, url },

--- a/packages/business/src/webhook/service.ts
+++ b/packages/business/src/webhook/service.ts
@@ -1,7 +1,22 @@
-import { db, eq } from "@chatbotx.io/database/client"
-import { webhookModel } from "@chatbotx.io/database/schema"
+import { and, db, eq } from "@chatbotx.io/database/client"
+import { conditionModel, webhookModel } from "@chatbotx.io/database/schema"
 import type { WebhookModel } from "@chatbotx.io/database/types"
+import { removeWebhookCache, updateWebhookCache } from "@chatbotx.io/events"
+import { distributedLock } from "@chatbotx.io/redis"
+import { createId } from "@chatbotx.io/utils"
 import { BaseService } from "../base.service"
+import { ChatbotXException, notFoundException } from "../errors"
+import { assertPublicUrl } from "../net/ssrf-guard"
+
+export const MAX_WEBHOOKS_PER_WORKSPACE = 100
+const LOCK_TIMEOUT_SECONDS = 30
+
+export type WebhookConditionInput = {
+  type: string
+  sourceId?: string | null
+  operator?: string | null
+  value?: unknown
+}
 
 class WebhookService extends BaseService {
   async listByWorkspaceId(workspaceId: string): Promise<WebhookModel[]> {
@@ -9,6 +24,83 @@ class WebhookService extends BaseService {
       .select()
       .from(webhookModel)
       .where(eq(webhookModel.workspaceId, workspaceId))
+  }
+
+  async register(props: {
+    workspaceId: string
+    name: string
+    url: string
+    conditions: WebhookConditionInput[]
+  }): Promise<WebhookModel> {
+    const { workspaceId, name, url, conditions } = props
+
+    try {
+      await assertPublicUrl(url, "Webhook URL")
+    } catch (error) {
+      throw new ChatbotXException(
+        error instanceof Error ? error.message : "Invalid webhook URL",
+        "invalidRequestData",
+        422,
+      )
+    }
+
+    const created = await distributedLock.runExclusive({
+      key: `webhook:${workspaceId}`,
+      timeoutInSeconds: LOCK_TIMEOUT_SECONDS,
+      fn: async () => {
+        const count = await db.$count(
+          webhookModel,
+          eq(webhookModel.workspaceId, workspaceId),
+        )
+        if (count >= MAX_WEBHOOKS_PER_WORKSPACE) {
+          throw new ChatbotXException(
+            `Workspace has reached the maximum of ${MAX_WEBHOOKS_PER_WORKSPACE} webhooks`,
+            "webhookLimitReached",
+          )
+        }
+
+        return await db.transaction(async (tx) => {
+          const [webhook] = await tx
+            .insert(webhookModel)
+            .values({ id: createId(), workspaceId, name, url })
+            .returning()
+
+          await tx.insert(conditionModel).values(
+            conditions.map((condition) => ({
+              id: createId(),
+              webhookId: webhook.id,
+              type: condition.type,
+              sourceId: condition.sourceId ?? null,
+              operator: condition.operator ?? null,
+              value: condition.value ?? null,
+            })),
+          )
+
+          return webhook
+        })
+      },
+    })
+
+    await updateWebhookCache(workspaceId)
+
+    return created
+  }
+
+  async unregister(props: { workspaceId: string; id: string }): Promise<void> {
+    const { workspaceId, id } = props
+
+    const deleted = await db
+      .delete(webhookModel)
+      .where(
+        and(eq(webhookModel.id, id), eq(webhookModel.workspaceId, workspaceId)),
+      )
+      .returning({ id: webhookModel.id })
+
+    if (deleted.length === 0) {
+      throw notFoundException("Webhook not found")
+    }
+
+    await removeWebhookCache(workspaceId)
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `POST /v1/webhooks` and `DELETE /v1/webhooks/{id}` (workspace-token auth) so external automation platforms (e.g. an n8n trigger node) can register/unregister a webhook against ChatbotX's existing system-event automation (`webhookModel` + `conditionModel`), matching the CRUD already exposed for the sibling `external-webhooks` (Make) feature.
- `webhookService.register()` reuses the SSRF guard + capped, lock-guarded insert pattern from `externalWebhookService`.
- Fixes both `register()` methods so an SSRF-rejected URL now surfaces as a clear `422 invalidRequestData` instead of a bare `500` (the oRPC error interceptor doesn't map plain `Error`s, only `ChatbotXException`).
- Extracts the previously-duplicated condition→DB-column mapping (`sourceId`/`operator`/`value`) into a shared `toConditionColumns()` helper, reused by the trigger action, webhook update action, and the new endpoint.

## Changes
- `packages/business/src/webhook/service.ts` — new `register()`/`unregister()`, moved `MAX_WEBHOOKS_PER_WORKSPACE` here.
- `packages/business/src/external-webhook/service.ts` — SSRF error now maps to `422`.
- `apps/builder/src/features/webhooks/api/workspace-token.ts` — new create/delete procedures.
- `apps/builder/src/features/webhooks/constants.ts` — re-exports the cap constant from `@chatbotx.io/business`.
- `apps/builder/src/features/conditions/schemas/index.ts` + new `to-condition-columns.ts` — shared condition-mapping helper.
- `apps/builder/src/features/triggers/actions/update-trigger-action.ts`, `apps/builder/src/features/webhooks/actions/update-webhook-action.ts` — use the shared helper.
- Test coverage: `packages/business/__tests__/webhook.service.test.ts`, `packages/business/__tests__/external-webhook.service.test.ts`, `apps/builder/__tests__/webhooks-workspace-token-api.test.ts`.

## Test plan
- [x] `pnpm --filter @chatbotx.io/business exec vitest run __tests__/webhook.service.test.ts __tests__/external-webhook.service.test.ts` — 11/11 pass
- [x] `pnpm --filter builder exec vitest run __tests__/webhooks-workspace-token-api.test.ts` — 6/6 pass
- [x] `pnpm lint` and `pnpm --filter builder check-types` / `pnpm --filter @chatbotx.io/business check-types` — clean
- [x] Manual verification against local dev server: created a webhook via `POST /v1/webhooks`, confirmed conditions persisted, listed it, deleted it (cascade-deletes conditions), confirmed re-delete returns 404, confirmed an SSRF-blocked URL now returns 422 instead of 500