### PR TITLE
feat(flows): show every carousel card and connect their buttons

### DIFF
--- a/apps/builder/src/features/flows/react-flow/__tests__/edge-routing.test.ts
+++ b/apps/builder/src/features/flows/react-flow/__tests__/edge-routing.test.ts
@@ -1,0 +1,128 @@
+import type { Edge } from "@xyflow/react"
+import { describe, expect, test } from "vitest"
+import {
+  getRoutableHandleId,
+  replaceSourceHandleEdge,
+  toRouteRemovals,
+} from "../edge-routing"
+
+const makeEdge = (
+  id: string,
+  source: string,
+  sourceHandle: string,
+  target: string,
+): Edge => ({
+  id,
+  source,
+  sourceHandle,
+  target,
+  targetHandle: target,
+})
+
+describe("replaceSourceHandleEdge", () => {
+  test("replaces only the edge owned by the same source and handle", () => {
+    const replaced = makeEdge("old", "source-1", "button-1", "target-1")
+    const otherHandle = makeEdge(
+      "other-handle",
+      "source-1",
+      "button-2",
+      "target-2",
+    )
+    const duplicateHandleOnAnotherNode = makeEdge(
+      "other-node",
+      "source-2",
+      "button-1",
+      "target-3",
+    )
+
+    const result = replaceSourceHandleEdge(
+      [replaced, otherHandle, duplicateHandleOnAnotherNode],
+      {
+        source: "source-1",
+        sourceHandle: "button-1",
+        target: "target-4",
+        targetHandle: "target-4",
+        type: "buttonedge",
+      },
+    )
+
+    expect(result).toHaveLength(3)
+    expect(result).not.toContain(replaced)
+    expect(result).toContain(otherHandle)
+    expect(result).toContain(duplicateHandleOnAnotherNode)
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        source: "source-1",
+        sourceHandle: "button-1",
+        target: "target-4",
+      }),
+    )
+  })
+
+  test("does not duplicate an identical connection", () => {
+    const existing = makeEdge("existing", "source", "button", "target")
+    const edges = [existing]
+
+    const result = replaceSourceHandleEdge(edges, {
+      source: "source",
+      sourceHandle: "button",
+      target: "target",
+      targetHandle: "target",
+      type: "buttonedge",
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result).toBe(edges)
+    expect(result[0].id).toBe("existing")
+    expect(result[0]).toMatchObject({
+      source: "source",
+      sourceHandle: "button",
+      target: "target",
+    })
+  })
+})
+
+describe("getRoutableHandleId", () => {
+  test("accepts a button handle and rejects the node's own continue handle", () => {
+    expect(getRoutableHandleId("node-1", "button-1")).toBe("button-1")
+    expect(getRoutableHandleId("node-1", "node-1")).toBeNull()
+  })
+
+  test("rejects a missing or empty handle id", () => {
+    expect(getRoutableHandleId("node-1", null)).toBeNull()
+    expect(getRoutableHandleId("node-1", undefined)).toBeNull()
+    expect(getRoutableHandleId("node-1", "")).toBeNull()
+  })
+})
+
+describe("toRouteRemovals", () => {
+  test("clears every button route and skips continue handles", () => {
+    const buttonEdge = makeEdge("edge-1", "source-1", "button-1", "target-1")
+    const continueEdge = makeEdge("edge-2", "source-2", "source-2", "target-2")
+    const handlelessEdge: Edge = {
+      id: "edge-3",
+      source: "source-3",
+      target: "target-3",
+    }
+
+    expect(toRouteRemovals([buttonEdge, continueEdge, handlelessEdge])).toEqual(
+      [{ sourceNodeId: "source-1", handleId: "button-1", route: null }],
+    )
+  })
+
+  test("keeps one removal per deleted edge, scoped to its own source node", () => {
+    const removals = toRouteRemovals([
+      makeEdge("edge-1", "source-1", "shared-id", "target-1"),
+      makeEdge("edge-2", "source-2", "shared-id", "target-2"),
+    ])
+
+    expect(removals).toEqual([
+      { sourceNodeId: "source-1", handleId: "shared-id", route: null },
+      { sourceNodeId: "source-2", handleId: "shared-id", route: null },
+    ])
+  })
+
+  test("returns nothing when no edge owns a route", () => {
+    expect(toRouteRemovals([])).toEqual([])
+  })
+})

--- a/apps/builder/src/features/flows/react-flow/edge-routing.ts
+++ b/apps/builder/src/features/flows/react-flow/edge-routing.ts
@@ -1,0 +1,50 @@
+import type { FlowRouteUpdate } from "@chatbotx.io/flow-config"
+import { addEdge, type Connection, type Edge } from "@xyflow/react"
+
+type NextButtonEdge = Connection & Partial<Pick<Edge, "id" | "type">>
+
+export const replaceSourceHandleEdge = (
+  edges: Edge[],
+  nextEdge: NextButtonEdge,
+): Edge[] => {
+  const isAlreadyConnected = edges.some(
+    (edge) =>
+      edge.source === nextEdge.source &&
+      edge.sourceHandle === nextEdge.sourceHandle &&
+      edge.target === nextEdge.target &&
+      edge.targetHandle === nextEdge.targetHandle,
+  )
+  if (isAlreadyConnected) {
+    return edges
+  }
+
+  const edgesFromOtherHandles = edges.filter(
+    (edge) =>
+      edge.source !== nextEdge.source ||
+      edge.sourceHandle !== nextEdge.sourceHandle,
+  )
+
+  return addEdge(nextEdge, edgesFromOtherHandles)
+}
+
+/**
+ * Resolves the button whose route a source handle owns, or `null` when the
+ * handle owns none.
+ *
+ * A node's continue handle reuses the node id and is routed by its edge alone,
+ * so only a handle carrying an id of its own writes into node data.
+ */
+export const getRoutableHandleId = (
+  sourceNodeId: string,
+  sourceHandleId: string | null | undefined,
+): string | null =>
+  sourceHandleId && sourceHandleId !== sourceNodeId ? sourceHandleId : null
+
+/** Clears the button route behind every routable handle that lost its edge. */
+export const toRouteRemovals = (edges: readonly Edge[]): FlowRouteUpdate[] =>
+  edges.flatMap((edge) => {
+    const handleId = getRoutableHandleId(edge.source, edge.sourceHandle)
+    return handleId
+      ? [{ sourceNodeId: edge.source, handleId, route: null }]
+      : []
+  })

--- a/apps/builder/src/features/flows/react-flow/react-flow-wrapper.tsx
+++ b/apps/builder/src/features/flows/react-flow/react-flow-wrapper.tsx
@@ -1,16 +1,12 @@
 import {
-  buttonTypes,
-  type EmailStepSchema,
+  applyRouteUpdatesInNodes,
   type FlowNode,
+  type FlowRouteUpdate,
   nodeTypeSchema,
-  type PageElementSchema,
-  pageElementTypes,
   sendMessageNodeDefaultFn,
-  startAnotherNodeStepDefaultFn,
 } from "@chatbotx.io/flow-config"
 import { useDebouncedCallback } from "@chatbotx.io/ui/hooks/use-debounced-callback"
 import {
-  addEdge,
   Background,
   type Connection,
   Controls,
@@ -55,9 +51,13 @@ import ZoomOutButton from "./panel-buttons/zoom-out-button"
 import { duplicateFlowNode } from "./toolbar/duplicate-node-data"
 import "./react-flow-wrapper.css"
 import { createId } from "@chatbotx.io/utils"
-import type { ButtonProps } from "react-day-picker"
 import type { FlowVersionResource } from "@/features/flow-versions/schema/resource"
 import { serializeFlowContent } from "../flow-version-content"
+import {
+  getRoutableHandleId,
+  replaceSourceHandleEdge,
+  toRouteRemovals,
+} from "./edge-routing"
 import ButtonEdge from "./edges/button-edge"
 import { hasMeaningfulNodeChange } from "./react-flow-node-change"
 import { useFlowHistoryStoreApi } from "./stores/flow-history-store-provider"
@@ -104,7 +104,6 @@ export function ReactFlowWrapper({
     addNodes,
     getNodes,
     updateNodeData,
-    addEdges,
     updateEdge,
     getEdges,
     deleteElements,
@@ -114,7 +113,7 @@ export function ReactFlowWrapper({
   const [nodes, setNodes, onNodesChange] = useNodesState(
     flowVersion.nodes as unknown as FlowNode[],
   )
-  const [edges, setEdges, onEdgesChange] = useEdgesState(
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>(
     (flowVersion.edges as unknown as Edge[]).map((edge) => ({
       ...edge,
       type: "buttonedge",
@@ -150,9 +149,11 @@ export function ReactFlowWrapper({
     )
 
   const handleChanges = useDebouncedCallback(
-    // biome-ignore lint/suspicious/noExplicitAny: wip
-    (changedNodes: any[], changedEdges: any[]) => {
-      savingDraft({ nodes: changedNodes, edges: changedEdges })
+    (changedNodes: FlowNode[], changedEdges: Edge[]) => {
+      savingDraft({
+        nodes: changedNodes,
+        edges: changedEdges as unknown as UpdateDraftFlowVersionSchema["edges"],
+      })
     },
     1500,
     4000,
@@ -203,17 +204,6 @@ export function ReactFlowWrapper({
     }
     releaseSnapshotSession()
   }, [takeSnapshot, releaseSnapshotSession])
-
-  // Snapshot first, then mutate React Flow's live node data. updateNodeData
-  // writes directly into the internal store, so callers must preserve the
-  // pre-mutation state before passing data in.
-  const updateNodeDataWithHistory = useCallback(
-    (nodeId: string, data: FlowNode["data"]) => {
-      takeCoalescedSnapshot()
-      updateNodeData(nodeId, data)
-    },
-    [takeCoalescedSnapshot, updateNodeData],
-  )
 
   const hasMeaningfulEdgeChange = useCallback(
     (changes: Parameters<typeof onEdgesChange>[0]) =>
@@ -390,92 +380,41 @@ export function ReactFlowWrapper({
     [updateNodeData],
   )
 
-  const onConnect = useCallback(
-    (params: Connection) => {
-      takeCoalescedSnapshot()
-      setEdges((eds) =>
-        addEdge(
-          {
-            ...params,
-            type: "buttonedge",
-          },
-          eds,
-        ),
+  const applyButtonRoutes = useCallback(
+    (routeUpdates: readonly FlowRouteUpdate[]) => {
+      setNodes((currentNodes) =>
+        applyRouteUpdatesInNodes(currentNodes, routeUpdates),
       )
     },
-    [setEdges, takeCoalescedSnapshot],
+    [setNodes],
   )
 
-  const connectButtonToNode = useCallback(
-    (connectionState: FinalConnectionState, toNodeId: string) => {
-      if (!connectionState.fromNode) {
+  const onConnect = useCallback(
+    (params: Connection) => {
+      if (params.source === params.target) {
         return
       }
 
       takeCoalescedSnapshot()
-      const fromNodeId = connectionState.fromNode.id
-      const handleId = connectionState.fromHandle?.id
-      const data = connectionState.fromNode.data as FlowNode["data"]
+      setEdges((currentEdges) =>
+        replaceSourceHandleEdge(currentEdges, {
+          ...params,
+          type: "buttonedge",
+        }),
+      )
 
-      // biome-ignore lint/suspicious/noExplicitAny: safe to use any
-      function connectButtonsInStep(step: any): boolean {
-        const buttonIndex = (step.buttons as ButtonProps[]).findIndex(
-          (button: ButtonProps) => button.id === handleId,
-        )
-        if (buttonIndex === -1) {
-          return false
-        }
-
-        const targetButton = step.buttons[buttonIndex]
-        targetButton.buttonType = buttonTypes.enum.startAnotherNode
-        targetButton.beforeStep = startAnotherNodeStepDefaultFn({
-          nodeId: toNodeId,
-          viewOnly: true,
-        })
-        step.buttons[buttonIndex] = targetButton
-        updateNodeDataWithHistory(fromNodeId, data)
-        return true
-      }
-
-      function connectElementsInStep(step: EmailStepSchema): boolean {
-        const elements = step.elements as PageElementSchema[]
-        for (
-          let elementIndex = 0;
-          elementIndex < elements.length;
-          elementIndex++
-        ) {
-          const element = elements[elementIndex]
-          if (
-            element.type === pageElementTypes.enum.button &&
-            element.beforeStep &&
-            element.beforeStep.id === handleId
-          ) {
-            element.beforeStep.stepType = buttonTypes.enum.startAnotherNode
-            element.beforeStep = startAnotherNodeStepDefaultFn({
-              nodeId: toNodeId,
-              viewOnly: true,
-            })
-            elements[elementIndex] = element
-            updateNodeDataWithHistory(fromNodeId, data)
-            return true
-          }
-        }
-        return false
-      }
-
-      if ("steps" in data.details) {
-        for (const step of data.details.steps as EmailStepSchema[]) {
-          if ("buttons" in step && connectButtonsInStep(step)) {
-            break
-          }
-
-          if ("elements" in step && connectElementsInStep(step)) {
-            return
-          }
-        }
+      const handleId = getRoutableHandleId(params.source, params.sourceHandle)
+      if (handleId) {
+        applyButtonRoutes([
+          {
+            sourceNodeId: params.source,
+            handleId,
+            route: { targetNodeId: params.target },
+          },
+        ])
       }
     },
-    [takeCoalescedSnapshot, updateNodeDataWithHistory],
+    [applyButtonRoutes, setEdges, takeCoalescedSnapshot],
   )
 
   const onConnectEnd = useCallback(
@@ -483,111 +422,63 @@ export function ReactFlowWrapper({
       _event: MouseEvent | TouchEvent,
       connectionState: FinalConnectionState,
     ): void => {
-      // cases:
-      // 1. From node to empty space: create new sendMessage node
-      // 2. From node to node: create new buttonedge
-      // 3.
-
-      // if from handle or from node is not set, return
-      if (!(connectionState.fromHandle && connectionState.fromNode)) {
+      const fromHandle = connectionState.fromHandle
+      const fromNode = connectionState.fromNode
+      if (
+        !(fromHandle?.id && fromNode) ||
+        fromHandle.type !== "source" ||
+        connectionState.toHandle ||
+        connectionState.toNode
+      ) {
         return
       }
 
-      // handle case of dragging from source handle
-      if (connectionState.fromHandle.type === "source") {
-        // drop connection to empty space
-        if (!(connectionState.toHandle && connectionState.toNode)) {
-          const allNodes = getNodes()
-          const messageNodesLength = allNodes.filter(
-            (node) => node.type === nodeTypeSchema.enum.sendMessage,
-          ).length
+      const fromHandleId = fromHandle.id
+      const messageNodesLength = getNodes().filter(
+        (node) => node.type === nodeTypeSchema.enum.sendMessage,
+      ).length
+      const position = connectionState.to
+        ? screenToFlowPosition(connectionState.to)
+        : { x: 300, y: 300 }
+      const newNode = sendMessageNodeDefaultFn({
+        nodeProps: { position },
+        dataProps: {
+          name: `${t("actions.sendMessage")} #${messageNodesLength + 1}`,
+        },
+      })
 
-          const position = connectionState.to
-            ? screenToFlowPosition(connectionState.to)
-            : { x: 300, y: 300 }
-          const newNode = sendMessageNodeDefaultFn({
-            nodeProps: {
-              position,
-            },
-            dataProps: {
-              name: `Send Message #${messageNodesLength + 1}`,
-            },
-          })
-          takeCoalescedSnapshot()
-          addNodes([newNode])
+      takeCoalescedSnapshot()
+      addNodes([newNode])
+      setEdges((currentEdges) =>
+        replaceSourceHandleEdge(currentEdges, {
+          id: createId(),
+          source: fromNode.id,
+          target: newNode.id,
+          sourceHandle: fromHandleId,
+          targetHandle: newNode.id,
+          type: "buttonedge",
+        }),
+      )
 
-          addEdges({
-            id: createId(),
-            source: connectionState.fromNode.id,
-            target: newNode.id,
-            sourceHandle: connectionState.fromHandle.id,
-            targetHandle: newNode.id,
-            type: "buttonedge",
-          })
-
-          // if the source is button, update the button data
-          if (connectionState.fromHandle.id !== connectionState.fromNode.id) {
-            connectButtonToNode(connectionState, newNode.id)
-          }
-
-          return
-        }
-
-        if (connectionState.toHandle && connectionState.toNode) {
-          // if to node is the same as from node, return
-          if (connectionState.toNode.id === connectionState.fromNode.id) {
-            return
-          }
-
-          const allEdges = getEdges()
-
-          // if it's already connected, return
-          const isConnected = allEdges.some(
-            (edge) =>
-              edge.sourceHandle === connectionState.fromHandle?.id &&
-              edge.targetHandle === connectionState.toHandle?.id,
-          )
-          if (isConnected) {
-            return
-          }
-
-          // this connection is from node to node, so we need to create a new buttonedge
-          if (connectionState.toHandle.id === connectionState.toNode.id) {
-            // Each source handle just can connect to one target handle
-            // Remove the existing edges that have the same source handle
-            const connectedEdges = allEdges.filter(
-              (edge) => edge.sourceHandle === connectionState.fromHandle?.id,
-            )
-
-            takeCoalescedSnapshot()
-            deleteElements({
-              edges: connectedEdges.map((edge) => ({
-                id: edge.id,
-              })),
-            })
-
-            // if the handle is from button, update the button data
-            if (connectionState.fromHandle.id !== connectionState.fromNode.id) {
-              connectButtonToNode(connectionState, connectionState.toNode.id)
-            }
-            return
-          }
-
-          return
-        }
-
-        return
+      const handleId = getRoutableHandleId(fromNode.id, fromHandleId)
+      if (handleId) {
+        applyButtonRoutes([
+          {
+            sourceNodeId: fromNode.id,
+            handleId,
+            route: { targetNodeId: newNode.id },
+          },
+        ])
       }
     },
     [
       addNodes,
-      addEdges,
       getNodes,
-      deleteElements,
-      getEdges,
-      connectButtonToNode,
+      setEdges,
+      applyButtonRoutes,
       screenToFlowPosition,
       takeCoalescedSnapshot,
+      t,
     ],
   )
 
@@ -616,68 +507,9 @@ export function ReactFlowWrapper({
   const onEdgesDelete = useCallback(
     (edges: Edge[]) => {
       takeCoalescedSnapshot()
-
-      for (const edge of edges) {
-        // if the edge is from node to node, do nothing
-        if (edge.source === edge.sourceHandle) {
-          continue
-        }
-
-        // the edge is from button to node, we need to update the button data
-        const foundedNode = getNodes().find((node) => node.id === edge.source)
-        if (!foundedNode) {
-          continue
-        }
-
-        const data = foundedNode.data as FlowNode["data"]
-        if ("details" in data && data.details && "steps" in data.details) {
-          const stepIndex = data.details.steps.findIndex(
-            (step) =>
-              "buttons" in step &&
-              step.buttons.some((button) => button.id === edge.sourceHandle),
-          )
-          if (stepIndex !== -1 && "buttons" in data.details.steps[stepIndex]) {
-            const buttonIndex = data.details.steps[stepIndex].buttons.findIndex(
-              (button: ButtonProps) => button.id === edge.sourceHandle,
-            )
-            if (buttonIndex !== -1) {
-              data.details.steps[stepIndex].buttons[buttonIndex].beforeStep =
-                null
-              data.details.steps[stepIndex].buttons[buttonIndex].buttonType =
-                null
-
-              // update the node data
-              updateNodeDataWithHistory(foundedNode.id, data)
-            }
-            continue
-          }
-
-          // Handle button page elements in steps (e.g. SendMail node)
-          let elementFound = false
-          for (const step of data.details.steps) {
-            if (!("elements" in step)) {
-              continue
-            }
-            for (const element of (step as EmailStepSchema).elements) {
-              if (
-                element.type === pageElementTypes.enum.button &&
-                element.beforeStep &&
-                element.beforeStep.id === edge.sourceHandle
-              ) {
-                Object.assign(element, { buttonType: null, beforeStep: null })
-                updateNodeDataWithHistory(foundedNode.id, data)
-                elementFound = true
-                break
-              }
-            }
-            if (elementFound) {
-              break
-            }
-          }
-        }
-      }
+      applyButtonRoutes(toRouteRemovals(edges))
     },
-    [getNodes, takeCoalescedSnapshot, updateNodeDataWithHistory],
+    [applyButtonRoutes, takeCoalescedSnapshot],
   )
 
   return (

--- a/apps/builder/src/features/flows/react-flow/steps/send-carousel/__tests__/viewer.test.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-carousel/__tests__/viewer.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+import {
+  buttonStepDefaultFn,
+  buttonTypes,
+  openWebsiteStepDefaultFn,
+  sendCardStepDefaultFn,
+  sendCarouselStepDefaultFn,
+} from "@chatbotx.io/flow-config"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import SendCarouselStepViewer from "../viewer"
+
+const mocks = vi.hoisted(() => ({
+  updateNodeInternals: vi.fn(),
+}))
+
+vi.mock("@xyflow/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@xyflow/react")>()),
+  useUpdateNodeInternals: () => mocks.updateNodeInternals,
+}))
+
+vi.mock("@/components/base-handle", () => ({
+  BaseHandle: ({ id }: { id?: string | null }) => (
+    <span data-handleid={id ?? ""} />
+  ),
+}))
+
+const HORIZONTAL_MARGIN_CLASS = /\bm[lrxe]-\d/
+const FIRST_CARD_FRAME_OFFSET = "mr-4"
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  ;(
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true
+  mocks.updateNodeInternals.mockReset()
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+const render = (ui: React.ReactElement) => {
+  act(() => {
+    root.render(ui)
+  })
+}
+
+const makeCarousel = (cardCount: number) => ({
+  ...sendCarouselStepDefaultFn(),
+  cards: Array.from({ length: cardCount }, (_, index) => ({
+    ...sendCardStepDefaultFn(),
+    id: `card-${index}`,
+    title: `Title ${index}`,
+    subtitle: `Subtitle ${index}`,
+    image: undefined,
+    buttons: [
+      {
+        ...buttonStepDefaultFn({ label: `Button ${index}` }),
+        id: `button-${index}`,
+      },
+    ],
+  })),
+})
+
+describe("SendCarouselStepViewer", () => {
+  test.each([
+    0, 1, 3, 10, 12,
+  ])("renders all cards and handles for a %i-card carousel", (cardCount) => {
+    render(
+      <SendCarouselStepViewer data={makeCarousel(cardCount)} nodeId="node-1" />,
+    )
+
+    expect(container.querySelectorAll("[data-carousel-card-id]")).toHaveLength(
+      cardCount,
+    )
+    expect(container.querySelectorAll("[data-handleid]")).toHaveLength(
+      cardCount,
+    )
+    for (let index = 0; index < cardCount; index += 1) {
+      expect(container.textContent).toContain(`Title ${index}`)
+      expect(container.textContent).toContain(`Subtitle ${index}`)
+      expect(container.textContent).toContain(`Button ${index}`)
+      expect(
+        container.querySelector(`[data-handleid="button-${index}"]`),
+      ).not.toBeNull()
+    }
+  })
+
+  test("uses a fixed 256px card width without clipping or disabling interaction", () => {
+    render(<SendCarouselStepViewer data={makeCarousel(3)} nodeId="node-1" />)
+
+    const row = container.querySelector('[data-slot="send-carousel-cards"]')
+    expect(row?.className).toContain("w-max")
+    expect(row?.className).not.toContain("pointer-events-none")
+    for (const card of Array.from(
+      container.querySelectorAll("[data-carousel-card-id]"),
+    )) {
+      expect(card.className).toContain("w-64")
+      expect(card.className).toContain("shrink-0")
+    }
+  })
+
+  test("offsets only the first card so the gutter stays even past the node frame", () => {
+    render(<SendCarouselStepViewer data={makeCarousel(3)} nodeId="node-1" />)
+
+    const row = container.querySelector('[data-slot="send-carousel-cards"]')
+    expect(row?.className).toContain("gap-3")
+
+    const cards = Array.from(
+      container.querySelectorAll("[data-carousel-card-id]"),
+    )
+    expect(cards[0].className).toContain(FIRST_CARD_FRAME_OFFSET)
+    for (const card of cards.slice(1)) {
+      expect(card.className).not.toMatch(HORIZONTAL_MARGIN_CLASS)
+    }
+  })
+
+  test("does not render a route handle for an external URL button", () => {
+    const internalButton = {
+      ...buttonStepDefaultFn({ label: "Internal" }),
+      id: "internal",
+    }
+    const externalButton = {
+      id: "external",
+      label: "External",
+      buttonType: buttonTypes.enum.openWebsite,
+      beforeStep: {
+        ...openWebsiteStepDefaultFn(),
+        url: "https://example.com",
+      },
+      steps: [],
+    }
+    const data = {
+      ...makeCarousel(1),
+      cards: [
+        {
+          ...sendCardStepDefaultFn(),
+          id: "card",
+          title: "Card",
+          buttons: [internalButton, externalButton],
+        },
+      ],
+    }
+
+    render(<SendCarouselStepViewer data={data} nodeId="node-1" />)
+
+    expect(container.querySelector('[data-handleid="internal"]')).not.toBeNull()
+    expect(container.querySelector('[data-handleid="external"]')).toBeNull()
+  })
+
+  test("renders cards without images or buttons", () => {
+    const data = {
+      ...makeCarousel(1),
+      cards: [
+        {
+          ...sendCardStepDefaultFn(),
+          id: "empty-card",
+          title: "No media",
+          image: undefined,
+          buttons: [],
+        },
+      ],
+    }
+
+    expect(() =>
+      render(<SendCarouselStepViewer data={data} nodeId="node-1" />),
+    ).not.toThrow()
+    expect(container.textContent).toContain("No media")
+    expect(container.querySelector("[data-handleid]")).toBeNull()
+  })
+
+  test("refreshes node internals only when node id or cards reference changes", () => {
+    const data = makeCarousel(1)
+    render(<SendCarouselStepViewer data={data} nodeId="node-1" />)
+    expect(mocks.updateNodeInternals).toHaveBeenCalledTimes(1)
+    expect(mocks.updateNodeInternals).toHaveBeenLastCalledWith("node-1")
+
+    render(<SendCarouselStepViewer data={{ ...data }} nodeId="node-1" />)
+    expect(mocks.updateNodeInternals).toHaveBeenCalledTimes(1)
+
+    render(
+      <SendCarouselStepViewer
+        data={{ ...data, cards: [...data.cards] }}
+        nodeId="node-1"
+      />,
+    )
+    expect(mocks.updateNodeInternals).toHaveBeenCalledTimes(2)
+
+    render(
+      <SendCarouselStepViewer
+        data={{ ...data, cards: [...data.cards] }}
+        nodeId="node-2"
+      />,
+    )
+    expect(mocks.updateNodeInternals).toHaveBeenCalledTimes(3)
+    expect(mocks.updateNodeInternals).toHaveBeenLastCalledWith("node-2")
+
+    render(
+      <SendCarouselStepViewer data={{ ...data, cards: [] }} nodeId="node-2" />,
+    )
+    expect(mocks.updateNodeInternals).toHaveBeenCalledTimes(4)
+    expect(
+      container.querySelector('[data-slot="send-carousel-cards"]'),
+    ).toBeNull()
+  })
+
+  test("does not update node internals when rendered without a node id", () => {
+    expect(() =>
+      render(<SendCarouselStepViewer data={makeCarousel(1)} />),
+    ).not.toThrow()
+    expect(mocks.updateNodeInternals).not.toHaveBeenCalled()
+  })
+})

--- a/apps/builder/src/features/flows/react-flow/steps/send-carousel/viewer.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-carousel/viewer.tsx
@@ -1,23 +1,71 @@
 "use client"
 
 import type { SendCarouselStepSchema } from "@chatbotx.io/flow-config"
-import {
-  Carousel,
-  CarouselContent,
-  CarouselItem,
-} from "@chatbotx.io/ui/components/ui/carousel"
+import { cn } from "@chatbotx.io/ui/lib/utils"
+import { useUpdateNodeInternals } from "@xyflow/react"
+import { useEffect } from "react"
 import SendCardStepViewer from "@/features/flows/react-flow/steps/send-card/viewer"
 
-const SendCarouselStepViewer = ({ data }: { data: SendCarouselStepSchema }) => (
-  <Carousel className="pointer-events-none">
-    <CarouselContent>
-      {data.cards.map((card) => (
-        <CarouselItem key={card.id}>
+/** 256px — the node card is `w-72` with `p-4` padding, so one card fills it. */
+const CAROUSEL_CARD_WIDTH = "w-64"
+
+/** 12px — the gutter seen between two cards. */
+const CAROUSEL_CARD_GAP = "gap-3"
+
+/**
+ * 16px — cancels the node's own right padding.
+ *
+ * The first card fills the node frame while the rest spill outside it, so the
+ * node's `p-4` already sits between card one and card two. Adding it back keeps
+ * the gutter even from the node border onward instead of letting the second
+ * card crowd the frame.
+ */
+const FIRST_CARD_FRAME_OFFSET = "mr-4"
+
+type SendCarouselStepViewerProps = {
+  data: SendCarouselStepSchema
+  nodeId?: string
+}
+
+const SendCarouselCards = ({ data, nodeId }: SendCarouselStepViewerProps) => {
+  const updateNodeInternals = useUpdateNodeInternals()
+
+  // Card content changes can add, remove, or move source handles.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: cards is an intentional geometry trigger
+  useEffect(() => {
+    if (nodeId) {
+      updateNodeInternals(nodeId)
+    }
+  }, [data.cards, nodeId, updateNodeInternals])
+
+  if (data.cards.length === 0) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn("flex w-max items-start", CAROUSEL_CARD_GAP)}
+      data-slot="send-carousel-cards"
+    >
+      {data.cards.map((card, cardIndex) => (
+        <div
+          className={cn(
+            CAROUSEL_CARD_WIDTH,
+            "shrink-0",
+            cardIndex === 0 && FIRST_CARD_FRAME_OFFSET,
+          )}
+          data-carousel-card-id={card.id}
+          key={card.id}
+        >
           <SendCardStepViewer data={card} />
-        </CarouselItem>
+        </div>
       ))}
-    </CarouselContent>
-  </Carousel>
+    </div>
+  )
+}
+
+const SendCarouselStepViewer = (props: SendCarouselStepViewerProps) => (
+  <SendCarouselCards {...props} />
 )
 
 export default SendCarouselStepViewer

--- a/packages/flow-config/__tests__/routable-handle.test.ts
+++ b/packages/flow-config/__tests__/routable-handle.test.ts
@@ -63,6 +63,15 @@ const stripQuickReplies = (node: FlowNode): FlowNode =>
     },
   }) as FlowNode
 
+/**
+ * Mirrors a card persisted before #381, when the schema was a union that let a
+ * card carry only a subtitle or only an image — with no `buttons` key at all.
+ */
+const stripCardButtons = <Card extends { buttons: unknown }>(card: Card) =>
+  Object.fromEntries(
+    Object.entries(card).filter(([key]) => key !== "buttons"),
+  ) as Card
+
 const getMailElements = (node: FlowNode) => {
   if (
     !(
@@ -503,6 +512,48 @@ describe("applyRouteInNode", () => {
     expect(disconnectedSteps[1].cards[0].buttons[0]).toMatchObject({
       buttonType: null,
       beforeStep: null,
+    })
+  })
+
+  test("routes past a legacy card persisted without a buttons array", () => {
+    const cardButton = makeButton("second-card-button", "Card")
+    const node = makeMessageNode("legacy-cards-node", {
+      steps: [
+        {
+          ...sendCarouselStepDefaultFn(),
+          cards: [
+            stripCardButtons({
+              ...sendCardStepDefaultFn(),
+              id: "subtitle-only-card",
+              title: "Subtitle only",
+              subtitle: "No buttons key at all",
+            }),
+            {
+              ...sendCardStepDefaultFn(),
+              id: "card-with-button",
+              title: "Card",
+              buttons: [cardButton],
+            },
+          ],
+        },
+      ],
+    })
+
+    expect("buttons" in getSteps(node)[0].cards[0]).toBe(false)
+    expect(getNodeFromButton([node], cardButton.id).nodeId).toBe(
+      "legacy-cards-node",
+    )
+
+    const connected = applyRouteInNode(node, cardButton.id, {
+      targetNodeId: "target-node",
+    })
+    const connectedSteps = getSteps(connected as FlowNode)
+    if (!("cards" in connectedSteps[0])) {
+      throw new Error("Expected a carousel step")
+    }
+    expect(connectedSteps[0].cards[1].buttons[0]).toMatchObject({
+      buttonType: buttonTypes.enum.startAnotherNode,
+      beforeStep: { nodeId: "target-node" },
     })
   })
 })

--- a/packages/flow-config/__tests__/routable-handle.test.ts
+++ b/packages/flow-config/__tests__/routable-handle.test.ts
@@ -1,0 +1,635 @@
+import { describe, expect, test } from "vitest"
+import type { FlowNode, PageElementSchema } from "../src"
+import {
+  applyRouteInNode,
+  applyRouteUpdatesInNodes,
+  buttonStepDefaultFn,
+  buttonTypes,
+  emailStepDefaultFn,
+  getNodeFromButton,
+  pageElementTypes,
+  sendCardStepDefaultFn,
+  sendCarouselStepDefaultFn,
+  sendMailNodeDefaultFn,
+  sendMessageNodeDefaultFn,
+  sendTextStepDefaultFn,
+  startAnotherNodeStepDefaultFn,
+  whatsappOptionListStepDefaultFn,
+} from "../src"
+
+type SendMessageDetails = Parameters<
+  typeof sendMessageNodeDefaultFn
+>[0]["detailProps"]
+
+const makeMessageNode = (
+  id: string,
+  detailProps: SendMessageDetails,
+): FlowNode =>
+  sendMessageNodeDefaultFn({
+    nodeProps: { id },
+    detailProps,
+  }) as FlowNode
+
+const makeButton = (id: string, label = id) => ({
+  ...buttonStepDefaultFn({ label }),
+  id,
+})
+
+const getMessageSteps = (node: FlowNode) => {
+  if (!("quickReplies" in node.data.details)) {
+    throw new Error("Expected a send-message node")
+  }
+  return node.data.details.steps
+}
+
+const getSteps = (node: FlowNode) => {
+  if (!("steps" in node.data.details)) {
+    throw new Error("Expected a node with steps")
+  }
+  return node.data.details.steps
+}
+
+/** Mirrors a flow version persisted before `quickReplies` joined the schema. */
+const stripQuickReplies = (node: FlowNode): FlowNode =>
+  ({
+    ...node,
+    data: {
+      ...node.data,
+      details: Object.fromEntries(
+        Object.entries(node.data.details).filter(
+          ([key]) => key !== "quickReplies",
+        ),
+      ),
+    },
+  }) as FlowNode
+
+const getMailElements = (node: FlowNode) => {
+  if (
+    !(
+      "steps" in node.data.details &&
+      node.data.details.steps.every((step) => "elements" in step)
+    )
+  ) {
+    throw new Error("Expected a send-mail node")
+  }
+  return node.data.details.steps[0].elements
+}
+
+describe("getNodeFromButton", () => {
+  test("finds top-level and carousel buttons without changing the result shape", () => {
+    const topLevelButton = makeButton("top-level", "Top level")
+    const cardButtons = [
+      makeButton("card-first", "First"),
+      makeButton("card-middle", "Middle"),
+      makeButton("card-last", "Last"),
+    ]
+    const cards = cardButtons.map((button, index) => ({
+      ...sendCardStepDefaultFn(),
+      id: `card-${index}`,
+      title: `Card ${index}`,
+      buttons: [button],
+    }))
+    const node = makeMessageNode("owner-node", {
+      steps: [
+        sendTextStepDefaultFn({ buttons: [topLevelButton], text: "Hello" }),
+        { ...sendCarouselStepDefaultFn(), cards },
+      ],
+    })
+
+    expect(getNodeFromButton([node], topLevelButton.id)).toEqual({
+      button: topLevelButton,
+      nodeId: "owner-node",
+    })
+    for (const button of cardButtons) {
+      expect(getNodeFromButton([node], button.id)).toEqual({
+        button,
+        nodeId: "owner-node",
+      })
+    }
+  })
+
+  test("prefers a step nodeId and preserves WhatsApp option synthesis", () => {
+    const button = makeButton("button")
+    const textStep = sendTextStepDefaultFn({
+      buttons: [button],
+      nodeId: "runtime-node",
+      text: "Hello",
+    })
+    const optionStep = whatsappOptionListStepDefaultFn({
+      nodeId: "option-runtime-node",
+      options: [{ id: "option", title: "Choice", description: "Description" }],
+    })
+    const node = makeMessageNode("owner-node", {
+      steps: [textStep, optionStep],
+    })
+
+    expect(getNodeFromButton([node], button.id).nodeId).toBe("runtime-node")
+    expect(getNodeFromButton([node], "option")).toEqual({
+      button: {
+        id: "option",
+        label: "Choice",
+        buttonType: null,
+        beforeStep: null,
+        steps: [],
+      },
+      nodeId: "option-runtime-node",
+    })
+  })
+
+  test("does not expose page elements and returns nulls for an unknown id", () => {
+    const handleId = "email-handle"
+    const mailNode = makeMailNode("mail-node", handleId)
+
+    expect(getNodeFromButton([mailNode], handleId)).toEqual({
+      button: null,
+      nodeId: null,
+    })
+    expect(getNodeFromButton([mailNode], "missing")).toEqual({
+      button: null,
+      nodeId: null,
+    })
+  })
+
+  test("preserves step order when legacy containers reuse a button id", () => {
+    const carouselButton = makeButton("duplicate", "Carousel first")
+    const topLevelButton = makeButton("duplicate", "Top level later")
+    const node = makeMessageNode("owner-node", {
+      steps: [
+        {
+          ...sendCarouselStepDefaultFn(),
+          cards: [
+            {
+              ...sendCardStepDefaultFn(),
+              title: "First step",
+              buttons: [carouselButton],
+            },
+          ],
+        },
+        sendTextStepDefaultFn({
+          buttons: [topLevelButton],
+          text: "Second step",
+        }),
+      ],
+    })
+
+    expect(getNodeFromButton([node], "duplicate").button).toEqual(
+      carouselButton,
+    )
+  })
+
+  test("finds buttons in legacy flow nodes without a React Flow type", () => {
+    const button = makeButton("legacy-button")
+    const node = makeMessageNode("legacy-node", {
+      steps: [sendTextStepDefaultFn({ buttons: [button], text: "Legacy" })],
+    })
+    node.type = undefined
+
+    expect(getNodeFromButton([node], button.id)).toEqual({
+      button,
+      nodeId: "legacy-node",
+    })
+  })
+})
+
+const makeMailNode = (id: string, buttonId: string): FlowNode => {
+  const button: PageElementSchema = {
+    id: buttonId,
+    type: pageElementTypes.enum.button,
+    label: "Email button",
+    buttonType: buttonTypes.enum.startAnotherNode,
+    beforeStep: {
+      ...startAnotherNodeStepDefaultFn({
+        nodeId: "old-target",
+        viewOnly: true,
+      }),
+      id: "email-before-step",
+    },
+    steps: [],
+  }
+  const node = sendMailNodeDefaultFn({ nodeProps: { id } })
+  node.data.details.steps = [
+    emailStepDefaultFn({
+      id: "email-step",
+      elements: [button],
+    }),
+  ]
+  return node as FlowNode
+}
+
+describe("applyRouteInNode", () => {
+  test("connects and disconnects a top-level button immutably", () => {
+    const button = makeButton("button")
+    const untouchedStep = sendTextStepDefaultFn({ text: "Untouched" })
+    const node = makeMessageNode("owner-node", {
+      steps: [
+        untouchedStep,
+        sendTextStepDefaultFn({ buttons: [button], text: "Target" }),
+      ],
+    })
+    const originalNode = structuredClone(node)
+
+    const connected = applyRouteInNode(node, button.id, {
+      targetNodeId: "target-node",
+    })
+    expect(connected).not.toBeNull()
+    expect(connected).not.toBe(node)
+    expect(getMessageSteps(connected as FlowNode)[0]).toBe(untouchedStep)
+    expect(node).toEqual(originalNode)
+
+    const connectedButton = getNodeFromButton(
+      [connected as FlowNode],
+      button.id,
+    ).button
+    expect(connectedButton).toMatchObject({
+      buttonType: buttonTypes.enum.startAnotherNode,
+      beforeStep: {
+        nodeId: "target-node",
+        viewOnly: true,
+      },
+    })
+
+    const disconnected = applyRouteInNode(
+      connected as FlowNode,
+      button.id,
+      null,
+    )
+    expect(
+      getNodeFromButton([disconnected as FlowNode], button.id).button,
+    ).toMatchObject({
+      buttonType: null,
+      beforeStep: null,
+    })
+  })
+
+  test.each([
+    "first",
+    "middle",
+    "last",
+  ] as const)("updates a carousel button in the %s card and preserves unrelated references", (position) => {
+    const positions = ["first", "middle", "last"] as const
+    const cards = positions.map((cardPosition) => ({
+      ...sendCardStepDefaultFn(),
+      id: `card-${cardPosition}`,
+      title: cardPosition,
+      buttons: [makeButton(`button-${cardPosition}`)],
+    }))
+    const carousel = { ...sendCarouselStepDefaultFn(), cards }
+    const node = makeMessageNode("owner-node", { steps: [carousel] })
+
+    const updated = applyRouteInNode(node, `button-${position}`, {
+      targetNodeId: "target-node",
+    })
+    const updatedCarousel = getMessageSteps(updated as FlowNode)[0]
+    if (!("cards" in updatedCarousel)) {
+      throw new Error("Expected carousel step")
+    }
+
+    expect(updated?.id).toBe("owner-node")
+    for (let index = 0; index < cards.length; index += 1) {
+      expect(updatedCarousel.cards[index] === cards[index]).toBe(
+        positions[index] !== position,
+      )
+    }
+    expect(
+      getNodeFromButton([updated as FlowNode], `button-${position}`).button,
+    ).toMatchObject({
+      buttonType: buttonTypes.enum.startAnotherNode,
+      beforeStep: { nodeId: "target-node" },
+    })
+    expect(getNodeFromButton([node], `button-${position}`).button).toEqual(
+      makeButton(`button-${position}`),
+    )
+
+    const disconnected = applyRouteInNode(
+      updated as FlowNode,
+      `button-${position}`,
+      null,
+    )
+    expect(
+      getNodeFromButton([disconnected as FlowNode], `button-${position}`)
+        .button,
+    ).toMatchObject({
+      buttonType: null,
+      beforeStep: null,
+    })
+  })
+
+  test("connects and disconnects a page button while keeping runtime lookup disabled", () => {
+    const node = makeMailNode("mail-node", "email-handle")
+    const connected = applyRouteInNode(node, "email-handle", {
+      targetNodeId: "new-target",
+    })
+    const connectedButton = getMailElements(
+      connected as FlowNode,
+    )[0] as Extract<PageElementSchema, { type: "button" }>
+    expect(connectedButton).toMatchObject({
+      buttonType: buttonTypes.enum.startAnotherNode,
+      beforeStep: {
+        nodeId: "new-target",
+        viewOnly: true,
+      },
+    })
+
+    expect(connectedButton.beforeStep?.id).not.toBe("email-handle")
+
+    const disconnected = applyRouteInNode(
+      connected as FlowNode,
+      "email-handle",
+      null,
+    )
+    const disconnectedButton = getMailElements(
+      disconnected as FlowNode,
+    )[0] as Extract<PageElementSchema, { type: "button" }>
+    expect(disconnectedButton).toMatchObject({
+      buttonType: null,
+      beforeStep: null,
+    })
+    expect(getMailElements(node)[0]).not.toBe(disconnectedButton)
+    expect(
+      getNodeFromButton([disconnected as FlowNode], "email-handle"),
+    ).toEqual({
+      button: null,
+      nodeId: null,
+    })
+  })
+
+  test("does not update WhatsApp options, unknown handles, or another owner node", () => {
+    const optionNode = makeMessageNode("option-owner", {
+      steps: [
+        whatsappOptionListStepDefaultFn({
+          options: [{ id: "shared-id", title: "Option" }],
+        }),
+      ],
+    })
+    const button = makeButton("shared-id")
+    const buttonNode = makeMessageNode("button-owner", {
+      steps: [sendTextStepDefaultFn({ buttons: [button], text: "Hello" })],
+    })
+
+    expect(
+      applyRouteInNode(optionNode, "shared-id", {
+        targetNodeId: "target-node",
+      }),
+    ).toBeNull()
+    expect(applyRouteInNode(buttonNode, "missing", null)).toBeNull()
+
+    const updated = applyRouteInNode(buttonNode, "shared-id", {
+      targetNodeId: "target-node",
+    })
+    expect(updated?.id).toBe("button-owner")
+    expect(optionNode.data).toBe(optionNode.data)
+  })
+
+  test("keeps the canvas owner id when a step has a runtime nodeId", () => {
+    const button = makeButton("button")
+    const node = makeMessageNode("owner-node", {
+      steps: [
+        sendTextStepDefaultFn({
+          buttons: [button],
+          nodeId: "runtime-node",
+          text: "Hello",
+        }),
+      ],
+    })
+
+    const updated = applyRouteInNode(node, button.id, {
+      targetNodeId: "target-node",
+    })
+
+    expect(updated?.id).toBe("owner-node")
+    expect(getNodeFromButton([updated as FlowNode], button.id).nodeId).toBe(
+      "runtime-node",
+    )
+  })
+
+  test("updates the same earliest step selected by runtime lookup for a duplicate legacy id", () => {
+    const carouselButton = makeButton("duplicate", "Carousel first")
+    const topLevelButton = makeButton("duplicate", "Top level later")
+    const node = makeMessageNode("owner-node", {
+      steps: [
+        {
+          ...sendCarouselStepDefaultFn(),
+          cards: [
+            {
+              ...sendCardStepDefaultFn(),
+              title: "First step",
+              buttons: [carouselButton],
+            },
+          ],
+        },
+        sendTextStepDefaultFn({
+          buttons: [topLevelButton],
+          text: "Second step",
+        }),
+      ],
+    })
+
+    const updated = applyRouteInNode(node, "duplicate", {
+      targetNodeId: "target-node",
+    })
+    const steps = getMessageSteps(updated as FlowNode)
+    if (!("cards" in steps[0] && "buttons" in steps[1])) {
+      throw new Error("Expected carousel and text steps")
+    }
+
+    expect(steps[0].cards[0].buttons[0]).toMatchObject({
+      buttonType: buttonTypes.enum.startAnotherNode,
+      beforeStep: { nodeId: "target-node" },
+    })
+    expect(steps[1].buttons[0]).toEqual(topLevelButton)
+    expect(getNodeFromButton([updated as FlowNode], "duplicate").button).toBe(
+      steps[0].cards[0].buttons[0],
+    )
+  })
+
+  test("routes buttons in a legacy node persisted without quickReplies", () => {
+    const topLevelButton = makeButton("legacy-top", "Top level")
+    const cardButton = makeButton("legacy-card", "Card")
+    const node = stripQuickReplies(
+      makeMessageNode("legacy-node", {
+        steps: [
+          sendTextStepDefaultFn({ buttons: [topLevelButton], text: "Hello" }),
+          {
+            ...sendCarouselStepDefaultFn(),
+            cards: [
+              {
+                ...sendCardStepDefaultFn(),
+                id: "legacy-card-container",
+                title: "Card",
+                buttons: [cardButton],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    expect("quickReplies" in node.data.details).toBe(false)
+    expect(getNodeFromButton([node], cardButton.id).nodeId).toBe("legacy-node")
+
+    const connected = applyRouteInNode(node, cardButton.id, {
+      targetNodeId: "target-node",
+    })
+    const connectedSteps = getSteps(connected as FlowNode)
+    if (!("cards" in connectedSteps[1])) {
+      throw new Error("Expected a carousel step")
+    }
+    expect(connectedSteps[1].cards[0].buttons[0]).toMatchObject({
+      buttonType: buttonTypes.enum.startAnotherNode,
+      beforeStep: { nodeId: "target-node" },
+    })
+
+    const topLevelConnected = applyRouteInNode(node, topLevelButton.id, {
+      targetNodeId: "target-node",
+    })
+    const topLevelSteps = getSteps(topLevelConnected as FlowNode)
+    if (!("buttons" in topLevelSteps[0])) {
+      throw new Error("Expected a text step")
+    }
+    expect(topLevelSteps[0].buttons[0]).toMatchObject({
+      buttonType: buttonTypes.enum.startAnotherNode,
+      beforeStep: { nodeId: "target-node" },
+    })
+
+    const disconnected = applyRouteInNode(
+      connected as FlowNode,
+      cardButton.id,
+      null,
+    )
+    const disconnectedSteps = getSteps(disconnected as FlowNode)
+    if (!("cards" in disconnectedSteps[1])) {
+      throw new Error("Expected a carousel step")
+    }
+    expect(disconnectedSteps[1].cards[0].buttons[0]).toMatchObject({
+      buttonType: null,
+      beforeStep: null,
+    })
+  })
+})
+
+describe("applyRouteUpdatesInNodes", () => {
+  test("applies multiple route changes to the same source node atomically", () => {
+    const firstButton = makeButton("first")
+    const secondButton = makeButton("second")
+    const sourceNode = makeMessageNode("source-node", {
+      steps: [
+        sendTextStepDefaultFn({
+          buttons: [firstButton],
+          text: "Top-level button",
+        }),
+        {
+          ...sendCarouselStepDefaultFn(),
+          cards: [
+            {
+              ...sendCardStepDefaultFn(),
+              buttons: [secondButton],
+              title: "Carousel button",
+            },
+          ],
+        },
+      ],
+    })
+    const connectedNode = applyRouteUpdatesInNodes(
+      [sourceNode],
+      [
+        {
+          sourceNodeId: sourceNode.id,
+          handleId: firstButton.id,
+          route: { targetNodeId: "first-target" },
+        },
+        {
+          sourceNodeId: sourceNode.id,
+          handleId: secondButton.id,
+          route: { targetNodeId: "second-target" },
+        },
+      ],
+    )[0]
+
+    const disconnectedNode = applyRouteUpdatesInNodes(
+      [connectedNode],
+      [
+        {
+          sourceNodeId: sourceNode.id,
+          handleId: firstButton.id,
+          route: null,
+        },
+        {
+          sourceNodeId: sourceNode.id,
+          handleId: secondButton.id,
+          route: null,
+        },
+      ],
+    )[0]
+
+    expect(
+      getNodeFromButton([disconnectedNode], firstButton.id).button,
+    ).toMatchObject({
+      buttonType: null,
+      beforeStep: null,
+    })
+    expect(
+      getNodeFromButton([disconnectedNode], secondButton.id).button,
+    ).toMatchObject({
+      buttonType: null,
+      beforeStep: null,
+    })
+  })
+
+  test("scopes duplicate handle ids to their declared source node", () => {
+    const firstNode = makeMessageNode("first-node", {
+      steps: [
+        sendTextStepDefaultFn({
+          buttons: [makeButton("duplicate")],
+          text: "First",
+        }),
+      ],
+    })
+    const secondNode = makeMessageNode("second-node", {
+      steps: [
+        sendTextStepDefaultFn({
+          buttons: [makeButton("duplicate")],
+          text: "Second",
+        }),
+      ],
+    })
+
+    const result = applyRouteUpdatesInNodes(
+      [firstNode, secondNode],
+      [
+        {
+          sourceNodeId: secondNode.id,
+          handleId: "duplicate",
+          route: { targetNodeId: "target-node" },
+        },
+      ],
+    )
+
+    expect(result[0]).toBe(firstNode)
+    expect(getNodeFromButton([result[0]], "duplicate").button).toMatchObject({
+      buttonType: null,
+      beforeStep: null,
+    })
+    expect(getNodeFromButton([result[1]], "duplicate").button).toMatchObject({
+      buttonType: buttonTypes.enum.startAnotherNode,
+      beforeStep: { nodeId: "target-node" },
+    })
+  })
+
+  test("preserves node and array references when no update applies", () => {
+    const node = makeMessageNode("source-node", {
+      steps: [sendTextStepDefaultFn({ text: "No button" })],
+    })
+    const nodes = [node]
+
+    const result = applyRouteUpdatesInNodes(nodes, [
+      {
+        sourceNodeId: node.id,
+        handleId: "missing",
+        route: null,
+      },
+    ])
+
+    expect(result).toBe(nodes)
+    expect(result[0]).toBe(node)
+  })
+})

--- a/packages/flow-config/src/index.ts
+++ b/packages/flow-config/src/index.ts
@@ -15,6 +15,11 @@ export * from "./nodes/send-message"
 export * from "./nodes/split-traffic"
 export * from "./nodes/start-flow"
 export * from "./nodes/wait"
+export type { FlowRoute, FlowRouteUpdate } from "./routable-handle"
+export {
+  applyRouteInNode,
+  applyRouteUpdatesInNodes,
+} from "./routable-handle"
 // Export all shared
 export * from "./shared"
 export * from "./states"

--- a/packages/flow-config/src/routable-handle.ts
+++ b/packages/flow-config/src/routable-handle.ts
@@ -40,6 +40,8 @@ type StepBearingDetails = Extract<
   { steps: readonly unknown[] }
 >
 type FlowNodeStep = StepBearingDetails["steps"][number]
+type CardBearingStep = Extract<FlowNodeStep, { cards: readonly unknown[] }>
+type FlowCard = CardBearingStep["cards"][number]
 type PageButtonElement = Extract<
   PageElementSchema,
   { type: typeof pageElementTypes.enum.button }
@@ -78,6 +80,18 @@ const replaceFirst = <Item>(
 
   return null
 }
+
+/**
+ * A card's buttons as persisted, which older rows may not carry at all.
+ *
+ * `buttons` only became a required card field in #381; before that the schema
+ * was a union accepting a card that held just a subtitle or just an image. Those
+ * rows are still in the database and reach this module unparsed, so the declared
+ * type describes new writes rather than old reads. Every other collection here
+ * sits behind an `in` gate on the step; a card's buttons are one level below
+ * that gate and so need their own.
+ */
+const readCardButtons = (card: FlowCard) => card.buttons ?? []
 
 const createRouteFields = (route: FlowRoute) =>
   route
@@ -214,7 +228,7 @@ const cardButtonsAccessor: RoutableHandleAccessor = {
       }
 
       for (const card of step.cards) {
-        const button = card.buttons.find(
+        const button = readCardButtons(card).find(
           (candidate) => candidate.id === handleId,
         )
         if (button) {
@@ -236,7 +250,7 @@ const cardButtonsAccessor: RoutableHandleAccessor = {
       }
 
       const cards = replaceFirst(step.cards, (card) => {
-        const buttons = replaceFirst(card.buttons, (button) =>
+        const buttons = replaceFirst(readCardButtons(card), (button) =>
           button.id === handleId ? updateButtonRoute(button, route) : null,
         )
         return buttons ? { ...card, buttons: buttons.items } : null

--- a/packages/flow-config/src/routable-handle.ts
+++ b/packages/flow-config/src/routable-handle.ts
@@ -1,0 +1,402 @@
+import type { FlowNode } from "./nodes/index"
+import { type ButtonStepProps, buttonTypes } from "./steps/button"
+import { type PageElementSchema, pageElementTypes } from "./steps/email"
+import { startAnotherNodeStepDefaultFn } from "./steps/start-another-node"
+
+export const routableHandleKinds = {
+  stepButtons: "stepButtons",
+  cardButtons: "cardButtons",
+  listOptions: "listOptions",
+  pageElements: "pageElements",
+} as const
+
+export type RoutableHandleKind =
+  (typeof routableHandleKinds)[keyof typeof routableHandleKinds]
+
+export type FlowRoute = Readonly<{ targetNodeId: string }> | null
+
+export type FlowRouteUpdate = Readonly<{
+  sourceNodeId: string
+  handleId: string
+  route: FlowRoute
+}>
+
+export type FoundRoutableButton = {
+  button: ButtonStepProps
+  runtimeNodeId: string
+}
+
+type LocatedRoutableButton = FoundRoutableButton & {
+  stepIndex: number
+}
+
+type LocatedRouteUpdate = {
+  node: FlowNode
+  stepIndex: number
+}
+
+type StepBearingDetails = Extract<
+  FlowNode["data"]["details"],
+  { steps: readonly unknown[] }
+>
+type FlowNodeStep = StepBearingDetails["steps"][number]
+type PageButtonElement = Extract<
+  PageElementSchema,
+  { type: typeof pageElementTypes.enum.button }
+>
+
+type RoutableHandleAccessor = {
+  readonly kind: RoutableHandleKind
+  readonly findButton: (
+    node: FlowNode,
+    handleId: string,
+  ) => LocatedRoutableButton | null
+  readonly applyRoute: (
+    node: FlowNode,
+    handleId: string,
+    route: FlowRoute,
+  ) => LocatedRouteUpdate | null
+}
+
+const replaceFirst = <Item>(
+  items: readonly Item[],
+  replaceItem: (item: Item) => Item | null,
+): { items: Item[]; index: number } | null => {
+  for (let index = 0; index < items.length; index += 1) {
+    const replacement = replaceItem(items[index])
+    if (replacement) {
+      return {
+        items: [
+          ...items.slice(0, index),
+          replacement,
+          ...items.slice(index + 1),
+        ],
+        index,
+      }
+    }
+  }
+
+  return null
+}
+
+const createRouteFields = (route: FlowRoute) =>
+  route
+    ? {
+        buttonType: buttonTypes.enum.startAnotherNode,
+        beforeStep: startAnotherNodeStepDefaultFn({
+          nodeId: route.targetNodeId,
+          viewOnly: true,
+        }),
+      }
+    : {
+        buttonType: null,
+        beforeStep: null,
+      }
+
+const updateButtonRoute = (
+  button: ButtonStepProps,
+  route: FlowRoute,
+): ButtonStepProps => ({
+  ...button,
+  ...createRouteFields(route),
+})
+
+const updatePageButtonRoute = (
+  button: PageButtonElement,
+  route: FlowRoute,
+): PageButtonElement => ({
+  ...button,
+  ...createRouteFields(route),
+})
+
+/**
+ * Rewrites the first step that `updateStep` claims and rebuilds the node around
+ * it.
+ *
+ * The gate is the structural presence of `steps`, mirroring the lookup side, so
+ * that flow versions persisted before a details field existed still route. Node
+ * JSON reaches this module straight from the database — drafts are stored as
+ * `z.array(z.any())` and are never schema-parsed on load — so a node-type marker
+ * field is not a dependable discriminator. Each accessor narrows the step it
+ * owns instead.
+ */
+const updateNodeSteps = (
+  node: FlowNode,
+  updateStep: (step: FlowNodeStep) => FlowNodeStep | null,
+): LocatedRouteUpdate | null => {
+  const details = node.data.details
+  if (!("steps" in details)) {
+    return null
+  }
+
+  const replacement = replaceFirst<FlowNodeStep>(details.steps, updateStep)
+  if (!replacement) {
+    return null
+  }
+
+  return {
+    // `updateStep` only ever returns the same step with one collection swapped,
+    // so the node keeps its original shape at runtime. TypeScript cannot
+    // correlate the details variant with its step variant across the union,
+    // which is what this assertion stands in for.
+    node: {
+      ...node,
+      data: {
+        ...node.data,
+        details: {
+          ...details,
+          steps: replacement.items,
+        },
+      },
+    } as FlowNode,
+    stepIndex: replacement.index,
+  }
+}
+
+const stepButtonsAccessor: RoutableHandleAccessor = {
+  kind: routableHandleKinds.stepButtons,
+  findButton: (node, handleId) => {
+    if (!("steps" in node.data.details)) {
+      return null
+    }
+
+    for (
+      let stepIndex = 0;
+      stepIndex < node.data.details.steps.length;
+      stepIndex += 1
+    ) {
+      const step = node.data.details.steps[stepIndex]
+      if (!("buttons" in step)) {
+        continue
+      }
+
+      const button = step.buttons.find((candidate) => candidate.id === handleId)
+      if (button) {
+        return {
+          button,
+          runtimeNodeId: step.nodeId ?? node.id,
+          stepIndex,
+        }
+      }
+    }
+
+    return null
+  },
+  applyRoute: (node, handleId, route) =>
+    updateNodeSteps(node, (step) => {
+      if (!("buttons" in step)) {
+        return null
+      }
+
+      const buttons = replaceFirst(step.buttons, (button) =>
+        button.id === handleId ? updateButtonRoute(button, route) : null,
+      )
+
+      return buttons ? { ...step, buttons: buttons.items } : null
+    }),
+}
+
+const cardButtonsAccessor: RoutableHandleAccessor = {
+  kind: routableHandleKinds.cardButtons,
+  findButton: (node, handleId) => {
+    if (!("steps" in node.data.details)) {
+      return null
+    }
+
+    for (
+      let stepIndex = 0;
+      stepIndex < node.data.details.steps.length;
+      stepIndex += 1
+    ) {
+      const step = node.data.details.steps[stepIndex]
+      if (!("cards" in step)) {
+        continue
+      }
+
+      for (const card of step.cards) {
+        const button = card.buttons.find(
+          (candidate) => candidate.id === handleId,
+        )
+        if (button) {
+          return {
+            button,
+            runtimeNodeId: step.nodeId ?? node.id,
+            stepIndex,
+          }
+        }
+      }
+    }
+
+    return null
+  },
+  applyRoute: (node, handleId, route) =>
+    updateNodeSteps(node, (step) => {
+      if (!("cards" in step)) {
+        return null
+      }
+
+      const cards = replaceFirst(step.cards, (card) => {
+        const buttons = replaceFirst(card.buttons, (button) =>
+          button.id === handleId ? updateButtonRoute(button, route) : null,
+        )
+        return buttons ? { ...card, buttons: buttons.items } : null
+      })
+
+      return cards ? { ...step, cards: cards.items } : null
+    }),
+}
+
+const listOptionsAccessor: RoutableHandleAccessor = {
+  kind: routableHandleKinds.listOptions,
+  findButton: (node, handleId) => {
+    if (!("steps" in node.data.details)) {
+      return null
+    }
+
+    for (
+      let stepIndex = 0;
+      stepIndex < node.data.details.steps.length;
+      stepIndex += 1
+    ) {
+      const step = node.data.details.steps[stepIndex]
+      if (!("options" in step)) {
+        continue
+      }
+
+      const option = step.options.find((candidate) => candidate.id === handleId)
+      if (option) {
+        return {
+          button: {
+            id: option.id,
+            label: option.title,
+            buttonType: null,
+            beforeStep: null,
+            steps: [],
+          },
+          runtimeNodeId: step.nodeId ?? node.id,
+          stepIndex,
+        }
+      }
+    }
+
+    return null
+  },
+  applyRoute: () => null,
+}
+
+const pageElementsAccessor: RoutableHandleAccessor = {
+  kind: routableHandleKinds.pageElements,
+  findButton: () => null,
+  applyRoute: (node, handleId, route) =>
+    updateNodeSteps(node, (step) => {
+      if (!("elements" in step)) {
+        return null
+      }
+
+      const elements = replaceFirst(step.elements, (element) => {
+        if (
+          element.type !== pageElementTypes.enum.button ||
+          element.id !== handleId
+        ) {
+          return null
+        }
+
+        return updatePageButtonRoute(element, route)
+      })
+
+      return elements ? { ...step, elements: elements.items } : null
+    }),
+}
+
+const routableHandleAccessors: readonly RoutableHandleAccessor[] = [
+  stepButtonsAccessor,
+  cardButtonsAccessor,
+  listOptionsAccessor,
+  pageElementsAccessor,
+]
+
+export const findButtonInNodes = (
+  nodes: readonly FlowNode[],
+  handleId: string,
+): FoundRoutableButton | null => {
+  for (const node of nodes) {
+    let firstMatch: LocatedRoutableButton | null = null
+
+    for (const accessor of routableHandleAccessors) {
+      const found = accessor.findButton(node, handleId)
+      if (found && (!firstMatch || found.stepIndex < firstMatch.stepIndex)) {
+        firstMatch = found
+      }
+    }
+
+    if (firstMatch) {
+      const { button, runtimeNodeId } = firstMatch
+      return { button, runtimeNodeId }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Every accessor runs even after one matches: a duplicated handle id must
+ * resolve to the earliest step so writes land where {@link findButtonInNodes}
+ * reads. The discarded copies are bounded by the accessor count and this runs
+ * once per builder interaction, never on a message-handling path.
+ */
+export const applyRouteInNode = (
+  sourceNode: FlowNode,
+  handleId: string,
+  route: FlowRoute,
+): FlowNode | null => {
+  let firstUpdate: LocatedRouteUpdate | null = null
+
+  for (const accessor of routableHandleAccessors) {
+    const update = accessor.applyRoute(sourceNode, handleId, route)
+    if (update && (!firstUpdate || update.stepIndex < firstUpdate.stepIndex)) {
+      firstUpdate = update
+    }
+  }
+
+  return firstUpdate?.node ?? null
+}
+
+export const applyRouteUpdatesInNodes = (
+  nodes: FlowNode[],
+  updates: readonly FlowRouteUpdate[],
+): FlowNode[] => {
+  const updatesBySourceNode = new Map<string, FlowRouteUpdate[]>()
+  for (const update of updates) {
+    const sourceUpdates = updatesBySourceNode.get(update.sourceNodeId)
+    if (sourceUpdates) {
+      sourceUpdates.push(update)
+    } else {
+      updatesBySourceNode.set(update.sourceNodeId, [update])
+    }
+  }
+
+  let hasChanges = false
+  const updatedNodes = nodes.map((node) => {
+    const sourceUpdates = updatesBySourceNode.get(node.id)
+    if (!sourceUpdates) {
+      return node
+    }
+
+    let updatedNode = node
+    for (const update of sourceUpdates) {
+      const nextNode = applyRouteInNode(
+        updatedNode,
+        update.handleId,
+        update.route,
+      )
+      if (nextNode) {
+        updatedNode = nextNode
+        hasChanges = true
+      }
+    }
+
+    return updatedNode
+  })
+
+  return hasChanges ? updatedNodes : nodes
+}

--- a/packages/flow-config/src/util.ts
+++ b/packages/flow-config/src/util.ts
@@ -1,10 +1,8 @@
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { z } from "zod"
 import type { FlowNode } from "./nodes"
-import type { BaseStepSchema } from "./steps/base"
+import { findButtonInNodes } from "./routable-handle"
 import type { ButtonStepProps } from "./steps/button"
-import type { SendCardStepSchema } from "./steps/send-card"
-import type { WhatsappOptionListItem } from "./steps/whatsapp-option-list"
 
 export const extractMetadata = (
   key: string,
@@ -112,59 +110,11 @@ export const appendCodeToMagicLink = (url: string, code: string): string => {
 }
 
 export function getNodeFromButton(nodes: FlowNode[], buttonId: string) {
-  let foundedButton: ButtonStepProps | null = null
-  let foundedNodeId: string | null = null
-
-  for (const node of nodes) {
-    if (!("steps" in node.data.details && node.data.details.steps)) {
-      continue
-    }
-    for (const step of node.data.details.steps as BaseStepSchema[]) {
-      if (!("buttons" in step || "cards" in step || "options" in step)) {
-        continue
-      }
-
-      let buttons: ButtonStepProps[] = []
-      if ("buttons" in step) {
-        buttons = step.buttons as ButtonStepProps[]
-      } else if ("cards" in step) {
-        const cards = step.cards as SendCardStepSchema[]
-        buttons = cards.flatMap(
-          (card) => (card.buttons ?? []) as ButtonStepProps[],
-        )
-      }
-
-      const button = buttons.find((b) => b.id === buttonId)
-      if (button) {
-        foundedButton = button
-        foundedNodeId = step.nodeId ?? node.id
-        break
-      }
-
-      if ("options" in step) {
-        const options = (step.options ?? []) as WhatsappOptionListItem[]
-        const option = options.find((o) => o.id === buttonId)
-        if (option) {
-          foundedButton = {
-            id: option.id,
-            label: option.title,
-            buttonType: null,
-            beforeStep: null,
-            steps: [],
-          }
-          foundedNodeId = step.nodeId ?? node.id
-          break
-        }
-      }
-    }
-    if (foundedButton) {
-      break
-    }
-  }
+  const found = findButtonInNodes(nodes, buttonId)
 
   return {
-    button: foundedButton,
-    nodeId: foundedNodeId,
+    button: found?.button ?? null,
+    nodeId: found?.runtimeNodeId ?? null,
   }
 }
 


### PR DESCRIPTION
## What changed

Carousel steps in the flow builder now show every card side by side, so all cards and all of their buttons stay visible at a glance instead of only the first one.

Buttons that live inside a carousel card can now be linked to another step by dragging a connection, and removing that connection clears the link again — the same behaviour buttons outside a carousel already had.

## Why

Previously only one card was visible at a time and the buttons inside a card could not be wired to a next step, so carousels could not be used to branch a conversation.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm --filter builder check-types` and `pnpm --filter @chatbotx.io/flow-config check-types` — clean
- [x] Full monorepo typecheck via pre-commit hook — 51/51 tasks passing
- [x] `pnpm --filter @chatbotx.io/flow-config test` — 155 passing
- [x] Builder flow-builder tests — 97 passing
- [ ] Manual: open a flow with a carousel, confirm every card renders and scrolls horizontally
- [ ] Manual: drag a connection from a card button to another step, reload, confirm it persists
- [ ] Manual: delete that connection and confirm the link is cleared
- [ ] Manual: confirm buttons outside a carousel still connect and disconnect as before
- [ ] Manual: open an older flow saved before this change and confirm it still works