### PR TITLE
fix(messenger): apply the carousel layout choice when sending cards

### DIFF
--- a/apps/builder/src/app/api/[[...rest]]/route.ts
+++ b/apps/builder/src/app/api/[[...rest]]/route.ts
@@ -71,7 +71,7 @@ const openAPIHandler = new OpenAPIHandler(router, {
   ],
 })
 
-export async function handleRequest(request: Request) {
+async function handleRequest(request: Request) {
   const { response } = await openAPIHandler.handle(request, {
     prefix: "/api",
     context: { headers: request.headers, url: request.url },

--- a/integrations/messenger/__tests__/send-carousel-layout.test.ts
+++ b/integrations/messenger/__tests__/send-carousel-layout.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "vitest"
+import { convertFlowStepCarousel } from "../src/handlers/message/outgoing-message/send-carousel"
+
+const createCard = (index: number) => ({
+  id: `card-${index}`,
+  stepType: "sendCard",
+  title: `Card ${index}`,
+  subtitle: `Subtitle ${index}`,
+  image: { url: `https://example.com/${index}.png` },
+  buttons: [
+    {
+      id: `btn-${index}`,
+      label: `Button ${index}`,
+      buttonType: null,
+      beforeStep: null,
+      steps: [],
+    },
+  ],
+})
+
+const createCards = (count: number) =>
+  Array.from({ length: count }, (_, index) => createCard(index + 1))
+
+const convert = (step: Record<string, unknown>) =>
+  Array.from(
+    convertFlowStepCarousel({
+      data: {
+        contact: { id: "ci-1" },
+        flowId: "flow-1",
+        flowVersionId: "fv-1",
+        step,
+      },
+    } as never),
+  )
+
+type CarouselMessage = ReturnType<typeof convert>[number]
+
+const payloadOf = (message: CarouselMessage) => message.attachment.payload
+
+describe("messenger carousel layout", () => {
+  test("renders a horizontal carousel at Meta's 1.91:1 aspect ratio", () => {
+    const [message, ...rest] = convert({
+      id: "step-1",
+      stepType: "sendCarousel",
+      layout: "horizontal",
+      cards: createCards(3),
+    })
+
+    expect(rest).toHaveLength(0)
+    expect(payloadOf(message)).toEqual(
+      expect.objectContaining({
+        template_type: "generic",
+        image_aspect_ratio: "horizontal",
+      }),
+    )
+  })
+
+  test("renders a vertical carousel at Meta's square aspect ratio", () => {
+    const [message] = convert({
+      id: "step-1",
+      stepType: "sendCarousel",
+      layout: "vertical",
+      cards: createCards(3),
+    })
+
+    expect(payloadOf(message)).toEqual(
+      expect.objectContaining({ image_aspect_ratio: "square" }),
+    )
+  })
+
+  test("keeps a vertical carousel in one scrollable strip rather than splitting it", () => {
+    const messages = convert({
+      id: "step-1",
+      stepType: "sendCarousel",
+      layout: "vertical",
+      cards: createCards(3),
+    })
+
+    expect(
+      messages.map((message) =>
+        payloadOf(message).elements.map((element) => element.title),
+      ),
+    ).toEqual([["Card 1", "Card 2", "Card 3"]])
+  })
+
+  test("keeps each card's subtitle, image and buttons", () => {
+    const [message] = convert({
+      id: "step-1",
+      stepType: "sendCarousel",
+      layout: "vertical",
+      cards: [createCard(1)],
+    })
+
+    expect(payloadOf(message).elements).toEqual([
+      expect.objectContaining({
+        title: "Card 1",
+        subtitle: "Subtitle 1",
+        image_url: "https://example.com/1.png",
+        buttons: [expect.objectContaining({ title: "Button 1" })],
+      }),
+    ])
+  })
+
+  test("repeats the aspect ratio on every chunk past the ten element limit", () => {
+    const messages = convert({
+      id: "step-1",
+      stepType: "sendCarousel",
+      layout: "vertical",
+      cards: createCards(12),
+    })
+
+    expect(
+      messages.map((message) => [
+        payloadOf(message).elements.length,
+        payloadOf(message).image_aspect_ratio,
+      ]),
+    ).toEqual([
+      [10, "square"],
+      [2, "square"],
+    ])
+  })
+
+  test("falls back to horizontal for rows persisted before the layout field existed", () => {
+    const [message] = convert({
+      id: "step-1",
+      stepType: "sendCarousel",
+      cards: createCards(3),
+    })
+
+    expect(payloadOf(message)).toEqual(
+      expect.objectContaining({ image_aspect_ratio: "horizontal" }),
+    )
+  })
+})

--- a/integrations/messenger/src/handlers/message/outgoing-message/send-carousel.ts
+++ b/integrations/messenger/src/handlers/message/outgoing-message/send-carousel.ts
@@ -1,13 +1,31 @@
-import type {
-  SendCardStepSchema,
-  SendCarouselStepSchema,
+import {
+  cardLayouts,
+  type SendCardStepSchema,
+  type SendCarouselStepSchema,
 } from "@chatbotx.io/flow-config"
 import type { SendFlowStepProps } from "@chatbotx.io/sdk"
 import { chunk } from "remeda"
-import type { MessengerAuthValue } from "../../../schema"
+import type {
+  FacebookImageAspectRatio,
+  MessengerAuthValue,
+} from "../../../schema"
 import { getButtonTemplate } from "./send-button"
 
 const MAX_CAROUSEL_ELEMENTS = 10
+
+/**
+ * The builder's orientation toggle sets how tall Messenger draws each card, not
+ * how the cards are stacked — a generic template always scrolls horizontally.
+ * Meta expresses that as a payload-level aspect ratio and accepts only
+ * `horizontal` (1.91:1) or `square` (1:1), so the upright card is `square`.
+ *
+ * `layout` postdates the step, so carousels persisted before the field existed
+ * keep the wide image they were authored with.
+ */
+const getImageAspectRatio = (
+  layout: SendCarouselStepSchema["layout"],
+): FacebookImageAspectRatio =>
+  layout === cardLayouts.enum.vertical ? "square" : "horizontal"
 
 export function* convertFlowStepCarousel(
   props: SendFlowStepProps<MessengerAuthValue, SendCarouselStepSchema>,
@@ -23,6 +41,7 @@ export function* convertFlowStepCarousel(
         type: "template",
         payload: {
           template_type: "generic",
+          image_aspect_ratio: getImageAspectRatio(step.layout),
           elements: chunk.map((card: SendCardStepSchema) => ({
             title: card.title,
             subtitle: "subtitle" in card ? card.subtitle : undefined,

--- a/integrations/messenger/src/schema.ts
+++ b/integrations/messenger/src/schema.ts
@@ -294,9 +294,20 @@ export const facebookElementSchema = z.object({
 })
 export type FacebookElement = z.infer<typeof facebookElementSchema>
 
+/**
+ * How Messenger sizes the images of a generic template's elements: `horizontal`
+ * is 1.91:1, `square` is 1:1. Meta accepts no other value and defaults to
+ * `horizontal` when the field is absent.
+ */
+export const facebookImageAspectRatioSchema = z.enum(["horizontal", "square"])
+export type FacebookImageAspectRatio = z.infer<
+  typeof facebookImageAspectRatioSchema
+>
+
 export const facebookMessageAttachmentPayloadSchema = z.object({
   url: z.url().optional(),
   is_reusable: z.boolean().optional(),
+  image_aspect_ratio: facebookImageAspectRatioSchema.optional(),
   template_type: z
     .enum([
       "generic",


### PR DESCRIPTION
## What

The flow builder lets you pick how a carousel looks — **horizontal** or **vertical**. The choice was saved with the flow but never sent to Messenger, so every carousel arrived with wide images no matter what was picked.

Carousels now go out the way they were set up in the editor.

Carousels created before this option existed keep the wide look they already had, so nothing changes for them.

## Also in this branch

One extra commit removes an unused export from the API route file. Next.js only allows a route file to export its request methods, and the extra one made the type check fail on machines that had already built the app. No change to how the app behaves.

## Test plan

- [x] New tests cover both layouts, long carousels, and older carousels saved without the option
- [x] Messenger tests pass (27 files, 187 tests)
- [x] Type check and lint pass
- [ ] Build a flow with a horizontal carousel, send it on Messenger, confirm wide images
- [ ] Switch the same carousel to vertical, republish, confirm the cards are taller
- [ ] Open a carousel made before this change and confirm it still sends as before

## Notes

Instagram uses the same card format and still ignores the option. Left alone for now — sending it there needs to be confirmed against Instagram's API first.