### PR TITLE
fix(products): show meta catalog sync errors

### DIFF
--- a/apps/worker/__tests__/meta-catalog-import.test.ts
+++ b/apps/worker/__tests__/meta-catalog-import.test.ts
@@ -1,3 +1,4 @@
+import { MetaCatalogException } from "@chatbotx.io/integration-meta-catalog"
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
@@ -15,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   runProgress: vi.fn(),
   runComplete: vi.fn(),
   runFail: vi.fn(),
+  loggerError: vi.fn(),
 }))
 
 vi.mock("@chatbotx.io/business", () => ({
@@ -49,16 +51,23 @@ vi.mock("@chatbotx.io/business", () => ({
   },
 }))
 
-vi.mock("@chatbotx.io/integration-meta-catalog", () => ({
-  MAX_META_CATALOG_PRODUCT_PAGES: 2,
-  getCatalogProductsPage: (...args: unknown[]) => mocks.getPage(...args),
-  toImportedMetaProduct: (...args: unknown[]) => mocks.mapProduct(...args),
-  isInvalidMetaTokenError: (...args: unknown[]) =>
-    mocks.isInvalidToken(...args),
-}))
+vi.mock("@chatbotx.io/integration-meta-catalog", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@chatbotx.io/integration-meta-catalog")
+    >()
+  return {
+    ...actual,
+    MAX_META_CATALOG_PRODUCT_PAGES: 2,
+    getCatalogProductsPage: (...args: unknown[]) => mocks.getPage(...args),
+    toImportedMetaProduct: (...args: unknown[]) => mocks.mapProduct(...args),
+    isInvalidMetaTokenError: (...args: unknown[]) =>
+      mocks.isInvalidToken(...args),
+  }
+})
 
 vi.mock("../src/lib/logger", () => ({
-  logger: { error: vi.fn(), warn: vi.fn() },
+  logger: { error: mocks.loggerError, warn: vi.fn() },
 }))
 
 const { importMetaCatalogProducts } = await import(
@@ -156,6 +165,39 @@ describe("Meta Catalog product import worker", () => {
     expect(mocks.markInvalid).toHaveBeenCalledWith("workspace-1")
     // Passed as the thrown value, not a flattened message — the service owns
     // the extraction so a channel error's user-facing detail is not lost here.
+    expect(mocks.failImport).toHaveBeenCalledWith("connection-1", error)
+  })
+
+  test("logs safe Graph diagnostics with the failing import phase", async () => {
+    const error = new MetaCatalogException(
+      "Unsupported get request for catalog",
+      400,
+      100,
+    )
+    mocks.getPage.mockRejectedValue(error)
+
+    await importMetaCatalogProducts({
+      workspaceId: "workspace-1",
+      integrationMetaCatalogId: "connection-1",
+    })
+
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: expect.objectContaining({
+          message: "Unsupported get request for catalog (code 100)",
+          name: "MetaCatalogException",
+        }),
+        error: "Unsupported get request for catalog (code 100)",
+        graphCode: 100,
+        statusCode: 400,
+        connectionId: "connection-1",
+        workspaceId: "workspace-1",
+        catalogId: "catalog-1",
+        pageIndex: 0,
+        phase: "fetch-products",
+      }),
+      "Unsupported get request for catalog (code 100)",
+    )
     expect(mocks.failImport).toHaveBeenCalledWith("connection-1", error)
   })
 

--- a/apps/worker/src/default/handlers/meta-catalog/__tests__/safe-error-log.test.ts
+++ b/apps/worker/src/default/handlers/meta-catalog/__tests__/safe-error-log.test.ts
@@ -5,22 +5,38 @@ import { safeMetaCatalogErrorLog } from "../safe-error-log"
 describe("safeMetaCatalogErrorLog", () => {
   test("redacts upstream credentials while retaining non-secret Graph metadata", () => {
     const error = new MetaCatalogException(
-      'Rejected {"access_token":"SECRET"} client_secret=OTHER authorization: Basic dXNlcjpwYXNz',
+      'Rejected {"access_token":"SECRET"}\nclient_secret=OTHER authorization: Basic dXNlcjpwYXNz',
       401,
       190,
+      {
+        graphSubcode: 463,
+        fbTraceId: "trace-1",
+      },
     )
 
-    expect(safeMetaCatalogErrorLog(error, "Meta request failed")).toEqual({
+    const safeLog = safeMetaCatalogErrorLog(error, "Meta request failed")
+
+    expect(safeLog).toEqual({
       details: {
+        err: expect.objectContaining({
+          message:
+            'Rejected {"access_token":"[REDACTED]"} client_secret=[REDACTED] Authorization: [REDACTED] (code 190)',
+          name: "MetaCatalogException",
+        }),
         error:
           'Rejected {"access_token":"[REDACTED]"} client_secret=[REDACTED] Authorization: [REDACTED] (code 190)',
         errorType: "MetaCatalogException",
+        fbTraceId: "trace-1",
         graphCode: 190,
+        graphSubcode: 463,
         statusCode: 401,
       },
       message:
         'Rejected {"access_token":"[REDACTED]"} client_secret=[REDACTED] Authorization: [REDACTED] (code 190)',
     })
+    expect(safeLog.details.err?.stack).not.toContain("SECRET")
+    expect(safeLog.details.err?.stack).not.toContain("OTHER")
+    expect(safeLog.details.err?.stack).not.toContain("dXNlcjpwYXNz")
   })
 
   test("does not log an untrusted error message or stack", () => {

--- a/apps/worker/src/default/handlers/meta-catalog/import-products.ts
+++ b/apps/worker/src/default/handlers/meta-catalog/import-products.ts
@@ -215,29 +215,35 @@ export async function importMetaCatalogProducts(
   }
   const tally = createImportTally()
   const { counters } = tally
+  let catalogId: string | undefined
+  let pageIndex = 0
+  let phase = "validate-import"
   try {
     if (run && run.integrationMetaCatalogId !== connection.id) {
       throw new Error("Meta Catalog import run does not match its connection")
     }
     // New history rows snapshot the source catalog. Keep the connection
     // fallback solely for legacy jobs that predate run catalog snapshots.
-    const catalogId = run?.catalogId ?? connection.catalogId
+    catalogId = run?.catalogId ?? connection.catalogId ?? undefined
     if (!catalogId) {
       throw new Error("Meta Catalog is not selected")
     }
+    phase = "resolve-auth"
     const auth = await integrationMetaCatalogService.resolveAuth(connection.id)
     let after: string | undefined
     for (
-      let pageIndex = 0;
+      pageIndex = 0;
       pageIndex < MAX_META_CATALOG_PRODUCT_PAGES;
       pageIndex++
     ) {
+      phase = "fetch-products"
       const page = await getCatalogProductsPage({
         accessToken: auth.accessToken,
         catalogId,
         version: auth.version,
         after,
       })
+      phase = "import-products"
       const result = await metaCatalogImportService.importPage({
         workspaceId: data.workspaceId,
         integrationMetaCatalogId: connection.id,
@@ -245,10 +251,12 @@ export async function importMetaCatalogProducts(
         products: tally.readPage(page),
       })
       tally.addImported(result.imported + result.existing)
+      phase = "report-progress"
       await reportProgress({ connectionId: connection.id, runId, counters })
 
       after = page.nextCursor
       if (!after) {
+        phase = "finish-import"
         await finishAfterLastPage({ connectionId: connection.id, runId, tally })
         return
       }
@@ -264,7 +272,15 @@ export async function importMetaCatalogProducts(
   } catch (error) {
     const safeLog = safeMetaCatalogErrorLog(error, "Meta Catalog import failed")
     logger.error(
-      { ...safeLog.details, connectionId: connection.id },
+      {
+        ...safeLog.details,
+        connectionId: connection.id,
+        workspaceId: data.workspaceId,
+        runId,
+        catalogId,
+        pageIndex,
+        phase,
+      },
       safeLog.message,
     )
     if (isInvalidMetaTokenError(error)) {

--- a/apps/worker/src/default/handlers/meta-catalog/safe-error-log.ts
+++ b/apps/worker/src/default/handlers/meta-catalog/safe-error-log.ts
@@ -1,8 +1,10 @@
 import { toPublicErrorMessage } from "@chatbotx.io/business/errors"
 
+const SAFE_FB_TRACE_ID_REGEX = /^[A-Za-z0-9_-]{1,128}$/
+
 const numericProperty = (
   value: unknown,
-  property: "graphCode" | "statusCode",
+  property: "graphCode" | "graphSubcode" | "statusCode",
 ): number | undefined => {
   if (typeof value !== "object" || value === null) {
     return
@@ -11,31 +13,73 @@ const numericProperty = (
   return typeof candidate === "number" ? candidate : undefined
 }
 
+const stringProperty = (
+  value: unknown,
+  property: "fbTraceId",
+): string | undefined => {
+  if (typeof value !== "object" || value === null) {
+    return
+  }
+  const candidate = Reflect.get(value, property)
+  return typeof candidate === "string" && SAFE_FB_TRACE_ID_REGEX.test(candidate)
+    ? candidate
+    : undefined
+}
+
+const isMappedMetaCatalogError = (error: unknown): error is Error =>
+  error instanceof Error &&
+  error.name === "MetaCatalogException" &&
+  numericProperty(error, "statusCode") !== undefined
+
+const toSafeLogError = (
+  error: unknown,
+  sanitizedMessage: string,
+): Error | undefined => {
+  if (!isMappedMetaCatalogError(error)) {
+    return
+  }
+  const safeError = new Error(sanitizedMessage)
+  safeError.name = error.name
+  return safeError
+}
+
 /**
- * Meta can return developer-authored text, so never attach the original error
- * object to a log entry: Pino would serialize its message and stack verbatim.
- * Keep only redacted text plus non-secret classification fields.
+ * Meta can return developer-authored text, and an upstream HTTPError may carry
+ * request headers. Only a sanitized clone of the integration's mapped
+ * exception is attached to `err`. Its stack is freshly created here because a
+ * multiline upstream message can occupy apparent "stack" lines and restore
+ * credentials removed from the public message. Unknown errors remain reduced
+ * to safe classification fields.
  */
 export const safeMetaCatalogErrorLog = (
   error: unknown,
   fallback: string,
 ): {
   details: {
+    err?: Error
     error: string
     errorType: string
     graphCode?: number
+    graphSubcode?: number
+    fbTraceId?: string
     statusCode?: number
   }
   message: string
 } => {
   const message = toPublicErrorMessage(error, fallback)
   const graphCode = numericProperty(error, "graphCode")
+  const graphSubcode = numericProperty(error, "graphSubcode")
+  const fbTraceId = stringProperty(error, "fbTraceId")
   const statusCode = numericProperty(error, "statusCode")
+  const safeError = toSafeLogError(error, message)
   return {
     details: {
+      ...(safeError ? { err: safeError } : {}),
       error: message,
       errorType: error instanceof Error ? error.name : typeof error,
       ...(graphCode === undefined ? {} : { graphCode }),
+      ...(graphSubcode === undefined ? {} : { graphSubcode }),
+      ...(fbTraceId === undefined ? {} : { fbTraceId }),
       ...(statusCode === undefined ? {} : { statusCode }),
     },
     message,

--- a/integrations/meta-catalog/__tests__/http-client.test.ts
+++ b/integrations/meta-catalog/__tests__/http-client.test.ts
@@ -37,6 +37,8 @@ describe("metaCatalogGraphClient error mapping", () => {
         error_user_msg:
           "This catalog is not connected to a commerce account yet.",
         code: 100,
+        error_subcode: 33,
+        fbtrace_id: "trace-1",
       }),
     )
 
@@ -45,7 +47,9 @@ describe("metaCatalogGraphClient error mapping", () => {
     ).rejects.toMatchObject({
       message:
         "Invalid parameter — This catalog is not connected to a commerce account yet.",
+      fbTraceId: "trace-1",
       graphCode: 100,
+      graphSubcode: 33,
       statusCode: 400,
     })
   })

--- a/integrations/meta-catalog/src/exception.ts
+++ b/integrations/meta-catalog/src/exception.ts
@@ -3,11 +3,23 @@ import { SdkException } from "@chatbotx.io/sdk"
 export class MetaCatalogException extends SdkException {
   readonly statusCode: number
   readonly graphCode?: number
+  readonly graphSubcode?: number
+  readonly fbTraceId?: string
 
-  constructor(message: string, statusCode: number, graphCode?: number) {
+  constructor(
+    message: string,
+    statusCode: number,
+    graphCode?: number,
+    details?: {
+      graphSubcode?: number
+      fbTraceId?: string
+    },
+  ) {
     super(message, graphCode ?? "metaCatalogError", statusCode)
     this.statusCode = statusCode
     this.graphCode = graphCode
+    this.graphSubcode = details?.graphSubcode
+    this.fbTraceId = details?.fbTraceId
   }
 }
 

--- a/integrations/meta-catalog/src/lib/http-client.ts
+++ b/integrations/meta-catalog/src/lib/http-client.ts
@@ -33,6 +33,8 @@ type GraphErrorBody = {
     /** Graph's own end-user-facing wording, when it has one. */
     error_user_title?: string
     error_user_msg?: string
+    error_subcode?: number
+    fbtrace_id?: string
   }
 }
 
@@ -102,6 +104,10 @@ class MetaCatalogHttpClient {
           graphErrorMessage(body.error) ?? `Meta Graph request failed: ${url}`,
           error.response.status,
           body.error?.code,
+          {
+            graphSubcode: body.error?.error_subcode,
+            fbTraceId: body.error?.fbtrace_id,
+          },
         )
       }
       throw error


### PR DESCRIPTION
## Summary
- Show clearer Meta Catalog sync errors
- Keep sensitive values out of logs
- Save sync failures for users to review

## Testing
- Lint passed
- Type checks passed
- Worker tests passed
- Meta Catalog tests passed