### PR TITLE
feat: add product url field and fix meta catalog follow-up bugs

### DIFF
--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -4061,7 +4061,8 @@
       "category": "Category",
       "vendor": "Vendor",
       "inventoryQuantity": "Inventory quantity",
-      "imageUrl": "Image URL"
+      "imageUrl": "Image URL",
+      "productUrl": "Product URL"
     },
     "template": {
       "sheetName": "Products",
@@ -4074,6 +4075,7 @@
       "vendor": "Vendor",
       "inventoryQuantity": "Inventory quantity",
       "imageUrl": "Image URL",
+      "productUrl": "Product URL",
       "exampleOne": {
         "name": "Classic T-shirt",
         "description": "Soft cotton T-shirt",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -4086,7 +4086,8 @@
       "category": "Danh mục",
       "vendor": "Thương hiệu",
       "inventoryQuantity": "Số lượng",
-      "imageUrl": "Hình ảnh"
+      "imageUrl": "Hình ảnh",
+      "productUrl": "URL sản phẩm"
     },
     "template": {
       "sheetName": "Sản phẩm",
@@ -4099,6 +4100,7 @@
       "vendor": "Thương hiệu",
       "inventoryQuantity": "Số lượng",
       "imageUrl": "Hình ảnh",
+      "productUrl": "URL sản phẩm",
       "exampleOne": {
         "name": "Áo thun cổ điển",
         "description": "Áo thun cotton mềm mại",

--- a/apps/builder/src/app/api/imports/products/template/route.ts
+++ b/apps/builder/src/app/api/imports/products/template/route.ts
@@ -21,6 +21,7 @@ export async function GET() {
     vendor: t("vendor"),
     inventoryQuantity: t("inventoryQuantity"),
     imageUrl: t("imageUrl"),
+    productUrl: t("productUrl"),
   }
   const template = await createProductImportTemplate({
     sheetName: t("sheetName"),
@@ -36,6 +37,7 @@ export async function GET() {
         vendor: t("exampleOne.vendor"),
         inventoryQuantity: 25,
         imageUrl: "https://example.com/product-one.jpg",
+        productUrl: "https://example.com/products/product-one",
       },
       {
         name: t("exampleTwo.name"),
@@ -47,6 +49,7 @@ export async function GET() {
         vendor: t("exampleTwo.vendor"),
         inventoryQuantity: 50,
         imageUrl: "https://example.com/product-two.jpg",
+        productUrl: "https://example.com/products/product-two",
       },
     ],
   })

--- a/apps/worker/__tests__/product-import-extractor.test.ts
+++ b/apps/worker/__tests__/product-import-extractor.test.ts
@@ -7,6 +7,7 @@ const columnMap = {
   discount: "Discount",
   inventoryQuantity: "Quantity",
   imageUrl: "Image",
+  productUrl: "Product URL",
 }
 
 describe("product import row extraction", () => {
@@ -19,6 +20,7 @@ describe("product import row extraction", () => {
           Discount: 10,
           Quantity: "5",
           Image: "https://example.com/product.jpg",
+          "Product URL": "https://example.com/products/product",
         },
         columnMap,
         2,
@@ -32,6 +34,7 @@ describe("product import row extraction", () => {
         discount: 10,
         inventoryQuantity: 5,
         imageUrl: "https://example.com/product.jpg",
+        productUrl: "https://example.com/products/product",
       },
     })
   })
@@ -44,6 +47,11 @@ describe("product import row extraction", () => {
     [{ Name: "P", Quantity: 1.5 }, "non-negative integer"],
     [{ Name: "P", Image: "ftp://example.com/a.jpg" }, "HTTP or HTTPS"],
     [{ Name: "P", Image: "not-a-url" }, "Image URL is invalid"],
+    [
+      { Name: "P", "Product URL": "ftp://example.com/product" },
+      "Product URL must use HTTP or HTTPS",
+    ],
+    [{ Name: "P", "Product URL": "not-a-url" }, "Product URL is invalid"],
   ])("returns a row-level error without throwing", (row, expected) => {
     const result = extractProductDraft(row, columnMap, 3)
     expect(result).toEqual({

--- a/apps/worker/__tests__/product-import-handler.test.ts
+++ b/apps/worker/__tests__/product-import-handler.test.ts
@@ -29,6 +29,7 @@ const productRow = {
   sourceRow: 2,
   name: "Product",
   categoryName: "Shoes",
+  productUrl: "https://example.com/products/product",
 }
 
 beforeEach(() => {
@@ -66,6 +67,7 @@ describe("productsImportHandler", () => {
         expect.objectContaining({
           name: "Product",
           categoryId: "category-1",
+          productUrl: "https://example.com/products/product",
         }),
       ],
     })

--- a/apps/worker/src/default/handlers/imports/handler/products/extractor.ts
+++ b/apps/worker/src/default/handlers/imports/handler/products/extractor.ts
@@ -12,6 +12,7 @@ export type ProductImportDraft = {
   vendor?: string
   inventoryQuantity?: number
   imageUrl?: string
+  productUrl?: string
 }
 
 export type ProductDraftResult =
@@ -39,7 +40,10 @@ const parseOptionalNumber = (
     : { error: `${fieldLabel} must be a number` }
 }
 
-const parseImageUrl = (value: unknown): { value?: string; error?: string } => {
+const parseOptionalHttpUrl = (
+  value: unknown,
+  fieldLabel: string,
+): { value?: string; error?: string } => {
   const text = cleanText(
     typeof value === "number" ? String(value) : value,
     2048,
@@ -51,9 +55,9 @@ const parseImageUrl = (value: unknown): { value?: string; error?: string } => {
     const url = new URL(text)
     return ["http:", "https:"].includes(url.protocol)
       ? { value: url.toString() }
-      : { error: "Image URL must use HTTP or HTTPS" }
+      : { error: `${fieldLabel} must use HTTP or HTTPS` }
   } catch {
-    return { error: "Image URL is invalid" }
+    return { error: `${fieldLabel} is invalid` }
   }
 }
 
@@ -76,12 +80,20 @@ export const extractProductDraft = (
     read(row, columnMap.inventoryQuantity),
     "Inventory quantity",
   )
-  const imageUrl = parseImageUrl(read(row, columnMap.imageUrl))
+  const imageUrl = parseOptionalHttpUrl(
+    read(row, columnMap.imageUrl),
+    "Image URL",
+  )
+  const productUrl = parseOptionalHttpUrl(
+    read(row, columnMap.productUrl),
+    "Product URL",
+  )
   const validationError = [
     price.error,
     discount.error,
     inventoryQuantity.error,
     imageUrl.error,
+    productUrl.error,
   ].find(Boolean)
   if (validationError) {
     return { ok: false, error: validationError }
@@ -115,6 +127,7 @@ export const extractProductDraft = (
       vendor: cleanText(read(row, columnMap.vendor), 255),
       inventoryQuantity: inventoryQuantity.value,
       imageUrl: imageUrl.value,
+      productUrl: productUrl.value,
     },
   }
 }

--- a/apps/worker/src/default/handlers/imports/handler/products/handler.ts
+++ b/apps/worker/src/default/handlers/imports/handler/products/handler.ts
@@ -91,6 +91,7 @@ const processProductBatch = async (
         vendor: row.vendor,
         inventoryQuantity: row.inventoryQuantity,
         images: row.imageUrl ? [{ url: row.imageUrl, type: "link" }] : [],
+        productUrl: row.productUrl,
       })),
     })
     return {

--- a/apps/worker/src/default/handlers/meta-catalog/submit.ts
+++ b/apps/worker/src/default/handlers/meta-catalog/submit.ts
@@ -176,6 +176,9 @@ export async function submitMetaCatalogSync(
         totalCount,
         handles,
         skippedItems: skipped,
+        // Confirmed failures only — `pendingItems` are batches not yet
+        // submitted, not failures, so they must stay out of failedCount.
+        failedCount: itemErrors.length,
         itemErrors: [...itemErrors, ...pendingItems],
       })
       if (!saved) {

--- a/packages/business/__tests__/meta-catalog-sync-run-service.test.ts
+++ b/packages/business/__tests__/meta-catalog-sync-run-service.test.ts
@@ -129,6 +129,7 @@ describe("metaCatalogSyncRunService error persistence", () => {
         totalCount: 1,
         handles: [],
         skippedItems: [],
+        failedCount: 1,
         itemErrors: [
           {
             retailerId: "retailer-1",
@@ -149,6 +150,27 @@ describe("metaCatalogSyncRunService error persistence", () => {
           },
         ],
       }),
+    )
+  })
+
+  test("writes the caller-provided failedCount instead of counting stored itemErrors", async () => {
+    await metaCatalogSyncRunService.recordSubmission({
+      runId: "run-1",
+      submissionLeaseId: "lease-1",
+      totalCount: 1,
+      handles: [],
+      skippedItems: [],
+      failedCount: 0,
+      itemErrors: [
+        {
+          retailerId: "retailer-1",
+          reason: "Submission was interrupted; sync this item again",
+        },
+      ],
+    })
+
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ failedCount: 0 }),
     )
   })
 })

--- a/packages/business/__tests__/product-category-service.test.ts
+++ b/packages/business/__tests__/product-category-service.test.ts
@@ -224,7 +224,9 @@ describe("productCategoryService missing rows", () => {
 
 describe("productCategoryService resolveByNames", () => {
   test("keys the result by lower-cased name so importers can match either casing", async () => {
-    mocks.findByNames.mockResolvedValue([{ id: "category-1", name: "Shoes" }])
+    mocks.list.mockResolvedValue([
+      { id: "category-1", name: "Shoes", parentId: null },
+    ])
 
     const resolved = await productCategoryService.resolveByNames({
       workspaceId,
@@ -235,28 +237,45 @@ describe("productCategoryService resolveByNames", () => {
     expect(resolved.get("shoes")).toBe("category-1")
   })
 
-  test("trims and de-duplicates the names before querying", async () => {
-    mocks.findByNames.mockResolvedValue([])
+  test("matches an existing category regardless of casing without creating a duplicate", async () => {
+    mocks.list.mockResolvedValue([
+      { id: "category-1", name: "Electronics", parentId: null },
+    ])
+
+    const resolved = await productCategoryService.resolveByNames({
+      workspaceId,
+      names: ["electronics"],
+      createMissing: true,
+    })
+
+    expect(mocks.createMissingByName).not.toHaveBeenCalled()
+    expect(resolved.get("electronics")).toBe("category-1")
+  })
+
+  test("collapses names that differ only by case into a single creation", async () => {
+    mocks.list.mockResolvedValue([])
+    mocks.createMissingByName.mockResolvedValue(undefined)
 
     await productCategoryService.resolveByNames({
       workspaceId,
-      names: [" Shoes ", "Shoes", "", "   "],
-      createMissing: false,
+      names: [" Shoes ", "SHOES", "shoes", "", "   "],
+      createMissing: true,
     })
 
-    expect(mocks.findByNames).toHaveBeenCalledWith(
-      {
-        workspaceId,
-        names: ["Shoes"],
-      },
+    expect(mocks.createMissingByName).toHaveBeenCalledTimes(1)
+    expect(mocks.createMissingByName).toHaveBeenCalledWith(
+      { workspaceId, names: ["shoes"] },
       { name: "default-db" },
     )
   })
 
   test("creates the missing rows only when the import asked it to", async () => {
-    mocks.createMissingByName.mockResolvedValue([
-      { id: "category-2", name: "Bags" },
-    ])
+    mocks.list
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { id: "category-2", name: "Bags", parentId: null },
+      ])
+    mocks.createMissingByName.mockResolvedValue(undefined)
 
     const resolved = await productCategoryService.resolveByNames({
       workspaceId,
@@ -264,8 +283,25 @@ describe("productCategoryService resolveByNames", () => {
       createMissing: true,
     })
 
-    expect(mocks.findByNames).not.toHaveBeenCalled()
+    expect(mocks.createMissingByName).toHaveBeenCalledWith(
+      { workspaceId, names: ["Bags"] },
+      { name: "default-db" },
+    )
     expect(resolved.get("bags")).toBe("category-2")
+  })
+
+  test("does not create anything when the name already exists", async () => {
+    mocks.list.mockResolvedValue([
+      { id: "category-1", name: "Shoes", parentId: null },
+    ])
+
+    await productCategoryService.resolveByNames({
+      workspaceId,
+      names: ["Shoes"],
+      createMissing: true,
+    })
+
+    expect(mocks.createMissingByName).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/business/src/meta-catalog/sync-run.service.ts
+++ b/packages/business/src/meta-catalog/sync-run.service.ts
@@ -218,6 +218,13 @@ class MetaCatalogSyncRunService extends BaseService {
     totalCount: number
     handles: MetaCatalogBatchHandle[]
     skippedItems: MetaCatalogSkippedItem[]
+    /**
+     * Confirmed failures only. `itemErrors` below may additionally carry
+     * provisional "not yet submitted" placeholders for crash recovery — those
+     * must never be counted here, or the history view would show a live run
+     * as having failed items it merely hasn't gotten to yet.
+     */
+    failedCount: number
     itemErrors?: MetaCatalogItemError[]
   }) {
     const itemErrors = sanitizeItemErrors(input.itemErrors ?? [])
@@ -253,7 +260,7 @@ class MetaCatalogSyncRunService extends BaseService {
           skippedItems: input.skippedItems.slice(0, MAX_DIAGNOSTIC_ITEMS),
           skippedCount: input.skippedItems.length,
           itemErrors: itemErrors.slice(0, MAX_DIAGNOSTIC_ITEMS),
-          failedCount: itemErrors.length,
+          failedCount: input.failedCount,
         })
         .where(eq(metaCatalogSyncRunModel.id, input.runId))
       return true

--- a/packages/business/src/product-category/service.ts
+++ b/packages/business/src/product-category/service.ts
@@ -106,6 +106,13 @@ class ProductCategoryService extends BaseService {
     return await productCategoryRepository.countProducts(input)
   }
 
+  /**
+   * Matching is case-insensitive (an importer's "electronics" must land on an
+   * existing "Electronics"), so — like `resolvePaths` — this loads the full
+   * top-level list and folds case in JS rather than querying by exact name.
+   * A DB round-trip that only matched exact case would create a duplicate
+   * category on every casing drift.
+   */
   async resolveByNames(input: {
     workspaceId: string
     names: string[]
@@ -114,29 +121,42 @@ class ProductCategoryService extends BaseService {
   }) {
     const { tx = db } = input
     const names = Array.from(
-      new Set(input.names.map(normalizeCategoryName).filter(Boolean)),
+      new Map(
+        input.names
+          .map(normalizeCategoryName)
+          .filter(Boolean)
+          .map((name) => [name.toLowerCase(), name] as const),
+      ).values(),
     )
-    const rows = input.createMissing
-      ? await productCategoryRepository.createMissingByName(
-          {
-            workspaceId: input.workspaceId,
-            names,
-          },
-          tx,
-        )
-      : await productCategoryRepository.findByNames(
-          {
-            workspaceId: input.workspaceId,
-            names,
-          },
-          tx,
-        )
 
+    let rows = await productCategoryRepository.list(input.workspaceId, tx)
+    const topLevelByName = () =>
+      new Map(
+        rows
+          .filter((row) => !row.parentId)
+          .map((row) => [normalizeCategoryName(row.name).toLowerCase(), row]),
+      )
+
+    if (input.createMissing) {
+      const existing = topLevelByName()
+      const missingNames = names.filter(
+        (name) => !existing.has(name.toLowerCase()),
+      )
+      if (missingNames.length > 0) {
+        await productCategoryRepository.createMissingByName(
+          { workspaceId: input.workspaceId, names: missingNames },
+          tx,
+        )
+        rows = await productCategoryRepository.list(input.workspaceId, tx)
+      }
+    }
+
+    const resolved = topLevelByName()
     return new Map(
-      rows.map((row) => [
-        normalizeCategoryName(row.name).toLowerCase(),
-        row.id,
-      ]),
+      names.flatMap((name) => {
+        const row = resolved.get(name.toLowerCase())
+        return row ? [[name.toLowerCase(), row.id] as const] : []
+      }),
     )
   }
 

--- a/packages/database/src/partials/import.ts
+++ b/packages/database/src/partials/import.ts
@@ -69,6 +69,7 @@ export const productImportFields = z.enum([
   "vendor",
   "inventoryQuantity",
   "imageUrl",
+  "productUrl",
 ])
 export type ProductImportField = z.infer<typeof productImportFields>
 
@@ -82,6 +83,7 @@ export const productImportColumnMapSchema = z.object({
   vendor: z.string().optional(),
   inventoryQuantity: z.string().optional(),
   imageUrl: z.string().optional(),
+  productUrl: z.string().optional(),
 })
 export type ProductImportColumnMap = z.infer<
   typeof productImportColumnMapSchema

--- a/packages/imports/__tests__/header-match.test.ts
+++ b/packages/imports/__tests__/header-match.test.ts
@@ -12,6 +12,8 @@ describe("product import header matching", () => {
     ["SKU", "sku"],
     ["Giá bán", "price"],
     ["Price", "price"],
+    ["Product URL", "productUrl"],
+    ["Link sản phẩm", "productUrl"],
   ])("maps %s to %s", (header, field) => {
     expect(matchProductImportHeaders([header])).toHaveProperty(field, header)
   })

--- a/packages/imports/src/modules/products/header-match.ts
+++ b/packages/imports/src/modules/products/header-match.ts
@@ -22,6 +22,7 @@ const HEADER_CANDIDATES = {
   vendor: ["vendor", "brand", "thuonghieu"],
   inventoryQuantity: ["inventoryquantity", "quantity", "soluong"],
   imageUrl: ["imageurl", "image", "hinhanh"],
+  productUrl: ["producturl", "url", "linksanpham"],
 } as const satisfies Record<ProductImportField, readonly string[]>
 
 const normalizedCandidates = Object.fromEntries(


### PR DESCRIPTION
## Summary
- Add a product URL field to the product import template (mapping, extraction, tests)
- Fix product category matching so importer names match existing categories regardless of letter case
- Fix the failed-item count shown while a Meta Catalog sync is still running

## Test plan
- [x] `pnpm --filter @chatbotx.io/imports test`
- [x] `pnpm --filter @chatbotx.io/business test`
- [x] `pnpm --filter worker test`