### PR TITLE
fix(instagram-facebook): send private reply via page node, not igId

### DIFF
--- a/integrations/instagram-facebook/src/apis/comment.ts
+++ b/integrations/instagram-facebook/src/apis/comment.ts
@@ -58,12 +58,10 @@ export const hideComment = (
 }
 
 /**
- * Sends a private DM reply to the author of a comment. Facebook-Login tokens
- * cannot use the `me` alias for the IG node, so — unlike the Instagram Login
- * package's `me/messages` — this addresses the account directly via `igId`,
- * matching this package's own `likeComment` (`${igId}/likes`) and Messenger's
- * `sendPrivateReply` (`${pageId}/messages`), which use the same
- * Page/Business-asset-token shape.
+ * Sends a private DM reply to the author of a comment via the Page node
+ * (Meta's Messenger Platform private-reply endpoint is `/<PAGE_ID>/messages`
+ * for Page-token connections — see
+ * https://developers.facebook.com/docs/messenger-platform/instagram/features/private-replies).
  */
 export const sendPrivateReply = (
   auth: InstagramAuthValue,
@@ -71,7 +69,7 @@ export const sendPrivateReply = (
   message: string,
 ): Promise<{ message_id?: string; recipient_id: string }> => {
   const version = auth.metadata.version ?? DEFAULT_API_VERSION
-  const endpoint = `${version}/${auth.metadata.igId}/messages`
+  const endpoint = `${version}/${auth.metadata.pageId}/messages`
 
   return rescue(endpoint, () =>
     instagramGraphClient.post<{


### PR DESCRIPTION
## Summary
- Instagram comment automation's private reply (DM) was silently broken for accounts connected via Facebook Login, while public comment replies worked fine.
- `sendPrivateReply` was posting to `${igId}/messages`, which is the endpoint for the separate Instagram-Login package. For Page-token connections (Facebook Login), Meta's Messenger Platform requires `POST /<PAGE_ID>/messages` for private replies.

## Changes
- `integrations/instagram-facebook/src/apis/comment.ts`: `sendPrivateReply` now posts to `${version}/${auth.metadata.pageId}/messages` instead of `${version}/${auth.metadata.igId}/messages`, matching Meta's documented private-reply endpoint for Page-token connections. Updated the misleading comment above the function (it previously and incorrectly justified the `igId` endpoint).

## Test plan
- [x] `pnpm --filter @chatbotx.io/integration-instagram-facebook check-types`
- [x] `pnpm lint`
- [ ] Manual verification: trigger a private-reply comment automation on an Instagram account connected via Facebook Login and confirm the DM is delivered