### PR TITLE
chore(codegraph): share mcp config and setup docs with team

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__codegraph__*"
+    ]
+  }
+}

--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "codegraph": {
+      "type": "stdio",
+      "command": "codegraph",
+      "args": ["serve", "--mcp"]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,8 @@ test-webchat
 .cursor/skills/
 CLAUDE.md
 
+# Per-developer Claude Code overrides (hooks, personal permissions)
+.claude/settings.local.json
+
 .pnpm-store/
 .plans/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "codegraph": {
+      "type": "stdio",
+      "command": "codegraph",
+      "args": ["serve", "--mcp"]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,32 @@ pnpm --filter @chatbotx.io/database make:migration <name>
 - **Docker Compose** provides PostgreSQL, Redis, object storage, MailHog, Adminer, and RedisInsight services. See `docker-compose.yml` and project docs.
 - Copy **`.env.example`** → **`.env`** (or per-app env as documented). Never commit secrets.
 
+### CodeGraph (optional, for AI editors)
+
+The repo ships MCP config for [CodeGraph](https://github.com/codegraph-ai/codegraph), a local code-intelligence index that lets Claude Code and Cursor answer "how does X work" without grepping. **Entirely optional** — if you don't use an AI editor, ignore this section; the config files are inert.
+
+To enable it, install the CLI once per machine (it is not a workspace dependency), then build the index from the repo root:
+
+```bash
+codegraph index
+```
+
+The index lives in `.codegraph/` and is **per-machine** — the directory self-ignores via its own `.gitignore`, so the multi-hundred-MB database never reaches git. Re-running `index` after a large rebase keeps it fresh; a file watcher handles incremental edits.
+
+Committed config: `.mcp.json` (Claude Code) and `.cursor/mcp.json` (Cursor) both point at the `codegraph` binary on your `PATH`, plus `.claude/settings.json` pre-allows the MCP tools.
+
+For automatic context injection on every prompt, add the hook to your **own** `.claude/settings.local.json` (gitignored, so it stays off other machines):
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      { "hooks": [{ "type": "command", "command": "codegraph prompt-hook" }] }
+    ]
+  }
+}
+```
+
 ## Where to change what
 
 ### Builder (Next.js app)


### PR DESCRIPTION
## Summary

Commits the CodeGraph MCP config so the whole team shares one setup instead of each developer wiring it by hand. CodeGraph is a local code-intelligence index that lets Claude Code and Cursor answer "how does X work" without grepping.

**CodeGraph stays entirely optional** — the config files are inert without the CLI installed, so nothing changes for anyone not using an AI editor.

## The split: CLI per-machine, config in repo, index never committed

| Artifact | Where it lives | Why |
|---|---|---|
| `codegraph` binary | Per-machine (`~/.local/bin`) | A personal dev tool like `ripgrep` — not a workspace dependency, not needed to build or run the app |
| MCP config | **Committed** | Small, portable, shared |
| `.codegraph/` index | Per-machine, gitignored | A multi-hundred-MB SQLite DB that changes on every file edit |

## Changes

- **`.mcp.json`** (Claude Code) and **`.cursor/mcp.json`** (Cursor) — resolve the binary from `PATH` and default to the repo cwd. The Cursor config previously carried an absolute path to one developer's home directory, which would have pointed elsewhere on every other machine.
- **`.claude/settings.json`** — pre-allows the CodeGraph MCP tools. The `UserPromptSubmit` hook is **deliberately omitted**: it runs `codegraph prompt-hook` on every prompt and would fail with command-not-found for anyone who hasn't installed the CLI. `AGENTS.md` documents how to opt in via a personal `settings.local.json`.
- **`.codegraph/.gitignore`** — the only file committed from that directory. It self-ignores (`*` + `!.gitignore`), so the index never reaches git on any clone.
- **`.gitignore`** — adds `.claude/settings.local.json`, which was previously covered only by one developer's personal global gitignore. Without this, teammates following the opt-in hook instructions would commit personal settings.
- **`AGENTS.md`** — a short setup section under *Local infrastructure*.

## Test plan

- [x] `git check-ignore` confirms the 156 MB `codegraph.db` is excluded; only `.codegraph/.gitignore` is visible to git
- [x] `git diff --cached --stat` — 6 files, 59 insertions, no large files
- [x] `pnpm exec ultracite check` passes on all touched files
- [x] `node scripts/sync-agent-instructions.mjs --check` passes (the new section sits outside the mirrored invariants block)
- [ ] Reviewer with the CLI installed: restart Claude Code / Cursor and confirm the `codegraph` MCP server still connects after the `--path` removal
- [ ] Reviewer **without** the CLI: confirm the repo behaves exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)