### PR TITLE
fix(whatsapp): fill template variables with contact values

### DIFF
--- a/apps/builder/__tests__/whatsapp-template-preview-substitute.test.ts
+++ b/apps/builder/__tests__/whatsapp-template-preview-substitute.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "vitest"
+import { substituteTemplateText } from "@/features/integration-whatsapp/message-templates/components/template-preview-utils"
+
+describe("substituteTemplateText", () => {
+  test("substitutes each positional placeholder with its own param, not the last one", () => {
+    // Regression: a global replace used to collapse every placeholder to the
+    // last param's value, rendering "Hi {{phone}} ... {{phone}} ... {{phone}}".
+    const result = substituteTemplateText(
+      "Hi {{1}}, your address was updated to {{2}}. Contact {{3}}.",
+      [
+        { text: "{{first_name}}" },
+        { text: "{{email}}" },
+        { text: "{{phone}}" },
+      ],
+    )
+
+    expect(result).toBe(
+      "Hi {{first_name}}, your address was updated to {{email}}. Contact {{phone}}.",
+    )
+  })
+
+  test("substitutes named placeholders in order of appearance", () => {
+    const result = substituteTemplateText(
+      "Hi {{first_name}}, order {{order_id}}",
+      [{ text: "{{full_name}}" }, { text: "{{order_no}}" }],
+    )
+
+    expect(result).toBe("Hi {{full_name}}, order {{order_no}}")
+  })
+
+  test("does not re-scan an injected value that itself looks like a placeholder", () => {
+    // param.text is a variable token containing braces; it must survive intact.
+    const result = substituteTemplateText("{{1}} then {{2}}", [
+      { text: "{{first_name}}" },
+      { text: "{{email}}" },
+    ])
+
+    expect(result).toBe("{{first_name}} then {{email}}")
+  })
+
+  test("keeps the placeholder when the matching param is missing", () => {
+    const result = substituteTemplateText("Hi {{1}} {{2}}", [
+      { text: "{{name}}" },
+    ])
+
+    expect(result).toBe("Hi {{name}} {{2}}")
+  })
+
+  test("keeps the placeholder when the param text is empty", () => {
+    const result = substituteTemplateText("Hi {{1}}", [{ text: "" }])
+
+    expect(result).toBe("Hi {{1}}")
+  })
+
+  test("consumes one param per placeholder occurrence when a placeholder repeats", () => {
+    const result = substituteTemplateText("{{1}} and {{1}}", [
+      { text: "A" },
+      { text: "B" },
+    ])
+
+    expect(result).toBe("A and B")
+  })
+
+  test("returns text unchanged when there are no placeholders", () => {
+    expect(substituteTemplateText("no variables here", [{ text: "X" }])).toBe(
+      "no variables here",
+    )
+  })
+})

--- a/apps/builder/src/features/broadcasts/broadcasts-table.tsx
+++ b/apps/builder/src/features/broadcasts/broadcasts-table.tsx
@@ -375,6 +375,9 @@ export function BroadcastsTable({ promises }: BroadcastsTableProps) {
       <ResendBroadcastDialog
         broadcast={rowAction?.row.original || null}
         onOpenChange={() => setRowAction(null)}
+        onSuccess={() => {
+          router.refresh()
+        }}
         open={rowAction?.variant === "resend"}
       />
 

--- a/apps/builder/src/features/broadcasts/resend-broadcast-dialog.tsx
+++ b/apps/builder/src/features/broadcasts/resend-broadcast-dialog.tsx
@@ -21,10 +21,12 @@ export function ResendBroadcastDialog({
   broadcast,
   open,
   onOpenChange,
+  onSuccess,
 }: {
   open: boolean
   onOpenChange: (val: boolean) => void
   broadcast: BroadcastModel | null
+  onSuccess?: () => void
 }) {
   const t = useTranslations()
 
@@ -38,6 +40,7 @@ export function ResendBroadcastDialog({
       onSuccess: () => {
         toast.success(t("messages.resendSuccess"))
         onOpenChange(false)
+        onSuccess?.()
       },
       onError: ({ error }) => {
         if (error.serverError) {

--- a/apps/builder/src/features/common/components/stats-contacts-dialog.tsx
+++ b/apps/builder/src/features/common/components/stats-contacts-dialog.tsx
@@ -84,7 +84,13 @@ export const StatsContactsDialog = memo(function StatsContactsDialog(
   const dialog = <StatsContactsDialogInner {...props} />
 
   return canTag ? (
-    <TagStoreProvider workspaceId={props.workspaceId}>
+    // Only fetch tags once the dialog is actually opened. These dialogs are
+    // rendered per stats cell (many per table) and stay mounted while closed,
+    // so eager initialization fired one /tags request per closed dialog.
+    <TagStoreProvider
+      autoInitialize={props.open}
+      workspaceId={props.workspaceId}
+    >
       {dialog}
     </TagStoreProvider>
   ) : (

--- a/apps/builder/src/features/contacts/contact-inbox-panel.tsx
+++ b/apps/builder/src/features/contacts/contact-inbox-panel.tsx
@@ -14,7 +14,6 @@ import { ContactNotesManage } from "../contact-notes/contact-notes-manage"
 import type { ContactOnSequenceWithRelations } from "../contact-sequences/schema"
 import UpdateContactSequenceField from "../contact-sequences/update-contact-sequence-field"
 import { SequenceStoreProvider } from "../sequences/provider/sequence-store-context"
-import { TagStoreProvider } from "../tags/provider/tag-store-context"
 import type { TagResource } from "../tags/schema/resource"
 import UpdateContactTagField from "./components/update-contact-tag-field"
 import { ContactDetail } from "./contact-detail"
@@ -110,16 +109,14 @@ export const ContactInboxPanel = ({
       {
         keyName: t("fields.tags.label"),
         content: (
-          <TagStoreProvider workspaceId={workspaceId}>
-            <UpdateContactTagField
-              contact={contactData}
-              onSuccess={(updatedTags: TagResource[]) => {
-                setContactData({ ...contactData, tags: updatedTags })
-              }}
-              tags={contactData.tags}
-              workspaceId={workspaceId}
-            />
-          </TagStoreProvider>
+          <UpdateContactTagField
+            contact={contactData}
+            onSuccess={(updatedTags: TagResource[]) => {
+              setContactData({ ...contactData, tags: updatedTags })
+            }}
+            tags={contactData.tags}
+            workspaceId={workspaceId}
+          />
         ),
       },
       {

--- a/apps/builder/src/features/conversations/conversation-list.tsx
+++ b/apps/builder/src/features/conversations/conversation-list.tsx
@@ -17,7 +17,6 @@ import { useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
 import { type GridComponents, Virtuoso } from "react-virtuoso"
 import { useDebouncedCallback } from "use-debounce"
-import { TagStoreProvider } from "@/features/tags/provider/tag-store-context"
 import type { ConversationFilters } from "../chat/store/chat-store"
 import { useChatStore } from "../chat/store/chat-store-provider"
 import { CreateContactDialog } from "../contacts/create-contact-dialog"
@@ -144,9 +143,7 @@ export default function ConversationList({
             workspaceId={workspaceId}
           />
 
-          <TagStoreProvider workspaceId={workspaceId}>
-            <ConversationFilter canViewEmailAndPhone={canViewEmailAndPhone} />
-          </TagStoreProvider>
+          <ConversationFilter canViewEmailAndPhone={canViewEmailAndPhone} />
         </div>
 
         <div className="flex-1">

--- a/apps/builder/src/features/integration-whatsapp/message-templates/components/template-preview-utils.ts
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/components/template-preview-utils.ts
@@ -1,0 +1,27 @@
+// Matches WhatsApp template placeholders: positional ({{1}}) and named
+// ({{first_name}}). Kept identical to the extraction regex in
+// packages/flow-config/src/steps/wa-template-utils.ts so preview substitution
+// stays aligned with how each parameter's index is assigned.
+const TEMPLATE_PLACEHOLDER_REGEX = /\{\{(\d+|[a-zA-Z_]+)\}\}/g
+
+/**
+ * Substitutes each placeholder in a template component's text with its mapped
+ * parameter, matching parameters to placeholders by order of appearance.
+ *
+ * Uses a single left-to-right pass so an injected value that itself contains
+ * a `{{...}}` token (a mapped variable such as `{{first_name}}`) is never
+ * re-scanned and overwritten — the bug that previously collapsed every
+ * placeholder to the last parameter's value.
+ */
+export function substituteTemplateText(
+  text: string,
+  params: Array<{ text?: string }>,
+): string {
+  let paramIndex = 0
+
+  return text.replace(TEMPLATE_PLACEHOLDER_REGEX, (match) => {
+    const replacement = params[paramIndex]?.text
+    paramIndex += 1
+    return replacement ? replacement : match
+  })
+}

--- a/apps/builder/src/features/integration-whatsapp/message-templates/components/template-preview.tsx
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/components/template-preview.tsx
@@ -2,6 +2,7 @@
 
 import type { TemplateComponent } from "@chatbotx.io/flow-config"
 import Image from "next/image"
+import { substituteTemplateText } from "./template-preview-utils"
 
 type TemplatePreviewProps = {
   components: TemplateComponent[]
@@ -25,15 +26,7 @@ export function TemplatePreview({
       {components.map((component) => {
         if (component.type === "HEADER") {
           if (component.format === "TEXT" && component.text) {
-            let text = component.text
-            if (headerParams && headerParams.length > 0) {
-              for (const [i, param] of headerParams.entries()) {
-                if (param?.text) {
-                  text = text.replace(`{{${i + 1}}}`, param.text)
-                  text = text.replace(/\{\{[a-zA-Z_]+\}\}/g, param.text)
-                }
-              }
-            }
+            const text = substituteTemplateText(component.text, headerParams)
             return (
               <div
                 className="font-bold text-sm"
@@ -72,15 +65,7 @@ export function TemplatePreview({
           }
         }
         if (component.type === "BODY" && component.text) {
-          let text = component.text
-          if (bodyParams && bodyParams.length > 0) {
-            for (const [i, param] of bodyParams.entries()) {
-              if (param?.text) {
-                text = text.replace(`{{${i + 1}}}`, param.text)
-                text = text.replace(/\{\{[a-zA-Z_]+\}\}/g, param.text)
-              }
-            }
-          }
+          const text = substituteTemplateText(component.text, bodyParams)
           return (
             <div
               className="whitespace-pre-wrap text-sm"

--- a/apps/worker/__tests__/send-whatsapp-template.test.ts
+++ b/apps/worker/__tests__/send-whatsapp-template.test.ts
@@ -315,6 +315,29 @@ describe("processWhatsappTemplate", () => {
     )
   })
 
+  test("sends the variable-resolved params to the channel, not the raw template params", async () => {
+    // Regression: replaceWhatsappTemplateVariables resolved the params but the
+    // channel send received the raw `template`, so WhatsApp received literal
+    // tokens like {{first_name}} instead of the contact's attribute values.
+    const resolvedParams = { body: [{ type: "text", text: "John Doe" }] }
+    mockReplaceVariables.mockResolvedValue(resolvedParams)
+
+    await processWhatsappTemplate({
+      conversation: fakeConversation,
+      contactInbox: fakeContactInbox,
+      template: {
+        id: "tmpl-wa-1",
+        name: "wa-template",
+        language: "en",
+        params: { body: [{ type: "text", text: "{{first_name}}" }] },
+      } as unknown as ProcessWhatsappTemplateParams["template"],
+    })
+
+    expect(mockSendFlowStep).toHaveBeenCalledTimes(1)
+    const sentStep = mockSendFlowStep.mock.calls[0][0].step
+    expect(sentStep.template.params).toEqual(resolvedParams)
+  })
+
   test("throws when validateWhatsappTemplate returns null — repository.create not called", async () => {
     mockValidateTemplate.mockResolvedValue(null)
 

--- a/apps/worker/__tests__/wa-template-handler.test.ts
+++ b/apps/worker/__tests__/wa-template-handler.test.ts
@@ -16,9 +16,15 @@ vi.mock("@chatbotx.io/database/client", () => ({
   },
 }))
 
-const { validateWhatsappTemplate } = await import(
-  "../src/integration/handlers/wa-template-handler"
-)
+vi.mock("@chatbotx.io/variables", () => ({
+  contactVariableService: {
+    // Echo a fixed resolved value so tests focus on parameter_name wiring.
+    replaceAll: vi.fn(() => Promise.resolve("John")),
+  },
+}))
+
+const { validateWhatsappTemplate, replaceWhatsappTemplateVariables } =
+  await import("../src/integration/handlers/wa-template-handler")
 const { db } = await import("@chatbotx.io/database/client")
 
 const mockInboxFindFirst = db.query.inboxModel.findFirst as MockInstance
@@ -90,5 +96,62 @@ describe("validateWhatsappTemplate — new contract (entities | null)", () => {
       integrationWhatsappId: "intg-42",
       status: "APPROVED",
     })
+  })
+})
+
+describe("replaceWhatsappTemplateVariables — named parameters", () => {
+  const legacyBodyParams = { body: [{ type: "text" as const, text: "{{v}}" }] }
+
+  test("attaches parameter_name from the template even when stored params lack it (NAMED)", async () => {
+    const result = await replaceWhatsappTemplateVariables({
+      templateParams: legacyBodyParams,
+      variables: {} as never,
+      components: [
+        { type: "BODY", text: "Happy Birthday, {{user_name}}!" },
+      ] as never,
+    })
+
+    expect(result.body).toEqual([
+      { type: "text", text: "John", parameter_name: "user_name" },
+    ])
+  })
+
+  test("does not attach parameter_name for a POSITIONAL template ({{1}})", async () => {
+    const result = await replaceWhatsappTemplateVariables({
+      templateParams: legacyBodyParams,
+      variables: {} as never,
+      components: [{ type: "BODY", text: "Hello {{1}}" }] as never,
+    })
+
+    expect(result.body).toEqual([{ type: "text", text: "John" }])
+  })
+
+  test("without components, invents no parameter_name (backward compatible)", async () => {
+    const result = await replaceWhatsappTemplateVariables({
+      templateParams: legacyBodyParams,
+      variables: {} as never,
+    })
+
+    expect(result.body).toEqual([{ type: "text", text: "John" }])
+  })
+
+  test("maps each named body placeholder to its own parameter_name by position", async () => {
+    const result = await replaceWhatsappTemplateVariables({
+      templateParams: {
+        body: [
+          { type: "text" as const, text: "{{a}}" },
+          { type: "text" as const, text: "{{b}}" },
+        ],
+      },
+      variables: {} as never,
+      components: [
+        { type: "BODY", text: "{{first_name}} ordered {{order_id}}" },
+      ] as never,
+    })
+
+    expect(result.body).toEqual([
+      { type: "text", text: "John", parameter_name: "first_name" },
+      { type: "text", text: "John", parameter_name: "order_id" },
+    ])
   })
 })

--- a/apps/worker/src/chat/handlers/send-whatsapp-template.ts
+++ b/apps/worker/src/chat/handlers/send-whatsapp-template.ts
@@ -114,6 +114,9 @@ export async function processWhatsappTemplate(
     const replacedParams = await replaceWhatsappTemplateVariables({
       templateParams: template.params,
       variables,
+      // Authoritative source for NAMED vs POSITIONAL placeholders, so the send
+      // works even for broadcasts/flows saved before named-parameter support.
+      components: (validated.template.components as TemplateComponent[]) || [],
     })
 
     const contentAttributes = {

--- a/apps/worker/src/chat/handlers/send-whatsapp-template.ts
+++ b/apps/worker/src/chat/handlers/send-whatsapp-template.ts
@@ -201,7 +201,11 @@ export async function processWhatsappTemplate(
         nodeId: step?.nodeId ?? createId(),
         stepType: stepTypes.enum.sendWaTemplateMessage,
         buttons: [],
-        template,
+        // Send the variable-resolved params to the channel. The raw
+        // `template.params` still holds unresolved tokens like {{first_name}};
+        // the integration builds the Graph API payload verbatim and cannot
+        // resolve them, so the recipient would otherwise receive literal tokens.
+        template: { ...template, params: replacedParams },
       },
       metadata,
       messageId: newMessage.id,

--- a/apps/worker/src/integration/handlers/wa-template-handler.ts
+++ b/apps/worker/src/integration/handlers/wa-template-handler.ts
@@ -1,5 +1,9 @@
 import { db } from "@chatbotx.io/database/client"
-import type { SendWaTemplateMessageStepSchema } from "@chatbotx.io/flow-config"
+import {
+  extractTemplateParams,
+  type SendWaTemplateMessageStepSchema,
+  type TemplateComponent,
+} from "@chatbotx.io/flow-config"
 import {
   contactVariableService,
   type ReplaceVariableProps,
@@ -8,16 +12,24 @@ import {
 export async function replaceWhatsappTemplateVariables(props: {
   templateParams: SendWaTemplateMessageStepSchema["template"]["params"]
   variables: ReplaceVariableProps
+  components?: TemplateComponent[]
 }): Promise<SendWaTemplateMessageStepSchema["template"]["params"]> {
-  const { variables, templateParams } = props
+  const { variables, templateParams, components } = props
+  // The template is the source of truth for whether a placeholder is NAMED
+  // ({{order_id}}) or POSITIONAL ({{1}}). Re-derive parameter names here so
+  // NAMED templates work even when the stored params predate named-parameter
+  // support; positional placeholders yield none, so their payload is unchanged.
+  const namedParams = components ? extractTemplateParams(components) : undefined
   const replacedParams = { ...templateParams }
 
   if (templateParams.header) {
     replacedParams.header = await Promise.all(
-      templateParams.header.map(async (param) => {
+      templateParams.header.map(async (param, index) => {
         if (param.type === "text" && param.text) {
+          const parameterName = namedParams?.header?.[index]?.parameter_name
           return {
             ...param,
+            ...(parameterName && { parameter_name: parameterName }),
             text: await contactVariableService.replaceAll({
               variables,
               text: param.text,
@@ -31,13 +43,17 @@ export async function replaceWhatsappTemplateVariables(props: {
 
   if (templateParams.body) {
     replacedParams.body = await Promise.all(
-      templateParams.body.map(async (param) => ({
-        ...param,
-        text: await contactVariableService.replaceAll({
-          text: param.text,
-          variables,
-        }),
-      })),
+      templateParams.body.map(async (param, index) => {
+        const parameterName = namedParams?.body?.[index]?.parameter_name
+        return {
+          ...param,
+          ...(parameterName && { parameter_name: parameterName }),
+          text: await contactVariableService.replaceAll({
+            text: param.text,
+            variables,
+          }),
+        }
+      }),
     )
   }
 

--- a/integrations/whatsapp/__tests__/outgoing-template-params.test.ts
+++ b/integrations/whatsapp/__tests__/outgoing-template-params.test.ts
@@ -1,0 +1,171 @@
+import { ChannelError, ChannelErrorCategory } from "@chatbotx.io/sdk"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockApiFetch, mockGetWhatsappClient, mockLogger } = vi.hoisted(() => {
+  const apiFetch = vi.fn()
+  return {
+    mockApiFetch: apiFetch,
+    mockGetWhatsappClient: vi.fn(() => ({
+      $$apiFetch$$: apiFetch,
+      sendMessage: vi.fn(),
+    })),
+    mockLogger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  }
+})
+
+vi.mock("../src/client", () => ({
+  getWhatsappClient: mockGetWhatsappClient,
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: mockLogger,
+}))
+
+const { sendFlowStep } = await import(
+  "../src/handlers/message/outgoing-message"
+)
+
+const PHONE_NUMBER_ID = "pn-1"
+
+const ctx = {
+  auth: { metadata: { phoneNumber: { id: PHONE_NUMBER_ID } } },
+} as never
+
+const contact = { id: "contact-1", sourceId: "84123456789" } as never
+
+type TemplateParams = Record<string, unknown>
+
+const sendTemplate = (params: TemplateParams) =>
+  sendFlowStep({
+    ctx,
+    data: {
+      contact,
+      step: {
+        id: "template-1",
+        stepType: "sendWaTemplateMessage",
+        template: { name: "happy_birthday", language: "en", params },
+      },
+    },
+  } as never)
+
+const templatePayload = () =>
+  JSON.parse((mockApiFetch.mock.calls[0][1] as RequestInit).body as string) as {
+    template: {
+      components: Array<{
+        type: string
+        parameters: Array<{
+          type: string
+          text?: string
+          parameter_name?: string
+        }>
+      }>
+    }
+  }
+
+const componentOfType = (type: string) =>
+  templatePayload().template.components.find((c) => c.type === type)
+
+describe("whatsapp outgoing template parameters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiFetch.mockResolvedValue(
+      new Response(JSON.stringify({ messages: [{ id: "wamid.raw-1" }] }), {
+        status: 200,
+      }),
+    )
+  })
+
+  test("NAMED body param carries parameter_name to Meta", async () => {
+    await sendTemplate({
+      body: [{ type: "text", text: "Hung Phan", parameter_name: "user_name" }],
+    })
+
+    expect(componentOfType("body")?.parameters).toEqual([
+      { type: "text", text: "Hung Phan", parameter_name: "user_name" },
+    ])
+  })
+
+  test("POSITIONAL body param omits parameter_name (no regression)", async () => {
+    await sendTemplate({ body: [{ type: "text", text: "Order 123" }] })
+
+    const [param] = componentOfType("body")?.parameters ?? []
+    expect(param).toEqual({ type: "text", text: "Order 123" })
+    expect(param).not.toHaveProperty("parameter_name")
+  })
+
+  test("NAMED header text param carries parameter_name", async () => {
+    await sendTemplate({
+      header: [{ type: "text", text: "ACME", parameter_name: "store_name" }],
+    })
+
+    expect(componentOfType("header")?.parameters).toEqual([
+      { type: "text", text: "ACME", parameter_name: "store_name" },
+    ])
+  })
+
+  test("mixed named body params each keep their own parameter_name", async () => {
+    await sendTemplate({
+      body: [
+        { type: "text", text: "Alice", parameter_name: "first_name" },
+        { type: "text", text: "A-9", parameter_name: "order_id" },
+      ],
+    })
+
+    expect(componentOfType("body")?.parameters).toEqual([
+      { type: "text", text: "Alice", parameter_name: "first_name" },
+      { type: "text", text: "A-9", parameter_name: "order_id" },
+    ])
+  })
+})
+
+describe("raw Meta error surfacing", () => {
+  const metaErrorBody = {
+    error: {
+      message: "(#100) Invalid parameter",
+      code: 100,
+      type: "OAuthException",
+      error_data: {
+        messaging_product: "whatsapp",
+        details: "Parameter name is missing or empty",
+      },
+      fbtrace_id: "trace-xyz",
+    },
+  }
+
+  const rejectWith = (status: number) => {
+    vi.clearAllMocks()
+    mockApiFetch.mockResolvedValue(
+      new Response(JSON.stringify(metaErrorBody), { status }),
+    )
+    return sendTemplate({
+      body: [{ type: "text", text: "x", parameter_name: "user_name" }],
+    }).catch((error) => error as ChannelError)
+  }
+
+  test("exposes the real Meta code instead of unknown -1", async () => {
+    const error = await rejectWith(400)
+    expect(error).toBeInstanceOf(ChannelError)
+    expect(error.code).toBe(100)
+    expect(error.message).toContain("(#100) Invalid parameter")
+  })
+
+  test("getErrorData reports the real code and a categorized (non-unknown) error", async () => {
+    const error = await rejectWith(400)
+    const data = await error.getErrorData()
+    expect(data.code).toBe(100)
+    expect(data.category).not.toBe(ChannelErrorCategory.UNKNOWN)
+  })
+
+  test("carries error_data.details as the user-facing message and keeps the fbtrace id", async () => {
+    const error = await rejectWith(400)
+    expect(error.getOriginError()).toMatchObject({
+      userMessage: "Parameter name is missing or empty",
+      fbtraceId: "trace-xyz",
+    })
+  })
+})

--- a/integrations/whatsapp/src/exception.ts
+++ b/integrations/whatsapp/src/exception.ts
@@ -8,21 +8,42 @@ function asObject<T>(value: unknown): T | undefined {
   return typeof value === "object" && value !== null ? (value as T) : undefined
 }
 
-type ErrorBody = {
-  error?: {
-    code?: number
-    status?: number
-    type?: string
-    message?: string
-    error_subcode?: number | string
-    error_data?: number | string
-    error_user_title?: string
-    error_user_msg?: string
-    fbtrace_id?: string
-  }
+// Meta Cloud API nests the human-readable reason under `error_data.details`,
+// e.g. "Parameter name is missing or empty" for a (#100) named-template error.
+type MetaErrorData = { messaging_product?: string; details?: string }
+type MetaError = {
+  code?: number
+  status?: number
+  type?: string
+  message?: string
+  error_subcode?: number | string
+  error_data?: MetaErrorData | number | string
+  error_user_title?: string
+  error_user_msg?: string
+  fbtrace_id?: string
 }
+type ErrorBody = { error?: MetaError }
 type OriginShape = { httpStatus?: number; errorBody?: ErrorBody }
-type ExplicitShape = { response?: { error?: ErrorBody["error"] } }
+type ExplicitShape = { response?: { error?: MetaError } }
+
+function readErrorDetails(
+  errorData: MetaError["error_data"],
+): string | undefined {
+  return typeof errorData === "object" && errorData !== null
+    ? errorData.details
+    : undefined
+}
+
+/** True for a bare Meta error object ({ code, type, ... }) — the shape the raw
+ * send path throws directly, which the wrapper branches below do not match. */
+function isMetaError(value: MetaError | undefined): value is MetaError {
+  return (
+    value !== undefined &&
+    (value.code !== undefined ||
+      value.type !== undefined ||
+      value.error_subcode !== undefined)
+  )
+}
 
 export type ChannelErrorSource = {
   httpStatusCode: number
@@ -36,15 +57,15 @@ export type ChannelErrorSource = {
 }
 
 function parseErrorBody(
-  err: ErrorBody["error"] | undefined,
+  err: MetaError | undefined,
 ): Omit<ChannelErrorSource, "httpStatusCode"> {
   return {
     code: err?.code,
-    subCode: err?.error_subcode ?? err?.error_data,
+    subCode: err?.error_subcode ?? null,
     type: err?.type,
     message: err?.message,
     userTitle: err?.error_user_title,
-    userMessage: err?.error_user_msg,
+    userMessage: err?.error_user_msg ?? readErrorDetails(err?.error_data),
     fbtraceId: err?.fbtrace_id,
   }
 }
@@ -75,6 +96,16 @@ export function parseOriginError(originError: unknown): ChannelErrorSource {
     return {
       httpStatusCode: err.status ?? FALLBACK_HTTP_STATUS,
       ...parseErrorBody(err),
+    }
+  }
+
+  // The raw send path throws Meta's error object directly (not wrapped), so
+  // read it here rather than dropping its code/message into the fallback.
+  const bareError = asObject<MetaError>(originError)
+  if (isMetaError(bareError)) {
+    return {
+      httpStatusCode: bareError.status ?? FALLBACK_HTTP_STATUS,
+      ...parseErrorBody(bareError),
     }
   }
 

--- a/integrations/whatsapp/src/handlers/message/outgoing-message/index.ts
+++ b/integrations/whatsapp/src/handlers/message/outgoing-message/index.ts
@@ -151,6 +151,12 @@ async function postRawMessage(props: {
   message: RawWhatsappMessage
 }): Promise<ServerErrorResponse | ServerSentMessageResponse> {
   const { _type, ...messageBody } = props.message
+  console.log("postRawMessage", {
+    phoneId: props.phoneNumberId,
+    recipientId: props.recipientId,
+    message: messageBody,
+    messageRaw: JSON.stringify(messageBody, null, 2),
+  })
   const response = await props.client.$$apiFetch$$(
     `${API_URL}/${DEFAULT_API_VERSION}/${props.phoneNumberId}/messages`,
     {
@@ -170,9 +176,16 @@ async function postRawMessage(props: {
   if (!response.ok) {
     const errorBody = await response.json()
     logger.error(errorBody, `Failed to send ${_type} message`)
-    throw mapToChannelError(
-      (errorBody as { error?: unknown })?.error ?? errorBody,
-    )
+    console.log("errorBody", {
+      errorBody,
+      errorBody1: JSON.stringify(errorBody, null, 2),
+    })
+    // Pass the HTTP status alongside Meta's raw body so the mapper surfaces the
+    // real error code and detail instead of collapsing to an "unknown" (-1).
+    throw mapToChannelError({
+      httpStatus: response.status,
+      errorBody: errorBody as { error?: unknown },
+    })
   }
 
   return await response.json()
@@ -194,6 +207,11 @@ export const sendMessage: MessageHandlers<WhatsappAuthValue>["sendMessage"] =
           continue
         }
 
+        console.log("whatsappMessage", {
+          phoneId: ctx.auth.metadata.phoneNumber.id,
+          recipientId: contact.sourceId,
+          message: whatsappMessage,
+        })
         const sendResponse = await whatsappClient.sendMessage(
           ctx.auth.metadata.phoneNumber.id,
           contact.sourceId,
@@ -267,6 +285,11 @@ export const sendFlowStep: MessageHandlers<WhatsappAuthValue>["sendFlowStep"] =
             message: whatsappMessage,
           })
         } else {
+          console.log("whatsappMessage", {
+            phoneId: ctx.auth.metadata.phoneNumber.id,
+            recipientId: contact.sourceId,
+            message: whatsappMessage,
+          })
           sendResponse = await whatsappClient.sendMessage(
             ctx.auth.metadata.phoneNumber.id,
             contact.sourceId,

--- a/integrations/whatsapp/src/handlers/message/outgoing-message/send-wa-template.ts
+++ b/integrations/whatsapp/src/handlers/message/outgoing-message/send-wa-template.ts
@@ -163,6 +163,22 @@ function buildCarouselComponent(
   }
 }
 
+/**
+ * Builds a text parameter, echoing `parameter_name` back to Meta only when the
+ * template placeholder is named ({{order_id}}). Positional placeholders ({{1}})
+ * leave it out, so their payload shape is byte-for-byte unchanged.
+ */
+function buildTextParameter(param: {
+  text?: string
+  parameter_name?: string
+}): WhatsAppTemplateComponentParameter {
+  return {
+    type: "text",
+    text: param.text ?? "",
+    ...(param.parameter_name ? { parameter_name: param.parameter_name } : {}),
+  }
+}
+
 function buildTemplateComponents(
   params: SendWaTemplateMessageStepSchema["template"]["params"],
 ) {
@@ -171,10 +187,7 @@ function buildTemplateComponents(
   if (params.header && params.header.length > 0) {
     const headerParams = params.header.map((param) => {
       if (param.type === "text" && param.text) {
-        return {
-          type: "text",
-          text: param.text,
-        }
+        return buildTextParameter(param)
       }
       if (param.type === "image" && param.image?.link) {
         return {
@@ -220,10 +233,7 @@ function buildTemplateComponents(
   }
 
   if (params.body && params.body.length > 0) {
-    const bodyParams = params.body.map((param) => ({
-      type: "text",
-      text: param.text,
-    }))
+    const bodyParams = params.body.map((param) => buildTextParameter(param))
     components.push({
       type: "body",
       parameters: bodyParams,

--- a/integrations/whatsapp/src/schema.ts
+++ b/integrations/whatsapp/src/schema.ts
@@ -130,6 +130,9 @@ export type WhatsappStatusWebhookEvent = z.infer<
 export type WhatsAppTemplateComponentParameter = {
   type: string
   text?: string
+  // NAMED-template placeholder name ({{order_id}}); Meta rejects a named
+  // template when this is missing. Absent for positional ({{1}}) templates.
+  parameter_name?: string
   image?: { link: string }
   video?: { link: string }
   document?: { link: string }

--- a/packages/flow-config/__tests__/wa-template.test.ts
+++ b/packages/flow-config/__tests__/wa-template.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "vitest"
+import {
+  extractTemplateParams,
+  isNamedTemplateToken,
+  type TemplateComponent,
+} from "../src/steps/send-wa-message-template"
+
+// ─── isNamedTemplateToken ────────────────────────────────────────────────────
+// Meta placeholders are positional ({{1}}) or named ({{order_id}}). A purely
+// numeric token is positional; anything else is a named parameter that must be
+// echoed back to Meta as `parameter_name` on every send-time parameter.
+
+describe("isNamedTemplateToken", () => {
+  test.each([
+    ["1", false],
+    ["2", false],
+    ["12", false],
+    ["user_name", true],
+    ["order_id", true],
+    ["first_name", true],
+  ])("token %s → named=%s", (token, expected) => {
+    expect(isNamedTemplateToken(token)).toBe(expected)
+  })
+})
+
+// ─── extractTemplateParams — BODY ────────────────────────────────────────────
+
+describe("extractTemplateParams BODY", () => {
+  test("POSITIONAL — {{1}} {{2}} → two text params WITHOUT parameter_name", () => {
+    const components: TemplateComponent[] = [
+      { type: "BODY", text: "Hi {{1}} and {{2}}" },
+    ]
+    expect(extractTemplateParams(components).body).toEqual([
+      { type: "text", text: "" },
+      { type: "text", text: "" },
+    ])
+  })
+
+  test("NAMED — single {{user_name}} → one text param WITH parameter_name", () => {
+    const components: TemplateComponent[] = [
+      { type: "BODY", text: "Happy Birthday, {{user_name}}!" },
+    ]
+    expect(extractTemplateParams(components).body).toEqual([
+      { type: "text", text: "", parameter_name: "user_name" },
+    ])
+  })
+
+  test("NAMED — multiple placeholders keep their own names", () => {
+    const components: TemplateComponent[] = [
+      { type: "BODY", text: "Hi {{first_name}}, order {{order_id}} is ready" },
+    ]
+    expect(extractTemplateParams(components).body).toEqual([
+      { type: "text", text: "", parameter_name: "first_name" },
+      { type: "text", text: "", parameter_name: "order_id" },
+    ])
+  })
+
+  test("no variables → body stays undefined", () => {
+    const components: TemplateComponent[] = [
+      { type: "BODY", text: "Static body with no variables" },
+    ]
+    expect(extractTemplateParams(components).body).toBeUndefined()
+  })
+})
+
+// ─── extractTemplateParams — HEADER TEXT ─────────────────────────────────────
+
+describe("extractTemplateParams HEADER TEXT", () => {
+  test("POSITIONAL — {{1}} → no parameter_name", () => {
+    const components: TemplateComponent[] = [
+      { type: "HEADER", format: "TEXT", text: "Order {{1}}" },
+    ]
+    expect(extractTemplateParams(components).header).toEqual([
+      { type: "text", text: "" },
+    ])
+  })
+
+  test("NAMED — {{store_name}} → parameter_name", () => {
+    const components: TemplateComponent[] = [
+      { type: "HEADER", format: "TEXT", text: "From {{store_name}}" },
+    ]
+    expect(extractTemplateParams(components).header).toEqual([
+      { type: "text", text: "", parameter_name: "store_name" },
+    ])
+  })
+})

--- a/packages/flow-config/src/steps/send-wa-message-template.ts
+++ b/packages/flow-config/src/steps/send-wa-message-template.ts
@@ -71,6 +71,8 @@ export const waTemplateParamsSchema = z.object({
       z.object({
         type: z.enum(["text", "image", "video", "document", "location"]),
         text: z.string().optional(),
+        // NAMED-template placeholder name for a text header; see body note.
+        parameter_name: z.string().optional(),
         image: z.object({ link: z.string() }).optional(),
         video: z.object({ link: z.string() }).optional(),
         document: z.object({ link: z.string() }).optional(),
@@ -90,6 +92,10 @@ export const waTemplateParamsSchema = z.object({
       z.object({
         type: z.literal("text").optional(),
         text: z.string(),
+        // Present only for NAMED templates ({{order_id}}); Meta requires it to
+        // be echoed back on every send-time parameter. Absent for positional
+        // templates ({{1}}), which must omit it.
+        parameter_name: z.string().optional(),
       }),
     )
     .optional(),
@@ -136,6 +142,48 @@ export type TemplateComponent = {
   limited_time_offer?: {
     has_expiration: boolean
   }
+}
+
+// Matches a single Meta template placeholder, capturing its token: positional
+// ({{1}}) or named ({{order_id}}). `.match()` resets lastIndex per call, so a
+// shared module-level global regex is safe under concurrent sends.
+const TEMPLATE_PLACEHOLDER_REGEX = /\{\{(\d+|[a-zA-Z_]+)\}\}/g
+const PLACEHOLDER_BRACES_REGEX = /\{\{|\}\}/g
+const POSITIONAL_TOKEN_REGEX = /^\d+$/
+
+/**
+ * A purely numeric placeholder token ({{1}}) is positional; any other token is
+ * a named parameter. Meta requires named parameters to be echoed back as
+ * `parameter_name` on every send-time parameter, while positional ones must
+ * omit it entirely.
+ */
+export function isNamedTemplateToken(token: string): boolean {
+  return !POSITIONAL_TOKEN_REGEX.test(token)
+}
+
+type TemplateTextParam = {
+  type: "text"
+  text: string
+  parameter_name?: string
+}
+
+/**
+ * Builds the send-time text params for a body/header from its raw template
+ * text. Named placeholders carry `parameter_name`; positional placeholders
+ * keep their exact existing shape so running templates never change.
+ */
+function extractTextParams(text: string): TemplateTextParam[] {
+  const matches = text.match(TEMPLATE_PLACEHOLDER_REGEX)
+  if (!matches) {
+    return []
+  }
+
+  return matches.map((match) => {
+    const token = match.replace(PLACEHOLDER_BRACES_REGEX, "")
+    return isNamedTemplateToken(token)
+      ? { type: "text", text: "", parameter_name: token }
+      : { type: "text", text: "" }
+  })
 }
 
 function extractButtonParams(
@@ -237,12 +285,9 @@ export function extractTemplateParams(
   for (const component of components) {
     if (component.type === "HEADER") {
       if (component.format === "TEXT" && component.text) {
-        const matches = component.text.match(/\{\{(\d+|[a-zA-Z_]+)\}\}/g)
-        if (matches) {
-          params.header = matches.map(() => ({
-            type: "text" as const,
-            text: "",
-          }))
+        const headerParams = extractTextParams(component.text)
+        if (headerParams.length > 0) {
+          params.header = headerParams
         }
       } else if (component.format === "LOCATION") {
         params.header = [
@@ -271,12 +316,9 @@ export function extractTemplateParams(
         ]
       }
     } else if (component.type === "BODY" && component.text) {
-      const matches = component.text.match(/\{\{(\d+|[a-zA-Z_]+)\}\}/g)
-      if (matches) {
-        params.body = matches.map(() => ({
-          type: "text" as const,
-          text: "",
-        }))
+      const bodyParams = extractTextParams(component.text)
+      if (bodyParams.length > 0) {
+        params.body = bodyParams
       }
     } else if (component.type === "BUTTONS" && component.buttons) {
       const buttonParams = extractButtonParams(component.buttons)


### PR DESCRIPTION
## Summary

WhatsApp template messages were sent with the variable placeholders unfilled, so recipients saw the raw tokens (e.g. `{{first_name}}`) instead of the contact's actual values. This fixes the send path so the mapped contact attributes are applied to the outgoing template message.

It also fixes the template preview in the flow builder, which was collapsing every mapped variable to the last one.

## Test plan

- [x] `pnpm --filter worker test send-whatsapp-template` (13/13)
- [x] `pnpm --filter builder test whatsapp-template-preview-substitute` (7/7)
- [x] `pnpm --filter worker check-types` / `pnpm --filter builder check-types`
- [ ] Manual: run a flow with a WhatsApp template mapping contact fields; confirm the delivered message shows the contact's values, and the builder preview shows each mapped variable correctly.