### PR TITLE
fix(instagram): correct story-reply message direction and contact profiles

### DIFF
--- a/apps/builder/messages/ar.json
+++ b/apps/builder/messages/ar.json
@@ -2602,6 +2602,7 @@
     "changeHideState": "تغيير حالة الإخفاء",
     "commentHidden": "تم إخفاء هذا التعليق",
     "messageDeleted": "تم حذف الرسالة.",
+    "repliedToStory": "رد على قصتك",
     "sentAttachments": "تم إرسال {count, plural, one {مرفق واحد} other {# مرفقات}}",
     "deleteComment": "حذف التعليق",
     "deleteCommentConfirmation": "هل أنت متأكد من رغبتك في حذف هذا التعليق؟ ستُحذف ردوده أيضًا من صندوق الوارد ومن Facebook. لا يمكن التراجع عن هذا الإجراء.",

--- a/apps/builder/messages/da.json
+++ b/apps/builder/messages/da.json
@@ -2597,6 +2597,7 @@
     "changeHideState": "Change hide state",
     "commentHidden": "Denne kommentar var hidden",
     "messageDeleted": "Den besked har been slettet.",
+    "repliedToStory": "Svarede på din story",
     "sentAttachments": "Sendte {count, plural, one {1 vedhæftet fil} other {# vedhæftede filer}}",
     "deleteComment": "Slet kommentar",
     "deleteCommentConfirmation": "Er du sikker du want til slet denne kommentar? Its svar vil also være slettet, both i din indbakke og på Facebook. Denne action kan ikke være undone.",

--- a/apps/builder/messages/de.json
+++ b/apps/builder/messages/de.json
@@ -1959,6 +1959,7 @@
     "changeHideState": "Sichtbarkeitsstatus ändern",
     "commentHidden": "Dieser Kommentar wurde ausgeblendet",
     "messageDeleted": "Die Nachricht wurde gelöscht.",
+    "repliedToStory": "Hat auf deine Story geantwortet",
     "sentAttachments": "{count, plural, one {1 Anhang gesendet} other {# Anhänge gesendet}}",
     "deleteComment": "Kommentar löschen",
     "deleteCommentConfirmation": "Möchten Sie diesen Kommentar wirklich löschen? Seine Antworten werden ebenfalls gelöscht, sowohl in Ihrem Posteingang als auch auf Facebook. Diese Aktion kann nicht rückgängig gemacht werden.",

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -2602,6 +2602,7 @@
     "changeHideState": "Change hide state",
     "commentHidden": "This comment was hidden",
     "messageDeleted": "The message has been deleted.",
+    "repliedToStory": "Replied to your story",
     "sentAttachments": "Sent {count, plural, one {1 attachment} other {# attachments}}",
     "deleteComment": "Delete comment",
     "deleteCommentConfirmation": "Are you sure you want to delete this comment? Its replies will also be deleted, both in your inbox and on Facebook. This action cannot be undone.",

--- a/apps/builder/messages/es.json
+++ b/apps/builder/messages/es.json
@@ -2597,6 +2597,7 @@
     "changeHideState": "Cambiar estado de visibilidad",
     "commentHidden": "Este comentario se ha ocultado",
     "messageDeleted": "The mensaje tiene been deleted.",
+    "repliedToStory": "Respondió a tu historia",
     "sentAttachments": "Se enviaron {count, plural, one {1 archivo adjunto} other {# archivos adjuntos}}",
     "deleteComment": "Eliminar comment",
     "deleteCommentConfirmation": "Are tú sure tú want un Eliminar este comment? Its respuestas se also be deleted, both en tu inbox y en Facebook. este action cannot be undone.",

--- a/apps/builder/messages/fi.json
+++ b/apps/builder/messages/fi.json
@@ -2597,6 +2597,7 @@
     "changeHideState": "Vaihda piilotustilaa",
     "commentHidden": "Tämä kommentti piilotettiin",
     "messageDeleted": "Viesti on poistettu.",
+    "repliedToStory": "Vastasi tarinaasi",
     "sentAttachments": "Lähetettiin {count, plural, one {1 liite} other {# liitettä}}",
     "deleteComment": "Poista kommentti",
     "deleteCommentConfirmation": "Haluatko varmasti poistaa tämän kommentin? Myös sen vastaukset poistetaan sekä saapuneet-kansiostasi että Facebookista. Tätä toimintoa ei voi kumota.",

--- a/apps/builder/messages/fr.json
+++ b/apps/builder/messages/fr.json
@@ -1988,6 +1988,7 @@
     "changeHideState": "Modifier l’état masqué",
     "commentHidden": "Ce commentaire a été masqué",
     "messageDeleted": "Le message a été supprimé.",
+    "repliedToStory": "A répondu à votre story",
     "sentAttachments": "{count, plural, one {1 pièce jointe envoyée} other {# pièces jointes envoyées}}",
     "deleteComment": "Supprimer le commentaire",
     "deleteCommentConfirmation": "Voulez-vous vraiment supprimer ce commentaire ? Ses réponses seront également supprimées de votre boîte de réception et de Facebook. Cette action est irréversible.",

--- a/apps/builder/messages/he.json
+++ b/apps/builder/messages/he.json
@@ -911,6 +911,7 @@
     "changeHideState": "שינוי מצב הסתרה",
     "commentHidden": "תגובה זו הוסתרה",
     "messageDeleted": "ההודעה נמחקה.",
+    "repliedToStory": "הגיב לסטורי שלך",
     "sentAttachments": "נשלחו {count, plural, one {קובץ מצורף אחד} other {# קבצים מצורפים}}",
     "deleteComment": "מחיקת תגובה",
     "deleteCommentConfirmation": "האם למחוק תגובה זו? גם התשובות שלה יימחקו, הן מתיבת הדואר הנכנס והן מ-Facebook. לא ניתן לבטל פעולה זו.",

--- a/apps/builder/messages/id.json
+++ b/apps/builder/messages/id.json
@@ -2597,6 +2597,7 @@
     "changeHideState": "Ubah status sembunyikan",
     "commentHidden": "Komentar ini disembunyikan",
     "messageDeleted": "Pesan telah dihapus.",
+    "repliedToStory": "Membalas story Anda",
     "sentAttachments": "Mengirim {count, plural, one {1 lampiran} other {# lampiran}}",
     "deleteComment": "Hapus komentar",
     "deleteCommentConfirmation": "Apakah Anda yakin ingin menghapus komentar ini? Balasannya juga akan dihapus, baik dari kotak masuk Anda maupun dari Facebook. Tindakan ini tidak dapat dibatalkan.",

--- a/apps/builder/messages/it.json
+++ b/apps/builder/messages/it.json
@@ -2343,6 +2343,7 @@
     "changeHideState": "Cambia stato di visibilità",
     "commentHidden": "Questo commento è stato nascosto",
     "messageDeleted": "Il messaggio è stato eliminato.",
+    "repliedToStory": "Ha risposto alla tua storia",
     "sentAttachments": "Inviati {count, plural, one {1 allegato} other {# allegati}}",
     "deleteComment": "Elimina commento",
     "deleteCommentConfirmation": "Vuoi davvero eliminare questo commento? Verranno eliminate anche le relative risposte, sia nella posta in arrivo sia su Facebook. Questa azione non può essere annullata.",

--- a/apps/builder/messages/ja.json
+++ b/apps/builder/messages/ja.json
@@ -2584,6 +2584,7 @@
     "changeHideState": "非表示状態を変更",
     "commentHidden": "このコメントは非表示になりました",
     "messageDeleted": "メッセージは削除されました。",
+    "repliedToStory": "あなたのストーリーに返信しました",
     "sentAttachments": "{count, plural, one {添付ファイル1件を送信} other {添付ファイル#件を送信}}",
     "deleteComment": "コメントを削除",
     "deleteCommentConfirmation": "このコメントを削除してもよろしいですか？返信も受信トレイとFacebookの両方から削除されます。この操作は元に戻せません。",

--- a/apps/builder/messages/nl.json
+++ b/apps/builder/messages/nl.json
@@ -2597,6 +2597,7 @@
     "changeHideState": "Verbergstatus wijzigen",
     "commentHidden": "Deze opmerking is verborgen",
     "messageDeleted": "Het bericht is verwijderd.",
+    "repliedToStory": "Heeft op je story gereageerd",
     "sentAttachments": "{count, plural, one {1 bijlage verzonden} other {# bijlagen verzonden}}",
     "deleteComment": "Opmerking verwijderen",
     "deleteCommentConfirmation": "Weet je zeker dat je deze opmerking wilt verwijderen? De antwoorden worden ook verwijderd, zowel uit je inbox als van Facebook. Deze actie kan niet ongedaan worden gemaakt.",

--- a/apps/builder/messages/pt-BR.json
+++ b/apps/builder/messages/pt-BR.json
@@ -2584,6 +2584,7 @@
     "changeHideState": "Alterar estado de ocultação",
     "commentHidden": "Este comentário foi ocultado",
     "messageDeleted": "A mensagem foi excluída.",
+    "repliedToStory": "Respondeu ao seu story",
     "sentAttachments": "Enviou {count, plural, one {1 anexo} other {# anexos}}",
     "deleteComment": "Excluir comentário",
     "deleteCommentConfirmation": "Tem certeza de que deseja excluir este comentário? As respostas também serão excluídas, tanto da sua caixa de entrada quanto do Facebook. Esta ação não pode ser desfeita.",

--- a/apps/builder/messages/pt-PT.json
+++ b/apps/builder/messages/pt-PT.json
@@ -2597,6 +2597,7 @@
     "changeHideState": "Alterar estado de ocultação",
     "commentHidden": "Este comentário foi ocultado",
     "messageDeleted": "A mensagem foi eliminada.",
+    "repliedToStory": "Respondeu ao seu story",
     "sentAttachments": "Enviou {count, plural, one {1 anexo} other {# anexos}}",
     "deleteComment": "Eliminar comentário",
     "deleteCommentConfirmation": "Tem a certeza de que pretende eliminar este comentário? As respetivas respostas também serão eliminadas, tanto da sua caixa de entrada como do Facebook. Esta ação não pode ser anulada.",

--- a/apps/builder/messages/ro.json
+++ b/apps/builder/messages/ro.json
@@ -2597,6 +2597,7 @@
     "changeHideState": "Schimbă starea de ascundere",
     "commentHidden": "Acest comentariu a fost ascuns",
     "messageDeleted": "Mesajul a fost șters.",
+    "repliedToStory": "A răspuns la story-ul tău",
     "sentAttachments": "S-a trimis {count, plural, one {1 atașament} other {# atașamente}}",
     "deleteComment": "Șterge comentariul",
     "deleteCommentConfirmation": "Ești sigur că vrei să ștergi acest comentariu? Răspunsurile sale vor fi șterse și ele, atât din mesajele primite, cât și de pe Facebook. Această acțiune nu poate fi anulată.",

--- a/apps/builder/messages/sv.json
+++ b/apps/builder/messages/sv.json
@@ -3112,6 +3112,7 @@
     "publishVersionSuccess": "En ny version har publicerats",
     "redoHistoryCleared": "Historiken för Gör om har rensats",
     "refreshTokenSuccessfully": "Token för {feature} har uppdaterats",
+    "repliedToStory": "Svarade på din story",
     "reply": "Svara",
     "resendFeature": "Skicka {feature} igen",
     "resendFeatureDescription": "Skicka {feature} igen till de kontakter som ännu inte har fått det.",

--- a/apps/builder/messages/tr.json
+++ b/apps/builder/messages/tr.json
@@ -2597,6 +2597,7 @@
     "changeHideState": "Gizleme durumunu değiştir",
     "commentHidden": "Bu yorum gizlendi",
     "messageDeleted": "Mesaj silindi.",
+    "repliedToStory": "Hikayenize yanıt verdi",
     "sentAttachments": "{count, plural, one {1 ek} other {# ek}} gönderildi",
     "deleteComment": "Yorumu sil",
     "deleteCommentConfirmation": "Bu yorumu silmek istediğinizden emin misiniz? Yanıtları da hem gelen kutunuzdan hem de Facebook'tan silinecektir. Bu işlem geri alınamaz.",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -2602,6 +2602,7 @@
     "changeHideState": "Thay đổi trạng thái ẩn",
     "commentHidden": "Bình luận này đã bị ẩn",
     "messageDeleted": "Tin nhắn này đã bị xoá.",
+    "repliedToStory": "Đã trả lời story của bạn",
     "sentAttachments": "Đã gửi {count, plural, one {1 tệp đính kèm} other {# tệp đính kèm}}",
     "deleteComment": "Xóa bình luận",
     "deleteCommentConfirmation": "Bạn có chắc muốn xóa bình luận này? Các bình luận trả lời cũng sẽ bị xóa, cả trong hộp thư và trên Facebook. Hành động này không thể hoàn tác.",

--- a/apps/builder/src/features/messages/components/message-item.tsx
+++ b/apps/builder/src/features/messages/components/message-item.tsx
@@ -2,6 +2,7 @@
 
 import type {
   MessageButtonTemplate,
+  MessageStoryReplyEntity,
   MessageTemplateEntity,
 } from "@chatbotx.io/sdk"
 import { Button, buttonVariants } from "@chatbotx.io/ui/components/ui/button"
@@ -17,6 +18,7 @@ import { cn } from "@chatbotx.io/ui/lib/utils"
 import { format } from "date-fns"
 import {
   ExternalLinkIcon,
+  ImageIcon,
   PaperclipIcon,
   ReplyIcon,
   ThumbsUp,
@@ -93,6 +95,7 @@ export const MessageItem = (props: MessageItemProps) => {
   const isLiked = attributes?.liked === true
   const isHidden = attributes?.hidden === true
   const hasAttachments = !!message.attachments?.length
+  const storyReply = getStoryReplyEntity(message.contentAttributes)
 
   return (
     <MessageBubble
@@ -101,6 +104,7 @@ export const MessageItem = (props: MessageItemProps) => {
       variant={variant}
     >
       <div className="flex min-h-11 max-w-[70%] flex-col gap-1">
+        {storyReply && <StoryReplyContext story={storyReply.story} />}
         {isComment ? (
           (message.text ||
             (message.attachments && message.attachments.length > 0)) && (
@@ -315,6 +319,46 @@ const RenderAttachmentItem = (props: { attachment: AttachmentResource }) => {
         </div>
       )
   }
+}
+
+const getStoryReplyEntity = (
+  contentAttributes: MessageResourceWithRelations["contentAttributes"],
+): MessageStoryReplyEntity | undefined => {
+  if (
+    !contentAttributes ||
+    typeof contentAttributes !== "object" ||
+    (contentAttributes as { type?: unknown }).type !== "story_reply"
+  ) {
+    return
+  }
+
+  return contentAttributes as MessageStoryReplyEntity
+}
+
+const StoryReplyContext = (props: {
+  story: MessageStoryReplyEntity["story"]
+}) => {
+  const { story } = props
+  const t = useTranslations("messages")
+
+  return (
+    <div className="flex items-center gap-2 rounded-lg border bg-secondary/50 px-2 py-1.5 text-muted-foreground text-xs">
+      {story.url ? (
+        <Image
+          alt={t("repliedToStory")}
+          className="size-8 rounded-md object-cover"
+          height={32}
+          src={story.url}
+          width={32}
+        />
+      ) : (
+        <span className="flex size-8 flex-none items-center justify-center rounded-md bg-secondary">
+          <ImageIcon className="size-4" />
+        </span>
+      )}
+      <span>{t("repliedToStory")}</span>
+    </div>
+  )
 }
 
 const RenderContentAttributes = (props: MessageItemProps) => {

--- a/apps/worker/__tests__/received-message.test.ts
+++ b/apps/worker/__tests__/received-message.test.ts
@@ -187,6 +187,17 @@ vi.mock("@chatbotx.io/sdk", () => ({
   contentTypes: { enum: { text: "text", location: "location" } },
   messageTypes: { enum: { incoming: "incoming", outgoing: "outgoing" } },
   SdkException: class SdkException extends Error {},
+  getStoryReply: (contentAttributes: unknown) => {
+    if (!contentAttributes || typeof contentAttributes !== "object") {
+      return
+    }
+    const attrs = contentAttributes as {
+      type?: string
+      story?: { id: string; url?: string }
+      storyReply?: { id: string; url?: string }
+    }
+    return attrs.type === "story_reply" ? attrs.story : attrs.storyReply
+  },
 }))
 
 vi.mock("@chatbotx.io/utils", async (importOriginal) => {
@@ -539,6 +550,44 @@ describe("receiveMessage — message repository branch", () => {
     )
   })
 
+  test("does not flip an outgoing story-reply echo for an already-known contact", async () => {
+    // Only a brand-new contact's outgoing story reply is corrected (see the
+    // "flips an outgoing story-reply echo..." test in the new-contact
+    // describe block). An agent genuinely replying to an existing contact's
+    // story via the native Instagram app must stay outgoing — flipping it
+    // would make story-reply automation auto-reply to the agent's own
+    // message.
+    mockRunChannelHandler.mockResolvedValue({
+      message: {
+        ...baseIncomingMessage,
+        messageType: "outgoing",
+        contentAttributes: {
+          type: "story_reply",
+          story: { id: "story-1", url: "https://example.com/story-1" },
+        },
+        attachments: [],
+      },
+      contact: { sourceId: "psid-123", firstName: "Test" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+    mockCreateOrUpdate.mockResolvedValue({
+      message: { ...fakeCreatedMessage, messageType: "outgoing" },
+      isNew: true,
+    })
+
+    await receiveMessage(baseProps)
+
+    expect(mockCreateOrUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageType: "outgoing",
+        senderType: "user",
+        senderId: null,
+      }),
+    )
+  })
+
   test("does NOT update lastMessageAt when isNew=false", async () => {
     mockRunChannelHandler.mockResolvedValue({
       message: { ...baseIncomingMessage, attachments: [] },
@@ -750,25 +799,40 @@ describe("receiveMessage — new contact MAC gate", () => {
     expect(mockQuotaIncrement).not.toHaveBeenCalled()
   })
 
-  test("skips getProfile for outgoing webhook echo when creating a new contact", async () => {
-    mockRunChannelHandler.mockResolvedValue({
-      message: {
-        ...baseIncomingMessage,
-        messageType: "outgoing",
-        attachments: [],
+  test("still fetches getProfile for an outgoing webhook echo when creating a new contact", async () => {
+    // A page-initiated echo (e.g. an agent replying to a story mention
+    // directly on Instagram) can be the FIRST time we see that contact.
+    // Skipping getProfile here would leave the contact without a name/avatar
+    // forever, since later inbound messages reuse the existing contactInbox
+    // and never re-fetch the profile.
+    mockRunChannelHandler.mockImplementation(
+      (_domain: string, action: string) => {
+        if (action === "getProfile") {
+          return Promise.resolve({
+            firstName: "Story Replier",
+            avatar: "https://example.com/avatar.jpg",
+          })
+        }
+        return Promise.resolve({
+          message: {
+            ...baseIncomingMessage,
+            messageType: "outgoing",
+            attachments: [],
+          },
+          contact: { sourceId: "psid-123" },
+          postbackAction: null,
+          quickReplyAction: null,
+          ref: null,
+        })
       },
-      contact: { sourceId: "psid-123" },
-      postbackAction: null,
-      quickReplyAction: null,
-      ref: null,
-    })
+    )
     mockCreateNewContactWithMac.mockResolvedValue({
       ok: true,
       value: {
         newContact: {
           id: "contact-new",
           workspaceId: "ws-1",
-          firstName: null,
+          firstName: "Story Replier",
           phoneNumber: null,
           email: null,
           blockedAt: null,
@@ -785,12 +849,72 @@ describe("receiveMessage — new contact MAC gate", () => {
 
     await receiveMessage(baseProps)
 
-    // The parse call ("message"/"receiveMessage") happens; getProfile must not.
-    expect(mockRunChannelHandler).toHaveBeenCalledTimes(1)
-    expect(mockRunChannelHandler).not.toHaveBeenCalledWith(
+    expect(mockRunChannelHandler).toHaveBeenCalledWith(
       "contact",
       "getProfile",
-      expect.anything(),
+      expect.objectContaining({ data: { sourceId: "psid-123" } }),
+    )
+    const rows = await runCapturedNewContactCreate()
+    expect(rows).toContainEqual(
+      expect.objectContaining({
+        firstName: "Story Replier",
+        avatar: "https://example.com/avatar.jpg",
+      }),
+    )
+  })
+
+  test("flips an outgoing story-reply echo to incoming when it creates a brand-new contact", async () => {
+    // Meta has been observed sending a real customer's first-ever story
+    // reply as an is_echo:true message with sender.id === the page's own
+    // id. A page can't have proactively DM'd a contact it never talked to,
+    // so this combination (new contact + outgoing + storyReply) must be
+    // corrected to incoming — otherwise story-reply automation never fires
+    // (see apps/worker/src/integration/worker.ts's `isFromContact` gate).
+    mockRunChannelHandler.mockResolvedValue({
+      message: {
+        ...baseIncomingMessage,
+        messageType: "outgoing",
+        contentAttributes: {
+          type: "story_reply",
+          story: { id: "story-1", url: "https://example.com/story-1" },
+        },
+        attachments: [],
+      },
+      contact: { sourceId: "psid-123" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+    const contactInbox = {
+      ...fakeContactInbox,
+      id: "ci-new",
+      contactId: "contact-new",
+    }
+    mockCreateNewContactWithMac.mockResolvedValue({
+      ok: true,
+      value: {
+        newContact: {
+          id: "contact-new",
+          workspaceId: "ws-1",
+          firstName: null,
+          phoneNumber: null,
+          email: null,
+          blockedAt: null,
+          createdAt: new Date("2026-06-21T00:00:00Z"),
+        },
+        contactInbox,
+        conversation: fakeConversation,
+      },
+    })
+
+    await receiveMessage(baseProps)
+
+    expect(mockCreateOrUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageType: "incoming",
+        senderType: "contact",
+        senderId: "contact-new",
+      }),
     )
   })
 

--- a/apps/worker/src/integration/handlers/received-message.ts
+++ b/apps/worker/src/integration/handlers/received-message.ts
@@ -45,6 +45,7 @@ import type { IncomingAttachment } from "@chatbotx.io/sdk"
 import {
   type AuthValue,
   contentTypes,
+  getStoryReply,
   type IncomingContact,
   type IncomingMessage,
   type MessageLocationEntity,
@@ -81,6 +82,22 @@ type ContactLocation = {
 type ReceivedMessageSystemFieldUpdates = {
   contactInboxTracking: ContactInboxTracking
   contactLocation: ContactLocation | null
+}
+
+const correctStoryReplyDirectionForNewContact = (
+  message: IncomingMessage | null,
+  isNewContact: boolean,
+): IncomingMessage | null => {
+  const storyReply = getStoryReply(message?.contentAttributes)
+  if (
+    message &&
+    isNewContact &&
+    message.messageType === messageTypes.enum.outgoing &&
+    storyReply
+  ) {
+    return { ...message, messageType: messageTypes.enum.incoming }
+  }
+  return message
 }
 
 export const metaReferralToContactSource = (
@@ -156,7 +173,7 @@ export const receiveMessage = async (
   }
 
   const {
-    message: incomingMessage,
+    message: rawIncomingMessage,
     contact: incomingContact,
     postbackAction: rawPostbackAction,
     quickReplyAction: rawQuickReplyAction,
@@ -178,7 +195,6 @@ export const receiveMessage = async (
     incomingContact,
     inbox,
     integrationRow,
-    skipProfileLookup: incomingMessage?.messageType === "outgoing",
     source:
       metaReferralToContactSource(referralSource) ??
       contactSources.enum.inboundMessage,
@@ -187,7 +203,14 @@ export const receiveMessage = async (
     throw new SdkException("Unable to resolve contact and conversation")
   }
   const { contactInbox, conversation, contact, isNewContact } = detected
-  const systemFieldUpdates = getReceivedMessageSystemFieldUpdates(parsedMessage)
+  const incomingMessage = correctStoryReplyDirectionForNewContact(
+    rawIncomingMessage,
+    isNewContact,
+  )
+  const systemFieldUpdates = getReceivedMessageSystemFieldUpdates({
+    ...parsedMessage,
+    message: incomingMessage,
+  })
 
   // Overwrite Contact.phoneNumber/email from message text — every inbound
   // channel. Unconditional: the customer just typed the value, so it's
@@ -779,15 +802,13 @@ export const detectContactAndConversation = async (props: {
     [x: string]: unknown
   }
   source: ContactSource
-  skipProfileLookup?: boolean
 }): Promise<{
   contactInbox: ContactInboxModel
   contact: ContactModel
   conversation: ConversationModel
   isNewContact: boolean
 }> => {
-  const { incomingContact, inbox, integrationRow, source, skipProfileLookup } =
-    props
+  const { incomingContact, inbox, integrationRow, source } = props
 
   const existingContactInbox = await db.query.contactInboxModel.findFirst({
     where: {
@@ -824,7 +845,7 @@ export const detectContactAndConversation = async (props: {
     ...incomingContact,
     workspaceId: inbox.workspaceId,
   }
-  if (canGetUserProfileIfNeeded(inbox.channel) && !skipProfileLookup) {
+  if (canGetUserProfileIfNeeded(inbox.channel)) {
     const integrationType =
       inbox.channel === "instagram" && isInstagramViaFacebook(integrationRow)
         ? "instagramFacebook"

--- a/apps/worker/src/integration/worker.ts
+++ b/apps/worker/src/integration/worker.ts
@@ -1,6 +1,7 @@
 import { automatedResponseService } from "@chatbotx.io/automated-response"
 import { conversationService } from "@chatbotx.io/business"
 import { emit } from "@chatbotx.io/event-bus"
+import { getStoryReply } from "@chatbotx.io/sdk"
 import {
   defaultWorkerOptions,
   getRedisConnection,
@@ -86,11 +87,7 @@ async function startIntegrationWorker() {
             const hasAttachment = message.attachments.length > 0
             const isLocation = message.contentType === "location"
 
-            const storyReply = (
-              message.contentAttributes as
-                | { storyReply?: { id: string; url?: string } }
-                | undefined
-            )?.storyReply
+            const storyReply = getStoryReply(message.contentAttributes)
 
             if (isFromContact && storyReply) {
               await integrationQueue.add(

--- a/integrations/instagram-facebook/src/handlers/message/incoming-message.ts
+++ b/integrations/instagram-facebook/src/handlers/message/incoming-message.ts
@@ -103,7 +103,9 @@ const getMessageEntity = async (
           : messageTypes.enum.incoming,
       text: messaging.message.text,
       contentType: contentTypes.enum.text,
-      contentAttributes: storyReply ? { storyReply } : undefined,
+      contentAttributes: storyReply
+        ? { type: "story_reply", story: storyReply }
+        : undefined,
       attachments: await getMessageAttachments(ctx, messaging.message),
     }
     quickReplyAction = messaging.message.quick_reply?.payload ?? null

--- a/integrations/instagram/src/handlers/message/incomming-message.ts
+++ b/integrations/instagram/src/handlers/message/incomming-message.ts
@@ -158,7 +158,9 @@ const getMessageEntity = async (
       contentType: location
         ? contentTypes.enum.location
         : contentTypes.enum.text,
-      contentAttributes: location ?? (storyReply ? { storyReply } : undefined),
+      contentAttributes:
+        location ??
+        (storyReply ? { type: "story_reply", story: storyReply } : undefined),
       attachments: await getMessageAttachments(ctx, messaging.message),
     }
     quickReplyAction = messaging.message.quick_reply?.payload ?? null

--- a/packages/sdk/src/lib/shared/message.ts
+++ b/packages/sdk/src/lib/shared/message.ts
@@ -57,6 +57,7 @@ export type IncomingMessage = {
     | MessageLocationEntity
     | MessageTemplateEntity
     | MessageWhatsappFlowResponseEntity
+    | MessageStoryReplyEntity
     | { [x: string]: unknown }
   attachments?: IncomingAttachment[]
   clientId?: string | null
@@ -68,6 +69,41 @@ export type MessageWhatsappFlowResponseEntity = {
   flowResponse: Record<string, unknown>
   flowToken: string | null
   decoded: ButtonPayload | null
+}
+
+/**
+ * Carried on a message that is the contact's reply to one of the workspace's
+ * Instagram/Messenger stories (Meta's `reply_to.story` webhook field), so the
+ * inbox can render "Replied to your story" context instead of showing it as
+ * a plain text message. `story.url` is Meta's CDN link and is short-lived.
+ */
+export type MessageStoryReplyEntity = {
+  type: "story_reply"
+  story: {
+    id: string
+    url?: string
+  }
+}
+
+/**
+ * Extracts the story-reply payload from a message's contentAttributes,
+ * accepting both the current `{ type: "story_reply", story }` shape and the
+ * legacy `{ storyReply }` shape some already-persisted rows still carry.
+ * Centralized so callers (worker routing, direction correction, inbox
+ * rendering) can't drift from each other on the shape check.
+ */
+export const getStoryReply = (
+  contentAttributes: unknown,
+): MessageStoryReplyEntity["story"] | undefined => {
+  if (!contentAttributes || typeof contentAttributes !== "object") {
+    return
+  }
+  const attrs = contentAttributes as {
+    type?: string
+    story?: MessageStoryReplyEntity["story"]
+    storyReply?: MessageStoryReplyEntity["story"]
+  }
+  return attrs.type === "story_reply" ? attrs.story : attrs.storyReply
 }
 
 export const MessageEntitySchema = z.custom<IncomingMessage>(


### PR DESCRIPTION
## Summary
- Meta echoes a genuine first-time customer message (Instagram story reply or plain inbox DM) as `is_echo:true` with `sender.id` equal to the page's own IG business account id, which the worker treated as page-authored.
- New contacts got no name/avatar because profile lookup was unconditionally skipped for any "outgoing" new-contact message.
- Story-reply automation never fired for a brand-new contact's first story reply, since the message stayed classified as agent-sent, failing the `isFromContact` gate.

## Changes
- `apps/worker/src/integration/handlers/received-message.ts` — always attempt profile lookup for new contacts (the existing try/catch already makes a failed lookup safe); flip a new-contact's outgoing story-reply message back to `incoming` before persisting. Existing contacts are left untouched so a real agent reply-echo isn't reinterpreted as inbound.
- `apps/worker/src/integration/worker.ts` — routes story-reply automation using the shared shape check instead of an inline duplicate.
- `packages/sdk/src/lib/shared/message.ts` — new `getStoryReply()` helper unifying the story-reply `contentAttributes` shape check (current `{ type: "story_reply", story }` vs. legacy `{ storyReply }` on historical rows), used by both the worker routing and the direction correction to prevent the two from drifting apart again.
- `integrations/instagram/src/handlers/message/incomming-message.ts`, `integrations/instagram-facebook/src/handlers/message/incoming-message.ts` — emit the current typed story-reply shape.
- `apps/builder/src/features/messages/components/message-item.tsx` + locale files — render "Replied to your story" context in the inbox for story-reply messages.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter worker check-types`
- [x] `pnpm --filter @chatbotx.io/sdk check-types`
- [x] `pnpm --filter builder check-types`
- [x] `pnpm --filter worker test` (140 files / 1313 tests passing, including new regression tests for the story-reply direction correction)