### PR TITLE
fix(instagram): resolve correct channelType for story-reply automation

### DIFF
--- a/apps/worker/src/integration/handlers/received-message.ts
+++ b/apps/worker/src/integration/handlers/received-message.ts
@@ -123,6 +123,7 @@ export const receiveMessage = async (
   postbackAction: string | null
   quickReplyAction: string | null
   ref?: string | null
+  channelType: "instagram" | "instagramFacebook"
 }> => {
   setWebhookExecutionContext({ source: "webhook" })
 
@@ -144,12 +145,13 @@ export const receiveMessage = async (
       `No integration registered for channel: ${integrationType}`,
     )
   }
-  if (
-    integrationType === "instagram" &&
-    isInstagramViaFacebook(integrationRow)
-  ) {
+  const isFacebookConnectedInstagram =
+    integrationType === "instagram" && isInstagramViaFacebook(integrationRow)
+  if (isFacebookConnectedInstagram) {
     integration = allIntegrations.instagramFacebook ?? integration
   }
+  const channelType: "instagram" | "instagramFacebook" =
+    isFacebookConnectedInstagram ? "instagramFacebook" : "instagram"
 
   const workspace = await workspaceService.findById({ id: inbox.workspaceId })
   const isWorkspaceActive = workspaceService.isActiveNow(workspace)
@@ -316,6 +318,7 @@ export const receiveMessage = async (
     postbackAction,
     quickReplyAction,
     ref,
+    channelType,
   }
 }
 

--- a/apps/worker/src/integration/worker.ts
+++ b/apps/worker/src/integration/worker.ts
@@ -68,8 +68,13 @@ async function startIntegrationWorker() {
       return await runIntegrationJobWithWebhookContext(job.data, async () => {
         switch (job.data.type) {
           case IntegrationJobAction.incomingMessage: {
-            const { message, postbackAction, quickReplyAction, conversation } =
-              await receiveMessage(job.data.data)
+            const {
+              message,
+              postbackAction,
+              quickReplyAction,
+              conversation,
+              channelType,
+            } = await receiveMessage(job.data.data)
 
             if (!message) {
               return
@@ -102,9 +107,7 @@ async function startIntegrationWorker() {
                     storyId: storyReply.id,
                     storyUrl: storyReply.url,
                     message: message.text ?? undefined,
-                    channelType: job.data.data.integrationType as
-                      | "instagram"
-                      | "instagramFacebook",
+                    channelType,
                   },
                 },
                 { jobId: `story-reply-auto-${message.id}` },


### PR DESCRIPTION
## Summary
- `worker.ts` cast `job.data.data.integrationType` directly to `"instagram" | "instagramFacebook"` for the `processStoryReplyAutomation` job, but the instagram-facebook webhook always tags incoming DM jobs with the raw `"instagram"` literal (the true channel can only be known after a DB lookup).
- `receiveMessage()` already resolves the real channel via `isInstagramViaFacebook(integrationRow)`, but never returned it — so story-reply automations scoped to `type: "instagramFacebook"` never matched and silently never fired for Facebook-connected Instagram accounts.
- `receiveMessage()` now returns the resolved `channelType`, and `worker.ts` uses it instead of the raw job payload field.

## Changes
- `apps/worker/src/integration/handlers/received-message.ts` — `receiveMessage()` return type gains `channelType`, computed from the existing Facebook-check.
- `apps/worker/src/integration/worker.ts` — destructures and uses the resolved `channelType` instead of casting `job.data.data.integrationType`.

## Test plan
- [x] `pnpm --filter worker check-types`
- [x] `pnpm lint`
- [ ] Manual verification: workspace with an Instagram integration where `type === "facebook"` and an active `igStoryAutomationModel` row with `type: "instagramFacebook"` should now have the automation actually match and fire on a story reply.