### PR TITLE
fix(flows): prevent toolbar menu labels from wrapping

### DIFF
--- a/apps/builder/src/features/flows/react-flow/flow-edit-toolbar.tsx
+++ b/apps/builder/src/features/flows/react-flow/flow-edit-toolbar.tsx
@@ -309,7 +309,7 @@ export function FlowEditToolbar({
         <DropdownMenuTrigger className="px-1.5">
           <EllipsisIcon />
         </DropdownMenuTrigger>
-        <DropdownMenuContent>
+        <DropdownMenuContent className="min-w-64 whitespace-nowrap">
           <DropdownMenuGroup>
             <DropdownMenuItem onClick={() => setAction("rename")}>
               <TypeIcon />


### PR DESCRIPTION
## Summary
- The flow editor's "..." toolbar dropdown menu was constrained to the trigger button's anchor width with only a 128px floor, causing longer labels (e.g. "Get JSON for Messenger Ads") to wrap onto multiple lines.
- Set a wider minimum width and `whitespace-nowrap` on this menu's `DropdownMenuContent`, following the same override pattern already used by other menus (`nav-user.tsx`, `workspace-switcher.tsx`).

## Changes
- `apps/builder/src/features/flows/react-flow/flow-edit-toolbar.tsx` — added `className="min-w-64 whitespace-nowrap"` to the toolbar's `DropdownMenuContent`.

## Test plan
- [x] pnpm lint
- [x] pnpm --filter builder check-types
- [ ] manual verification: open a flow, click the "..." toolbar menu, confirm all labels render on a single line