### PR TITLE
feat(broadcasts): show target page in broadcast names and details

### DIFF
--- a/apps/builder/src/features/broadcasts/actions/create-broadcast.action.ts
+++ b/apps/builder/src/features/broadcasts/actions/create-broadcast.action.ts
@@ -1,5 +1,6 @@
 "use server"
 
+import { broadcastService } from "@chatbotx.io/business"
 import { db } from "@chatbotx.io/database/client"
 import { findBroadcastChannelCapability } from "@chatbotx.io/database/partials"
 import { pruneEmailPhoneFilterConditions } from "@chatbotx.io/database/queries/contact-filter/permission"
@@ -124,45 +125,25 @@ export const createBroadcastAction = workspaceActionClient
     }
 
     if (parsedInput.templateId) {
-      if (parsedInput.channel === "messenger") {
-        const template = await db.query.messengerMessageTemplateModel.findFirst(
-          {
-            where: {
-              id: parsedInput.templateId,
-              integrationMessengerId: parsedInput.integrationMessengerId,
-              integrationMessenger: { workspaceId },
-            },
-          },
-        )
-        if (!template) {
-          return returnValidationErrors(createBroadcastRequest, {
-            _errors: ["Validation Exception"],
-            templateId: {
-              _errors: ["Template not found"],
-            },
-          })
-        }
-        broadcastName = template.name
-      } else {
-        const template = await db.query.whatsappMessageTemplateModel.findFirst({
-          where: {
-            id: parsedInput.templateId,
-            integrationWhatsapp: {
-              workspaceId,
-              id: parsedInput.integrationWhatsappId,
-            },
+      const templateBroadcastName =
+        await broadcastService.resolveTemplateBroadcastName({
+          workspaceId,
+          channel: parsedInput.channel,
+          templateId: parsedInput.templateId,
+          integrationMessengerId: parsedInput.integrationMessengerId,
+          integrationWhatsappId: parsedInput.integrationWhatsappId,
+        })
+
+      if (!templateBroadcastName) {
+        return returnValidationErrors(createBroadcastRequest, {
+          _errors: ["Validation Exception"],
+          templateId: {
+            _errors: ["Template not found"],
           },
         })
-        if (!template) {
-          return returnValidationErrors(createBroadcastRequest, {
-            _errors: ["Validation Exception"],
-            templateId: {
-              _errors: ["Template not found"],
-            },
-          })
-        }
-        broadcastName = template.name
       }
+
+      broadcastName = templateBroadcastName
     }
 
     const { buttons, ...insertValues } = parsedInput

--- a/apps/builder/src/features/broadcasts/broadcast-detail-dialog.tsx
+++ b/apps/builder/src/features/broadcasts/broadcast-detail-dialog.tsx
@@ -120,6 +120,15 @@ export function BroadcastDetailDialog({
     | null
     | undefined
 
+  // Omnichannel broadcasts target every connected page, so they have no single
+  // integration; otherwise show the connected page (inbox) name it sends to.
+  const integrationValue =
+    channelValue === channelTypes.enum.omnichannel
+      ? t("fields.omnichannel.label")
+      : (broadcast.integrationWhatsapp?.name ??
+        broadcast.integrationMessenger?.name ??
+        "-")
+
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent className="max-h-screen overflow-y-auto sm:max-w-3xl">
@@ -142,6 +151,10 @@ export function BroadcastDetailDialog({
                   size="small"
                 />
               }
+            />
+            <DetailField
+              label={t("broadcasts.detail.integration")}
+              value={integrationValue}
             />
             <DetailField
               label={t("broadcasts.detail.subaction")}

--- a/apps/builder/src/features/broadcasts/queries/index.ts
+++ b/apps/builder/src/features/broadcasts/queries/index.ts
@@ -37,6 +37,18 @@ export async function listBroadcasts(
             name: true,
           },
         },
+        integrationWhatsapp: {
+          columns: {
+            id: true,
+            name: true,
+          },
+        },
+        integrationMessenger: {
+          columns: {
+            id: true,
+            name: true,
+          },
+        },
       },
       ...pagination,
       orderBy,

--- a/apps/builder/src/features/broadcasts/schemas/resource.ts
+++ b/apps/builder/src/features/broadcasts/schemas/resource.ts
@@ -2,13 +2,20 @@ import {
   broadcastModel,
   createSelectSchema,
 } from "@chatbotx.io/database/schema"
-import type { BroadcastModel, FlowModel } from "@chatbotx.io/database/types"
+import type {
+  BroadcastModel,
+  FlowModel,
+  IntegrationMessengerModel,
+  IntegrationWhatsappModel,
+} from "@chatbotx.io/database/types"
 
 export const broadcastResource = createSelectSchema(broadcastModel)
 export type BroadcastResource = BroadcastModel
 
 export type BroadcastResourceWithRelations = BroadcastResource & {
   flow?: Pick<FlowModel, "id" | "name"> | null
+  integrationWhatsapp?: Pick<IntegrationWhatsappModel, "id" | "name"> | null
+  integrationMessenger?: Pick<IntegrationMessengerModel, "id" | "name"> | null
   contactsCount?: number
 }
 

--- a/packages/business/src/broadcast/__tests__/broadcast.service.test.ts
+++ b/packages/business/src/broadcast/__tests__/broadcast.service.test.ts
@@ -658,6 +658,150 @@ describe("broadcastService.getTemplateDetail", () => {
   })
 })
 
+describe("broadcastService.resolveTemplateBroadcastName", () => {
+  test("prefixes the whatsapp page name and scopes to the chosen integration", async () => {
+    mocks.selectRows = [
+      {
+        id: "template-1",
+        name: "order_confirmation",
+        language: "en",
+        category: "UTILITY",
+        status: "APPROVED",
+        components: [],
+        integrationName: "Acme WhatsApp",
+      },
+    ]
+
+    const name = await broadcastService.resolveTemplateBroadcastName({
+      workspaceId: "ws-1",
+      channel: "whatsapp",
+      templateId: "template-1",
+      integrationWhatsappId: "whatsapp-1",
+    })
+
+    expect(name).toBe("Acme WhatsApp - order_confirmation")
+    expect(mocks.selectWhere).toHaveBeenCalledWith({
+      __and: [
+        { __eq: ["WhatsappMessageTemplate.id", "template-1"] },
+        { __eq: ["IntegrationWhatsapp.workspaceId", "ws-1"] },
+        {
+          __eq: ["WhatsappMessageTemplate.integrationWhatsappId", "whatsapp-1"],
+        },
+      ],
+    })
+  })
+
+  test("prefixes the messenger page name and scopes to the chosen integration", async () => {
+    mocks.selectRows = [
+      {
+        id: "template-2",
+        name: "promo_update",
+        language: "en",
+        category: "MARKETING",
+        status: "APPROVED",
+        parameterFormat: "POSITIONAL",
+        components: [],
+        integrationName: "Acme Page",
+      },
+    ]
+
+    const name = await broadcastService.resolveTemplateBroadcastName({
+      workspaceId: "ws-1",
+      channel: "messenger",
+      templateId: "template-2",
+      integrationMessengerId: "messenger-1",
+    })
+
+    expect(name).toBe("Acme Page - promo_update")
+    expect(mocks.selectWhere).toHaveBeenCalledWith({
+      __and: [
+        { __eq: ["MessengerMessageTemplate.id", "template-2"] },
+        { __eq: ["IntegrationMessenger.workspaceId", "ws-1"] },
+        {
+          __eq: [
+            "MessengerMessageTemplate.integrationMessengerId",
+            "messenger-1",
+          ],
+        },
+      ],
+    })
+  })
+
+  test("falls back to the template name when the page name is missing", async () => {
+    mocks.selectRows = [
+      {
+        id: "template-3",
+        name: "standalone_template",
+        language: "en",
+        category: "UTILITY",
+        status: "APPROVED",
+        components: [],
+        integrationName: null,
+      },
+    ]
+
+    const name = await broadcastService.resolveTemplateBroadcastName({
+      workspaceId: "ws-1",
+      channel: "whatsapp",
+      templateId: "template-3",
+      integrationWhatsappId: "whatsapp-1",
+    })
+
+    expect(name).toBe("standalone_template")
+  })
+
+  test("omits the integration scope when no integration id is provided", async () => {
+    mocks.selectRows = [
+      {
+        id: "template-4",
+        name: "order_confirmation",
+        language: "en",
+        category: "UTILITY",
+        status: "APPROVED",
+        components: [],
+        integrationName: "Acme WhatsApp",
+      },
+    ]
+
+    await broadcastService.resolveTemplateBroadcastName({
+      workspaceId: "ws-1",
+      channel: "whatsapp",
+      templateId: "template-4",
+    })
+
+    expect(mocks.selectWhere).toHaveBeenCalledWith({
+      __and: [
+        { __eq: ["WhatsappMessageTemplate.id", "template-4"] },
+        { __eq: ["IntegrationWhatsapp.workspaceId", "ws-1"] },
+      ],
+    })
+  })
+
+  test("returns null when the template is not found in the workspace/page", async () => {
+    mocks.selectRows = []
+
+    const name = await broadcastService.resolveTemplateBroadcastName({
+      workspaceId: "ws-1",
+      channel: "whatsapp",
+      templateId: "missing-template",
+      integrationWhatsappId: "whatsapp-1",
+    })
+
+    expect(name).toBeNull()
+  })
+
+  test("returns null for channels that do not support template broadcasts", async () => {
+    const name = await broadcastService.resolveTemplateBroadcastName({
+      workspaceId: "ws-1",
+      channel: "telegram",
+      templateId: "template-5",
+    })
+
+    expect(name).toBeNull()
+    expect(mocks.selectWhere).not.toHaveBeenCalled()
+  })
+})
+
 describe("broadcastService.forEachAudienceChunk", () => {
   test("does not invoke the chunk callback when no inboxes resolve", async () => {
     mocks.resolveBroadcastInboxIds.mockResolvedValue([])

--- a/packages/business/src/broadcast/service.ts
+++ b/packages/business/src/broadcast/service.ts
@@ -45,8 +45,25 @@ const OPTION_LIST_LIMIT = 500
 const DEFAULT_PREVIEW_PER_PAGE = 20
 const MAX_PREVIEW_PER_PAGE = 50
 
+// Separates the page name from the template name in an auto-generated broadcast
+// name, e.g. "Acme WhatsApp - order_confirmation".
+const BROADCAST_NAME_SEPARATOR = " - "
+
 type ContactInboxRow = typeof contactInboxModel.$inferSelect
 type SelectOptionRow = { id: string; name: string }
+
+// Scopes a template lookup to a workspace, optionally narrowing it to the chosen
+// integration so a template can only be paired with its own page.
+type BroadcastTemplateLookup = {
+  workspaceId: string
+  templateId: string
+  integrationWhatsappId?: string | null
+  integrationMessengerId?: string | null
+}
+
+type BroadcastTemplateLoader = (
+  lookup: BroadcastTemplateLookup,
+) => Promise<BroadcastTemplateDetail | null>
 
 class BroadcastService extends BaseService {
   async listOptions(input: {
@@ -213,6 +230,105 @@ class BroadcastService extends BaseService {
     }))
   }
 
+  // One loader per template-capable channel. Each owns its own tables and the
+  // integration id it scopes by, so callers dispatch by channel without a
+  // per-channel branch and adding a channel means adding one entry here.
+  private readonly templateLoaders: Partial<
+    Record<ChannelType, BroadcastTemplateLoader>
+  > = {
+    whatsapp: (lookup) => this.loadWhatsappTemplateDetail(lookup),
+    messenger: (lookup) => this.loadMessengerTemplateDetail(lookup),
+  }
+
+  private loadTemplateDetail(
+    channel: ChannelType,
+    lookup: BroadcastTemplateLookup,
+  ): Promise<BroadcastTemplateDetail | null> {
+    const loadDetail = this.templateLoaders[channel]
+    return loadDetail ? loadDetail(lookup) : Promise.resolve(null)
+  }
+
+  private async loadWhatsappTemplateDetail(
+    lookup: BroadcastTemplateLookup,
+  ): Promise<BroadcastTemplateDetail | null> {
+    const conditions = [
+      eq(whatsappMessageTemplateModel.id, lookup.templateId),
+      eq(integrationWhatsappModel.workspaceId, lookup.workspaceId),
+    ]
+    if (lookup.integrationWhatsappId) {
+      conditions.push(
+        eq(
+          whatsappMessageTemplateModel.integrationWhatsappId,
+          lookup.integrationWhatsappId,
+        ),
+      )
+    }
+
+    const [template] = await db
+      .select({
+        id: whatsappMessageTemplateModel.id,
+        name: whatsappMessageTemplateModel.name,
+        language: whatsappMessageTemplateModel.language,
+        category: whatsappMessageTemplateModel.category,
+        status: whatsappMessageTemplateModel.status,
+        components: whatsappMessageTemplateModel.components,
+        integrationName: integrationWhatsappModel.name,
+      })
+      .from(whatsappMessageTemplateModel)
+      .innerJoin(
+        integrationWhatsappModel,
+        eq(
+          integrationWhatsappModel.id,
+          whatsappMessageTemplateModel.integrationWhatsappId,
+        ),
+      )
+      .where(and(...conditions))
+      .limit(1)
+
+    return template ? { ...template, channel: "whatsapp" } : null
+  }
+
+  private async loadMessengerTemplateDetail(
+    lookup: BroadcastTemplateLookup,
+  ): Promise<BroadcastTemplateDetail | null> {
+    const conditions = [
+      eq(messengerMessageTemplateModel.id, lookup.templateId),
+      eq(integrationMessengerModel.workspaceId, lookup.workspaceId),
+    ]
+    if (lookup.integrationMessengerId) {
+      conditions.push(
+        eq(
+          messengerMessageTemplateModel.integrationMessengerId,
+          lookup.integrationMessengerId,
+        ),
+      )
+    }
+
+    const [template] = await db
+      .select({
+        id: messengerMessageTemplateModel.id,
+        name: messengerMessageTemplateModel.name,
+        language: messengerMessageTemplateModel.language,
+        category: messengerMessageTemplateModel.category,
+        status: messengerMessageTemplateModel.status,
+        parameterFormat: messengerMessageTemplateModel.parameterFormat,
+        components: messengerMessageTemplateModel.components,
+        integrationName: integrationMessengerModel.name,
+      })
+      .from(messengerMessageTemplateModel)
+      .innerJoin(
+        integrationMessengerModel,
+        eq(
+          integrationMessengerModel.id,
+          messengerMessageTemplateModel.integrationMessengerId,
+        ),
+      )
+      .where(and(...conditions))
+      .limit(1)
+
+    return template ? { ...template, channel: "messenger" } : null
+  }
+
   async getTemplateDetail(input: {
     workspaceId: string
     broadcastId: string
@@ -232,68 +348,37 @@ class BroadcastService extends BaseService {
       return null
     }
 
-    if (broadcast.channel === "whatsapp") {
-      const [template] = await db
-        .select({
-          id: whatsappMessageTemplateModel.id,
-          name: whatsappMessageTemplateModel.name,
-          language: whatsappMessageTemplateModel.language,
-          category: whatsappMessageTemplateModel.category,
-          status: whatsappMessageTemplateModel.status,
-          components: whatsappMessageTemplateModel.components,
-          integrationName: integrationWhatsappModel.name,
-        })
-        .from(whatsappMessageTemplateModel)
-        .innerJoin(
-          integrationWhatsappModel,
-          eq(
-            integrationWhatsappModel.id,
-            whatsappMessageTemplateModel.integrationWhatsappId,
-          ),
-        )
-        .where(
-          and(
-            eq(whatsappMessageTemplateModel.id, broadcast.templateId),
-            eq(integrationWhatsappModel.workspaceId, input.workspaceId),
-          ),
-        )
-        .limit(1)
+    return this.loadTemplateDetail(broadcast.channel as ChannelType, {
+      workspaceId: input.workspaceId,
+      templateId: broadcast.templateId,
+    })
+  }
 
-      return template ? { ...template, channel: "whatsapp" } : null
+  // Builds the stored broadcast name from the chosen template, prefixed with the
+  // page name so broadcasts from different pages stay distinguishable in the
+  // list. Returns null when the template does not belong to the workspace/page,
+  // letting the caller surface a "template not found" validation error.
+  async resolveTemplateBroadcastName(input: {
+    workspaceId: string
+    channel: ChannelType
+    templateId: string
+    integrationWhatsappId?: string | null
+    integrationMessengerId?: string | null
+  }): Promise<string | null> {
+    const detail = await this.loadTemplateDetail(input.channel, {
+      workspaceId: input.workspaceId,
+      templateId: input.templateId,
+      integrationWhatsappId: input.integrationWhatsappId,
+      integrationMessengerId: input.integrationMessengerId,
+    })
+
+    if (!detail) {
+      return null
     }
 
-    if (broadcast.channel === "messenger") {
-      const [template] = await db
-        .select({
-          id: messengerMessageTemplateModel.id,
-          name: messengerMessageTemplateModel.name,
-          language: messengerMessageTemplateModel.language,
-          category: messengerMessageTemplateModel.category,
-          status: messengerMessageTemplateModel.status,
-          parameterFormat: messengerMessageTemplateModel.parameterFormat,
-          components: messengerMessageTemplateModel.components,
-          integrationName: integrationMessengerModel.name,
-        })
-        .from(messengerMessageTemplateModel)
-        .innerJoin(
-          integrationMessengerModel,
-          eq(
-            integrationMessengerModel.id,
-            messengerMessageTemplateModel.integrationMessengerId,
-          ),
-        )
-        .where(
-          and(
-            eq(messengerMessageTemplateModel.id, broadcast.templateId),
-            eq(integrationMessengerModel.workspaceId, input.workspaceId),
-          ),
-        )
-        .limit(1)
-
-      return template ? { ...template, channel: "messenger" } : null
-    }
-
-    return null
+    return detail.integrationName
+      ? `${detail.integrationName}${BROADCAST_NAME_SEPARATOR}${detail.name}`
+      : detail.name
   }
 
   async forEachAudienceChunk(


### PR DESCRIPTION
## Summary

Broadcasts created from different pages were hard to tell apart: the auto-generated name used only the template name, and the detail view didn't show which page a broadcast targets. This adds page context in both places.

### Changes
- The auto-generated broadcast name now includes the **page name** (`<Page> - <Template>`), falling back to the template name when no page is available. Applies to WhatsApp and Messenger template broadcasts.
- The broadcast **detail dialog** now shows which page/integration the broadcast targets; omnichannel broadcasts show "Omnichannel".

### Design notes
- Template lookup and naming live in the **business layer** (`broadcastService.resolveTemplateBroadcastName`); the action delegates and adds no new raw DB queries.
- Per-channel differences use a small **strategy registry** (one loader per template-capable channel) instead of `if/else` on the channel. The existing `getTemplateDetail` was refactored onto the same loaders — no behavior change, no query duplication.

## Test plan
- [x] `broadcastService` unit tests — 27 passing, covering page-prefixed naming, no-page fallback, per-channel integration scoping, template-not-found, and unsupported channels.
- [x] Typecheck (`builder` + `@chatbotx.io/business`) and lint clean.
- [ ] Manual: schedule a template broadcast from two different pages → each name reads `<Page> - <template>`.
- [ ] Manual: open a broadcast's detail → target page is shown; an omnichannel broadcast shows "Omnichannel".
