### PR TITLE
feat(comment-automation): rich text reply editor with variable resolution

### DIFF
--- a/apps/builder/src/app/space/[workspaceId]/fb-comments/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/fb-comments/layout.tsx
@@ -1,6 +1,7 @@
 import { getIdFromParams } from "@chatbotx.io/utils"
 import { notFound } from "next/navigation"
 import { AIAgentStoreProvider } from "@/features/ai-agents/provider/ai-agent-store-context"
+import { CustomFieldStoreProvider } from "@/features/custom-fields/provider/custom-field-store-context"
 import { FlowStoreProvider } from "@/features/flows/provider/flow-store-context"
 
 export default async function FbCommentsLayout({
@@ -16,10 +17,12 @@ export default async function FbCommentsLayout({
   }
 
   return (
-    <FlowStoreProvider autoInitialize={true} workspaceId={workspaceId}>
-      <AIAgentStoreProvider autoInitialize={true} workspaceId={workspaceId}>
-        {children}
-      </AIAgentStoreProvider>
-    </FlowStoreProvider>
+    <CustomFieldStoreProvider workspaceId={workspaceId}>
+      <FlowStoreProvider autoInitialize={true} workspaceId={workspaceId}>
+        <AIAgentStoreProvider autoInitialize={true} workspaceId={workspaceId}>
+          {children}
+        </AIAgentStoreProvider>
+      </FlowStoreProvider>
+    </CustomFieldStoreProvider>
   )
 }

--- a/apps/builder/src/app/space/[workspaceId]/ig-comments/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/ig-comments/layout.tsx
@@ -1,6 +1,7 @@
 import { getIdFromParams } from "@chatbotx.io/utils"
 import { notFound } from "next/navigation"
 import { AIAgentStoreProvider } from "@/features/ai-agents/provider/ai-agent-store-context"
+import { CustomFieldStoreProvider } from "@/features/custom-fields/provider/custom-field-store-context"
 import { FlowStoreProvider } from "@/features/flows/provider/flow-store-context"
 
 export default async function IgCommentsLayout({
@@ -16,10 +17,12 @@ export default async function IgCommentsLayout({
   }
 
   return (
-    <FlowStoreProvider autoInitialize={true} workspaceId={workspaceId}>
-      <AIAgentStoreProvider autoInitialize={true} workspaceId={workspaceId}>
-        {children}
-      </AIAgentStoreProvider>
-    </FlowStoreProvider>
+    <CustomFieldStoreProvider workspaceId={workspaceId}>
+      <FlowStoreProvider autoInitialize={true} workspaceId={workspaceId}>
+        <AIAgentStoreProvider autoInitialize={true} workspaceId={workspaceId}>
+          {children}
+        </AIAgentStoreProvider>
+      </FlowStoreProvider>
+    </CustomFieldStoreProvider>
   )
 }

--- a/apps/builder/src/app/space/[workspaceId]/ig-stories/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/ig-stories/layout.tsx
@@ -1,6 +1,7 @@
 import { getIdFromParams } from "@chatbotx.io/utils"
 import { notFound } from "next/navigation"
 import { AIAgentStoreProvider } from "@/features/ai-agents/provider/ai-agent-store-context"
+import { CustomFieldStoreProvider } from "@/features/custom-fields/provider/custom-field-store-context"
 import { FlowStoreProvider } from "@/features/flows/provider/flow-store-context"
 
 export default async function IgStoriesLayout({
@@ -16,10 +17,12 @@ export default async function IgStoriesLayout({
   }
 
   return (
-    <FlowStoreProvider autoInitialize={true} workspaceId={workspaceId}>
-      <AIAgentStoreProvider autoInitialize={true} workspaceId={workspaceId}>
-        {children}
-      </AIAgentStoreProvider>
-    </FlowStoreProvider>
+    <CustomFieldStoreProvider workspaceId={workspaceId}>
+      <FlowStoreProvider autoInitialize={true} workspaceId={workspaceId}>
+        <AIAgentStoreProvider autoInitialize={true} workspaceId={workspaceId}>
+          {children}
+        </AIAgentStoreProvider>
+      </FlowStoreProvider>
+    </CustomFieldStoreProvider>
   )
 }

--- a/apps/builder/src/features/fb-comments/components/fb-comment-form.tsx
+++ b/apps/builder/src/features/fb-comments/components/fb-comment-form.tsx
@@ -30,6 +30,7 @@ import { useTranslations } from "next-intl"
 import { useState } from "react"
 import type { UseFormReturn } from "react-hook-form"
 import { useWatch } from "react-hook-form"
+import { TiptapEditorField } from "@/components/tiptap/tiptap-editor-field"
 import { useAIAgentStore } from "@/features/ai-agents/provider/ai-agent-store-context"
 import { useFlowSelectOptions } from "@/features/flows/provider/flow-hook"
 import type { CreateFbCommentRequest } from "../schema/action"
@@ -245,7 +246,8 @@ export function FbCommentForm({
               required
             />
             {privateReplyType === "text" && (
-              <InputField
+              <TiptapEditorField
+                channels={["messenger"]}
                 label={t("facebookCommentAutomation.replyMessage")}
                 name="privateReply.value"
                 placeholder={t(
@@ -289,7 +291,8 @@ export function FbCommentForm({
               required
             />
             {publicReplyType === "text" && (
-              <InputField
+              <TiptapEditorField
+                channels={["messenger"]}
                 label={t("facebookCommentAutomation.replyMessage")}
                 name="publicReply.value"
                 placeholder={t(

--- a/apps/builder/src/features/ig-comments/components/ig-comment-form.tsx
+++ b/apps/builder/src/features/ig-comments/components/ig-comment-form.tsx
@@ -30,6 +30,7 @@ import { useTranslations } from "next-intl"
 import { useState } from "react"
 import type { UseFormReturn } from "react-hook-form"
 import { useWatch } from "react-hook-form"
+import { TiptapEditorField } from "@/components/tiptap/tiptap-editor-field"
 import { useAIAgentStore } from "@/features/ai-agents/provider/ai-agent-store-context"
 import { useFlowSelectOptions } from "@/features/flows/provider/flow-hook"
 import type { CreateIgCommentRequest, IgCommentVariant } from "../schema/action"
@@ -253,7 +254,8 @@ export function IgCommentForm({
               required
             />
             {privateReplyType === "text" && (
-              <InputField
+              <TiptapEditorField
+                channels={["instagram"]}
                 label={t("instagramCommentAutomation.replyMessage")}
                 name="privateReply.value"
                 placeholder={t(
@@ -297,7 +299,8 @@ export function IgCommentForm({
               required
             />
             {publicReplyType === "text" && (
-              <InputField
+              <TiptapEditorField
+                channels={["instagram"]}
                 label={t("instagramCommentAutomation.replyMessage")}
                 name="publicReply.value"
                 placeholder={t(

--- a/apps/builder/src/features/ig-stories/components/ig-story-form.tsx
+++ b/apps/builder/src/features/ig-stories/components/ig-story-form.tsx
@@ -23,6 +23,7 @@ import { useTranslations } from "next-intl"
 import { useState } from "react"
 import type { UseFormReturn } from "react-hook-form"
 import { useWatch } from "react-hook-form"
+import { TiptapEditorField } from "@/components/tiptap/tiptap-editor-field"
 import { useAIAgentStore } from "@/features/ai-agents/provider/ai-agent-store-context"
 import { useFlowSelectOptions } from "@/features/flows/provider/flow-hook"
 import type { CreateIgStoryRequest, IgStoryVariant } from "../schema/action"
@@ -148,7 +149,8 @@ export function IgStoryForm({
               required
             />
             {replyType === "text" && (
-              <InputField
+              <TiptapEditorField
+                channels={["instagram"]}
                 label={t("instagramStoryAutomation.replyMessage")}
                 name="reply.value"
                 placeholder={t(

--- a/apps/worker/__tests__/comment-automation.test.ts
+++ b/apps/worker/__tests__/comment-automation.test.ts
@@ -28,6 +28,8 @@ const {
   mockGenerateAIReplyText,
   mockLoggerInfo,
   mockLoggerWarn,
+  mockContactVariableGetAll,
+  mockContactVariableReplaceAll,
 } = vi.hoisted(() => ({
   mockFindContactInboxBy: vi.fn(),
   mockFindActiveAutomations: vi.fn(),
@@ -52,6 +54,8 @@ const {
   mockGenerateAIReplyText: vi.fn(),
   mockLoggerInfo: vi.fn(),
   mockLoggerWarn: vi.fn(),
+  mockContactVariableGetAll: vi.fn(),
+  mockContactVariableReplaceAll: vi.fn(),
 }))
 
 vi.mock("@chatbotx.io/business", () => ({
@@ -92,6 +96,13 @@ vi.mock("@chatbotx.io/integration-instagram-facebook", () => ({
 
 vi.mock("@chatbotx.io/partysocket-config", () => ({
   RealtimeEventType: { messageCreated: "messageCreated" },
+}))
+
+vi.mock("@chatbotx.io/variables", () => ({
+  contactVariableService: {
+    getAll: mockContactVariableGetAll,
+    replaceAll: mockContactVariableReplaceAll,
+  },
 }))
 
 vi.mock("@chatbotx.io/worker-config", () => ({
@@ -248,6 +259,8 @@ beforeEach(() => {
   mockInsertDedup.mockResolvedValue(undefined)
   mockChatQueueAdd.mockResolvedValue(undefined)
   mockIntegrationQueueAdd.mockResolvedValue(undefined)
+  mockContactVariableGetAll.mockResolvedValue({})
+  mockContactVariableReplaceAll.mockImplementation(({ text }) => text)
 })
 
 // ---------------------------------------------------------------------------
@@ -513,6 +526,88 @@ describe("processCommentAutomation text private reply channel routing", () => {
     // Neither the Messenger nor the Instagram Login endpoint must be used.
     expect(mockSendPrivateReply).not.toHaveBeenCalled()
     expect(mockSendInstagramPrivateReply).not.toHaveBeenCalled()
+  })
+})
+
+describe("processCommentAutomation text reply variable resolution", () => {
+  test("private reply text is resolved through contactVariableService before sending", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({
+        privateReply: { type: "text", value: "Hi {{contact.firstName}}" },
+      }),
+    ])
+    mockContactVariableReplaceAll.mockResolvedValue("Hi Jane")
+
+    await processCommentAutomation(buildJobData() as any)
+
+    expect(mockContactVariableGetAll).toHaveBeenCalledWith({
+      contactId: "contact-1",
+      contactInbox: { id: "contact-inbox-1", contactId: "contact-1" },
+    })
+    expect(mockContactVariableReplaceAll).toHaveBeenCalledWith({
+      text: "Hi {{contact.firstName}}",
+      variables: {},
+    })
+    expect(mockSendPrivateReply).toHaveBeenCalledWith(
+      expect.anything(),
+      COMMENT_ID,
+      "Hi Jane",
+    )
+  })
+
+  test("public reply text is resolved through contactVariableService before the outgoing message is created", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({
+        publicReply: { type: "text", value: "Hi {{contact.firstName}}" },
+      }),
+    ])
+    mockContactVariableReplaceAll.mockResolvedValue("Hi Jane")
+
+    await processCommentAutomation(buildJobData() as any)
+
+    expect(mockContactVariableGetAll).toHaveBeenCalledWith({
+      contactId: "contact-1",
+      contactInbox: { id: "contact-inbox-1", contactId: "contact-1" },
+    })
+    expect(mockContactVariableReplaceAll).toHaveBeenCalledWith({
+      text: "Hi {{contact.firstName}}",
+      variables: {},
+    })
+    expect(mockMessageCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Hi Jane" }),
+    )
+  })
+
+  test("private reply falls back to the raw text when variable resolution fails", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({
+        privateReply: { type: "text", value: "Hi {{contact.firstName}}" },
+      }),
+    ])
+    mockContactVariableReplaceAll.mockRejectedValue(new Error("db down"))
+
+    await processCommentAutomation(buildJobData() as any)
+
+    expect(mockSendPrivateReply).toHaveBeenCalledWith(
+      expect.anything(),
+      COMMENT_ID,
+      "Hi {{contact.firstName}}",
+    )
+  })
+
+  test("public reply falls back to the raw text when variable resolution fails", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({
+        publicReply: { type: "text", value: "Hi {{contact.firstName}}" },
+      }),
+    ])
+    mockContactVariableGetAll.mockRejectedValue(new Error("db down"))
+
+    await processCommentAutomation(buildJobData() as any)
+
+    expect(mockMessageCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Hi {{contact.firstName}}" }),
+    )
   })
 })
 

--- a/apps/worker/__tests__/story-reply-automation.test.ts
+++ b/apps/worker/__tests__/story-reply-automation.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// Hoist mock references
+// ---------------------------------------------------------------------------
+
+const {
+  mockFindContactInboxBy,
+  mockFindActiveAutomations,
+  mockIsWithinSchedule,
+  mockIncrementRepliesCount,
+  mockWorkspaceFindById,
+  mockAiAgentFindBy,
+  mockChatQueueAdd,
+  mockIntegrationQueueAdd,
+  mockGenerateAIReplyText,
+  mockContactVariableGetAll,
+  mockContactVariableReplaceAll,
+  mockLoggerInfo,
+  mockLoggerWarn,
+} = vi.hoisted(() => ({
+  mockFindContactInboxBy: vi.fn(),
+  mockFindActiveAutomations: vi.fn(),
+  mockIsWithinSchedule: vi.fn(),
+  mockIncrementRepliesCount: vi.fn(),
+  mockWorkspaceFindById: vi.fn(),
+  mockAiAgentFindBy: vi.fn(),
+  mockChatQueueAdd: vi.fn(),
+  mockIntegrationQueueAdd: vi.fn(),
+  mockGenerateAIReplyText: vi.fn(),
+  mockContactVariableGetAll: vi.fn(),
+  mockContactVariableReplaceAll: vi.fn(),
+  mockLoggerInfo: vi.fn(),
+  mockLoggerWarn: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  contactInboxService: { findBy: mockFindContactInboxBy },
+  aiAgentService: { findBy: mockAiAgentFindBy },
+  fbCommentAutomationService: { isWithinSchedule: mockIsWithinSchedule },
+  igStoryAutomationService: {
+    findActiveAutomations: mockFindActiveAutomations,
+    incrementRepliesCount: mockIncrementRepliesCount,
+  },
+  workspaceService: { findById: mockWorkspaceFindById },
+}))
+
+vi.mock("@chatbotx.io/variables", () => ({
+  contactVariableService: {
+    getAll: mockContactVariableGetAll,
+    replaceAll: mockContactVariableReplaceAll,
+  },
+}))
+
+vi.mock("@chatbotx.io/worker-config", () => ({
+  ChatJobAction: { sendChatMessage: "sendChatMessage" },
+  chatQueue: { add: mockChatQueueAdd },
+  IntegrationJobAction: { sendFlow: "sendFlow" },
+  integrationQueue: { add: mockIntegrationQueueAdd },
+}))
+
+vi.mock("@chatbotx.io/events/context", () => ({
+  webhookChannelOrigin: vi.fn().mockReturnValue("webhook"),
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: mockLoggerWarn,
+    info: mockLoggerInfo,
+    debug: vi.fn(),
+  },
+}))
+
+vi.mock("../src/integration/handlers/automated-response/replies", () => ({
+  generateAIReplyText: mockGenerateAIReplyText,
+}))
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { processStoryReplyAutomation } = await import(
+  "../src/integration/handlers/story-reply-automation"
+)
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STORY_ID = "2357494887629356"
+const MESSAGE_ID = "message-1"
+
+function buildAutomation(reply: { type: string; value: string | null }) {
+  return {
+    id: "automation-1",
+    story: { type: "all", value: [] },
+    includeKeywords: { type: "all", value: [] },
+    reply,
+  }
+}
+
+function buildJobData(overrides: { message?: string } = {}) {
+  return {
+    workspaceId: "workspace-1",
+    conversationId: "conversation-1",
+    contactInboxId: "contact-inbox-1",
+    messageId: MESSAGE_ID,
+    storyId: STORY_ID,
+    message: overrides.message ?? "hello",
+    channelType: "instagram",
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFindContactInboxBy.mockResolvedValue({
+    id: "contact-inbox-1",
+    contactId: "contact-1",
+  })
+  mockWorkspaceFindById.mockResolvedValue({ timezone: "UTC" })
+  mockIsWithinSchedule.mockReturnValue(true)
+  mockIncrementRepliesCount.mockResolvedValue(undefined)
+  mockChatQueueAdd.mockResolvedValue(undefined)
+  mockContactVariableGetAll.mockResolvedValue({})
+  mockContactVariableReplaceAll.mockImplementation(({ text }) => text)
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("processStoryReplyAutomation text reply variable resolution", () => {
+  test("resolves {{variable}} tokens through contactVariableService before sending the story reply", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({ type: "text", value: "Hi {{contact.firstName}}" }),
+    ])
+    mockContactVariableReplaceAll.mockResolvedValue("Hi Jane")
+
+    await processStoryReplyAutomation(buildJobData() as any)
+
+    expect(mockContactVariableGetAll).toHaveBeenCalledWith({
+      contactId: "contact-1",
+      contactInbox: { id: "contact-inbox-1", contactId: "contact-1" },
+    })
+    expect(mockContactVariableReplaceAll).toHaveBeenCalledWith({
+      text: "Hi {{contact.firstName}}",
+      variables: {},
+    })
+    expect(mockChatQueueAdd).toHaveBeenCalledWith("sendChatMessage", {
+      type: "sendChatMessage",
+      data: {
+        conversation: { id: "conversation-1", workspaceId: "workspace-1" },
+        contactInbox: { id: "contact-inbox-1", contactId: "contact-1" },
+        text: "Hi Jane",
+      },
+    })
+    expect(mockIncrementRepliesCount).toHaveBeenCalledWith("automation-1")
+  })
+
+  test("sends the raw text unchanged when it contains no variable tokens", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({ type: "text", value: "Thanks for the reply!" }),
+    ])
+
+    await processStoryReplyAutomation(buildJobData() as any)
+
+    expect(mockChatQueueAdd).toHaveBeenCalledWith(
+      "sendChatMessage",
+      expect.objectContaining({
+        data: expect.objectContaining({ text: "Thanks for the reply!" }),
+      }),
+    )
+  })
+
+  test("falls back to the raw text when variable resolution fails", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({ type: "text", value: "Hi {{contact.firstName}}" }),
+    ])
+    mockContactVariableReplaceAll.mockRejectedValue(new Error("db down"))
+
+    await processStoryReplyAutomation(buildJobData() as any)
+
+    expect(mockChatQueueAdd).toHaveBeenCalledWith(
+      "sendChatMessage",
+      expect.objectContaining({
+        data: expect.objectContaining({ text: "Hi {{contact.firstName}}" }),
+      }),
+    )
+    expect(mockIncrementRepliesCount).toHaveBeenCalledWith("automation-1")
+  })
+})

--- a/apps/worker/src/integration/handlers/comment-automation/index.ts
+++ b/apps/worker/src/integration/handlers/comment-automation/index.ts
@@ -31,6 +31,7 @@ import {
   sendPrivateReply,
 } from "@chatbotx.io/integration-messenger"
 import { RealtimeEventType } from "@chatbotx.io/partysocket-config"
+import { contactVariableService } from "@chatbotx.io/variables"
 import {
   ChatJobAction,
   chatQueue,
@@ -250,8 +251,24 @@ async function executePublicReply(
   }
 
   if (publicReply.type === "text" && publicReply.value) {
+    let text = publicReply.value
+    try {
+      const variables = await contactVariableService.getAll({
+        contactId: ctx.contactInbox.contactId,
+        contactInbox: ctx.contactInbox,
+      })
+      text = await contactVariableService.replaceAll({
+        text: publicReply.value,
+        variables,
+      })
+    } catch (err) {
+      logger.warn(
+        { err, commentId: ctx.commentId },
+        "Failed to resolve variables in reply text, sending raw text",
+      )
+    }
     await postPublicCommentReply({
-      text: publicReply.value,
+      text,
       commentId: ctx.commentId,
       conversationId: ctx.conversationId,
       contactInboxId: ctx.contactInboxId,
@@ -318,6 +335,7 @@ async function executePrivateReply(
     channelType: "messenger" | "instagram" | "instagramFacebook"
     conversationId: string
     contactInboxId: string
+    contactInbox: ContactInboxModel
     workspaceId: string
     delay: number
     message?: string
@@ -328,11 +346,28 @@ async function executePrivateReply(
   }
 
   if (privateReply.type === "text" && privateReply.value) {
+    let text = privateReply.value
+    try {
+      const variables = await contactVariableService.getAll({
+        contactId: ctx.contactInbox.contactId,
+        contactInbox: ctx.contactInbox,
+      })
+      text = await contactVariableService.replaceAll({
+        text: privateReply.value,
+        variables,
+      })
+    } catch (err) {
+      logger.warn(
+        { err, commentId: ctx.commentId },
+        "Failed to resolve variables in reply text, sending raw text",
+      )
+    }
+
     if (ctx.channelType === "messenger") {
       await sendPrivateReply(
         ctx.auth as MessengerAuthValue,
         ctx.commentId,
-        privateReply.value,
+        text,
       )
     } else if (ctx.channelType === "instagram") {
       // Instagram Login sends the private DM through the me/messages endpoint,
@@ -340,7 +375,7 @@ async function executePrivateReply(
       await sendInstagramLoginPrivateReply(
         ctx.auth as InstagramAuthValue,
         ctx.commentId,
-        privateReply.value,
+        text,
       )
     } else if (ctx.channelType === "instagramFacebook") {
       // Instagram via Facebook Login sends the private DM through the
@@ -349,7 +384,7 @@ async function executePrivateReply(
       await sendInstagramFacebookPrivateReply(
         ctx.auth as InstagramFacebookAuthValue,
         ctx.commentId,
-        privateReply.value,
+        text,
       )
     }
     return
@@ -726,6 +761,7 @@ export async function processCommentAutomation(
           channelType,
           conversationId,
           contactInboxId,
+          contactInbox,
           workspaceId,
           delay,
           message,

--- a/apps/worker/src/integration/handlers/story-reply-automation/index.ts
+++ b/apps/worker/src/integration/handlers/story-reply-automation/index.ts
@@ -14,6 +14,7 @@ import type {
   ConversationModel,
 } from "@chatbotx.io/database/types"
 import { webhookChannelOrigin } from "@chatbotx.io/events/context"
+import { contactVariableService } from "@chatbotx.io/variables"
 import {
   ChatJobAction,
   chatQueue,
@@ -202,8 +203,24 @@ export async function processStoryReplyAutomation(
       let dispatched = false
 
       if (reply.type === "text" && reply.value) {
+        let text = reply.value
+        try {
+          const variables = await contactVariableService.getAll({
+            contactId: contactInbox.contactId,
+            contactInbox,
+          })
+          text = await contactVariableService.replaceAll({
+            text: reply.value,
+            variables,
+          })
+        } catch (err) {
+          logger.warn(
+            { err, messageId, storyId },
+            "Failed to resolve variables in reply text, sending raw text",
+          )
+        }
         await sendStoryReplyText({
-          text: reply.value,
+          text,
           conversationId,
           workspaceId,
           contactInbox,


### PR DESCRIPTION
## Summary
- Facebook comment, Instagram comment, and Instagram story reply automations used a plain single-line `InputField` for text replies and never resolved `{{variable}}` tokens before sending, even though the UI copy already advertised variable/spintax support.
- Swap `InputField` for `TiptapEditorField` on the `privateReply`/`publicReply`/`reply` text fields, and add the `CustomFieldStoreProvider` each of their layouts was missing (`TiptapEditorField`'s variable picker throws without it).
- Resolve `{{contact.xxx}}` variables via the existing `contactVariableService` (`@chatbotx.io/variables`) before dispatching public/private comment replies and story replies, with a try/catch fallback to the raw text so a transient resolution failure never drops the reply outright.

## Changes
- `apps/builder/src/features/fb-comments/components/fb-comment-form.tsx`, `ig-comments/components/ig-comment-form.tsx`, `ig-stories/components/ig-story-form.tsx` — swap `InputField` → `TiptapEditorField` for text-reply values.
- `apps/builder/src/app/space/[workspaceId]/{fb-comments,ig-comments,ig-stories}/layout.tsx` — add `CustomFieldStoreProvider`.
- `apps/worker/src/integration/handlers/comment-automation/index.ts` — resolve variables (with try/catch fallback) in `executePublicReply`/`executePrivateReply`; `executePrivateReply` ctx now carries the full `contactInbox`.
- `apps/worker/src/integration/handlers/story-reply-automation/index.ts` — same resolution + fallback for the story reply text.
- `apps/worker/__tests__/comment-automation.test.ts` — variable-resolution and fallback test cases.
- `apps/worker/__tests__/story-reply-automation.test.ts` — new test file (none existed before), scoped to the new text-resolution behavior.

## Test plan
- [x] `pnpm --filter worker vitest run __tests__/comment-automation.test.ts __tests__/story-reply-automation.test.ts` (41 tests pass)
- [x] `pnpm --filter worker check-types`
- [x] `pnpm --filter builder check-types`
- [x] `pnpm lint` on changed files
- [ ] Manual verification in the builder UI (create/edit a comment or story automation, insert a variable, confirm it renders correctly)