### PR TITLE
fix(instagram-facebook): capture Send API message_id to prevent inbox duplicates

### DIFF
--- a/integrations/instagram-facebook/__tests__/outgoing-message-ids.test.ts
+++ b/integrations/instagram-facebook/__tests__/outgoing-message-ids.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockSendInstagramMessage } = vi.hoisted(() => ({
+  mockSendInstagramMessage: vi.fn(),
+}))
+
+vi.mock("../src/apis/page", () => ({
+  sendInstagramMessage: mockSendInstagramMessage,
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+const { sendMessage, sendFlowStep } = await import(
+  "../src/handlers/message/outgoing-message"
+)
+
+const ctx = { auth: { tokens: { accessToken: "tok" } } } as never
+const contact = { id: "contact-1", sourceId: "igsid-1" } as never
+
+describe("instagram-facebook outgoing handlers return provider message ids", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSendInstagramMessage.mockResolvedValue({
+      recipient_id: "igsid-1",
+      message_id: "ig_provider-1",
+    })
+  })
+
+  test("sendMessage returns the Send API message_id", async () => {
+    const result = await sendMessage({
+      ctx,
+      data: {
+        contact,
+        message: { id: "msg-1", contentType: "text", text: "hello" },
+      },
+    } as never)
+
+    expect(mockSendInstagramMessage).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ messageIds: ["ig_provider-1"] })
+  })
+
+  test("sendFlowStep (sendText) returns the Send API message_id", async () => {
+    const result = await sendFlowStep({
+      ctx,
+      data: {
+        contact,
+        step: {
+          id: "step-1",
+          nodeId: "node-1",
+          stepType: "sendText",
+          text: "automated reply",
+          buttons: [],
+        },
+      },
+    } as never)
+
+    expect(mockSendInstagramMessage).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ messageIds: ["ig_provider-1"] })
+  })
+})

--- a/integrations/instagram-facebook/src/handlers/message/outgoing-message/index.ts
+++ b/integrations/instagram-facebook/src/handlers/message/outgoing-message/index.ts
@@ -41,6 +41,7 @@ export const sendMessage: MessageHandlers<InstagramAuthValue>["sendMessage"] =
       data: { contact, message, quickReplies },
     } = props
 
+    const messageIds: string[] = []
     try {
       const instagramMessages = [...convertMessageToInstagramMessage(message)]
       const lastMessage = instagramMessages.at(-1)
@@ -50,7 +51,10 @@ export const sendMessage: MessageHandlers<InstagramAuthValue>["sendMessage"] =
       }
       for (const instagramMessage of instagramMessages) {
         const payload = buildMessagePayload(contact, instagramMessage)
-        await sendInstagramMessage(ctx.auth, payload)
+        const response = await sendInstagramMessage(ctx.auth, payload)
+        if (response.message_id) {
+          messageIds.push(response.message_id)
+        }
         logger.info(`Message sent for IGSID: ${contact.sourceId}`)
       }
     } catch (error) {
@@ -59,7 +63,7 @@ export const sendMessage: MessageHandlers<InstagramAuthValue>["sendMessage"] =
     }
 
     return {
-      messageIds: [],
+      messageIds,
     }
   }
 
@@ -191,14 +195,18 @@ export const sendFlowStep = async (
     ctx,
     data: { contact },
   } = props
+  const messageIds: string[] = []
   try {
     for await (const instagramMessage of convertFlowStepToInstagramMessage(
       props,
     )) {
-      await sendInstagramMessage(
+      const response = await sendInstagramMessage(
         ctx.auth,
         buildMessagePayload(contact, instagramMessage),
       )
+      if (response.message_id) {
+        messageIds.push(response.message_id)
+      }
       logger.info(`Message sent for IGSID: ${contact.sourceId}`)
     }
   } catch (error) {
@@ -207,6 +215,6 @@ export const sendFlowStep = async (
   }
 
   return {
-    messageIds: [],
+    messageIds,
   }
 }


### PR DESCRIPTION
## Summary
- `sendMessage`/`sendFlowStep` in the `instagram-facebook` integration always returned `messageIds: []`, discarding the `message_id` Meta's Send API returns.
- Without a `sourceId`, the worker can't dedup the message when Meta replays the sent message via the `message_echo` webhook (coexist), so a duplicate row is inserted into the inbox.
- Mirrors the fix already shipped for the `instagram` (#613) and `messenger` integrations.

## Changes
- `integrations/instagram-facebook/src/handlers/message/outgoing-message/index.ts`: capture `response.message_id` in both `sendMessage` and `sendFlowStep`, returning `{ messageIds }` instead of a hardcoded empty array.
- `integrations/instagram-facebook/__tests__/outgoing-message-ids.test.ts`: new regression test asserting both handlers return the provider `message_id`.

## Test plan
- [x] `pnpm --filter @chatbotx.io/integration-instagram-facebook test` — new tests pass; verified they fail against the pre-fix code
- [x] `pnpm lint`
- [x] `pnpm --filter @chatbotx.io/integration-instagram-facebook check-types`