### PR TITLE
fix(flows): sync node rename and keep confirm enabled for button step actions

### DIFF
--- a/apps/builder/src/features/flows/react-flow/nodes/__tests__/selected-node-equality.test.ts
+++ b/apps/builder/src/features/flows/react-flow/nodes/__tests__/selected-node-equality.test.ts
@@ -1,0 +1,52 @@
+import type { FlowNode } from "@chatbotx.io/flow-config"
+import { describe, expect, test } from "vitest"
+import { selectedNodeEqualityFn } from "../selected-node-equality"
+
+const flowNode = (
+  id: string,
+  name: string,
+  details: Record<string, unknown> = {},
+): FlowNode =>
+  ({
+    id,
+    type: "sendMessage",
+    position: { x: 0, y: 0 },
+    data: { name, details },
+  }) as unknown as FlowNode
+
+describe("selectedNodeEqualityFn", () => {
+  test("treats the same reference as equal", () => {
+    const node = flowNode("1", "Send Message #2")
+
+    expect(selectedNodeEqualityFn(node, node)).toBe(true)
+  })
+
+  test("re-renders when the node name changes so the sheet title stays in sync", () => {
+    const before = flowNode("1", "Send Message #2")
+    const after = flowNode("1", "PF-01")
+
+    expect(selectedNodeEqualityFn(before, after)).toBe(false)
+  })
+
+  test("does not re-render when only node details change (avoid re-seeding the editor while typing)", () => {
+    const before = flowNode("1", "Send Message #2", { text: "hello" })
+    const after = flowNode("1", "Send Message #2", { text: "hello world" })
+
+    expect(selectedNodeEqualityFn(before, after)).toBe(true)
+  })
+
+  test("re-renders when a different node becomes selected", () => {
+    const first = flowNode("1", "Send Message #2")
+    const second = flowNode("2", "Send Message #2")
+
+    expect(selectedNodeEqualityFn(first, second)).toBe(false)
+  })
+
+  test("handles null transitions when selection clears or begins", () => {
+    const node = flowNode("1", "Send Message #2")
+
+    expect(selectedNodeEqualityFn(null, null)).toBe(true)
+    expect(selectedNodeEqualityFn(null, node)).toBe(false)
+    expect(selectedNodeEqualityFn(node, null)).toBe(false)
+  })
+})

--- a/apps/builder/src/features/flows/react-flow/nodes/node-detail-sheet.tsx
+++ b/apps/builder/src/features/flows/react-flow/nodes/node-detail-sheet.tsx
@@ -7,34 +7,25 @@ import {
   SheetDescription,
   SheetTitle,
 } from "@chatbotx.io/ui/components/ui/sheet"
-import { type ReactFlowState, useReactFlow, useStore } from "@xyflow/react"
+import { useReactFlow, useStore } from "@xyflow/react"
 import { LoaderCircleIcon } from "lucide-react"
 import { memo, useEffect, useMemo, useRef, useState } from "react"
 import { useCustomFieldStore } from "@/features/custom-fields/provider/custom-field-store-context"
 import { NodeEditor } from "./editor"
 import { NodeNameEditor } from "./node-name-editor"
+import {
+  selectedNodeEqualityFn,
+  selectSelectedNode,
+} from "./selected-node-equality"
 
 type NodeDetailSheetProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
 }
 
-// Select only the selected node from the store
-const selectSelectedNode = (state: ReactFlowState): FlowNode | null =>
-  (state.nodes.find((node) => node.selected) as FlowNode) || null
-
-// Keep the sheet mounted against the selected node ID so the editor does not
-// re-render from its own form writes while typing.
-const equalityFn = (a: FlowNode | null, b: FlowNode | null): boolean => {
-  if (a === b) {
-    return true
-  }
-  return a?.id === b?.id
-}
-
 export function NodeDetailSheet({ open, onOpenChange }: NodeDetailSheetProps) {
   // Use store selector with custom equality function
-  const activeNode = useStore(selectSelectedNode, equalityFn)
+  const activeNode = useStore(selectSelectedNode, selectedNodeEqualityFn)
   const { getNode } = useReactFlow()
 
   // Bump the editor key only on the discrete open transition so reopening a

--- a/apps/builder/src/features/flows/react-flow/nodes/selected-node-equality.ts
+++ b/apps/builder/src/features/flows/react-flow/nodes/selected-node-equality.ts
@@ -1,0 +1,22 @@
+import type { FlowNode } from "@chatbotx.io/flow-config"
+import type { ReactFlowState } from "@xyflow/react"
+
+// Select only the selected node from the store
+export const selectSelectedNode = (state: ReactFlowState): FlowNode | null =>
+  (state.nodes.find((node) => node.selected) as FlowNode) || null
+
+// Re-render the detail sheet only when the selected node's identity or its
+// display name changes. The big editor form below streams its keystrokes into
+// `data.details`; ignoring those here keeps the form from re-seeding while the
+// user types. A rename is a discrete, explicit change we DO want to surface so
+// the sheet title (NodeNameEditor) syncs immediately instead of waiting for a
+// full remount (F5).
+export const selectedNodeEqualityFn = (
+  a: FlowNode | null,
+  b: FlowNode | null,
+): boolean => {
+  if (a === b) {
+    return true
+  }
+  return a?.id === b?.id && a?.data.name === b?.data.name
+}

--- a/apps/builder/src/features/flows/react-flow/steps/base/__tests__/use-parent-step-commit.test.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/base/__tests__/use-parent-step-commit.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { zodResolver } from "@hookform/resolvers/zod"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { FormProvider, type UseFormReturn, useForm } from "react-hook-form"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { z } from "zod"
+import { useParentStepCommit } from "../use-parent-step-commit"
+
+const stepSchema = z.object({
+  id: z.string(),
+  stepType: z.literal("demo"),
+  name: z.string().min(1),
+  states: z.tuple([z.object({ id: z.string() })]),
+})
+type Step = z.infer<typeof stepSchema>
+
+const invalidStep: Step = {
+  id: "step-1",
+  stepType: "demo",
+  name: "",
+  states: [{ id: "state-1" }],
+}
+
+let container: HTMLDivElement
+let root: Root
+let commit: ((patch: Partial<Step>) => void) | null = null
+let formApi: UseFormReturn<{ step: Step }> | null = null
+
+function StepConsumer() {
+  commit = useParentStepCommit<Step>("step")
+  return null
+}
+
+function Harness() {
+  const form = useForm<{ step: Step }>({
+    resolver: zodResolver(z.object({ step: stepSchema })),
+    mode: "onChange",
+    defaultValues: { step: invalidStep },
+  })
+  formApi = form
+  const { isValid, isDirty } = form.formState
+
+  return (
+    <FormProvider {...form}>
+      <div data-testid="valid">{String(isValid)}</div>
+      <div data-testid="dirty">{String(isDirty)}</div>
+      <StepConsumer />
+    </FormProvider>
+  )
+}
+
+const flush = async () => {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+const read = (testId: string) =>
+  container.querySelector(`[data-testid="${testId}"]`)?.textContent
+
+beforeEach(() => {
+  ;(
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true
+  commit = null
+  formApi = null
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+describe("useParentStepCommit", () => {
+  const renderHarness = async () => {
+    act(() => {
+      root.render(<Harness />)
+    })
+    await flush()
+  }
+
+  test("re-runs the parent validation so a valid patch enables the form", async () => {
+    await renderHarness()
+    expect(read("valid")).toBe("false")
+
+    await act(async () => {
+      commit?.({ name: "Renamed" })
+      await Promise.resolve()
+    })
+    await flush()
+
+    expect(read("valid")).toBe("true")
+  })
+
+  test("merges the patch over the current value and preserves untouched fields", async () => {
+    await renderHarness()
+
+    await act(async () => {
+      commit?.({ name: "Renamed" })
+      await Promise.resolve()
+    })
+    await flush()
+
+    expect(formApi?.getValues("step")).toEqual({
+      id: "step-1",
+      stepType: "demo",
+      name: "Renamed",
+      states: [{ id: "state-1" }],
+    })
+  })
+
+  test("marks the parent field dirty", async () => {
+    await renderHarness()
+    expect(read("dirty")).toBe("false")
+
+    await act(async () => {
+      commit?.({ name: "Renamed" })
+      await Promise.resolve()
+    })
+    await flush()
+
+    expect(read("dirty")).toBe("true")
+  })
+
+  test("keeps the form invalid when the patch is still invalid", async () => {
+    await renderHarness()
+
+    await act(async () => {
+      commit?.({ name: "" })
+      await Promise.resolve()
+    })
+    await flush()
+
+    expect(read("valid")).toBe("false")
+  })
+})

--- a/apps/builder/src/features/flows/react-flow/steps/base/use-parent-step-commit.ts
+++ b/apps/builder/src/features/flows/react-flow/steps/base/use-parent-step-commit.ts
@@ -1,0 +1,33 @@
+import { useCallback } from "react"
+import { useFormContext } from "react-hook-form"
+
+/**
+ * Commit a nested step editor's values back into the parent flow-step form.
+ *
+ * A step editor (Set Custom Field, Coupon, Call API, …) runs its own isolated
+ * form and, on save, writes the result into the parent step. React Hook Form's
+ * `setValue` updates a field silently by default, but the parent form (e.g. the
+ * Edit Button dialog) gates its Confirm button on `formState.isValid` — so a
+ * write that skips revalidation leaves Confirm disabled until a remount.
+ * Centralizing the write here guarantees every editor re-runs the parent's
+ * validation and cannot drift from that contract again.
+ *
+ * The returned `commit` merges a partial patch over the current step value, so
+ * fields the editor does not manage — `id`, `stepType`, success/error `states`
+ * — are preserved untouched.
+ */
+export function useParentStepCommit<TStep extends object>(parentName: string) {
+  const { setValue, getValues } = useFormContext()
+
+  return useCallback(
+    (patch: Partial<TStep>) => {
+      const current = getValues(parentName) as TStep
+      setValue(
+        parentName,
+        { ...current, ...patch },
+        { shouldDirty: true, shouldValidate: true },
+      )
+    },
+    [getValues, setValue, parentName],
+  )
+}

--- a/apps/builder/src/features/flows/react-flow/steps/coupon/__tests__/editor.test.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/coupon/__tests__/editor.test.tsx
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
-import { type CouponStepSchema, stepTypes } from "@chatbotx.io/flow-config"
+import {
+  type CouponStepSchema,
+  setUpCouponStepSchema,
+  stepTypes,
+} from "@chatbotx.io/flow-config"
+import { zodResolver } from "@hookform/resolvers/zod"
 import {
   act,
   type ButtonHTMLAttributes,
@@ -7,8 +12,14 @@ import {
   type ReactNode,
 } from "react"
 import { createRoot, type Root } from "react-dom/client"
-import { Controller, FormProvider, useForm } from "react-hook-form"
+import {
+  Controller,
+  FormProvider,
+  type Resolver,
+  useForm,
+} from "react-hook-form"
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import { z } from "zod"
 import { CouponActionEditor } from "../editor"
 
 const useCouponTopicOptionsMock = vi.fn()
@@ -163,6 +174,7 @@ beforeEach(() => {
   ;(
     globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
   ).IS_REACT_ACT_ENVIRONMENT = true
+  readCouponStep = null
   useCouponTopicOptionsMock.mockReset()
   useCouponTopicOptionsMock.mockImplementation(
     ({ issueableOnly }: { issueableOnly?: boolean } = {}) => ({
@@ -220,7 +232,92 @@ function Harness({
   )
 }
 
+let readCouponStep: (() => CouponStepSchema) | null = null
+
+const invalidCouponStep = {
+  id: "step-1",
+  stepType: stepTypes.enum.setUpCoupon,
+  topicId: "",
+} as CouponStepSchema
+
+const couponParentResolver = zodResolver(
+  z.object({ step: setUpCouponStepSchema }),
+) as unknown as Resolver<{ step: CouponStepSchema }>
+
+function ValidityHarness() {
+  const form = useForm<{ step: CouponStepSchema }>({
+    resolver: couponParentResolver,
+    mode: "onChange",
+    defaultValues: { step: invalidCouponStep },
+  })
+  readCouponStep = () => form.getValues("step")
+  const { isValid } = form.formState
+
+  return (
+    <FormProvider {...form}>
+      <div data-testid="outer-valid">{String(isValid)}</div>
+      <CouponActionEditor parentName="step" />
+    </FormProvider>
+  )
+}
+
+const flushCoupon = async () => {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
 describe("CouponActionEditor", () => {
+  test("enables the parent form once a coupon topic is chosen and saved", async () => {
+    // Real coupon topic ids are numeric (validated by zodBigintAsString).
+    useCouponTopicOptionsMock.mockReturnValue({
+      options: [{ label: "Topic 1", value: "1" }],
+      labelById: new Map([["1", "Topic 1"]]),
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(),
+      topics: [],
+    })
+    render(<ValidityHarness />)
+    await flushCoupon()
+
+    // The empty default topicId keeps the parent form invalid at first.
+    expect(
+      container.querySelector('[data-testid="outer-valid"]')?.textContent,
+    ).toBe("false")
+
+    const topicSelect = container.querySelector(
+      '[data-testid="combobox-topicId"]',
+    ) as HTMLSelectElement
+
+    await act(async () => {
+      topicSelect.value = "1"
+      topicSelect.dispatchEvent(new Event("change", { bubbles: true }))
+      await Promise.resolve()
+    })
+    await flushCoupon()
+
+    const submitButton = container.querySelector(
+      'form button[type="submit"]',
+    ) as HTMLButtonElement
+
+    await act(async () => {
+      submitButton.click()
+      await Promise.resolve()
+    })
+    await flushCoupon()
+
+    expect(
+      container.querySelector('[data-testid="outer-valid"]')?.textContent,
+    ).toBe("true")
+    expect(readCouponStep?.()).toEqual({
+      id: "step-1",
+      stepType: stepTypes.enum.setUpCoupon,
+      topicId: "1",
+    })
+  })
+
   test("switches schemas and preserves topicId while changing type", async () => {
     render(<Harness />)
 

--- a/apps/builder/src/features/flows/react-flow/steps/coupon/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/coupon/editor.tsx
@@ -26,6 +26,7 @@ import type { Resolver, SubmitHandler } from "react-hook-form"
 import { useForm, useFormContext } from "react-hook-form"
 import { useCouponTopicOptions } from "@/features/coupons/provider/use-coupon-topic-options"
 import { BaseStepEditor } from "../base/editor"
+import { useParentStepCommit } from "../base/use-parent-step-commit"
 
 type CouponStepType =
   | typeof stepTypes.enum.setUpCoupon
@@ -33,7 +34,8 @@ type CouponStepType =
 
 export function CouponActionEditor({ parentName }: { parentName: string }) {
   const t = useTranslations()
-  const { getValues, setValue } = useFormContext()
+  const { getValues } = useFormContext()
+  const commitStep = useParentStepCommit<CouponStepSchema>(parentName)
   const current = getValues(parentName) as CouponStepSchema
   const [open, setOpen] = useState(false)
   const [selectedType, setSelectedType] = useState<CouponStepType>(
@@ -86,8 +88,7 @@ export function CouponActionEditor({ parentName }: { parentName: string }) {
   }, [form, getValues, open, parentName])
 
   const onSubmit: SubmitHandler<CouponStepSchema> = (values) => {
-    const latest = getValues(parentName) as CouponStepSchema
-    setValue(parentName, { ...latest, ...values }, { shouldDirty: true })
+    commitStep(values)
     setOpen(false)
   }
 

--- a/apps/builder/src/features/flows/react-flow/steps/external-request/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/external-request/editor.tsx
@@ -38,6 +38,7 @@ import {
 import type { z } from "zod"
 import { CustomFieldSelect } from "@/features/custom-fields/custom-field-select"
 import { BaseStepEditor } from "../base/editor"
+import { useParentStepCommit } from "../base/use-parent-step-commit"
 import {
   JsonSourceProvider,
   useJsonSourceContext,
@@ -60,7 +61,8 @@ const ExternalRequestStepEditor = ({ parentName }: { parentName: string }) => {
 const ExternalRequestDialog = ({ parentName }: { parentName: string }) => {
   const t = useTranslations()
   const [open, setOpen] = useState(false)
-  const { setValue, getValues } = useFormContext()
+  const { getValues } = useFormContext()
+  const commitStep = useParentStepCommit<ExternalRequestStepSchema>(parentName)
 
   const form = useForm<
     z.input<typeof externalRequestStepSchema>,
@@ -125,11 +127,15 @@ const ExternalRequestDialog = ({ parentName }: { parentName: string }) => {
   }
 
   const onSubmit = (data: ExternalRequestStepSchema) => {
-    setValue(`${parentName}.method`, data.method)
-    setValue(`${parentName}.url`, data.url)
-    setValue(`${parentName}.headers`, data.headers)
-    setValue(`${parentName}.body`, data.body)
-    setValue(`${parentName}.mapping`, data.mapping)
+    // Only the request fields are edited here; id/stepType and success/error
+    // states stay as they are on the parent step.
+    commitStep({
+      method: data.method,
+      url: data.url,
+      headers: data.headers,
+      body: data.body,
+      mapping: data.mapping,
+    })
     setOpen(false)
   }
 

--- a/apps/builder/src/features/flows/react-flow/steps/set-custom-field/__tests__/editor.test.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/set-custom-field/__tests__/editor.test.tsx
@@ -1,0 +1,273 @@
+// @vitest-environment jsdom
+import {
+  FieldOperationType,
+  type SetCustomFieldStepSchema,
+  setCustomFieldStepSchema,
+  stepTypes,
+} from "@chatbotx.io/flow-config"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { act, type ButtonHTMLAttributes, type ReactNode } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import {
+  Controller,
+  FormProvider,
+  type UseFormReturn,
+  useForm,
+} from "react-hook-form"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import { z } from "zod"
+import SetCustomFieldStepEditor from "../editor"
+
+vi.mock("@/features/contact-filter/lib/timezone", () => ({
+  getBrowserTimezone: () => "UTC",
+}))
+
+vi.mock("@/features/custom-fields/provider/custom-field-store-context", () => ({
+  useCustomFieldStore: (selector: (state: { customFields: [] }) => unknown) =>
+    selector({ customFields: [] }),
+}))
+
+vi.mock("@/features/custom-fields/custom-field-select", async () => {
+  const { useFormContext } = await import("react-hook-form")
+  return {
+    CustomFieldSelect: ({ name, label }: { name: string; label?: string }) => {
+      const form = useFormContext()
+      return (
+        <Controller
+          control={form.control}
+          name={name}
+          render={({ field }) => (
+            <label>
+              {label}
+              <select
+                data-testid={`custom-field-${name}`}
+                onChange={(event) => field.onChange(event.target.value)}
+                value={field.value ?? ""}
+              >
+                <option value="">--</option>
+                <option value="field-1">Field 1</option>
+              </select>
+            </label>
+          )}
+        />
+      )
+    },
+  }
+})
+
+vi.mock("@chatbotx.io/ui/components/form/input-field", async () => {
+  const { useFormContext } = await import("react-hook-form")
+  return {
+    InputField: ({ name, label }: { name: string; label?: string }) => {
+      const form = useFormContext()
+      return (
+        <Controller
+          control={form.control}
+          name={name}
+          render={({ field }) => (
+            <label>
+              {label}
+              <input
+                data-testid={`input-${name}`}
+                onChange={(event) => field.onChange(event.target.value)}
+                value={field.value ?? ""}
+              />
+            </label>
+          )}
+        />
+      )
+    },
+  }
+})
+
+vi.mock("@chatbotx.io/ui/components/form/select-field", async () => {
+  const { useFormContext } = await import("react-hook-form")
+  return {
+    SelectField: ({
+      name,
+      options,
+      label,
+    }: {
+      name: string
+      options: { label: string; value: string }[]
+      label?: string
+    }) => {
+      const form = useFormContext()
+      return (
+        <Controller
+          control={form.control}
+          name={name}
+          render={({ field }) => (
+            <label>
+              {label}
+              <select
+                data-testid={`select-${name}`}
+                onChange={(event) => field.onChange(event.target.value)}
+                value={field.value ?? ""}
+              >
+                {options.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+        />
+      )
+    },
+  }
+})
+
+vi.mock("@chatbotx.io/ui/components/ui/button", () => ({
+  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock("@chatbotx.io/ui/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DialogContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DialogDescription: ({ children }: { children?: ReactNode }) => (
+    <>{children}</>
+  ),
+  DialogHeader: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DialogTrigger: () => null,
+}))
+
+vi.mock("@chatbotx.io/ui/components/ui/form", async () => {
+  const { FormProvider } = await import("react-hook-form")
+  return { Form: FormProvider }
+})
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+let container: HTMLDivElement
+let root: Root
+let formApi: UseFormReturn<{ step: SetCustomFieldStepSchema }> | null = null
+
+beforeEach(() => {
+  ;(
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true
+  formApi = null
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+const invalidStep: SetCustomFieldStepSchema = {
+  id: "step-1",
+  stepType: stepTypes.enum.setCustomField,
+  inputFieldId: "",
+  operation: FieldOperationType.set,
+  value: "",
+}
+
+function Harness() {
+  const form = useForm<{ step: SetCustomFieldStepSchema }>({
+    resolver: zodResolver(z.object({ step: setCustomFieldStepSchema })),
+    mode: "onChange",
+    defaultValues: { step: invalidStep },
+  })
+  formApi = form
+  const { isValid } = form.formState
+
+  return (
+    <FormProvider {...form}>
+      <div data-testid="outer-valid">{String(isValid)}</div>
+      <SetCustomFieldStepEditor parentName="step" />
+    </FormProvider>
+  )
+}
+
+const flush = async () => {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+// Setting `.value` directly bypasses React's controlled-input value tracker, so
+// `onChange` never fires. Go through the native setter the way user-event does.
+const setInputValue = (input: HTMLInputElement, value: string) => {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )?.set
+  setter?.call(input, value)
+  input.dispatchEvent(new Event("input", { bubbles: true }))
+}
+
+describe("SetCustomFieldStepEditor", () => {
+  test("enables the parent form after valid custom field data is submitted", async () => {
+    act(() => {
+      root.render(<Harness />)
+    })
+    await flush()
+
+    // The empty default inputFieldId keeps the parent form invalid at first.
+    expect(
+      container.querySelector('[data-testid="outer-valid"]')?.textContent,
+    ).toBe("false")
+
+    const fieldSelect = container.querySelector(
+      '[data-testid="custom-field-inputFieldId"]',
+    ) as HTMLSelectElement
+    const operationSelect = container.querySelector(
+      '[data-testid="select-operation"]',
+    ) as HTMLSelectElement
+    const valueInput = container.querySelector(
+      '[data-testid="input-value"]',
+    ) as HTMLInputElement
+
+    await act(async () => {
+      fieldSelect.value = "field-1"
+      fieldSelect.dispatchEvent(new Event("change", { bubbles: true }))
+      operationSelect.value = FieldOperationType.append
+      operationSelect.dispatchEvent(new Event("change", { bubbles: true }))
+      setInputValue(valueInput, "Hello")
+      await Promise.resolve()
+    })
+    await flush()
+
+    const submitButton = container.querySelector(
+      "form button:last-of-type",
+    ) as HTMLButtonElement
+
+    await act(async () => {
+      submitButton.click()
+      await Promise.resolve()
+    })
+    await flush()
+
+    // Writing the valid values back into the parent must re-run its validation
+    // so Confirm becomes enabled without a remount.
+    expect(
+      container.querySelector('[data-testid="outer-valid"]')?.textContent,
+    ).toBe("true")
+
+    // Every edited field must land on the parent step, and id/stepType are
+    // preserved.
+    expect(formApi?.getValues("step")).toEqual({
+      id: "step-1",
+      stepType: stepTypes.enum.setCustomField,
+      inputFieldId: "field-1",
+      operation: FieldOperationType.append,
+      value: "Hello",
+      timezone: "UTC",
+    })
+  })
+})

--- a/apps/builder/src/features/flows/react-flow/steps/set-custom-field/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/set-custom-field/editor.tsx
@@ -24,10 +24,12 @@ import { useForm, useFormContext } from "react-hook-form"
 import { getBrowserTimezone } from "@/features/contact-filter/lib/timezone"
 import { CustomFieldSelect } from "@/features/custom-fields/custom-field-select"
 import { useCustomFieldStore } from "@/features/custom-fields/provider/custom-field-store-context"
+import { useParentStepCommit } from "../base/use-parent-step-commit"
 
 const SetCustomFieldStepEditor = ({ parentName }: { parentName: string }) => {
   const t = useTranslations()
-  const { setValue, getValues } = useFormContext()
+  const { getValues } = useFormContext()
+  const commitStep = useParentStepCommit<SetCustomFieldStepSchema>(parentName)
   const defaultValues: SetCustomFieldStepSchema = getValues(parentName)
 
   const [open, setOpen] = useState<boolean>(false)
@@ -54,12 +56,14 @@ const SetCustomFieldStepEditor = ({ parentName }: { parentName: string }) => {
     selectedFieldType === "date" || selectedFieldType === "datetime"
 
   function onSubmit(values: SetCustomFieldStepSchema) {
-    setValue(`${parentName}.inputFieldId`, values.inputFieldId)
-    setValue(`${parentName}.operation`, values.operation)
-    setValue(`${parentName}.value`, values.value)
-    // Freeze the editor's browser zone so the worker (no browser context) can
-    // anchor a naive date/datetime value and render "now" for a blank one.
-    setValue(`${parentName}.timezone`, getBrowserTimezone())
+    commitStep({
+      inputFieldId: values.inputFieldId,
+      operation: values.operation,
+      value: values.value,
+      // Freeze the editor's browser zone so the worker (no browser context) can
+      // anchor a naive date/datetime value and render "now" for a blank one.
+      timezone: getBrowserTimezone(),
+    })
 
     setOpen(false)
   }


### PR DESCRIPTION
## What & why

Two flow-builder bugs where an edit did not show in the UI until a full page refresh:

1. **Renaming a node did not update the detail panel.** After renaming a node, the panel title kept showing the old name until F5. The panel only re-rendered when the selected node's `id` changed, so a rename (same id, new name) was ignored.

2. **Confirm stayed disabled after editing a button's step actions.** In the Edit Button dialog, adding an action (Set Custom Field, Set Up Coupon, Call API) and filling it in left the Confirm button greyed out until a remount. Each nested action editor wrote its values back to the parent form without re-running the parent's validation, so its "is valid" state never updated.

## Changes

- The detail panel now re-renders when the selected node's name changes, not only its id.
- Added a small shared hook that commits a step editor's values back to the parent form and re-runs validation, and applied it to the Set Custom Field, Coupon, and Call API editors. This removes the duplicated write-back logic and stops the same class of bug from recurring.
- Fields the editor does not manage (id, step type, success/error routing) are preserved on commit.

No behavior changes outside these editors; no schema, API, or channel-specific changes.

## Test plan

- [x] Unit tests for node-selection equality (a rename re-renders; unrelated edits do not)
- [x] Unit tests for the shared commit hook (re-validates, merges, preserves untouched fields including routing state)
- [x] Editor tests: Set Custom Field and Coupon enable Confirm after valid input and write every field back
- [x] `pnpm --filter builder check-types` and Biome pass on all touched files
- [x] Full flow-builder test suite green (123 tests)
- [ ] Manual: rename a node and confirm the panel title updates immediately
- [ ] Manual: add each button action (Set Custom Field, Set Up Coupon, Call API), fill it in, and confirm the Confirm button enables
