### PR TITLE
fix(messages): prevent duplicate inbox messages from channel echoes

### DIFF
--- a/packages/database/__tests__/sharded-message-repository.test.ts
+++ b/packages/database/__tests__/sharded-message-repository.test.ts
@@ -1432,6 +1432,50 @@ describe("ShardedMessageRepository.createOrUpdate — idempotent echo save", () 
     // Last-resort best-effort input content (id from makeMessage) — never throws.
     expect(result.message.id).toBe("msg-1")
   })
+
+  // Regression: an Instagram outbound message is saved first (Send API returns
+  // the mid → stored as sourceId), then Instagram echoes that same message back
+  // ~1.4s later with is_echo:true and NO metadata. The echo must be deduped
+  // against the already-saved row. It was not, because the guard read passed
+  // sinceTime === echo.createdAt, and findBySourceId's gte(createdAt, sinceTime)
+  // filter then excluded the earlier row → a duplicate row was inserted.
+  test("dedup guard read looks back past the message's own createdAt so an echo of a just-sent message is caught", async () => {
+    const sentAt = new Date("2026-08-04T08:19:29.777Z") // Row A: bot's outbound
+    const echoAt = new Date("2026-08-04T08:19:31.191Z") // Row B: echo, ~1.4s later
+    const priorRow = { ...existingRow, sourceId: "mid-2", createdAt: sentAt }
+
+    const shardDb = makeInsertShardDb([{ ...priorRow, id: "must-not-insert" }])
+    const shardManager = {
+      getShardForWrite: vi.fn().mockResolvedValue(shardDb),
+    }
+    const repo = new ShardedMessageRepository(
+      shardManager as never,
+      passthroughLock as never,
+    )
+    // Faithfully model findBySourceId's gte(createdAt, sinceTime): the earlier
+    // row is visible only when the guard read looks back to at or before sentAt.
+    vi.spyOn(repo, "findBySourceId").mockImplementation((async (
+      _sourceId: string,
+      _conversationId: string,
+      _workspaceId: string,
+      sinceTime?: Date,
+    ) =>
+      sinceTime && sinceTime.getTime() <= sentAt.getTime()
+        ? priorRow
+        : null) as never)
+
+    const echo = makeMessage({
+      id: "echo-1",
+      sourceId: "mid-2",
+      messageType: "outgoing",
+      createdAt: echoAt,
+    })
+    const result = await repo.createOrUpdate(echo)
+
+    expect(result.isNew).toBe(false)
+    expect(result.message).toEqual(priorRow)
+    expect(shardDb.insert).not.toHaveBeenCalled()
+  })
 })
 
 describe("ShardedMessageRepository.createOrUpdateWithAttachments — idempotent echo save", () => {
@@ -1472,5 +1516,59 @@ describe("ShardedMessageRepository.createOrUpdateWithAttachments — idempotent 
     expect(result.result).toEqual(existingWithAttachments)
     expect(txChain.onConflictDoNothing).toHaveBeenCalledTimes(1)
     expect(shardDb.transaction).toHaveBeenCalledTimes(1)
+  })
+
+  // Same send→echo regression as createOrUpdate, on the attachments path: the
+  // guard read must look back far enough to see the message saved seconds ago,
+  // otherwise the echo is inserted a second time.
+  test("dedup guard read looks back past the message's own createdAt so an echo of a just-sent message is caught", async () => {
+    const sentAt = new Date("2026-08-04T08:19:29.777Z")
+    const echoAt = new Date("2026-08-04T08:19:31.191Z")
+    const priorRow = { ...existingRow, sourceId: "mid-2", createdAt: sentAt }
+
+    const txChain = {
+      values: vi.fn().mockReturnThis(),
+      onConflictDoNothing: vi.fn().mockReturnThis(),
+      returning: vi
+        .fn()
+        .mockResolvedValue([{ ...priorRow, id: "must-not-insert" }]),
+    }
+    const tx = { insert: vi.fn().mockReturnValue(txChain) }
+    const shardDb = {
+      transaction: vi.fn(async (fn: (t: unknown) => Promise<unknown>) =>
+        fn(tx),
+      ),
+    }
+    const shardManager = {
+      getShardForWrite: vi.fn().mockResolvedValue(shardDb),
+    }
+    const repo = new ShardedMessageRepository(
+      shardManager as never,
+      passthroughLock as never,
+    )
+    vi.spyOn(repo, "findBySourceId").mockImplementation((async (
+      _sourceId: string,
+      _conversationId: string,
+      _workspaceId: string,
+      sinceTime?: Date,
+    ) =>
+      sinceTime && sinceTime.getTime() <= sentAt.getTime()
+        ? priorRow
+        : null) as never)
+    vi.spyOn(repo, "findById").mockResolvedValue({
+      ...priorRow,
+      attachments: [],
+    } as never)
+
+    const echo = makeMessage({
+      id: "echo-1",
+      sourceId: "mid-2",
+      messageType: "outgoing",
+      createdAt: echoAt,
+    })
+    const result = await repo.createOrUpdateWithAttachments(echo, [])
+
+    expect(result.isNew).toBe(false)
+    expect(shardDb.transaction).not.toHaveBeenCalled()
   })
 })

--- a/packages/database/src/sharding/message/repository/sharded-message-repository.ts
+++ b/packages/database/src/sharding/message/repository/sharded-message-repository.ts
@@ -21,6 +21,7 @@ import {
   MessageShardUnavailableError,
 } from "../../../errors"
 import { logger } from "../../../logger"
+import { getSafeSinceTime } from "../../../repositories"
 import type {
   AttachmentLookupRow,
   BulkCreateAttachmentInput,
@@ -67,6 +68,11 @@ const SHARD_RANGE_CACHE_TAG = "message-shard-range"
 const SHARD_RANGE_CACHE_TTL_S = 30
 const ATTACHMENT_FALLBACK_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000
 const RICH_RESPONSE_FALLBACK_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000
+// Echo dedup lookback. An outbound message we save is echoed back by the channel
+// (Instagram/Messenger) seconds later carrying the same sourceId (mid). The dedup
+// guard read must look back past the echo's own createdAt to find the already-saved
+// row; a day comfortably covers channel echo latency plus webhook redelivery.
+const ECHO_DEDUP_LOOKBACK_MS = 24 * 60 * 60 * 1000
 const LIST_INCOMING_TEXTS_BATCH_SIZE = 1000
 
 function dedupeShardsByPhysicalId<T extends { shard: { id: string } }>(
@@ -1023,7 +1029,7 @@ export class ShardedMessageRepository implements IMessageRepository {
           message.sourceId as string,
           message.conversationId,
           message.workspaceId,
-          message.createdAt,
+          getSafeSinceTime(message.createdAt, ECHO_DEDUP_LOOKBACK_MS),
         )
         if (existing) {
           return { message: existing, isNew: false }
@@ -1053,7 +1059,7 @@ export class ShardedMessageRepository implements IMessageRepository {
             message.sourceId as string,
             message.conversationId,
             message.workspaceId,
-            message.createdAt,
+            getSafeSinceTime(message.createdAt, ECHO_DEDUP_LOOKBACK_MS),
           )) ?? (await this.findOnWriteShardBySource(message))
         logger.info(
           {
@@ -1203,7 +1209,7 @@ export class ShardedMessageRepository implements IMessageRepository {
           message.sourceId as string,
           message.conversationId,
           message.workspaceId,
-          message.createdAt,
+          getSafeSinceTime(message.createdAt, ECHO_DEDUP_LOOKBACK_MS),
         )
         return existing ? await buildExistingResult(existing) : null
       }
@@ -1241,7 +1247,7 @@ export class ShardedMessageRepository implements IMessageRepository {
             message.sourceId as string,
             message.conversationId,
             message.workspaceId,
-            message.createdAt,
+            getSafeSinceTime(message.createdAt, ECHO_DEDUP_LOOKBACK_MS),
           )) ?? (await this.findOnWriteShardBySource(message))
         logger.info(
           {


### PR DESCRIPTION
## Problem

When the bot replies on Instagram/Messenger, the outbound message is saved once (the Send API returns the `mid`, stored as `sourceId`). The channel then echoes that same message back a few seconds later (`is_echo: true`, same `mid`). In production this echo was saved a **second time**, so a single reply appeared twice in the inbox.

The echo dedup already keys on `sourceId`, but the guard read used the incoming row's own `createdAt` as its lower bound. Because `findBySourceId` filters `createdAt >= sinceTime`, the earlier row (saved ~1.4s before) fell outside the window and was never found, so a duplicate row was inserted.

## Fix

Widen the dedup guard read to look back a bounded window (1 day) so it can see the message saved moments earlier, reusing the existing `getSafeSinceTime` helper. Applied to every dedup lookup in both `createOrUpdate` and `createOrUpdateWithAttachments`.

- Channel-agnostic — fixes the same class of duplicate for Instagram, Messenger, and echo redelivery.
- No schema change / no migration.
- Shard fan-out is unchanged in normal operation (shards do not auto-rotate; a 1-day window resolves to the same active shard), and the lookup stays a `LIMIT 1` on a highly selective `sourceId`.

## Test plan

- [x] `pnpm --filter @chatbotx.io/database test` — 377 passing, incl. 2 new regression tests (`createOrUpdate` and `createOrUpdateWithAttachments`) reproducing the send→echo duplicate
- [x] `pnpm --filter @chatbotx.io/database check-types`
- [x] `pnpm lint`
- [x] `pnpm check:circular` — no new circular dependency
- [ ] Manual: reply from the bot on an Instagram-connected inbox and confirm the reply appears exactly once after the echo webhook arrives
