### PR TITLE
fix(external-webhooks): accept provider from input instead of hardcoding make

### DIFF
--- a/apps/builder/src/features/external-webhooks/api/workspace-token.ts
+++ b/apps/builder/src/features/external-webhooks/api/workspace-token.ts
@@ -47,6 +47,7 @@ const createExternalWebhookWorkspaceTokenAPI = workspaceTokenAuthAPI
     z.object({
       url: z.string().trim().url(),
       event: z.string().trim().min(1).max(100),
+      provider: z.enum(["make", "n8n"]).default("make"),
     }),
   )
   .output(externalWebhookResource)
@@ -55,7 +56,7 @@ const createExternalWebhookWorkspaceTokenAPI = workspaceTokenAuthAPI
     async ({ context, input }) =>
       await externalWebhookService.register({
         workspaceId: context.workspace.id,
-        provider: "make",
+        provider: input.provider,
         event: input.event,
         url: input.url,
       }),


### PR DESCRIPTION
## Summary
- `POST /v1/external-webhooks` always stamped `provider: "make"` server-side, even though the field is pure metadata (nothing in the codebase branches on its value).
- Accepts `provider` from the request body as `z.enum(["make", "n8n"]).default("make")`, so other automation platforms (e.g. n8n) registering a webhook get an accurate label instead of being mislabeled as Make.

## Changes
- `apps/builder/src/features/external-webhooks/api/workspace-token.ts` — `createExternalWebhookWorkspaceTokenAPI` input now includes `provider`, handler passes `input.provider` through instead of the hardcoded string.

## Test plan
- [x] `pnpm lint` — clean
- [x] `pnpm --filter builder check-types` — clean
- [x] Backward compatibility verified: existing Make callers never send `provider`, so the `.default("make")` preserves current behavior exactly; confirmed no code anywhere branches on `provider`'s value (grepped `apps/builder`, `apps/worker`, `packages/business`).