### PR TITLE
feat(auth): add facebook sso login and reuse token for messenger connect

### DIFF
--- a/apps/builder/__tests__/channels-create-messenger-handoff.test.ts
+++ b/apps/builder/__tests__/channels-create-messenger-handoff.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockGetCurrentUserId, mockRedirect, mockResolveForOwner } = vi.hoisted(
+  () => ({
+    mockGetCurrentUserId: vi.fn(async () => "user-1"),
+    mockRedirect: vi.fn((path: string) => {
+      throw new Error(`redirect:${path}`)
+    }),
+    mockResolveForOwner: vi.fn(),
+  }),
+)
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("not found")
+  }),
+  redirect: mockRedirect,
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  platformCredentialService: { resolveForOwner: mockResolveForOwner },
+  workspaceService: { find: vi.fn(async () => ({ ownerId: "owner-1" })) },
+}))
+
+vi.mock("@chatbotx.io/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@chatbotx.io/utils")>()
+  return {
+    ...actual,
+    getIdFromParams: (
+      params: Record<string, string | null | undefined>,
+      key: string,
+    ) => params[key] ?? null,
+  }
+})
+
+vi.mock("@/lib/auth/require-workspace-permission", () => ({
+  requireWorkspacePermission: vi.fn(async () => undefined),
+}))
+
+vi.mock("@/lib/auth/utils", () => ({ getCurrentUserId: mockGetCurrentUserId }))
+
+vi.mock("@/features/inboxes/components/inbox-select-card", () => ({
+  default: () => null,
+}))
+vi.mock(
+  "@/features/integration-instagram/components/instagram-login-select",
+  () => ({ InstagramLoginSelect: () => null }),
+)
+vi.mock("@/features/integration-instagram/libs/oauth", () => ({
+  generateInstagramRedirectUri: vi.fn(async () => ""),
+}))
+vi.mock("@/features/integration-instagram/libs/oauth-facebook", () => ({
+  generateInstagramFacebookRedirectUri: vi.fn(async () => ""),
+}))
+vi.mock("@/features/integration-telegram/components/telegram-connect", () => ({
+  TelegramConnect: () => null,
+}))
+vi.mock("@/features/integration-tiktok/libs/tiktok", () => ({
+  generateTiktokRedirectUri: vi.fn(async () => ""),
+}))
+vi.mock("@/features/integration-webchat/simple-create-webchat", () => ({
+  SimpleCreateWebchat: () => null,
+}))
+vi.mock("@/features/integration-whatsapp/components/whatsapp-create", () => ({
+  default: () => null,
+}))
+vi.mock("@/features/integration-zalo/libs/zalo", () => ({
+  generateZaloRedirectUri: vi.fn(async () => ""),
+}))
+
+const { default: CreateChannelPage } = await import(
+  "../src/app/(no-sidebar)/channels/create/page"
+)
+
+describe("channels/create — hands the messenger channel off to the reuse-check route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetCurrentUserId.mockResolvedValue("user-1")
+    mockResolveForOwner.mockImplementation(({ type }: { type: string }) =>
+      Promise.resolve(
+        type === "messenger" ? { config: {}, publicConfig: {} } : undefined,
+      ),
+    )
+  })
+
+  test("redirects to the reuse-check route, carrying the workspaceId", async () => {
+    await expect(
+      CreateChannelPage({
+        searchParams: Promise.resolve({
+          channel: "messenger",
+          workspaceId: "ws-1",
+        }),
+      }),
+    ).rejects.toThrow("redirect:/channels/create/messenger?workspaceId=ws-1")
+  })
+
+  test("redirects without a query string when there is no workspace yet", async () => {
+    await expect(
+      CreateChannelPage({
+        searchParams: Promise.resolve({
+          channel: "messenger",
+          workspaceId: null,
+        }),
+      }),
+    ).rejects.toThrow("redirect:/channels/create/messenger")
+  })
+})

--- a/apps/builder/__tests__/channels-create-messenger-reuse.test.ts
+++ b/apps/builder/__tests__/channels-create-messenger-reuse.test.ts
@@ -1,0 +1,198 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+  mockBuildMessengerReferer,
+  mockCookieSet,
+  mockCookies,
+  mockEncryptAuth,
+  mockFindWorkspace,
+  mockFindWorkspaceById,
+  mockGenerateMessengerRedirectUri,
+  mockGetCurrentUserId,
+  mockRedirect,
+  mockRequireWorkspacePermission,
+  mockResolveForOwner,
+  mockTryReuseFacebookSsoToken,
+  mockWorkspaceCreate,
+} = vi.hoisted(() => ({
+  mockBuildMessengerReferer: vi.fn(async () => "https://tenant.example.com"),
+  mockCookieSet: vi.fn(),
+  mockCookies: vi.fn(),
+  mockEncryptAuth: vi.fn(async () => "encrypted-token"),
+  mockFindWorkspace: vi.fn(async () => ({ ownerId: "owner-1" })),
+  mockFindWorkspaceById: vi.fn(async () => ({
+    id: "ws-1",
+    ownerId: "owner-1",
+  })),
+  mockGenerateMessengerRedirectUri: vi.fn(
+    async () => "https://facebook.com/oauth-dialog",
+  ),
+  mockGetCurrentUserId: vi.fn(async () => "user-1"),
+  mockRedirect: vi.fn((path: string) => {
+    throw new Error(`redirect:${path}`)
+  }),
+  mockRequireWorkspacePermission: vi.fn(async () => undefined),
+  mockResolveForOwner: vi.fn(),
+  mockTryReuseFacebookSsoToken: vi.fn(),
+  mockWorkspaceCreate: vi.fn(async () => ({ id: "ws-new", ownerId: "user-1" })),
+}))
+
+vi.mock("next/headers", () => ({
+  cookies: mockCookies,
+}))
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("not found")
+  }),
+  redirect: mockRedirect,
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  platformCredentialService: { resolveForOwner: mockResolveForOwner },
+  workspaceService: {
+    find: mockFindWorkspace,
+    findById: mockFindWorkspaceById,
+    create: mockWorkspaceCreate,
+  },
+}))
+
+vi.mock("@/lib/auth/require-workspace-permission", () => ({
+  requireWorkspacePermission: mockRequireWorkspacePermission,
+}))
+
+vi.mock("@/lib/auth/utils", () => ({
+  getCurrentUserId: mockGetCurrentUserId,
+}))
+
+vi.mock("@/lib/facebook-pending-auth", () => ({
+  encryptAuth: mockEncryptAuth,
+  FB_MESSENGER_PENDING_AUTH_COOKIE: "fb_messenger_pending_auth",
+  FB_PENDING_AUTH_MAX_AGE: 600,
+}))
+
+vi.mock("@/features/integration-messenger/libs/oauth", () => ({
+  buildMessengerReferer: mockBuildMessengerReferer,
+  generateMessengerRedirectUri: mockGenerateMessengerRedirectUri,
+}))
+
+vi.mock("@/features/integration-messenger/libs/sso-reuse", () => ({
+  tryReuseFacebookSsoToken: mockTryReuseFacebookSsoToken,
+}))
+
+const { GET } = await import(
+  "../src/app/(no-sidebar)/channels/create/messenger/route"
+)
+
+const messengerCredential = {
+  config: { clientId: "app-id", clientSecret: "app-secret", version: "v23.0" },
+  publicConfig: { clientId: "app-id", version: "v23.0" },
+}
+
+function requestWithWorkspaceId(workspaceId: string | null) {
+  const url = new URL("http://localhost/channels/create/messenger")
+  if (workspaceId) {
+    url.searchParams.set("workspaceId", workspaceId)
+  }
+  return { nextUrl: url } as unknown as Parameters<typeof GET>[0]
+}
+
+/** Only the messenger credential resolves; every other channel is unconfigured. */
+function resolveOnlyMessenger() {
+  mockResolveForOwner.mockImplementation(({ type }: { type: string }) =>
+    Promise.resolve(type === "messenger" ? messengerCredential : undefined),
+  )
+}
+
+describe("GET /channels/create/messenger — Facebook SSO token reuse", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetCurrentUserId.mockResolvedValue("user-1")
+    mockCookies.mockResolvedValue({ set: mockCookieSet })
+    resolveOnlyMessenger()
+  })
+
+  test("reuses a valid SSO token: writes the pending-auth cookie and redirects straight to the Page picker", async () => {
+    mockTryReuseFacebookSsoToken.mockResolvedValue({
+      reusable: true,
+      userToken: "long-lived-user-token",
+      userId: "fb-1",
+      userName: "Jane Doe",
+      userAvatarUrl: "https://example.com/a.png",
+    })
+
+    await expect(GET(requestWithWorkspaceId("ws-1"))).rejects.toThrow(
+      "redirect:/channels/messenger/select",
+    )
+
+    expect(mockRequireWorkspacePermission).toHaveBeenCalledWith(
+      "ws-1",
+      "superAdmin",
+    )
+    expect(mockFindWorkspaceById).toHaveBeenCalledWith({ id: "ws-1" })
+    expect(mockWorkspaceCreate).not.toHaveBeenCalled()
+    expect(mockEncryptAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userToken: "long-lived-user-token",
+        userId: "fb-1",
+        userName: "Jane Doe",
+        userAvatarUrl: "https://example.com/a.png",
+        workspaceId: "ws-1",
+        version: "v23.0",
+      }),
+    )
+    expect(mockCookieSet).toHaveBeenCalledWith(
+      "fb_messenger_pending_auth",
+      "encrypted-token",
+      expect.objectContaining({ path: "/channels/messenger/select" }),
+    )
+    expect(mockGenerateMessengerRedirectUri).not.toHaveBeenCalled()
+  })
+
+  test("creates a workspace first when reusing a token with no workspaceId yet (first channel ever)", async () => {
+    mockTryReuseFacebookSsoToken.mockResolvedValue({
+      reusable: true,
+      userToken: "long-lived-user-token",
+    })
+
+    await expect(GET(requestWithWorkspaceId(null))).rejects.toThrow(
+      "redirect:/channels/messenger/select",
+    )
+
+    expect(mockRequireWorkspacePermission).not.toHaveBeenCalled()
+    expect(mockWorkspaceCreate).toHaveBeenCalledWith({
+      data: { name: "New Workspace", ownerId: "user-1" },
+      createdBy: "user-1",
+    })
+    expect(mockEncryptAuth).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: "ws-new" }),
+    )
+  })
+
+  test("falls back to the full OAuth redirect when there is no reusable token", async () => {
+    mockTryReuseFacebookSsoToken.mockResolvedValue({ reusable: false })
+
+    await expect(GET(requestWithWorkspaceId("ws-1"))).rejects.toThrow(
+      "redirect:https://facebook.com/oauth-dialog",
+    )
+
+    expect(mockEncryptAuth).not.toHaveBeenCalled()
+    expect(mockCookieSet).not.toHaveBeenCalled()
+    expect(mockGenerateMessengerRedirectUri).toHaveBeenCalledWith(
+      messengerCredential.publicConfig,
+      "ws-1",
+    )
+  })
+
+  test("404s when the workspace has no messenger credential configured", async () => {
+    mockResolveForOwner.mockResolvedValue(undefined)
+
+    await expect(GET(requestWithWorkspaceId("ws-1"))).rejects.toThrow(
+      "not found",
+    )
+
+    expect(mockTryReuseFacebookSsoToken).not.toHaveBeenCalled()
+  })
+})

--- a/apps/builder/__tests__/facebook-sso-reuse.test.ts
+++ b/apps/builder/__tests__/facebook-sso-reuse.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const REQUIRED_SCOPES = ["pages_show_list", "pages_messaging"]
+
+const {
+  mockDebugToken,
+  mockFindByUserAndProvider,
+  mockGetFacebookUser,
+  mockToAppAccessToken,
+} = vi.hoisted(() => ({
+  mockDebugToken: vi.fn(),
+  mockFindByUserAndProvider: vi.fn(),
+  mockGetFacebookUser: vi.fn(),
+  mockToAppAccessToken: vi.fn(() => "client-id|client-secret"),
+}))
+
+vi.mock("@chatbotx.io/database/repositories", () => ({
+  authAccountRepository: { findByUserAndProvider: mockFindByUserAndProvider },
+}))
+
+vi.mock("@chatbotx.io/integration-messenger", () => ({
+  debugToken: mockDebugToken,
+  getFacebookUser: mockGetFacebookUser,
+  MESSENGER_REUSE_REQUIRED_SCOPES: REQUIRED_SCOPES,
+  toAppAccessToken: mockToAppAccessToken,
+}))
+
+const { tryReuseFacebookSsoToken } = await import(
+  "@/features/integration-messenger/libs/sso-reuse"
+)
+
+const messengerCredential = {
+  clientId: "client-id",
+  clientSecret: "client-secret",
+  version: "v23.0",
+}
+
+describe("tryReuseFacebookSsoToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("no linked Facebook account is not reusable", async () => {
+    mockFindByUserAndProvider.mockResolvedValue(null)
+
+    const result = await tryReuseFacebookSsoToken({
+      userId: "user-1",
+      messengerCredential,
+    })
+
+    expect(result).toEqual({ reusable: false })
+    expect(mockDebugToken).not.toHaveBeenCalled()
+  })
+
+  test("an invalid token (revoked, or rotated app secret) is not reusable", async () => {
+    mockFindByUserAndProvider.mockResolvedValue({ accessToken: "fb-token" })
+    mockDebugToken.mockResolvedValue({ is_valid: false, scopes: [] })
+
+    const result = await tryReuseFacebookSsoToken({
+      userId: "user-1",
+      messengerCredential,
+    })
+
+    expect(result).toEqual({ reusable: false })
+  })
+
+  test("debugToken rejecting (e.g. app secret rotated) is not reusable", async () => {
+    mockFindByUserAndProvider.mockResolvedValue({ accessToken: "fb-token" })
+    mockDebugToken.mockRejectedValue(new Error("(#100) token not for this app"))
+
+    const result = await tryReuseFacebookSsoToken({
+      userId: "user-1",
+      messengerCredential,
+    })
+
+    expect(result).toEqual({ reusable: false })
+  })
+
+  test("a valid token missing a required scope is not reusable", async () => {
+    mockFindByUserAndProvider.mockResolvedValue({ accessToken: "fb-token" })
+    mockDebugToken.mockResolvedValue({
+      is_valid: true,
+      scopes: ["pages_show_list"], // missing pages_messaging
+    })
+
+    const result = await tryReuseFacebookSsoToken({
+      userId: "user-1",
+      messengerCredential,
+    })
+
+    expect(result).toEqual({ reusable: false })
+    expect(mockGetFacebookUser).not.toHaveBeenCalled()
+  })
+
+  test("a valid token carrying every required scope is reusable", async () => {
+    mockFindByUserAndProvider.mockResolvedValue({ accessToken: "fb-token" })
+    mockDebugToken.mockResolvedValue({
+      is_valid: true,
+      scopes: REQUIRED_SCOPES,
+    })
+    mockGetFacebookUser.mockResolvedValue({
+      id: "fb-1",
+      name: "Jane Doe",
+      avatarUrl: "https://example.com/avatar.png",
+    })
+
+    const result = await tryReuseFacebookSsoToken({
+      userId: "user-1",
+      messengerCredential,
+    })
+
+    expect(result).toEqual({
+      reusable: true,
+      userToken: "fb-token",
+      userId: "fb-1",
+      userName: "Jane Doe",
+      userAvatarUrl: "https://example.com/avatar.png",
+    })
+    expect(mockDebugToken).toHaveBeenCalledWith({
+      inputToken: "fb-token",
+      appAccessToken: "client-id|client-secret",
+      version: "v23.0",
+    })
+  })
+
+  test("a failed profile lookup still reports reusable (best-effort)", async () => {
+    mockFindByUserAndProvider.mockResolvedValue({ accessToken: "fb-token" })
+    mockDebugToken.mockResolvedValue({
+      is_valid: true,
+      scopes: REQUIRED_SCOPES,
+    })
+    mockGetFacebookUser.mockRejectedValue(new Error("network error"))
+
+    const result = await tryReuseFacebookSsoToken({
+      userId: "user-1",
+      messengerCredential,
+    })
+
+    expect(result).toEqual({
+      reusable: true,
+      userToken: "fb-token",
+      userId: undefined,
+      userName: undefined,
+      userAvatarUrl: undefined,
+    })
+  })
+})

--- a/apps/builder/__tests__/social-auth-instances.test.ts
+++ b/apps/builder/__tests__/social-auth-instances.test.ts
@@ -5,12 +5,15 @@ import { beforeEach, describe, expect, test, vi } from "vitest"
 const ROOT_TENANT_ID = "1"
 const SOCIAL_PROVIDERS = ["google", "facebook"] as const
 
+const FACEBOOK_SSO_SCOPES = ["email", "public_profile", "pages_messaging"]
+
 const {
   mockCreateAuth,
   mockFindDecryptedPlatform,
   mockResolveForOwner,
   mockResolveTenantByDomain,
   mockResolveTenantOwnerId,
+  mockUpgradeFacebookAccount,
 } = vi.hoisted(() => ({
   // createAuth is mocked to a cheap stub tagged by the (provider, clientId) it
   // was built with, so we can assert which app an instance signs in with and
@@ -29,6 +32,9 @@ const {
   mockResolveForOwner: vi.fn(),
   mockResolveTenantByDomain: vi.fn(),
   mockResolveTenantOwnerId: vi.fn(),
+  // upgradeFacebookAccount(credential) returns a hook function; the mock
+  // returns a stub function so we can assert the credential it was built with.
+  mockUpgradeFacebookAccount: vi.fn(() => vi.fn()),
 }))
 
 vi.mock("@chatbotx.io/auth/server", () => ({
@@ -50,6 +56,11 @@ vi.mock("@chatbotx.io/business", () => ({
 
 vi.mock("@chatbotx.io/database/schema", () => ({
   ROOT_TENANT_ID,
+}))
+
+vi.mock("@/lib/auth/upgrade-facebook-account", () => ({
+  FACEBOOK_SSO_SCOPES,
+  upgradeFacebookAccount: mockUpgradeFacebookAccount,
 }))
 
 const credential = (clientId: string, clientSecret = "secret") => ({
@@ -197,5 +208,90 @@ describe("getSocialAuthForTenant", () => {
         socialCredentials: { google: null },
       }),
     )
+  })
+
+  test("facebook requests Messenger-grade scopes and upgrades the token, keyed to the resolved credential", async () => {
+    mockFindDecryptedPlatform.mockResolvedValue(credential("meta-app"))
+    const { getSocialAuthForTenant } = await loadModule()
+
+    await getSocialAuthForTenant(ROOT_TENANT_ID, "facebook")
+
+    expect(mockCreateAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        socialCredentials: {
+          facebook: expect.objectContaining({
+            clientId: "meta-app",
+            clientSecret: "secret",
+          }),
+        },
+        socialScopes: { facebook: FACEBOOK_SSO_SCOPES },
+        upgradeOAuthAccount: expect.any(Function),
+      }),
+    )
+    expect(mockUpgradeFacebookAccount).toHaveBeenCalledWith({
+      clientId: "meta-app",
+      clientSecret: "secret",
+      version: "v1",
+    })
+  })
+
+  test("google does not get facebook-only scope/upgrade wiring", async () => {
+    mockFindDecryptedPlatform.mockResolvedValue(credential("platform-client"))
+    const { getSocialAuthForTenant } = await loadModule()
+
+    await getSocialAuthForTenant(ROOT_TENANT_ID, "google")
+
+    const call = mockCreateAuth.mock.calls[0]?.[0]
+    expect(call).not.toHaveProperty("socialScopes")
+    expect(call).not.toHaveProperty("upgradeOAuthAccount")
+  })
+
+  test("disabled facebook (no credential) skips scope/upgrade wiring", async () => {
+    mockFindDecryptedPlatform.mockResolvedValue(undefined)
+    const { getSocialAuthForTenant } = await loadModule()
+
+    await getSocialAuthForTenant(ROOT_TENANT_ID, "facebook")
+
+    const call = mockCreateAuth.mock.calls[0]?.[0]
+    expect(call).not.toHaveProperty("socialScopes")
+    expect(call).not.toHaveProperty("upgradeOAuthAccount")
+    expect(mockUpgradeFacebookAccount).not.toHaveBeenCalled()
+  })
+
+  test("a version-only credential change (same clientId/secret) busts the cache", async () => {
+    mockFindDecryptedPlatform.mockResolvedValueOnce({
+      config: {
+        clientId: "meta-app",
+        clientSecret: "secret",
+        verifyToken: "token",
+        version: "v22.0",
+      },
+    })
+    const { getSocialAuthForTenant } = await loadModule()
+
+    const first = await getSocialAuthForTenant(ROOT_TENANT_ID, "facebook")
+
+    mockFindDecryptedPlatform.mockResolvedValueOnce({
+      config: {
+        clientId: "meta-app",
+        clientSecret: "secret",
+        verifyToken: "token",
+        version: "v23.0",
+      },
+    })
+    const second = await getSocialAuthForTenant(ROOT_TENANT_ID, "facebook")
+
+    expect(first).not.toBe(second)
+    expect(mockCreateAuth).toHaveBeenCalledTimes(2)
+    expect(mockUpgradeFacebookAccount).toHaveBeenNthCalledWith(1, {
+      clientId: "meta-app",
+      clientSecret: "secret",
+      version: "v22.0",
+    })
+    expect(mockUpgradeFacebookAccount).toHaveBeenNthCalledWith(2, {
+      clientId: "meta-app",
+      clientSecret: "secret",
+      version: "v23.0",
+    })
   })
 })

--- a/apps/builder/src/app/(no-sidebar)/channels/create/messenger/route.ts
+++ b/apps/builder/src/app/(no-sidebar)/channels/create/messenger/route.ts
@@ -1,0 +1,97 @@
+import {
+  platformCredentialService,
+  workspaceService,
+} from "@chatbotx.io/business"
+import { cookies } from "next/headers"
+import { notFound, redirect } from "next/navigation"
+import type { NextRequest } from "next/server"
+import {
+  buildMessengerReferer,
+  generateMessengerRedirectUri,
+} from "@/features/integration-messenger/libs/oauth"
+import { tryReuseFacebookSsoToken } from "@/features/integration-messenger/libs/sso-reuse"
+import { requireWorkspacePermission } from "@/lib/auth/require-workspace-permission"
+import { getCurrentUserId } from "@/lib/auth/utils"
+import {
+  encryptAuth,
+  FB_MESSENGER_PENDING_AUTH_COOKIE,
+  FB_PENDING_AUTH_MAX_AGE,
+} from "@/lib/facebook-pending-auth"
+
+/**
+ * Reached only via a redirect from `/channels/create?channel=messenger`
+ * (never linked to directly). The Facebook SSO token reuse check needs to set
+ * the pending-auth cookie on a hit, and cookies can only be written from a
+ * Server Action or a Route Handler — never from a Server Component's render,
+ * which is what `/channels/create` is. This route re-runs the auth/workspace
+ * guards itself since it's a public GET endpoint, not just an internal helper.
+ */
+export async function GET(req: NextRequest) {
+  const workspaceId = req.nextUrl.searchParams.get("workspaceId")
+
+  if (workspaceId) {
+    await requireWorkspacePermission(workspaceId, "superAdmin")
+  }
+
+  const userId = await getCurrentUserId()
+  if (!userId) {
+    return notFound()
+  }
+
+  const platformOwnerId = workspaceId
+    ? ((await workspaceService.find({ where: { id: workspaceId } }))?.ownerId ??
+      userId)
+    : userId
+
+  const messenger = await platformCredentialService.resolveForOwner({
+    ownerId: platformOwnerId,
+    type: "messenger",
+  })
+  if (!messenger) {
+    return notFound()
+  }
+
+  const reuse = await tryReuseFacebookSsoToken({
+    userId,
+    messengerCredential: messenger.config,
+  })
+
+  if (reuse.reusable) {
+    // Mirror the OAuth callback's workspace resolution (`callback.ts`): a
+    // channel connect can be the very first one for a user, with no
+    // workspace yet — create it now instead of writing a pending-auth cookie
+    // that points nowhere.
+    const targetWorkspace = workspaceId
+      ? await workspaceService.findById({ id: workspaceId })
+      : await workspaceService.create({
+          data: { name: "New Workspace", ownerId: userId },
+          createdBy: userId,
+        })
+    const referer = await buildMessengerReferer(targetWorkspace.id)
+    const token = await encryptAuth({
+      userToken: reuse.userToken,
+      userId: reuse.userId,
+      userName: reuse.userName,
+      userAvatarUrl: reuse.userAvatarUrl,
+      workspaceId: targetWorkspace.id,
+      referer,
+      version: messenger.config.version,
+      expiresAt: Date.now() + FB_PENDING_AUTH_MAX_AGE * 1000,
+    })
+    const cookieStore = await cookies()
+    cookieStore.set(FB_MESSENGER_PENDING_AUTH_COOKIE, token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: FB_PENDING_AUTH_MAX_AGE,
+      path: "/channels/messenger/select",
+    })
+    redirect("/channels/messenger/select")
+  }
+
+  const redirectUri = await generateMessengerRedirectUri(
+    messenger.publicConfig,
+    workspaceId,
+  )
+  redirect(redirectUri)
+}

--- a/apps/builder/src/app/(no-sidebar)/channels/create/page.tsx
+++ b/apps/builder/src/app/(no-sidebar)/channels/create/page.tsx
@@ -9,7 +9,6 @@ import InboxSelectCard from "@/features/inboxes/components/inbox-select-card"
 import { InstagramLoginSelect } from "@/features/integration-instagram/components/instagram-login-select"
 import { generateInstagramRedirectUri } from "@/features/integration-instagram/libs/oauth"
 import { generateInstagramFacebookRedirectUri } from "@/features/integration-instagram/libs/oauth-facebook"
-import { generateMessengerRedirectUri } from "@/features/integration-messenger/libs/oauth"
 import { TelegramConnect } from "@/features/integration-telegram/components/telegram-connect"
 import { generateTiktokRedirectUri } from "@/features/integration-tiktok/libs/tiktok"
 import { SimpleCreateWebchat } from "@/features/integration-webchat/simple-create-webchat"
@@ -93,11 +92,13 @@ export default async function CreateChannelPage(props: CreateChannelPageProps) {
   }
 
   if (selectedChannel === "messenger" && messenger) {
-    const redirectUri = await generateMessengerRedirectUri(
-      messenger.publicConfig,
-      workspaceId,
+    // The Facebook SSO token reuse check needs to set a cookie on a hit, which
+    // a Server Component's render can't do — hand off to a Route Handler that
+    // re-checks reuse and either redirects to the Page picker (cookie set) or
+    // falls back to the full OAuth dialog. See that route's comment.
+    redirect(
+      `/channels/create/messenger${workspaceId ? `?workspaceId=${workspaceId}` : ""}`,
     )
-    redirect(redirectUri)
   }
 
   if (selectedChannel === "instagram" && instagram) {

--- a/apps/builder/src/features/auth/sso-sign-in.tsx
+++ b/apps/builder/src/features/auth/sso-sign-in.tsx
@@ -1,6 +1,8 @@
 "use client"
 
 import type { SocialProvider } from "@chatbotx.io/auth/server"
+import { Button } from "@chatbotx.io/ui/components/ui/button"
+import { useTranslations } from "next-intl"
 import GoogleButton from "react-google-button"
 import { authClient } from "@/lib/auth/auth-client"
 
@@ -19,22 +21,22 @@ const signInWith = async (provider: SocialProvider): Promise<void> => {
   })
 }
 
-// function FacebookIcon() {
-//   return (
-//     <svg
-//       aria-hidden="true"
-//       fill="currentColor"
-//       height="20"
-//       viewBox="0 0 24 24"
-//       width="20"
-//     >
-//       <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
-//     </svg>
-//   )
-// }
+function FacebookIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="currentColor"
+      height="20"
+      viewBox="0 0 24 24"
+      width="20"
+    >
+      <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
+    </svg>
+  )
+}
 
 export default function SSOSignIn({ providers }: SSOSignInProps) {
-  // const t = useTranslations()
+  const t = useTranslations()
 
   return (
     <div className="flex flex-col items-center gap-3">
@@ -47,7 +49,7 @@ export default function SSOSignIn({ providers }: SSOSignInProps) {
         />
       )}
 
-      {/* {providers.includes("facebook") && (
+      {providers.includes("facebook") && (
         <Button
           aria-label={t("auth.continueWithFacebook")}
           className="w-full bg-[#1877F2] text-white hover:bg-[#0F6FE5]"
@@ -59,7 +61,7 @@ export default function SSOSignIn({ providers }: SSOSignInProps) {
           <FacebookIcon />
           {t("auth.continueWithFacebook")}
         </Button>
-      )} */}
+      )}
     </div>
   )
 }

--- a/apps/builder/src/features/integration-messenger/libs/oauth.ts
+++ b/apps/builder/src/features/integration-messenger/libs/oauth.ts
@@ -3,6 +3,21 @@ import { generateAuthUrl } from "@chatbotx.io/integration-messenger"
 import { getOriginFromHeader } from "@/lib/domain"
 import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 
+/**
+ * Where a Messenger OAuth flow returns the user once tokens are stored — the
+ * workspace's space if known, otherwise the current origin. Shared by the
+ * OAuth "Connect" redirect and the SSO-token reuse short-circuit, both of
+ * which need to build the same `FacebookAuthCallback.referer`.
+ */
+export async function buildMessengerReferer(
+  workspaceId?: string | null,
+): Promise<string> {
+  const baseUrl = await getOriginFromHeader()
+  return workspaceId
+    ? new URL(`/space/${workspaceId}`, baseUrl).toString()
+    : baseUrl
+}
+
 export async function generateMessengerRedirectUri(
   publicConfig: MessengerCredentialPublic,
   workspaceId?: string | null,
@@ -12,10 +27,7 @@ export async function generateMessengerRedirectUri(
   // always send Facebook to the fixed broker callback and recover the originating
   // branded domain from `referer` (the callback relays back to it).
   const redirectUrl = buildBrokerCallbackUrl("/integrations/messenger/callback")
-  const baseUrl = await getOriginFromHeader()
-  const referer = workspaceId
-    ? new URL(`/space/${workspaceId}`, baseUrl).toString()
-    : baseUrl
+  const referer = await buildMessengerReferer(workspaceId)
 
   return generateAuthUrl({
     clientId: publicConfig.clientId,

--- a/apps/builder/src/features/integration-messenger/libs/sso-reuse.ts
+++ b/apps/builder/src/features/integration-messenger/libs/sso-reuse.ts
@@ -1,0 +1,77 @@
+import { authAccountRepository } from "@chatbotx.io/database/repositories"
+import {
+  debugToken,
+  getFacebookUser,
+  MESSENGER_REUSE_REQUIRED_SCOPES,
+  toAppAccessToken,
+} from "@chatbotx.io/integration-messenger"
+
+export type FacebookSsoReuse =
+  | {
+      reusable: true
+      userToken: string
+      userId?: string
+      userName?: string
+      userAvatarUrl?: string
+    }
+  | { reusable: false }
+
+/**
+ * Whether the current user's Facebook SSO login (see `upgrade-facebook-account.ts`)
+ * already carries every permission the Messenger connect flow would otherwise
+ * request, so "Connect" can skip straight to the Page picker instead of
+ * round-tripping through Facebook's OAuth dialog again.
+ *
+ * Validates against the workspace's CURRENT `messenger` credential (the same
+ * one `resolveForOwner` always returns) rather than whichever app minted the
+ * token — if the reseller ever rotates their Meta app secret, this simply
+ * fails closed (falls back to the full OAuth flow) until the user's next
+ * Facebook SSO login re-mints against the new app.
+ */
+export async function tryReuseFacebookSsoToken(props: {
+  userId: string
+  messengerCredential: {
+    clientId: string
+    clientSecret: string
+    version: string
+  }
+}): Promise<FacebookSsoReuse> {
+  const account = await authAccountRepository.findByUserAndProvider({
+    userId: props.userId,
+    providerId: "facebook",
+  })
+  if (!account?.accessToken) {
+    return { reusable: false }
+  }
+
+  const debug = await debugToken({
+    inputToken: account.accessToken,
+    appAccessToken: toAppAccessToken(props.messengerCredential),
+    version: props.messengerCredential.version,
+  }).catch(() => null)
+
+  if (!debug?.is_valid) {
+    return { reusable: false }
+  }
+
+  const grantedScopes = debug.scopes ?? []
+  const hasAllRequiredScopes = MESSENGER_REUSE_REQUIRED_SCOPES.every((scope) =>
+    grantedScopes.includes(scope),
+  )
+  if (!hasAllRequiredScopes) {
+    return { reusable: false }
+  }
+
+  const fbUser = await getFacebookUser(
+    account.accessToken,
+    props.messengerCredential.version,
+  ).catch(() => undefined)
+
+  return {
+    reusable: true,
+    userToken: account.accessToken,
+    userId: fbUser?.id,
+    userName: fbUser?.name,
+    userAvatarUrl: fbUser?.avatarUrl,
+  }
+}

--- a/apps/builder/src/lib/auth/auth-instances.ts
+++ b/apps/builder/src/lib/auth/auth-instances.ts
@@ -13,6 +13,10 @@ import { platformCredentialService } from "@chatbotx.io/business"
 import type { CredentialType } from "@chatbotx.io/database/partials"
 import { ROOT_TENANT_ID } from "@chatbotx.io/database/schema"
 import { onUserCreated } from "./on-user-created"
+import {
+  FACEBOOK_SSO_SCOPES,
+  upgradeFacebookAccount,
+} from "./upgrade-facebook-account"
 
 /**
  * White-label social login (Google, Facebook, …).
@@ -49,31 +53,38 @@ const PROVIDER_CREDENTIAL_TYPE: Record<SocialProvider, SocialCredentialType> = {
 /**
  * One instance cache per provider, keyed by a fingerprint of the credential.
  *
- * The key folds in BOTH the client id and the client secret, so a reseller
- * rotating their OAuth secret — even keeping the same client id — resolves to a
- * fresh instance instead of signing users in with the now-stale secret captured
- * in the old instance's closure. The set of distinct credentials is small and
- * bounded (platform defaults + the resellers who registered their own), so
- * orphaned post-rotation entries stay negligible.
+ * The key folds in the client id, the client secret, AND (for Facebook) the
+ * Meta API `version`, so a reseller rotating their OAuth secret — or just
+ * bumping the API version while keeping the same clientId/secret — resolves
+ * to a fresh instance instead of reusing one whose `upgradeOAuthAccount`
+ * closure was built once with the now-stale secret/version. The set of
+ * distinct credentials is small and bounded (platform defaults + the
+ * resellers who registered their own), so orphaned post-rotation entries stay
+ * negligible.
  */
 const instancesByProvider: Record<SocialProvider, Map<string, Auth>> = {
   google: new Map(),
   facebook: new Map(),
 }
 
-/** A stable, non-reversible cache key for a credential (client id + secret). */
-function credentialKey(credential: SocialAuthCredential | null): string {
+/** A resolved credential, carrying the Meta API `version` for Facebook. */
+type FacebookAwareCredential = SocialAuthCredential & { version?: string }
+
+/** A stable, non-reversible cache key for a credential (client id + secret + version). */
+function credentialKey(credential: FacebookAwareCredential | null): string {
   if (!credential) {
     return NO_CREDENTIAL_KEY
   }
   return createHash("sha256")
-    .update(`${credential.clientId} ${credential.clientSecret}`)
+    .update(
+      `${credential.clientId} ${credential.clientSecret} ${credential.version ?? ""}`,
+    )
     .digest("hex")
 }
 
 function getAuthForCredential(
   provider: SocialProvider,
-  credential: SocialAuthCredential | null,
+  credential: FacebookAwareCredential | null,
 ): Auth {
   const cache = instancesByProvider[provider]
   const key = credentialKey(credential)
@@ -85,10 +96,26 @@ function getAuthForCredential(
   const instance = createAuth({
     socialCredentials: { [provider]: credential },
     onUserCreated,
+    // Facebook SSO requests the same Messenger-grade scopes as the channel
+    // connect flow (so the token can later be reused to list Pages) and
+    // upgrades the short-lived token it gets into a long-lived one before
+    // persisting it — see `upgrade-facebook-account.ts`.
+    ...(provider === "facebook" &&
+      credential && {
+        socialScopes: { facebook: FACEBOOK_SSO_SCOPES },
+        upgradeOAuthAccount: upgradeFacebookAccount({
+          clientId: credential.clientId,
+          clientSecret: credential.clientSecret,
+          version: credential.version ?? DEFAULT_MESSENGER_API_VERSION,
+        }),
+      }),
   })
   cache.set(key, instance)
   return instance
 }
+
+/** Fallback only reached if a resolved messenger credential is somehow missing `version` (schema requires it). */
+const DEFAULT_MESSENGER_API_VERSION = "v23.0"
 
 /**
  * The credential a tenant signs in with for `provider`: the reseller's own app
@@ -98,7 +125,7 @@ function getAuthForCredential(
 async function resolveCredentialForTenant(
   tenantId: string,
   provider: SocialProvider,
-): Promise<SocialAuthCredential | null> {
+): Promise<FacebookAwareCredential | null> {
   const type = PROVIDER_CREDENTIAL_TYPE[provider]
   const decrypted =
     tenantId === ROOT_TENANT_ID
@@ -111,7 +138,14 @@ async function resolveCredentialForTenant(
     return null
   }
 
-  return { clientId, clientSecret }
+  return {
+    clientId,
+    clientSecret,
+    version:
+      provider === "facebook"
+        ? (decrypted?.config as { version: string }).version
+        : undefined,
+  }
 }
 
 function resolveResellerCredential(

--- a/apps/builder/src/lib/auth/upgrade-facebook-account.ts
+++ b/apps/builder/src/lib/auth/upgrade-facebook-account.ts
@@ -1,0 +1,52 @@
+import type {
+  AuthOAuthAccount,
+  AuthOAuthAccountPatch,
+} from "@chatbotx.io/auth/server"
+import { MESSENGER_SCOPES } from "@chatbotx.io/integration-messenger"
+import { exchangeLongLivedToken } from "@chatbotx.io/integration-messenger/apis/page"
+import { logger } from "@/lib/log"
+
+/**
+ * Scopes requested at Facebook SSO login — the same set the Messenger connect
+ * flow requests, so the resulting token can later be reused to list Pages
+ * without a second OAuth round-trip. See `tryReuseFacebookSsoToken`.
+ */
+export const FACEBOOK_SSO_SCOPES = MESSENGER_SCOPES
+
+/**
+ * Wired into `createAuth` as `upgradeOAuthAccount` for the Facebook SSO
+ * instance. better-auth's own code exchange only yields a short-lived user
+ * token (~1-2h); this upgrades it to a long-lived one (~60 days) before it's
+ * persisted, using the exact credential this closure was built with (see
+ * `auth-instances.ts`) — the same app that will later validate the token.
+ * Best-effort: on failure the short-lived token is left in place; nothing
+ * blocks sign-in.
+ */
+export function upgradeFacebookAccount(credential: {
+  clientId: string
+  clientSecret: string
+  version: string
+}) {
+  return async (
+    account: AuthOAuthAccount,
+  ): Promise<AuthOAuthAccountPatch | undefined> => {
+    if (account.providerId !== "facebook" || !account.accessToken) {
+      return
+    }
+
+    try {
+      const accessToken = await exchangeLongLivedToken(
+        credential,
+        account.accessToken,
+      )
+      // `exchangeLongLivedToken` doesn't return an expiry; reuse always
+      // re-validates live via `debugToken` rather than trusting this column.
+      return { accessToken, accessTokenExpiresAt: null }
+    } catch (error) {
+      logger.warn(
+        { err: error },
+        "Facebook SSO long-lived token exchange failed",
+      )
+    }
+  }
+}

--- a/integrations/messenger/src/apis/auth.ts
+++ b/integrations/messenger/src/apis/auth.ts
@@ -169,7 +169,7 @@ function sortConnectableFirst(
 
 const FACEBOOK_OAUTH_BASE = "https://www.facebook.com"
 
-const MESSENGER_SCOPES = [
+export const MESSENGER_SCOPES = [
   "email",
   "public_profile",
   "pages_manage_ads",
@@ -183,6 +183,17 @@ const MESSENGER_SCOPES = [
   "business_management",
   "pages_utility_messaging",
 ]
+
+/**
+ * `MESSENGER_SCOPES` minus the two identity-only scopes (`email`,
+ * `public_profile` are not Graph permissions and are implicitly present on
+ * every token). Used to decide whether a Facebook SSO token already carries
+ * every permission the Messenger connect flow would otherwise request, so the
+ * page-connect step can reuse it instead of re-running OAuth.
+ */
+export const MESSENGER_REUSE_REQUIRED_SCOPES = MESSENGER_SCOPES.filter(
+  (scope) => scope !== "email" && scope !== "public_profile",
+)
 
 /**
  * Scopes requested by the Facebook Lead Ads "Add New" re-auth. Granting these

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -238,6 +238,22 @@ export type AuthCreatedUser = {
   isAnonymous?: boolean
 }
 
+/**
+ * A patch an `upgradeOAuthAccount` hook may apply to an OAuth `Account` row
+ * before better-auth persists it (e.g. swapping a short-lived token for a
+ * long-lived one).
+ */
+export type AuthOAuthAccountPatch = {
+  accessToken?: string | null
+  accessTokenExpiresAt?: Date | null
+}
+
+/** The subset of an `Account` row an `upgradeOAuthAccount` hook can inspect. */
+export type AuthOAuthAccount = {
+  providerId: string
+  accessToken: string | null
+}
+
 export type AuthConfig = {
   /**
    * The per-provider OAuth apps this instance signs in with. A provider is
@@ -246,6 +262,23 @@ export type AuthConfig = {
   socialCredentials?: Partial<
     Record<SocialProvider, SocialAuthCredential | null>
   >
+  /**
+   * Extra scopes requested at authorize time for a provider, REPLACING (not
+   * appending to) better-auth's own default scope list — packages/auth has no
+   * opinion on what the scopes mean; the caller (builder) supplies them.
+   */
+  socialScopes?: Partial<Record<SocialProvider, string[]>>
+  /**
+   * Called from `account.create.before` / `account.update.before`, right
+   * before better-auth persists an OAuth account row — on every social
+   * sign-in, not just the first. Return a patch to upgrade the row before it's
+   * written (e.g. Facebook short-lived → long-lived token exchange).
+   * Best-effort: errors are caught and the original data is persisted
+   * unmodified. Omit to disable.
+   */
+  upgradeOAuthAccount?: (
+    account: AuthOAuthAccount,
+  ) => Promise<AuthOAuthAccountPatch | undefined>
   /**
    * Called once after a new `User` row is created, on every sign-up path
    * (email/password, social, magic link). The builder wires this to provision
@@ -263,6 +296,7 @@ export type AuthConfig = {
  */
 function buildSocialProviders(
   socialCredentials: AuthConfig["socialCredentials"],
+  socialScopes: AuthConfig["socialScopes"],
 ) {
   if (process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD || !socialCredentials) {
     return
@@ -271,13 +305,19 @@ function buildSocialProviders(
   const providers: Partial<
     Record<
       SocialProvider,
-      { enabled: true; redirectURI: string } & SocialAuthCredential
+      {
+        enabled: true
+        redirectURI: string
+        scope?: string[]
+        disableDefaultScope?: boolean
+      } & SocialAuthCredential
     >
   > = {}
   const brokerOrigin = new URL(getBrokerUrl()).origin
   for (const provider of SOCIAL_PROVIDERS) {
     const credential = socialCredentials[provider]
     if (credential?.clientId && credential.clientSecret) {
+      const scope = socialScopes?.[provider]
       providers[provider] = {
         enabled: true,
         clientId: credential.clientId,
@@ -290,6 +330,10 @@ function buildSocialProviders(
           `/api/auth/callback/${provider}`,
           brokerOrigin,
         ).toString(),
+        // Replace (not append to) better-auth's own default scope list when the
+        // caller supplies one, so the caller-provided scopes are the single
+        // source of truth regardless of the provider's internal defaults.
+        ...(scope && { scope, disableDefaultScope: true }),
       }
     }
   }
@@ -298,47 +342,90 @@ function buildSocialProviders(
 }
 
 /**
- * Build the `databaseHooks` that fire `config.onUserCreated` after a new user
- * row is written. Returns `undefined` when no callback is configured so
- * better-auth keeps its default behavior. The callback is awaited inside a
- * try/catch — a throwing after-hook would otherwise abort sign-up, and default
- * plan provisioning is strictly best-effort.
+ * Build the `databaseHooks` block: `user.create.after` fires
+ * `config.onUserCreated`; `account.create.before` / `account.update.before`
+ * fire `config.upgradeOAuthAccount` right before an OAuth account row is
+ * persisted (e.g. Facebook short-lived → long-lived token exchange, run on
+ * every social sign-in — a returning user hits `update`, not `create`).
+ * Returns `undefined` when neither is configured so better-auth keeps its
+ * default behavior. Both hooks are best-effort: a throwing hook never blocks
+ * sign-up/sign-in, and on failure the original data is persisted unmodified.
  */
-function buildDatabaseHooks(onUserCreated: AuthConfig["onUserCreated"]) {
-  if (!onUserCreated) {
+function buildDatabaseHooks({
+  onUserCreated,
+  upgradeOAuthAccount,
+}: Pick<AuthConfig, "onUserCreated" | "upgradeOAuthAccount">) {
+  if (!(onUserCreated || upgradeOAuthAccount)) {
     return
   }
 
-  return {
-    user: {
-      create: {
-        after: async (user: Record<string, unknown>) => {
-          try {
-            await onUserCreated({
-              id: String(user.id),
-              email: String(user.email),
-              tenantId:
-                typeof user.tenantId === "string" ? user.tenantId : undefined,
-              isAnonymous:
-                typeof user.isAnonymous === "boolean"
-                  ? user.isAnonymous
-                  : undefined,
-            })
-          } catch {
-            // Best-effort: provisioning must never block sign-up. The callback
-            // is responsible for logging its own failures.
-          }
+  const userHooks = onUserCreated
+    ? {
+        create: {
+          after: async (user: Record<string, unknown>) => {
+            try {
+              await onUserCreated({
+                id: String(user.id),
+                email: String(user.email),
+                tenantId:
+                  typeof user.tenantId === "string" ? user.tenantId : undefined,
+                isAnonymous:
+                  typeof user.isAnonymous === "boolean"
+                    ? user.isAnonymous
+                    : undefined,
+              })
+            } catch {
+              // Best-effort: provisioning must never block sign-up. The
+              // callback is responsible for logging its own failures.
+            }
+          },
         },
+      }
+    : undefined
+
+  const upgradeAccountBeforeHook = upgradeOAuthAccount
+    ? async (account: Record<string, unknown>) => {
+        try {
+          const patch = await upgradeOAuthAccount({
+            providerId: String(account.providerId),
+            accessToken:
+              typeof account.accessToken === "string"
+                ? account.accessToken
+                : null,
+          })
+          if (!patch) {
+            return
+          }
+          return { data: { ...account, ...patch } }
+        } catch {
+          // Best-effort: a failed token upgrade must never block sign-in —
+          // the original (short-lived) token is persisted instead.
+        }
+      }
+    : undefined
+
+  return {
+    ...(userHooks && { user: userHooks }),
+    ...(upgradeAccountBeforeHook && {
+      account: {
+        create: { before: upgradeAccountBeforeHook },
+        update: { before: upgradeAccountBeforeHook },
       },
-    },
+    }),
   }
 }
 
 export function createAuth(config: AuthConfig) {
-  const socialProviders = buildSocialProviders(config.socialCredentials)
+  const socialProviders = buildSocialProviders(
+    config.socialCredentials,
+    config.socialScopes,
+  )
 
   return betterAuth({
-    databaseHooks: buildDatabaseHooks(config.onUserCreated),
+    databaseHooks: buildDatabaseHooks({
+      onUserCreated: config.onUserCreated,
+      upgradeOAuthAccount: config.upgradeOAuthAccount,
+    }),
     database: createTenantScopedAdapter(
       drizzleAdapter(db, {
         provider: "pg",

--- a/packages/database/src/repositories/auth-account/index.ts
+++ b/packages/database/src/repositories/auth-account/index.ts
@@ -1,0 +1,1 @@
+export * from "./repository"

--- a/packages/database/src/repositories/auth-account/repository.ts
+++ b/packages/database/src/repositories/auth-account/repository.ts
@@ -1,0 +1,40 @@
+import { and, type DatabaseClient, db, eq } from "../../client"
+import { accountModel } from "../../schema"
+
+type FindByUserAndProviderInput = {
+  userId: string
+  providerId: string
+}
+
+type AuthAccountToken = {
+  accessToken: string | null
+}
+
+class AuthAccountRepository {
+  /**
+   * A user's linked OAuth account for one provider. Filtering by `userId` is
+   * inherently tenant-safe (a `User` row belongs to exactly one tenant), so no
+   * separate `tenantId` filter is needed here — unlike the identity lookup
+   * (`providerId` + `accountId`) the auth adapter scopes by tenant to prevent
+   * cross-tenant identity collisions.
+   */
+  async findByUserAndProvider(
+    input: FindByUserAndProviderInput,
+    tx: DatabaseClient = db,
+  ): Promise<AuthAccountToken | null> {
+    const [row] = await tx
+      .select({ accessToken: accountModel.accessToken })
+      .from(accountModel)
+      .where(
+        and(
+          eq(accountModel.userId, input.userId),
+          eq(accountModel.providerId, input.providerId),
+        ),
+      )
+      .limit(1)
+
+    return row ?? null
+  }
+}
+
+export const authAccountRepository = new AuthAccountRepository()

--- a/packages/database/src/repositories/index.ts
+++ b/packages/database/src/repositories/index.ts
@@ -1,6 +1,7 @@
 export * from "./ai-conversation-embedding"
 export * from "./ai-conversation-source"
 export * from "./ai-workspace-scope"
+export * from "./auth-account"
 export * from "./contact-custom-field"
 export * from "./conversation-ai-context"
 export * from "./coupon"


### PR DESCRIPTION
## Summary
- Add a "Sign in with Facebook" button on `/auth/sign-in`, alongside Google, using the existing per-tenant whitelabel OAuth mechanism (reuses each reseller's `messenger` Meta App credential — no new app registration needed).
- Facebook SSO now requests the same Messenger-grade scopes (`pages_messaging`, `pages_manage_metadata`, `business_management`, ...) as the channel connect flow, and a new `upgradeOAuthAccount` hook on `packages/auth` exchanges the short-lived login token for a long-lived one right after sign-in.
- When connecting a Messenger Page (`/channels/create?channel=messenger`), a valid/still-scoped SSO token is detected and reused directly (skips the Facebook OAuth "Connect" round-trip) via a new Route Handler (`/channels/create/messenger`) — Server Components can't write cookies, so the reuse-check + pending-auth cookie write had to move there instead of staying inline in the page.
- Includes a small standalone fix found in code review: the per-credential auth-instance cache key now also folds in the Meta API `version`, so bumping just the version (same clientId/secret) busts the cache instead of serving a stale instance.

## Test plan
- [x] `pnpm --filter builder check-types` / `pnpm lint` clean
- [x] New/updated unit tests: `social-auth-instances.test.ts`, `facebook-sso-reuse.test.ts`, `channels-create-messenger-reuse.test.ts`, `channels-create-messenger-handoff.test.ts`
- [x] Full `apps/builder` test suite compared against baseline — no regressions (same pre-existing unrelated failures before/after)
- [ ] Manual: sign in with Facebook on a tenant with a configured `messenger` platform credential, confirm the button appears and the long-lived token is stored
- [ ] Manual: connect a Messenger Page after SSO login, confirm it skips the Facebook OAuth dialog and goes straight to the Page picker
- [ ] Manual: whitelabel reseller with their own Meta App credential behaves the same, isolated from the platform default

🤖 Generated with [Claude Code](https://claude.com/claude-code)