### PR TITLE
fix(tiptap): prefer html clipboard source in prompt editor paste

### DIFF
--- a/apps/builder/src/components/tiptap/plain-text-tiptap-editor.tsx
+++ b/apps/builder/src/components/tiptap/plain-text-tiptap-editor.tsx
@@ -211,11 +211,11 @@ export const PlainTextTiptapEditor = ({
           : "tiptap-plain-text",
       },
       handlePaste(view, event) {
-        const clipboardText = event.clipboardData?.getData("text/plain")
         const clipboardHtml = event.clipboardData?.getData("text/html")
-        const text =
-          clipboardText ??
-          (clipboardHtml ? htmlToPlainTextWithBlocks(clipboardHtml) : "")
+        const clipboardText = event.clipboardData?.getData("text/plain")
+        const text = clipboardHtml
+          ? htmlToPlainTextWithBlocks(clipboardHtml)
+          : (clipboardText ?? "")
 
         if (!text) {
           return false


### PR DESCRIPTION
## Summary
- `PlainTextTiptapEditor`'s custom `handlePaste` used `clipboardText ?? (...)`, but `DataTransfer.getData` returns `""` (not `null`) when a MIME type is absent, so raw OS `text/plain` was used almost every time and the existing `htmlToPlainTextWithBlocks` helper (which already dedupes line breaks between adjacent blocks) was effectively dead code.
- Browsers insert a blank line between block-level elements when serializing a multi-paragraph selection to `text/plain`, so pasting multi-line prompt content produced an extra blank line after every line.
- Now prefers `clipboardHtml` (via `htmlToPlainTextWithBlocks`) when present, falling back to raw `clipboardText` only when no HTML clipboard data exists.
- `TiptapEditor` (used in the send-message step) has no custom `handlePaste` and was unaffected — left untouched.

## Changes
- `apps/builder/src/components/tiptap/plain-text-tiptap-editor.tsx`: swap clipboard-source priority in `handlePaste`.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [ ] Manual: copy multi-line content into a prompt field (`PlainTextEditorField`) and paste it back — confirm no extra blank line appears between adjacent lines
- [ ] Manual: paste content with a genuine blank line between paragraphs — confirm exactly one blank line is preserved
- [ ] Manual: confirm send-message step (`TiptapEditorField`) paste behavior is unchanged