### PR TITLE
feat(auth): add google sso sign-in and share tiptap paste-to-text conversion

### DIFF
--- a/apps/builder/__tests__/html-to-plain-text.test.ts
+++ b/apps/builder/__tests__/html-to-plain-text.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+import { htmlToPlainTextWithBlocks } from "@/components/tiptap/html-to-plain-text"
+
+describe("htmlToPlainTextWithBlocks", () => {
+  it("dedupes a lone <br> used as an ordinary block separator", () => {
+    expect(htmlToPlainTextWithBlocks("<p>Hello</p><br><p>World</p>")).toBe(
+      "Hello\nWorld",
+    )
+  })
+
+  it("preserves a deliberate blank line from a doubled <br><br>", () => {
+    expect(htmlToPlainTextWithBlocks("<p>Hello</p><br><br><p>World</p>")).toBe(
+      "Hello\n\nWorld",
+    )
+  })
+
+  it("preserves a blank line from a genuinely empty paragraph", () => {
+    expect(htmlToPlainTextWithBlocks("<p>Hello</p><p></p><p>World</p>")).toBe(
+      "Hello\n\nWorld",
+    )
+  })
+
+  it("preserves the exact count of consecutive blank paragraphs", () => {
+    expect(
+      htmlToPlainTextWithBlocks("<p>Hello</p><p></p><p></p><p>World</p>"),
+    ).toBe("Hello\n\n\nWorld")
+  })
+
+  it("preserves the exact count of consecutive doubled <br> blank lines", () => {
+    expect(
+      htmlToPlainTextWithBlocks("<p>Hello</p><br><br><br><p>World</p>"),
+    ).toBe("Hello\n\n\nWorld")
+  })
+
+  it("preserves multiple blank lines embedded as raw newlines in a text node", () => {
+    expect(htmlToPlainTextWithBlocks("<p>1\n\n\n2</p>")).toBe("1\n\n\n2")
+  })
+})

--- a/apps/builder/messages/ar.json
+++ b/apps/builder/messages/ar.json
@@ -2899,6 +2899,7 @@
   "auth": {
     "orContinueWith": "أو المتابعة باستخدام",
     "continueWithFacebook": "المتابعة باستخدام Facebook",
+    "continueWithGoogle": "المتابعة باستخدام Google",
     "dontHaveAnAccount": "ليس لديك حساب؟",
     "alreadyHaveAnAccount": "لديك حساب بالفعل؟",
     "signUp": "إنشاء حساب",

--- a/apps/builder/messages/da.json
+++ b/apps/builder/messages/da.json
@@ -2892,6 +2892,7 @@
   "auth": {
     "orContinueWith": "Eller fortsæt med",
     "continueWithFacebook": "Fortsæt med Facebook",
+    "continueWithGoogle": "Fortsæt med Google",
     "dontHaveAnAccount": "Don't har an konto?",
     "alreadyHaveAnAccount": "Allerede har an konto?",
     "signUp": "Log up",

--- a/apps/builder/messages/de.json
+++ b/apps/builder/messages/de.json
@@ -2250,6 +2250,7 @@
   "auth": {
     "orContinueWith": "Oder fortfahren mit",
     "continueWithFacebook": "Mit Facebook fortfahren",
+    "continueWithGoogle": "Mit Google fortfahren",
     "dontHaveAnAccount": "Noch kein Konto?",
     "alreadyHaveAnAccount": "Bereits ein Konto?",
     "signUp": "Registrieren",

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -2899,6 +2899,7 @@
   "auth": {
     "orContinueWith": "Or continue with",
     "continueWithFacebook": "Continue with Facebook",
+    "continueWithGoogle": "Continue with Google",
     "dontHaveAnAccount": "Don't have an account?",
     "alreadyHaveAnAccount": "Already have an account?",
     "signUp": "Sign up",

--- a/apps/builder/messages/es.json
+++ b/apps/builder/messages/es.json
@@ -2892,6 +2892,7 @@
   "auth": {
     "orContinueWith": "O continuar con",
     "continueWithFacebook": "Continue con Facebook",
+    "continueWithGoogle": "Continuar con Google",
     "dontHaveAnAccount": "Don't tiene un cuenta?",
     "alreadyHaveAnAccount": "Already tiene un cuenta?",
     "signUp": "Registrarse",

--- a/apps/builder/messages/fi.json
+++ b/apps/builder/messages/fi.json
@@ -2892,6 +2892,7 @@
   "auth": {
     "orContinueWith": "Tai jatka käyttäen",
     "continueWithFacebook": "Jatka Facebookilla",
+    "continueWithGoogle": "Jatka Googlella",
     "dontHaveAnAccount": "Eikö sinulla ole tiliä?",
     "alreadyHaveAnAccount": "Onko sinulla jo tili?",
     "signUp": "Rekisteröidy",

--- a/apps/builder/messages/fr.json
+++ b/apps/builder/messages/fr.json
@@ -2279,6 +2279,7 @@
   "auth": {
     "orContinueWith": "Ou continuer avec",
     "continueWithFacebook": "Continuer avec Facebook",
+    "continueWithGoogle": "Continuer avec Google",
     "dontHaveAnAccount": "Vous n’avez pas de compte ?",
     "alreadyHaveAnAccount": "Vous avez déjà un compte ?",
     "signUp": "S’inscrire",

--- a/apps/builder/messages/he.json
+++ b/apps/builder/messages/he.json
@@ -1193,6 +1193,7 @@
   "auth": {
     "orContinueWith": "או המשך באמצעות",
     "continueWithFacebook": "המשך באמצעות Facebook",
+    "continueWithGoogle": "המשך באמצעות Google",
     "dontHaveAnAccount": "אין לכם חשבון?",
     "alreadyHaveAnAccount": "כבר יש לכם חשבון?",
     "signUp": "הרשמה",

--- a/apps/builder/messages/id.json
+++ b/apps/builder/messages/id.json
@@ -2892,6 +2892,7 @@
   "auth": {
     "orContinueWith": "Atau lanjutkan dengan",
     "continueWithFacebook": "Lanjutkan dengan Facebook",
+    "continueWithGoogle": "Lanjutkan dengan Google",
     "dontHaveAnAccount": "Belum memiliki akun?",
     "alreadyHaveAnAccount": "Sudah memiliki akun?",
     "signUp": "Daftar",

--- a/apps/builder/messages/it.json
+++ b/apps/builder/messages/it.json
@@ -2638,6 +2638,7 @@
   "auth": {
     "orContinueWith": "Oppure continua con",
     "continueWithFacebook": "Continua con Facebook",
+    "continueWithGoogle": "Continua con Google",
     "dontHaveAnAccount": "Non hai un account?",
     "alreadyHaveAnAccount": "Hai già un account?",
     "signUp": "Registrati",

--- a/apps/builder/messages/ja.json
+++ b/apps/builder/messages/ja.json
@@ -2879,6 +2879,7 @@
   "auth": {
     "orContinueWith": "または次の方法で続行",
     "continueWithFacebook": "Facebookで続行",
+    "continueWithGoogle": "Googleで続行",
     "dontHaveAnAccount": "アカウントをお持ちでないですか？",
     "alreadyHaveAnAccount": "すでにアカウントをお持ちですか？",
     "signUp": "新規登録",

--- a/apps/builder/messages/nl.json
+++ b/apps/builder/messages/nl.json
@@ -2892,6 +2892,7 @@
   "auth": {
     "orContinueWith": "Of ga verder met",
     "continueWithFacebook": "Doorgaan met Facebook",
+    "continueWithGoogle": "Doorgaan met Google",
     "dontHaveAnAccount": "Heb je nog geen account?",
     "alreadyHaveAnAccount": "Heb je al een account?",
     "signUp": "Registreren",

--- a/apps/builder/messages/pt-BR.json
+++ b/apps/builder/messages/pt-BR.json
@@ -2879,6 +2879,7 @@
   "auth": {
     "orContinueWith": "Ou continue com",
     "continueWithFacebook": "Continuar com o Facebook",
+    "continueWithGoogle": "Continuar com o Google",
     "dontHaveAnAccount": "Não tem uma conta?",
     "alreadyHaveAnAccount": "Já tem uma conta?",
     "signUp": "Cadastre-se",

--- a/apps/builder/messages/pt-PT.json
+++ b/apps/builder/messages/pt-PT.json
@@ -2892,6 +2892,7 @@
   "auth": {
     "orContinueWith": "Ou continue com",
     "continueWithFacebook": "Continuar com o Facebook",
+    "continueWithGoogle": "Continuar com o Google",
     "dontHaveAnAccount": "Não tem uma conta?",
     "alreadyHaveAnAccount": "Já tem uma conta?",
     "signUp": "Registar",

--- a/apps/builder/messages/ro.json
+++ b/apps/builder/messages/ro.json
@@ -2892,6 +2892,7 @@
   "auth": {
     "orContinueWith": "Sau continuă cu",
     "continueWithFacebook": "Continuă cu Facebook",
+    "continueWithGoogle": "Continuă cu Google",
     "dontHaveAnAccount": "Nu ai un cont?",
     "alreadyHaveAnAccount": "Ai deja un cont?",
     "signUp": "Înregistrare",

--- a/apps/builder/messages/sv.json
+++ b/apps/builder/messages/sv.json
@@ -329,6 +329,7 @@
     "changePasswordTitle": "Ändra ditt lösenord",
     "checkYourEmail": "Kontrollera din e-post",
     "continueWithFacebook": "Fortsätt med Facebook",
+    "continueWithGoogle": "Fortsätt med Google",
     "didNotReceiveEmail": "Fick du inget e-postmeddelande? Kontrollera skräppostmappen.",
     "dontHaveAnAccount": "Har du inget konto?",
     "forgotPassword": "Glömt lösenordet?",

--- a/apps/builder/messages/tr.json
+++ b/apps/builder/messages/tr.json
@@ -2892,6 +2892,7 @@
   "auth": {
     "orContinueWith": "Veya şununla devam et",
     "continueWithFacebook": "Facebook ile devam et",
+    "continueWithGoogle": "Google ile devam et",
     "dontHaveAnAccount": "Hesabınız yok mu?",
     "alreadyHaveAnAccount": "Zaten bir hesabınız var mı?",
     "signUp": "Kaydol",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -2899,6 +2899,7 @@
   "auth": {
     "orContinueWith": "Hoặc tiếp tục với",
     "continueWithFacebook": "Tiếp tục với Facebook",
+    "continueWithGoogle": "Tiếp tục với Google",
     "dontHaveAnAccount": "Chưa có tài khoản?",
     "alreadyHaveAnAccount": "Đã có tài khoản?",
     "signUp": "Đăng ký",

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -120,7 +120,6 @@
     "react-day-picker": "9.14.0",
     "react-dom": "19.2.5",
     "react-dropzone": "^15.0.0",
-    "react-google-button": "^0.8.0",
     "react-hook-form": "^7.74.0",
     "react-qr-code": "^2.0.21",
     "react-virtuoso": "^4.18.6",

--- a/apps/builder/src/components/tiptap/extensions/variable-injection/mention.ts
+++ b/apps/builder/src/components/tiptap/extensions/variable-injection/mention.ts
@@ -71,9 +71,14 @@ const lineToHtml = (
   }
 
   html += escapeHtml(line.slice(cursor))
-  return html || "<br>"
+  return html
 }
 
+// A blank line must become `<p></p>`, not `<p><br></p>`: ProseMirror renders
+// an empty paragraph's cursor line on its own, but a real <br> node adds its
+// own "\n" via HardBreak's renderText on top of the blockSeparator that
+// editor.getText() already inserts between blocks — doubling every blank
+// line on each save/reload round trip.
 export const plainTextToParagraphHtmlWithVariableMentions = (
   value: string,
   variableOptions: PromptVariableOption[],

--- a/apps/builder/src/components/tiptap/html-to-plain-text.ts
+++ b/apps/builder/src/components/tiptap/html-to-plain-text.ts
@@ -1,0 +1,134 @@
+import { htmlToText } from "html-to-text"
+
+const LINE_BREAK_REGEX = /\r\n?|\n/
+
+const BLOCK_TAG_NAMES = new Set([
+  "ADDRESS",
+  "ARTICLE",
+  "ASIDE",
+  "BLOCKQUOTE",
+  "BR",
+  "DD",
+  "DIV",
+  "DL",
+  "DT",
+  "FIELDSET",
+  "FIGCAPTION",
+  "FIGURE",
+  "FOOTER",
+  "FORM",
+  "H1",
+  "H2",
+  "H3",
+  "H4",
+  "H5",
+  "H6",
+  "HEADER",
+  "HR",
+  "LI",
+  "MAIN",
+  "NAV",
+  "OL",
+  "P",
+  "PRE",
+  "SECTION",
+  "TABLE",
+  "TBODY",
+  "TD",
+  "TFOOT",
+  "TH",
+  "THEAD",
+  "TR",
+  "UL",
+])
+
+// Converts pasted HTML into plain text while keeping block/line breaks as "\n",
+// so callers can re-wrap it into <p> tags themselves instead of losing the
+// paragraph structure to a single flattened text node.
+export const htmlToPlainTextWithBlocks = (html: string) => {
+  if (typeof DOMParser === "undefined") {
+    return htmlToText(html, { wordwrap: false })
+  }
+
+  const document = new DOMParser().parseFromString(html, "text/html")
+  const parts: string[] = []
+
+  const appendLineBreak = () => {
+    if (parts.at(-1) !== "\n") {
+      parts.push("\n")
+    }
+  }
+
+  const walk = (node: Node, previousSiblingWasBr = false) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      parts.push(node.textContent ?? "")
+      return
+    }
+
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return
+    }
+
+    const element = node as Element
+    const tagName = element.tagName
+
+    if (tagName === "BR") {
+      if (previousSiblingWasBr) {
+        // A <br> directly following another <br> is a deliberate blank
+        // line and must be forced through instead of deduped away.
+        parts.push("\n")
+      } else {
+        // A lone <br> is an ordinary separator (e.g. between block-level
+        // elements in email-signature-style HTML) — dedupe it like any
+        // other block boundary so it doesn't add a spurious blank line.
+        appendLineBreak()
+      }
+      return
+    }
+
+    const isBlock = BLOCK_TAG_NAMES.has(tagName)
+
+    if (isBlock && parts.length > 0) {
+      appendLineBreak()
+    }
+
+    const contentStart = parts.length
+
+    if (tagName === "LI") {
+      parts.push("- ")
+    }
+
+    walkChildren(Array.from(element.childNodes))
+
+    if (isBlock) {
+      if (parts.length === contentStart) {
+        // Genuinely empty block (e.g. a blank paragraph between two lines of
+        // text) — force the break instead of deduping it away, otherwise the
+        // blank line silently disappears on paste.
+        parts.push("\n")
+      } else {
+        appendLineBreak()
+      }
+    }
+  }
+
+  function walkChildren(nodes: ChildNode[]) {
+    let previousWasBr = false
+    for (const child of nodes) {
+      walk(child, previousWasBr)
+      previousWasBr =
+        child.nodeType === Node.ELEMENT_NODE &&
+        (child as Element).tagName === "BR"
+    }
+  }
+
+  walkChildren(Array.from(document.body.childNodes))
+
+  return parts
+    .join("")
+    .replace(/\xA0/g, " ")
+    .split(LINE_BREAK_REGEX)
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .trim()
+}

--- a/apps/builder/src/components/tiptap/plain-text-tiptap-editor.tsx
+++ b/apps/builder/src/components/tiptap/plain-text-tiptap-editor.tsx
@@ -24,9 +24,9 @@ import {
 } from "@chatbotx.io/ui/components/ui/popover"
 import { cn } from "@chatbotx.io/ui/lib/utils"
 import EmojiPicker, { type EmojiClickData } from "emoji-picker-react"
-import { htmlToText } from "html-to-text"
 import { CodeXml, Smile } from "lucide-react"
 import { useCallback, useEffect, useRef, useState } from "react"
+import { htmlToPlainTextWithBlocks } from "./html-to-plain-text"
 import { usePromptVariableOptions } from "./use-prompt-variable-options"
 
 type PlainTextTiptapEditorProps = {
@@ -39,114 +39,6 @@ type PlainTextTiptapEditorProps = {
   onChange?: (content: string) => void
   /** Single-line height with the variable picker rendered inside on the right. */
   inline?: boolean
-}
-
-const LINE_BREAK_REGEX = /\r\n?|\n/
-const COLLAPSED_LINE_BREAK_REGEX = /\n{3,}/g
-
-const BLOCK_TAG_NAMES = new Set([
-  "ADDRESS",
-  "ARTICLE",
-  "ASIDE",
-  "BLOCKQUOTE",
-  "BR",
-  "DD",
-  "DIV",
-  "DL",
-  "DT",
-  "FIELDSET",
-  "FIGCAPTION",
-  "FIGURE",
-  "FOOTER",
-  "FORM",
-  "H1",
-  "H2",
-  "H3",
-  "H4",
-  "H5",
-  "H6",
-  "HEADER",
-  "HR",
-  "LI",
-  "MAIN",
-  "NAV",
-  "OL",
-  "P",
-  "PRE",
-  "SECTION",
-  "TABLE",
-  "TBODY",
-  "TD",
-  "TFOOT",
-  "TH",
-  "THEAD",
-  "TR",
-  "UL",
-])
-
-const htmlToPlainTextWithBlocks = (html: string) => {
-  if (typeof DOMParser === "undefined") {
-    return htmlToText(html, { wordwrap: false })
-  }
-
-  const document = new DOMParser().parseFromString(html, "text/html")
-  const parts: string[] = []
-
-  const appendLineBreak = () => {
-    if (parts.at(-1) !== "\n") {
-      parts.push("\n")
-    }
-  }
-
-  const walk = (node: Node) => {
-    if (node.nodeType === Node.TEXT_NODE) {
-      parts.push(node.textContent ?? "")
-      return
-    }
-
-    if (node.nodeType !== Node.ELEMENT_NODE) {
-      return
-    }
-
-    const element = node as Element
-    const tagName = element.tagName
-
-    if (tagName === "BR") {
-      appendLineBreak()
-      return
-    }
-
-    const isBlock = BLOCK_TAG_NAMES.has(tagName)
-
-    if (isBlock && parts.length > 0) {
-      appendLineBreak()
-    }
-
-    if (tagName === "LI") {
-      parts.push("- ")
-    }
-
-    for (const child of Array.from(element.childNodes)) {
-      walk(child)
-    }
-
-    if (isBlock) {
-      appendLineBreak()
-    }
-  }
-
-  for (const child of Array.from(document.body.childNodes)) {
-    walk(child)
-  }
-
-  return parts
-    .join("")
-    .replace(/\xA0/g, " ")
-    .replace(COLLAPSED_LINE_BREAK_REGEX, "\n\n")
-    .split(LINE_BREAK_REGEX)
-    .map((line) => line.trimEnd())
-    .join("\n")
-    .trim()
 }
 
 export const PlainTextTiptapEditor = ({

--- a/apps/builder/src/components/tiptap/tiptap-editor.tsx
+++ b/apps/builder/src/components/tiptap/tiptap-editor.tsx
@@ -13,6 +13,7 @@ import {
   toVariableMentionAttrs,
 } from "./extensions/variable-injection/mention"
 import variableInjectionSuggestion from "./extensions/variable-injection/suggestion"
+import { htmlToPlainTextWithBlocks } from "./html-to-plain-text"
 import "./tiptap-editor.css"
 import type { ChannelType } from "@chatbotx.io/database/partials"
 import { Button } from "@chatbotx.io/ui/components/ui/button"
@@ -22,7 +23,6 @@ import {
   PopoverTrigger,
 } from "@chatbotx.io/ui/components/ui/popover"
 import EmojiPicker, { type EmojiClickData } from "emoji-picker-react"
-import { htmlToText } from "html-to-text"
 import { CodeXml, Smile } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { usePromptVariableOptions } from "./use-prompt-variable-options"
@@ -84,7 +84,10 @@ export const TiptapEditor = ({
         return text.replace(/\xA0/g, " ")
       },
       transformPastedHTML(html) {
-        return htmlToText(html)
+        return plainTextToParagraphHtmlWithVariableMentions(
+          htmlToPlainTextWithBlocks(html),
+          promptVariableOptionsRef.current,
+        )
       },
     },
     // Don't render immediately on the server to avoid SSR issues

--- a/apps/builder/src/features/auth/sso-sign-in.tsx
+++ b/apps/builder/src/features/auth/sso-sign-in.tsx
@@ -3,7 +3,6 @@
 import type { SocialProvider } from "@chatbotx.io/auth/server"
 import { Button } from "@chatbotx.io/ui/components/ui/button"
 import { useTranslations } from "next-intl"
-import GoogleButton from "react-google-button"
 import { authClient } from "@/lib/auth/auth-client"
 
 type SSOSignInProps = {
@@ -35,18 +34,47 @@ function FacebookIcon() {
   )
 }
 
+function GoogleIcon() {
+  return (
+    <svg aria-hidden="true" height="20" viewBox="0 0 48 48" width="20">
+      <path
+        d="M45.12 24.5c0-1.56-.14-3.06-.4-4.5H24v8.51h11.84c-.51 2.75-2.06 5.08-4.39 6.64v5.52h7.11c4.16-3.83 6.56-9.47 6.56-16.17z"
+        fill="#4285F4"
+      />
+      <path
+        d="M24 46c5.94 0 10.92-1.97 14.56-5.33l-7.11-5.52c-1.97 1.32-4.49 2.1-7.45 2.1-5.73 0-10.58-3.87-12.31-9.07H4.34v5.7C7.96 41.07 15.4 46 24 46z"
+        fill="#34A853"
+      />
+      <path
+        d="M11.69 28.18C11.25 26.86 11 25.45 11 24s.25-2.86.69-4.18v-5.7H4.34C2.85 17.09 2 20.45 2 24s.85 6.91 2.34 9.88l7.35-5.7z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M24 10.75c3.23 0 6.13 1.11 8.41 3.29l6.31-6.31C34.91 4.18 29.93 2 24 2 15.4 2 7.96 6.93 4.34 14.12l7.35 5.7c1.73-5.2 6.58-9.07 12.31-9.07z"
+        fill="#EA4335"
+      />
+    </svg>
+  )
+}
+
 export default function SSOSignIn({ providers }: SSOSignInProps) {
   const t = useTranslations()
 
   return (
     <div className="flex flex-col items-center gap-3">
       {providers.includes("google") && (
-        <GoogleButton
+        <Button
+          aria-label={t("auth.continueWithGoogle")}
           className="w-full"
           onClick={async () => {
             await signInWith("google")
           }}
-        />
+          type="button"
+          variant="outline"
+        >
+          <GoogleIcon />
+          {t("auth.continueWithGoogle")}
+        </Button>
       )}
 
       {providers.includes("facebook") && (

--- a/apps/builder/src/features/flows/react-flow/button-editor-dialog.tsx
+++ b/apps/builder/src/features/flows/react-flow/button-editor-dialog.tsx
@@ -191,7 +191,7 @@ function ButtonSteps() {
             </Button>
           }
         />
-        <DropdownMenuContent>
+        <DropdownMenuContent className="w-max">
           <RecursiveDropdownMenu
             data={sendMessageEditorMenusWithButton(t)}
             onClick={onAddAction}

--- a/apps/builder/src/features/flows/react-flow/panel-buttons/add-node-button.tsx
+++ b/apps/builder/src/features/flows/react-flow/panel-buttons/add-node-button.tsx
@@ -35,13 +35,13 @@ export default function AddNodeButton() {
           </ControlButton>
         }
       />
-      <PopoverContent className="w-44 p-2">
+      <PopoverContent className="w-max max-w-xs p-2">
         <div className="flex flex-col items-start">
           {Object.values(allNodesConfig).map((it, idx) => {
             const item = it?.(t)
             return item ? (
               <Button
-                className="w-full justify-start"
+                className="w-full justify-start whitespace-nowrap"
                 key={item.type}
                 onClick={() => onClickAction(item.type)}
                 variant="ghost"

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -32,6 +32,7 @@ export const UiProvider = ({
       <AnalyticsProvider> */}
         <TooltipProvider>{children}</TooltipProvider>
         <Toaster
+          closeButton
           duration={DEFAULT_TOAST_DURATION_MS}
           position="top-right"
           richColors

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,9 +371,6 @@ importers:
       react-dropzone:
         specifier: ^15.0.0
         version: 15.0.0(react@19.2.5)
-      react-google-button:
-        specifier: ^0.8.0
-        version: 0.8.0(react@19.2.5)
       react-hook-form:
         specifier: ^7.74.0
         version: 7.77.0(react@19.2.5)
@@ -9799,11 +9796,6 @@ packages:
       react: '>=16.4.0'
       react-dom: '>=16.4.0'
 
-  react-google-button@0.8.0:
-    resolution: {integrity: sha512-0u6mbDcTUmWzgXsld8FJpbrXP+zDsNQVYPIt225aBqwgJ/CdrDiep1PZOpnyntyjsejWG0TtQr6uZB4eIaXlJQ==}
-    peerDependencies:
-      react: '>= 16.8.0'
-
   react-hook-form@7.77.0:
     resolution: {integrity: sha512-Sslh9YDYc0GDlWT/lxasnIduNo4v3yyvqRGvmGKUre5AFjDs/HV9/OafHGD8d+sB2yoL4UIL9L8X9i0WlZZebg==}
     engines: {node: '>=18.0.0'}
@@ -17979,11 +17971,6 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
-
-  react-google-button@0.8.0(react@19.2.5):
-    dependencies:
-      prop-types: 15.8.1
-      react: 19.2.5
 
   react-hook-form@7.77.0(react@19.2.5):
     dependencies:


### PR DESCRIPTION
## Summary
- Add Google SSO sign-in: swap `react-google-button` (unstyled div, no keyboard handling, no RTL support) for the shared shadcn `Button` + a `GoogleIcon`, matching the existing Facebook button. Adds the `continueWithGoogle` translation key across all 18 locales.
- Extract `htmlToPlainTextWithBlocks` out of `plain-text-tiptap-editor.tsx` into its own module (`html-to-plain-text.ts`) so `tiptap-editor.tsx` can reuse it too, instead of flattening pasted HTML with `htmlToText` and losing paragraph structure.
- Fix two paste round-trip bugs found while sharing this code: a lone `<br>` between blocks (e.g. email-signature HTML) was forced into a spurious blank line, and a leftover `/\n{3,}/` collapse capped any run of blank lines down to exactly one — so copying a message with 2+ blank lines and pasting it back silently dropped all but one.

## Changes
- `apps/builder/src/features/auth/sso-sign-in.tsx` — Google button swap, drops `react-google-button` dependency
- `apps/builder/src/components/tiptap/html-to-plain-text.ts` — new shared module, `<br>`-run and blank-line-count fixes
- `apps/builder/src/components/tiptap/plain-text-tiptap-editor.tsx`, `tiptap-editor.tsx`, `extensions/variable-injection/mention.ts` — reuse the shared module, blank-line encoding fix
- `apps/builder/src/features/flows/react-flow/button-editor-dialog.tsx`, `panel-buttons/add-node-button.tsx` — widen menus clipped by the new, longer Google button label
- `packages/ui/src/index.tsx` — enable `Toaster` `closeButton`
- `apps/builder/messages/*.json` — add `auth.continueWithGoogle` across all locales
- `apps/builder/__tests__/html-to-plain-text.test.ts` — new tests for `<br>` handling and exact blank-line-count preservation

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [x] `pnpm --filter builder exec vitest run __tests__/html-to-plain-text.test.ts` (6/6 passing)
- [ ] Manual: sign in with Google in the builder auth screen
- [ ] Manual: paste a message with multiple blank lines into the prompt/template tiptap editor and confirm all blank lines are preserved