### PR TITLE
fix(flows): stop button editor dialog reading stale node data

### DIFF
--- a/apps/builder/src/features/flows/react-flow/button-editor-dialog.tsx
+++ b/apps/builder/src/features/flows/react-flow/button-editor-dialog.tsx
@@ -237,6 +237,7 @@ export function ButtonEditorDialog() {
   )
   const buttonPath = useStepStore((state) => state.buttonPath)
   const setButtonPath = useStepStore((state) => state.setButtonPath)
+  const buttonInitialData = useStepStore((state) => state.buttonInitialData)
   const openButtonEditorDialog = useStepStore(
     (state) => state.openButtonEditorDialog,
   )
@@ -257,25 +258,21 @@ export function ButtonEditorDialog() {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: wip
   useEffect(() => {
-    if (buttonPath && openButtonEditorDialog) {
+    if (buttonPath && openButtonEditorDialog && buttonInitialData) {
       const allNodes = getNodes()
       const foundNode = allNodes.find((node) => node.selected) as FlowNode
       if (foundNode) {
-        const rawData = getProperty(foundNode, buttonPath)
-
-        if (rawData) {
-          setActiveNode(foundNode)
-          form.reset(rawData as ButtonStepProps)
-          setOpenButtonEditorDialog(true)
-          return
-        }
+        setActiveNode(foundNode)
+        form.reset(buttonInitialData)
+        setOpenButtonEditorDialog(true)
+        return
       }
     }
 
     form.reset()
     setActiveNode(null)
     setOpenButtonEditorDialog(false)
-  }, [buttonPath, openButtonEditorDialog])
+  }, [buttonPath, openButtonEditorDialog, buttonInitialData])
 
   const onSave = useCallback(() => {
     if (!(activeNode && buttonPath)) {

--- a/apps/builder/src/features/flows/react-flow/steps/button/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/button/editor.tsx
@@ -22,8 +22,12 @@ export const ButtonStepEditor = (props: ButtonStepEditorProps) => {
   const { parentName, editorConfig, ...rest } = props
 
   const { getValues } = useFormContext()
-  const { setButtonPath, setOpenButtonEditorDialog, setButtonEditorConfig } =
-    useStepStore((state) => state)
+  const {
+    setButtonPath,
+    setButtonInitialData,
+    setOpenButtonEditorDialog,
+    setButtonEditorConfig,
+  } = useStepStore((state) => state)
 
   const buttonData = getValues(`${parentName}`)
 
@@ -34,6 +38,7 @@ export const ButtonStepEditor = (props: ButtonStepEditorProps) => {
         onClick={() => {
           setButtonEditorConfig(editorConfig ?? null)
           setButtonPath(`data.details.${parentName}`)
+          setButtonInitialData(buttonData)
           setOpenButtonEditorDialog(true)
         }}
         type="button"

--- a/apps/builder/src/features/flows/react-flow/stores/step-store.ts
+++ b/apps/builder/src/features/flows/react-flow/stores/step-store.ts
@@ -16,6 +16,7 @@ export type StepState = {
   activeFlowId: string | null
 
   buttonPath: string | null
+  buttonInitialData: ButtonStepProps | null
   updatedButtonData: UpdatedButtonData | null
   openButtonEditorDialog: boolean
 
@@ -29,6 +30,7 @@ export type StepStore = StepState & {
 
   setOpenButtonEditorDialog: (open: boolean) => void
   setButtonPath: (buttonPath: string | null) => void
+  setButtonInitialData: (buttonInitialData: ButtonStepProps | null) => void
   setOpenNodeDetailSheet: (openNodeDetailSheet: boolean) => void
   onChangeButtonData: (updatedButtonData: UpdatedButtonData | null) => void
   setButtonEditorConfig: (config: ButtonEditorConfig | null) => void
@@ -37,6 +39,7 @@ export type StepStore = StepState & {
 export const createStepStore = (initState?: Partial<StepState>) => {
   const defaultProps = {
     buttonPath: null,
+    buttonInitialData: null,
     updatedButtonData: null,
     openButtonEditorDialog: false,
 
@@ -52,6 +55,7 @@ export const createStepStore = (initState?: Partial<StepState>) => {
     setOpenButtonEditorDialog: (openButtonEditorDialog) =>
       set({ openButtonEditorDialog }),
     setButtonPath: (buttonPath) => set({ buttonPath }),
+    setButtonInitialData: (buttonInitialData) => set({ buttonInitialData }),
     setOpenNodeDetailSheet: (openNodeDetailSheet) =>
       set({ openNodeDetailSheet }),
     onChangeButtonData: (updatedButtonData: UpdatedButtonData | null) => {


### PR DESCRIPTION
## Summary
- Clicking a just-added quick-reply/card button before the node editor's 700ms debounced sync landed opened the shared "Edit Button" dialog with the *previous* button's data instead of the new one's, and left Cancel unable to close it.
- The dialog's reconciliation effect sourced the button's data via `getProperty(getNodes().find(selected), buttonPath)` — reading from the ReactFlow node mirror, which lags the node editor form by up to 700ms (`pushToFlow` debounce in `nodes/editor.tsx`). Clicking immediately after "Add" raced that sync.
- Fix: pass the button's live form value straight through the step store (`buttonInitialData`) when opening the dialog, instead of re-deriving it from the debounced node mirror.

## Changes
- `apps/builder/src/features/flows/react-flow/stores/step-store.ts` — add `buttonInitialData` state + setter
- `apps/builder/src/features/flows/react-flow/steps/button/editor.tsx` — pass the button's current form value (`getValues(parentName)`) into the store on click
- `apps/builder/src/features/flows/react-flow/button-editor-dialog.tsx` — reconciliation effect now uses `buttonInitialData` instead of `getProperty(foundNode, buttonPath)`

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [x] Manually reproduced and verified against a live flow: add button → click it immediately → dialog now shows the correct button's data and Cancel closes it (previously showed stale data and Cancel did nothing)
- [x] Stress-tested 5 rapid add/click/cancel cycles across 3 buttons, interleaved — correct data loaded and Cancel worked every time
- [x] Verified Save (Confirm) and Delete still work correctly after the change