### PR TITLE
feat(automated-response): press enter to navigate keyword inputs

### DIFF
--- a/apps/builder/src/features/automated-response/create-automated-response-form.tsx
+++ b/apps/builder/src/features/automated-response/create-automated-response-form.tsx
@@ -19,6 +19,7 @@ import { useFieldArray } from "react-hook-form"
 import { toast } from "sonner"
 import { useFlowSelectOptions } from "../flows/provider/flow-hook"
 import { createAutomatedResponseAction } from "./actions/create-automated-response-action"
+import { useKeywordFieldNavigation } from "./hooks/use-keyword-field-navigation"
 import { createAutomatedResponseRequest, responseModes } from "./schema/action"
 
 type CreateAutomatedResponseFormProps = {
@@ -93,6 +94,12 @@ export function CreateAutomatedResponseForm(
     name: "keywords",
   })
 
+  const handleKeywordInputKeyDown = useKeywordFieldNavigation(
+    form,
+    keywords.length,
+    () => appendKeywords({ value: "" }),
+  )
+
   return (
     <Form {...form}>
       <form
@@ -104,24 +111,31 @@ export function CreateAutomatedResponseForm(
             {t("fields.keywords.label")}
           </Label>
 
-          {keywords.map((_, index) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: wip
-            <div className="flex gap-2" key={index}>
-              <InputField name={`keywords.${index}.value`} />
-              {index === 0 ? (
-                <div className="w-12">&nbsp;</div>
-              ) : (
-                <Button
-                  onClick={() => {
-                    removeKeywords(index)
+          <div className="flex flex-col gap-2">
+            {keywords.map((_, index) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: wip
+              <div className="flex gap-2" key={index}>
+                <InputField
+                  name={`keywords.${index}.value`}
+                  onKeyDown={(event) => {
+                    handleKeywordInputKeyDown(event, index)
                   }}
-                  variant="ghost"
-                >
-                  <XIcon />
-                </Button>
-              )}
-            </div>
-          ))}
+                />
+                {index === 0 ? (
+                  <div className="w-12">&nbsp;</div>
+                ) : (
+                  <Button
+                    onClick={() => {
+                      removeKeywords(index)
+                    }}
+                    variant="ghost"
+                  >
+                    <XIcon />
+                  </Button>
+                )}
+              </div>
+            ))}
+          </div>
           <FormMessage />
           <div>
             <Button

--- a/apps/builder/src/features/automated-response/edit-automated-response-form.tsx
+++ b/apps/builder/src/features/automated-response/edit-automated-response-form.tsx
@@ -20,6 +20,7 @@ import { useFieldArray } from "react-hook-form"
 import { toast } from "sonner"
 import { useFlowSelectOptions } from "../flows/provider/flow-hook"
 import { updateAutomatedResponseAction } from "./actions/update-automated-response-action"
+import { useKeywordFieldNavigation } from "./hooks/use-keyword-field-navigation"
 import { responseModes, updateAutomatedResponseRequest } from "./schema/action"
 
 type EditAutomatedResponseFormProps = {
@@ -96,6 +97,12 @@ export default function EditAutomatedResponseForm(
     name: "keywords",
   })
 
+  const handleKeywordInputKeyDown = useKeywordFieldNavigation(
+    form,
+    keywords.length,
+    () => appendKeywords({ value: "" }),
+  )
+
   return (
     <Form {...form}>
       <form className="flex-1 space-y-4" onSubmit={handleSubmitWithAction}>
@@ -103,27 +110,32 @@ export default function EditAutomatedResponseForm(
           <Label className="flex-1" htmlFor="keywords">
             {t("fields.keywords.label")}
           </Label>
-          {keywords.map((_, index) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: wip
-            <div className="flex gap-2" key={index}>
-              <InputField
-                formItemClassName="w-1/2"
-                name={`keywords.${index}.value`}
-              />
-              {index === 0 ? (
-                <div className="w-12">&nbsp;</div>
-              ) : (
-                <Button
-                  onClick={() => {
-                    removeKeywords(index)
+          <div className="flex flex-col gap-2">
+            {keywords.map((_, index) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: wip
+              <div className="flex gap-2" key={index}>
+                <InputField
+                  formItemClassName="w-1/2"
+                  name={`keywords.${index}.value`}
+                  onKeyDown={(event) => {
+                    handleKeywordInputKeyDown(event, index)
                   }}
-                  variant="ghost"
-                >
-                  <XIcon />
-                </Button>
-              )}
-            </div>
-          ))}
+                />
+                {index === 0 ? (
+                  <div className="w-12">&nbsp;</div>
+                ) : (
+                  <Button
+                    onClick={() => {
+                      removeKeywords(index)
+                    }}
+                    variant="ghost"
+                  >
+                    <XIcon />
+                  </Button>
+                )}
+              </div>
+            ))}
+          </div>
           <FormMessage />
           <div>
             <Button

--- a/apps/builder/src/features/automated-response/hooks/use-keyword-field-navigation.ts
+++ b/apps/builder/src/features/automated-response/hooks/use-keyword-field-navigation.ts
@@ -1,0 +1,26 @@
+import type { KeyboardEvent } from "react"
+import type { FieldValues, Path, UseFormReturn } from "react-hook-form"
+
+type KeywordFieldValues = FieldValues & {
+  keywords: { value: string }[]
+}
+
+export function useKeywordFieldNavigation<T extends KeywordFieldValues>(
+  form: UseFormReturn<T>,
+  keywordsCount: number,
+  appendKeyword: () => void,
+) {
+  return (event: KeyboardEvent<HTMLInputElement>, index: number) => {
+    if (event.key !== "Enter" || event.nativeEvent.isComposing) {
+      return
+    }
+    event.preventDefault()
+
+    if (index === keywordsCount - 1) {
+      appendKeyword()
+    }
+    requestAnimationFrame(() => {
+      form.setFocus(`keywords.${index + 1}.value` as Path<T>)
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- Pressing Enter inside a keyword input in the create/edit automated response forms no longer submits the form.
- On the last keyword input, Enter appends a new keyword row (like clicking "Add more") and focuses it; on any other input, Enter focuses the next keyword input.
- IME composition Enter events (CJK input confirmation) are ignored so composing text isn't interrupted.

## Changes
- `apps/builder/src/features/automated-response/hooks/use-keyword-field-navigation.ts` (new): shared `useKeywordFieldNavigation` hook using `form.setFocus` for navigation.
- `apps/builder/src/features/automated-response/create-automated-response-form.tsx`: wire keyword inputs to the new hook via `onKeyDown`.
- `apps/builder/src/features/automated-response/edit-automated-response-form.tsx`: same wiring for the edit form.

## Test plan
- [x] pnpm lint
- [x] pnpm --filter builder check-types
- [ ] manual verification: create/edit automated response, press Enter on last keyword (adds row + focuses it), press Enter on a middle keyword (focuses next), press Enter mid IME composition (does not submit/append)