### PR TITLE
feat(flows): support variables in set custom field value

### DIFF
--- a/apps/builder/src/features/flows/react-flow/steps/set-custom-field/__tests__/editor.test.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/set-custom-field/__tests__/editor.test.tsx
@@ -55,10 +55,16 @@ vi.mock("@/features/custom-fields/custom-field-select", async () => {
   }
 })
 
-vi.mock("@chatbotx.io/ui/components/form/input-field", async () => {
+vi.mock("@/components/tiptap/plain-text-editor-field", async () => {
   const { useFormContext } = await import("react-hook-form")
   return {
-    InputField: ({ name, label }: { name: string; label?: string }) => {
+    PlainTextEditorField: ({
+      name,
+      label,
+    }: {
+      name: string
+      label?: string
+    }) => {
       const form = useFormContext()
       return (
         <Controller

--- a/apps/builder/src/features/flows/react-flow/steps/set-custom-field/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/set-custom-field/editor.tsx
@@ -5,7 +5,6 @@ import {
   type SetCustomFieldStepSchema,
   setCustomFieldStepSchema,
 } from "@chatbotx.io/flow-config"
-import { InputField } from "@chatbotx.io/ui/components/form/input-field"
 import { SelectField } from "@chatbotx.io/ui/components/form/select-field"
 import { Button } from "@chatbotx.io/ui/components/ui/button"
 import {
@@ -21,6 +20,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { useTranslations } from "next-intl"
 import { useState } from "react"
 import { useForm, useFormContext } from "react-hook-form"
+import { PlainTextEditorField } from "@/components/tiptap/plain-text-editor-field"
 import { getBrowserTimezone } from "@/features/contact-filter/lib/timezone"
 import { CustomFieldSelect } from "@/features/custom-fields/custom-field-select"
 import { useCustomFieldStore } from "@/features/custom-fields/provider/custom-field-store-context"
@@ -100,7 +100,13 @@ const SetCustomFieldStepEditor = ({ parentName }: { parentName: string }) => {
               required
             />
             <div className="flex flex-col gap-1.5">
-              <InputField label={t("fields.value.label")} name="value" />
+              <PlainTextEditorField
+                includeRawCustomFieldVariables
+                inline
+                label={t("fields.value.label")}
+                name="value"
+                showEmojiPicker={false}
+              />
               {isTemporalField ? (
                 <p className="text-muted-foreground text-xs">
                   {t("flows.setCustomField.temporalHint")}

--- a/apps/worker/__tests__/set-custom-field-step.test.ts
+++ b/apps/worker/__tests__/set-custom-field-step.test.ts
@@ -18,6 +18,17 @@ vi.mock("@chatbotx.io/business", () => ({
   tagSyncService: { enqueueAttach: vi.fn(), enqueueDetach: vi.fn() },
 }))
 
+// The handler now resolves {{variable}} tokens in the value before persisting.
+// Mock the boundary: `getAll` returns an opaque context, `replaceAll` is an
+// identity by default so plain literals pass through unchanged; individual
+// tests override `replaceAll` to assert the resolved value is what gets stored.
+const getAllVariables = vi.fn(async () => ({}) as unknown)
+const replaceAll = vi.fn(async ({ text }: { text: string }) => text)
+
+vi.mock("@chatbotx.io/variables", () => ({
+  contactVariableService: { getAll: getAllVariables, replaceAll },
+}))
+
 vi.mock("@chatbotx.io/business/contact-sequence", () => ({
   contactSequenceService: { removeContactSequencesForContact: vi.fn() },
 }))
@@ -71,6 +82,7 @@ type Step = {
 function props(step: Step, workspaceId = "ws-1", contactId = "c-1") {
   return {
     conversation: { workspaceId, contactId },
+    contactInbox: { id: "ci-1" },
     step,
   } as unknown as Parameters<typeof setContactCustomField>[0]
 }
@@ -112,6 +124,23 @@ describe("setContactCustomField", () => {
         value: "",
         fillEmptyTemporalWithNow: true,
       }),
+    )
+  })
+
+  test("resolves {{variable}} tokens in the value before persisting", async () => {
+    replaceAll.mockResolvedValueOnce("Hello Jane")
+
+    await setContactCustomField(
+      props({ inputFieldId: "greeting", value: "Hello {{first_name}}" }),
+    )
+
+    // The raw token string is handed to the resolver...
+    expect(replaceAll).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Hello {{first_name}}" }),
+    )
+    // ...and the resolved output — not the raw tokens — is what gets stored.
+    expect(setValueByKey).toHaveBeenCalledWith(
+      expect.objectContaining({ keyword: "greeting", value: "Hello Jane" }),
     )
   })
 

--- a/apps/worker/src/integration/handlers/contact.ts
+++ b/apps/worker/src/integration/handlers/contact.ts
@@ -35,17 +35,33 @@ import type {
 import { enrollContactInSequence } from "@chatbotx.io/sequence-scheduler"
 import { createId } from "@chatbotx.io/utils"
 import { TemporalInputParsing } from "@chatbotx.io/utils/datetime"
+import { contactVariableService } from "@chatbotx.io/variables"
 import type { ExecuteStepProps } from "./flow"
 
 export async function setContactCustomField({
   conversation,
+  contactInbox,
   step,
 }: ExecuteStepProps<SetCustomFieldStepSchema>) {
+  // The value can contain {{variable}} tokens inserted via the editor (contact
+  // fields, coupons, etc.); resolve them against this contact before persisting.
+  // Unresolvable tokens are left as-is, and a value that resolves to empty still
+  // falls through to the temporal "now" handling below.
+  const variables = await contactVariableService.getAll({
+    contactId: conversation.contactId,
+    contactInbox,
+    conversation,
+  })
+  const resolvedValue = await contactVariableService.replaceAll({
+    text: step.value,
+    variables,
+  })
+
   await contactCustomFieldService.setValueByKey({
     workspaceId: conversation.workspaceId,
     contactId: conversation.contactId,
     keyword: step.inputFieldId,
-    value: step.value,
+    value: resolvedValue,
     // The editor captured its browser zone at save time; anchor naive
     // date/datetime values to it (worker has no browser context). Lenient
     // parsing accepts flexible user input (unix ts, "23/07/2026", ...), and a


### PR DESCRIPTION
## Summary

The **Set Custom Field** flow step now lets you build the value from contact variables instead of only static text.

- The **Value** input is a variable-aware editor: insert contact fields (and other custom fields) via the `</>` picker or by typing `{{`.
- At runtime the worker resolves those variables against the contact before saving, so `Hello {{first_name}}` is stored as `Hello Jane`. Unresolvable tokens are left as-is, and a blank value still stamps "now" for date/datetime fields.
- The emoji picker is hidden on this field to keep it focused on the value.

## Test plan

- [ ] In a flow, add a **Set Custom Field** step, insert a variable into the value, and save.
- [ ] Run the flow for a contact and confirm the stored value shows the resolved data, not the raw `{{token}}`.
- [ ] Confirm date/datetime fields still work with a blank value (stamps "now") and with a literal date.
- [x] Unit tests updated and passing (builder editor + worker handler).