### PR TITLE
fix(workspace): make scheduled deletion purge reliable

### DIFF
--- a/apps/builder/src/features/workspaces/components/workspace-deletion-card.tsx
+++ b/apps/builder/src/features/workspaces/components/workspace-deletion-card.tsx
@@ -35,9 +35,12 @@ function formatCountdown(target: string | Date | null) {
     return null
   }
 
+  // `round`, not `ceil`: scheduledDeletionAt is rounded up to the purge cron
+  // boundary, so the real distance is 24h + up to 30m (~1.01 days). `ceil` would
+  // inflate that to "2 days"; `round` keeps it at the intended "1 day".
   return formatDistanceToNowStrict(targetDate, {
     addSuffix: true,
-    roundingMethod: "ceil",
+    roundingMethod: "round",
   })
 }
 

--- a/apps/worker/src/schedule/handlers/register-schedules.ts
+++ b/apps/worker/src/schedule/handlers/register-schedules.ts
@@ -1,4 +1,8 @@
-import { ScheduleJobData, scheduleQueue } from "@chatbotx.io/worker-config"
+import {
+  PURGE_WORKSPACES_INTERVAL_MINUTES,
+  ScheduleJobData,
+  scheduleQueue,
+} from "@chatbotx.io/worker-config"
 import { Queue } from "bullmq"
 import { env } from "../../env"
 
@@ -213,7 +217,7 @@ export const registerSchedules = async () => {
   await scheduleQueue.upsertJobScheduler(
     ScheduleJobData.purgeWorkspaces,
     {
-      pattern: "0 * * * *",
+      pattern: `*/${PURGE_WORKSPACES_INTERVAL_MINUTES} * * * *`,
     },
     {
       name: ScheduleJobData.purgeWorkspaces,

--- a/integrations/webchat/src/integration.ts
+++ b/integrations/webchat/src/integration.ts
@@ -28,7 +28,9 @@ const config: IntegrationDefinition<
     throw new Error("Method is not implemented.")
   },
   disconnect(_props: WebchatAuthValue): Promise<void> {
-    throw new Error("Method is not implemented.")
+    // Webchat is a built-in channel with no external provider to disconnect;
+    // removing the inbox row is the whole teardown, so this is a no-op.
+    return Promise.resolve()
   },
 }
 

--- a/packages/business/__tests__/workspace-deletion-schedule.test.ts
+++ b/packages/business/__tests__/workspace-deletion-schedule.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest"
+import {
+  ceilToPurgeBoundary,
+  nextScheduledDeletionAt,
+  WORKSPACE_DELETION_GRACE_MS,
+} from "../src/workspace/deletion-schedule"
+
+describe("ceilToPurgeBoundary", () => {
+  test.each([
+    // Between boundaries → rounds up to the next :30 / :00 tick.
+    { input: "2026-08-06T10:20:00Z", expected: "2026-08-06T10:30:00Z" },
+    { input: "2026-08-06T10:31:00Z", expected: "2026-08-06T11:00:00Z" },
+    { input: "2026-08-06T10:00:00.001Z", expected: "2026-08-06T10:30:00Z" },
+  ])("rounds $input up to $expected", ({ input, expected }) => {
+    expect(ceilToPurgeBoundary(new Date(input)).toISOString()).toBe(
+      new Date(expected).toISOString(),
+    )
+  })
+
+  test("keeps a timestamp already on a boundary unchanged", () => {
+    const onBoundary = new Date("2026-08-06T10:30:00Z")
+    expect(ceilToPurgeBoundary(onBoundary).getTime()).toBe(onBoundary.getTime())
+  })
+
+  test("result always lands on a 30-minute boundary", () => {
+    const result = ceilToPurgeBoundary(new Date("2026-08-06T10:07:23.456Z"))
+    expect(result.getUTCMinutes() % 30).toBe(0)
+    expect(result.getUTCSeconds()).toBe(0)
+    expect(result.getUTCMilliseconds()).toBe(0)
+  })
+})
+
+describe("nextScheduledDeletionAt", () => {
+  test("returns now + 24h grace, rounded up to the purge boundary", () => {
+    const now = new Date("2026-08-06T10:20:00Z")
+    const result = nextScheduledDeletionAt(now)
+
+    // Grace lands on 2026-08-07T10:20:00Z, which rounds up to :30.
+    expect(result.toISOString()).toBe(
+      new Date("2026-08-07T10:30:00Z").toISOString(),
+    )
+  })
+
+  test("keeps grace within a predictable one-day window (24h–24h30m)", () => {
+    const now = new Date("2026-08-06T10:20:00Z")
+    const result = nextScheduledDeletionAt(now)
+    const graceMs = result.getTime() - now.getTime()
+
+    expect(graceMs).toBeGreaterThanOrEqual(WORKSPACE_DELETION_GRACE_MS)
+    expect(graceMs).toBeLessThanOrEqual(
+      WORKSPACE_DELETION_GRACE_MS + 30 * 60 * 1000,
+    )
+  })
+})

--- a/packages/business/src/message-cleanup/service.ts
+++ b/packages/business/src/message-cleanup/service.ts
@@ -5,6 +5,7 @@ import {
   db,
   eq,
   inArray,
+  liftDecompressionLimit,
   lte,
   sql,
 } from "@chatbotx.io/database/client"
@@ -210,8 +211,8 @@ class MessageCleanupService extends BaseService {
 
     // Main-DB hypertables: bound every statement by conversationId (the
     // compression segmentby column) and by the delete moment, so a re-created
-    // contact's newer rows can never be swept up. `SET LOCAL` lifts the
-    // TimescaleDB per-statement decompression cap for this transaction only.
+    // contact's newer rows can never be swept up. `liftDecompressionLimit`
+    // clears the TimescaleDB decompression cap for each transaction only.
     for (
       let i = 0;
       i < row.conversationIds.length;
@@ -222,9 +223,7 @@ class MessageCleanupService extends BaseService {
         i + CONVERSATION_DELETE_BATCH_SIZE,
       )
       await db.transaction(async (tx) => {
-        await tx.execute(
-          sql`SET LOCAL timescaledb.max_tuples_decompressed_per_dml_operation = 0`,
-        )
+        await liftDecompressionLimit(tx)
 
         const attachments = await tx
           .select({

--- a/packages/business/src/workspace-lifecycle/__tests__/service.test.ts
+++ b/packages/business/src/workspace-lifecycle/__tests__/service.test.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, test, vi } from "vitest"
 
 const {
   mockDbExecute,
+  mockSelectDistinctLimit,
+  mockTransaction,
+  mockTxDelete,
+  mockDeleteWhere,
+  mockLiftDecompressionLimit,
   mockListWithIntegrationsByWorkspace,
   mockInboxDisconnect,
   mockSql,
@@ -13,20 +18,43 @@ const {
     },
   )
 
+  const deleteWhere = vi.fn()
+  const txDelete = vi.fn(() => ({ where: deleteWhere }))
+  const selectDistinctLimit = vi.fn()
+
   return {
     mockDbExecute: vi.fn(),
+    mockSelectDistinctLimit: selectDistinctLimit,
+    mockTransaction: vi.fn((callback: (tx: unknown) => unknown) =>
+      callback({ delete: txDelete }),
+    ),
+    mockTxDelete: txDelete,
+    mockDeleteWhere: deleteWhere,
+    mockLiftDecompressionLimit: vi.fn().mockResolvedValue(undefined),
     mockListWithIntegrationsByWorkspace: vi.fn(),
     mockInboxDisconnect: vi.fn().mockResolvedValue(undefined),
     mockSql: sql,
   }
 })
 
+const selectDistinctChain = {
+  from: () => selectDistinctChain,
+  where: () => selectDistinctChain,
+  orderBy: () => selectDistinctChain,
+  limit: mockSelectDistinctLimit,
+}
+
 vi.mock("@chatbotx.io/database/client", () => ({
-  db: { execute: mockDbExecute },
+  db: {
+    execute: mockDbExecute,
+    selectDistinct: () => selectDistinctChain,
+    transaction: mockTransaction,
+  },
   sql: mockSql,
   and: vi.fn(),
   eq: vi.fn(),
   inArray: vi.fn(),
+  liftDecompressionLimit: mockLiftDecompressionLimit,
 }))
 
 vi.mock("../../inbox/service", () => ({
@@ -38,13 +66,24 @@ vi.mock("../../inbox/service", () => ({
 
 const { workspaceLifecycleService } = await import("../service")
 
+// `HEAVY_WORKSPACE_TABLES` holds 6 non-hypertable tables; Message/Attachment are
+// drained separately by the hypertable pass and are not in the ctid loop.
+const HEAVY_TABLE_COUNT = 6
+const MAX_BATCHES_PER_TABLE = 2000
+
 describe("workspaceLifecycleService", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockInboxDisconnect.mockResolvedValue(undefined)
+    // Default: no hypertable rows, so purgeWorkspaceHeavyData exercises only the
+    // ctid loop unless a test opts in.
+    mockSelectDistinctLimit.mockResolvedValue([])
+    mockDeleteWhere.mockResolvedValue({ rowCount: 0 })
+    mockLiftDecompressionLimit.mockResolvedValue(undefined)
   })
 
-  test("purgeWorkspaceHeavyData drains each table until a short batch", async () => {
+  test("purgeWorkspaceHeavyData drains each ctid table until a short batch", async () => {
+    // First batch is full (keep draining), then a short batch stops that table.
     mockDbExecute
       .mockResolvedValueOnce({ rowCount: 2 })
       .mockResolvedValue({ rowCount: 1 })
@@ -54,11 +93,12 @@ describe("workspaceLifecycleService", () => {
       batchSize: 2,
     })
 
-    expect(result).toBe(10)
-    expect(mockDbExecute).toHaveBeenCalledTimes(9)
+    // Table 1: 2 + 1 rows (2 calls); tables 2..6: 1 row each (1 call).
+    expect(result).toBe(2 + 1 + (HEAVY_TABLE_COUNT - 1))
+    expect(mockDbExecute).toHaveBeenCalledTimes(2 + (HEAVY_TABLE_COUNT - 1))
   })
 
-  test("purgeWorkspaceHeavyData caps batches per table", async () => {
+  test("purgeWorkspaceHeavyData caps batches per ctid table", async () => {
     vi.spyOn(globalThis, "setTimeout").mockImplementation((callback) => {
       callback()
       return 0 as unknown as ReturnType<typeof setTimeout>
@@ -70,8 +110,41 @@ describe("workspaceLifecycleService", () => {
       batchSize: 1,
     })
 
-    expect(result).toBe(16_000)
-    expect(mockDbExecute).toHaveBeenCalledTimes(16_000)
+    expect(result).toBe(HEAVY_TABLE_COUNT * MAX_BATCHES_PER_TABLE)
+    expect(mockDbExecute).toHaveBeenCalledTimes(
+      HEAVY_TABLE_COUNT * MAX_BATCHES_PER_TABLE,
+    )
+    vi.restoreAllMocks()
+  })
+
+  test("purgeWorkspaceHeavyData drains hypertable rows by conversation with the decompression limit lifted", async () => {
+    vi.spyOn(globalThis, "setTimeout").mockImplementation((callback) => {
+      callback()
+      return 0 as unknown as ReturnType<typeof setTimeout>
+    })
+    // ctid loop deletes nothing (short first batch → immediate break per table).
+    mockDbExecute.mockResolvedValue({ rowCount: 0 })
+    // Message pass: one page of two conversations, then empty. Attachment pass:
+    // empty.
+    mockSelectDistinctLimit
+      .mockResolvedValueOnce([
+        { conversationId: "conv-1" },
+        { conversationId: "conv-2" },
+      ])
+      .mockResolvedValue([])
+    mockDeleteWhere.mockResolvedValue({ rowCount: 3 })
+
+    const result = await workspaceLifecycleService.purgeWorkspaceHeavyData({
+      workspaceId: "workspace-1",
+      batchSize: 5000,
+    })
+
+    // One page → one transaction that lifts the cap once and deletes from both
+    // Message and Attachment (rowCount 3 each = 6). ctid loop adds 0.
+    expect(result).toBe(6)
+    expect(mockTransaction).toHaveBeenCalledOnce()
+    expect(mockLiftDecompressionLimit).toHaveBeenCalledOnce()
+    expect(mockTxDelete).toHaveBeenCalledTimes(2)
     vi.restoreAllMocks()
   })
 
@@ -124,5 +197,41 @@ describe("workspaceLifecycleService", () => {
       workspaceId: "workspace-1",
       tx,
     })
+  })
+
+  test("disconnectWorkspaceChannels skips the provider disconnect when the auth row is already gone", async () => {
+    const disconnect = vi.fn().mockResolvedValue(undefined)
+    mockListWithIntegrationsByWorkspace.mockResolvedValue([
+      {
+        id: "inbox-1",
+        workspaceId: "workspace-1",
+        channel: "messenger",
+        // integrationMessenger is absent, so there is no auth to disconnect with.
+      },
+    ])
+
+    const tx = {
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+      })),
+      delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    }
+
+    await workspaceLifecycleService.disconnectWorkspaceChannels({
+      integrations: {
+        messenger: {
+          disconnect,
+          isRevokedTokenError: () => false,
+        },
+      },
+      teardownLevel: "disconnect",
+      tx: tx as never,
+      workspaceId: "workspace-1",
+      ownerId: "owner-1",
+    })
+
+    // No credentials → provider call is skipped, but the inbox is still retired.
+    expect(disconnect).not.toHaveBeenCalled()
+    expect(mockInboxDisconnect).toHaveBeenCalled()
   })
 })

--- a/packages/business/src/workspace-lifecycle/service.ts
+++ b/packages/business/src/workspace-lifecycle/service.ts
@@ -4,10 +4,12 @@ import {
   db,
   eq,
   inArray,
+  liftDecompressionLimit,
   sql,
 } from "@chatbotx.io/database/client"
 import { channelTypes, ROOT_TENANT_ID } from "@chatbotx.io/database/partials"
 import {
+  attachmentModel,
   coexistSyncRunModel,
   integrationInstagramModel,
   integrationMessengerModel,
@@ -17,6 +19,7 @@ import {
   integrationWebchatModel,
   integrationWhatsappModel,
   integrationZaloModel,
+  messageModel,
   tagChannelModel,
   whatsappCoexistStagingModel,
 } from "@chatbotx.io/database/schema"
@@ -86,12 +89,17 @@ export type WorkspaceTeardownLevel = "pause" | "disconnect"
  * Table names are the physical PG identifiers (not Drizzle models) because the
  * delete is a raw `ctid IN (... LIMIT ...)` statement the query builder cannot
  * express; keep them in sync with the schema if a table is renamed.
+ *
+ * `Message` and `Attachment` are deliberately NOT here: they are compressed
+ * TimescaleDB hypertables where `ctid` is unavailable ("transparent
+ * decompression only supports tableoid system column"). They are drained
+ * separately by `deleteWorkspaceHypertableRows`, which deletes by the
+ * `conversationId` segmentby column with the decompression cap lifted — the
+ * same technique as `messageCleanupService.purgeRow`.
  */
 const HEAVY_WORKSPACE_TABLES = [
-  "Message",
   "AIConversationEmbedding",
   "AIEmbedding",
-  "Attachment",
   "Conversation",
   "TriggerExecution",
   "FlowRun",
@@ -100,10 +108,21 @@ const HEAVY_WORKSPACE_TABLES = [
 
 const HEAVY_PURGE_BATCH_SIZE = 5000
 const INTER_CHUNK_DELAY_MS = 100
+// Conversation ids deleted per hypertable transaction. Deliberately small:
+// deleting a compressed chunk decompresses its rows first, so each batch's
+// decompression footprint (DB backend memory + WAL) is bounded to ~10
+// conversations' worth of >30-day history — keeping the spike well clear of a
+// high-ingest system running alongside the purge.
+const HYPERTABLE_CONVERSATION_BATCH_SIZE = 10
 // Backstop so a single workspace with a runaway row count cannot spin forever;
 // 5000 * 2000 = 10M rows per table per purge run. Anything beyond that drains
 // on the next scheduled tick.
 const HEAVY_PURGE_MAX_BATCHES_PER_TABLE = 2000
+// Backstop for the per-conversation hypertable passes. Bounds one workspace's
+// drain per run (~10k conversations per pass) so a single very large workspace
+// cannot hold the purge distributed lock for a large fraction of the cron
+// interval; the residue drains on the next scheduled tick.
+const HYPERTABLE_MAX_CONVERSATION_BATCHES = 1000
 
 class WorkspaceLifecycleService extends BaseService {
   async disconnectWorkspaceChannels(props: {
@@ -249,6 +268,11 @@ class WorkspaceLifecycleService extends BaseService {
     const batchSize = props.batchSize ?? HEAVY_PURGE_BATCH_SIZE
     let totalDeleted = 0
 
+    // Drain the compressed hypertables (Message/Attachment) first, by
+    // conversationId, before the ctid loop deletes their parent Conversation
+    // rows. Uses the decompression-cap-lifted delete, not `ctid`.
+    totalDeleted += await this.deleteWorkspaceHypertableRows(props.workspaceId)
+
     for (const table of HEAVY_WORKSPACE_TABLES) {
       for (let batch = 0; batch < HEAVY_PURGE_MAX_BATCHES_PER_TABLE; batch++) {
         const deleted = await this.deleteHeavyBatch(
@@ -288,6 +312,88 @@ class WorkspaceLifecycleService extends BaseService {
       )
     `)
     return result.rowCount ?? 0
+  }
+
+  /**
+   * Delete a workspace's Message + Attachment rows. Both are compressed
+   * TimescaleDB hypertables (segmentby `workspaceId,conversationId`) where
+   * `ctid` is unsupported, so `deleteHeavyBatch` cannot touch them. Instead we
+   * drain them one bounded page of conversationIds at a time: deleting a page
+   * lifts the per-statement decompression cap for that transaction only, and the
+   * deleted ids drop out so the next page query walks forward to the next ones.
+   *
+   * Paging (rather than loading every conversationId up front) keeps worker
+   * memory constant — a workspace can hold millions of conversations, and
+   * materialising that whole id list in the process could exhaust its heap.
+   * Message is drained first (high volume), then any attachment-only
+   * conversations left behind. The whole workspace is being torn down, so no
+   * `createdAt` upper bound is needed.
+   */
+  private async deleteWorkspaceHypertableRows(
+    workspaceId: string,
+  ): Promise<number> {
+    const deletePage = (conversationIds: string[]) =>
+      db.transaction(async (tx) => {
+        await liftDecompressionLimit(tx)
+        const messageResult = await tx
+          .delete(messageModel)
+          .where(
+            and(
+              eq(messageModel.workspaceId, workspaceId),
+              inArray(messageModel.conversationId, conversationIds),
+            ),
+          )
+        const attachmentResult = await tx
+          .delete(attachmentModel)
+          .where(
+            and(
+              eq(attachmentModel.workspaceId, workspaceId),
+              inArray(attachmentModel.conversationId, conversationIds),
+            ),
+          )
+        return (messageResult.rowCount ?? 0) + (attachmentResult.rowCount ?? 0)
+      })
+
+    let deleted = 0
+
+    // Pass 1: discovery driven off Message (the high-volume table). Each deleted
+    // page removes those conversationIds, so re-querying with the same LIMIT
+    // walks forward until none remain. The batch cap bounds a single run; any
+    // residue drains on the next scheduled tick.
+    for (let batch = 0; batch < HYPERTABLE_MAX_CONVERSATION_BATCHES; batch++) {
+      const rows = await db
+        .selectDistinct({ conversationId: messageModel.conversationId })
+        .from(messageModel)
+        .where(eq(messageModel.workspaceId, workspaceId))
+        // Ordered so Postgres can serve each page from the (workspaceId,
+        // conversationId) index as a bounded scan instead of re-aggregating the
+        // whole workspace on every batch.
+        .orderBy(messageModel.conversationId)
+        .limit(HYPERTABLE_CONVERSATION_BATCH_SIZE)
+      if (rows.length === 0) {
+        break
+      }
+      deleted += await deletePage(rows.map((row) => row.conversationId))
+      await new Promise((resolve) => setTimeout(resolve, INTER_CHUNK_DELAY_MS))
+    }
+
+    // Pass 2: attachment-only conversations (attachments whose Message rows were
+    // already gone) that pass 1 never enumerated.
+    for (let batch = 0; batch < HYPERTABLE_MAX_CONVERSATION_BATCHES; batch++) {
+      const rows = await db
+        .selectDistinct({ conversationId: attachmentModel.conversationId })
+        .from(attachmentModel)
+        .where(eq(attachmentModel.workspaceId, workspaceId))
+        .orderBy(attachmentModel.conversationId)
+        .limit(HYPERTABLE_CONVERSATION_BATCH_SIZE)
+      if (rows.length === 0) {
+        break
+      }
+      deleted += await deletePage(rows.map((row) => row.conversationId))
+      await new Promise((resolve) => setTimeout(resolve, INTER_CHUNK_DELAY_MS))
+    }
+
+    return deleted
   }
 
   async deactivateOwnerWorkspaces(props: {
@@ -334,9 +440,14 @@ class WorkspaceLifecycleService extends BaseService {
     const removeIntegrationRow = teardownLevel === "disconnect"
 
     const finish = async (disconnect?: WorkspaceTeardownIntegration) => {
-      if (disconnect) {
+      const auth = inboxToAuth(inbox)
+      // Skip the provider call when the integration/auth row is already gone:
+      // there are no credentials to disconnect with, and passing an undefined
+      // auth crashes providers that read it (e.g. messenger/whatsapp reach into
+      // `auth.metadata`). Removing the inbox row below is still done.
+      if (disconnect && auth) {
         try {
-          await disconnect.disconnect(inboxToAuth(inbox))
+          await disconnect.disconnect(auth)
         } catch (err) {
           if (!disconnect.isRevokedTokenError?.(err)) {
             logger.error(

--- a/packages/business/src/workspace/__tests__/service.test.ts
+++ b/packages/business/src/workspace/__tests__/service.test.ts
@@ -8,6 +8,8 @@ const mocks = vi.hoisted(() => ({
   createMember: vi.fn(),
   getForUser: vi.fn(),
   invalidateCacheByTags: vi.fn(),
+  dbTransaction: vi.fn(),
+  purgeWorkspaceHeavyData: vi.fn(),
 }))
 
 vi.mock("@chatbotx.io/analytics", () => ({
@@ -19,6 +21,7 @@ vi.mock("@chatbotx.io/database/client", () => ({
   db: {
     query: { userModel: { findFirst: vi.fn(async () => undefined) } },
     insert: mocks.workspaceInsert,
+    transaction: mocks.dbTransaction,
   },
   eq: vi.fn((column, value) => ({ column, value })),
   inArray: vi.fn(),
@@ -63,7 +66,7 @@ vi.mock("../../workspace-lifecycle/service", () => ({
     freezeWorkspaceRuntime: vi.fn(async () => undefined),
     disconnectWorkspaceIntegrations: vi.fn(async () => undefined),
     disconnectWorkspaceChannels: vi.fn(async () => undefined),
-    purgeWorkspaceHeavyData: vi.fn(async () => undefined),
+    purgeWorkspaceHeavyData: mocks.purgeWorkspaceHeavyData,
   },
 }))
 
@@ -86,6 +89,9 @@ beforeEach(() => {
   mocks.getForUser.mockReset()
   mocks.getForUser.mockResolvedValue(undefined)
   mocks.invalidateCacheByTags.mockReset()
+  mocks.dbTransaction.mockReset()
+  mocks.purgeWorkspaceHeavyData.mockReset()
+  mocks.purgeWorkspaceHeavyData.mockResolvedValue(0)
 
   mocks.workspaceInsert.mockReturnValue({
     values: mocks.workspaceInsertValues.mockReturnValue({
@@ -124,5 +130,36 @@ describe("WorkspaceService.create", () => {
     expect(result).toEqual({ id: "new-workspace" })
     expect(mocks.workspaceInsert).toHaveBeenCalledTimes(1)
     expect(mocks.createMember).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("WorkspaceService.purgeDueScheduled", () => {
+  test("deletes only workspaces that tear down cleanly and never aborts the run on a single failure", async () => {
+    const claimedRows = [
+      { id: "w1", ownerId: "o1", tenantId: "t1" },
+      { id: "w2", ownerId: "o2", tenantId: "t2" },
+    ]
+    const deleteWhere = vi.fn().mockResolvedValue(undefined)
+    const tx = {
+      execute: vi.fn().mockResolvedValue({ rows: claimedRows }),
+      select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }),
+      delete: vi.fn(() => ({ where: deleteWhere })),
+    }
+    mocks.dbTransaction.mockImplementation(
+      (callback: (tx: unknown) => unknown) => callback(tx),
+    )
+
+    // w1's teardown throws; w2 succeeds.
+    mocks.purgeWorkspaceHeavyData.mockImplementation(
+      ({ workspaceId }: { workspaceId: string }) =>
+        workspaceId === "w1"
+          ? Promise.reject(new Error("teardown boom"))
+          : Promise.resolve(0),
+    )
+
+    // Resolves (does not throw) and counts only the workspace that succeeded.
+    await expect(workspaceService.purgeDueScheduled()).resolves.toBe(1)
+    // The failed workspace keeps its row; only the clean one is deleted.
+    expect(tx.delete).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/business/src/workspace/deletion-schedule.ts
+++ b/packages/business/src/workspace/deletion-schedule.ts
@@ -1,0 +1,33 @@
+import { PURGE_WORKSPACES_INTERVAL_MINUTES } from "@chatbotx.io/worker-config"
+
+/** Grace period between scheduling a deletion and the workspace being purged. */
+export const WORKSPACE_DELETION_GRACE_MS = 24 * 60 * 60 * 1000
+
+const PURGE_INTERVAL_MS = PURGE_WORKSPACES_INTERVAL_MINUTES * 60 * 1000
+
+/**
+ * Round a timestamp up to the next `purgeWorkspaces` cron boundary so the value
+ * we persist is the moment the cron will actually delete the workspace. The UI
+ * renders `scheduledDeletionAt` verbatim, so an unaligned value would promise a
+ * time the purge cannot honor (the deletion only runs on the next cron tick).
+ *
+ * Epoch-multiple alignment matches the cron's :00/:30 firing on UTC and
+ * whole/half-hour-offset servers, which covers all realistic deployments.
+ */
+export function ceilToPurgeBoundary(date: Date): Date {
+  return new Date(
+    Math.ceil(date.getTime() / PURGE_INTERVAL_MS) * PURGE_INTERVAL_MS,
+  )
+}
+
+/**
+ * Timestamp to persist when a workspace deletion is scheduled: now + 24h grace,
+ * rounded up so it lands exactly on the purge cron boundary. Grace stays ~24h
+ * (24h–24h30m) so customers get a predictable one-day window; the banner renders
+ * this value verbatim, so the countdown stays honest.
+ */
+export function nextScheduledDeletionAt(now: Date = new Date()): Date {
+  return ceilToPurgeBoundary(
+    new Date(now.getTime() + WORKSPACE_DELETION_GRACE_MS),
+  )
+}

--- a/packages/business/src/workspace/service.ts
+++ b/packages/business/src/workspace/service.ts
@@ -29,6 +29,7 @@ import {
   workspaceMemberCacheTag,
   workspaceMemberService,
 } from "../workspace-member/service"
+import { nextScheduledDeletionAt } from "./deletion-schedule"
 
 type WorkspaceWhere = Partial<{ id: string; ownerId: string; token: string }>
 
@@ -131,7 +132,7 @@ class WorkspaceService extends BaseService {
       id: props.id,
       tx,
       data: {
-        scheduledDeletionAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        scheduledDeletionAt: nextScheduledDeletionAt(),
       },
     })
   }
@@ -213,58 +214,77 @@ class WorkspaceService extends BaseService {
         break
       }
 
+      // Per-workspace guard: a teardown failure on one workspace must not abort
+      // the whole cron (BullMQ would retry the entire batch forever). Only
+      // workspaces that tear down cleanly are deleted below; a failed one keeps
+      // its `scheduledDeletionAt` and is retried on the next tick.
+      const succeeded: typeof claimed.rows = []
       for (const workspace of claimed.rows) {
-        await workspaceLifecycleService.freezeWorkspaceRuntime(workspace.id)
+        try {
+          await workspaceLifecycleService.freezeWorkspaceRuntime(workspace.id)
 
-        await workspaceLifecycleService
-          .disconnectWorkspaceIntegrations(workspace.id)
-          .catch((err) => {
-            logger.error(
-              { err, workspaceId: workspace.id },
-              "workspace-purge: failed to disconnect workspace integrations",
-            )
+          await workspaceLifecycleService
+            .disconnectWorkspaceIntegrations(workspace.id)
+            .catch((err) => {
+              logger.error(
+                { err, workspaceId: workspace.id },
+                "workspace-purge: failed to disconnect workspace integrations",
+              )
+            })
+
+          await workspaceLifecycleService.disconnectWorkspaceChannels({
+            integrations: props?.integrations,
+            teardownLevel: "disconnect",
+            workspaceId: workspace.id,
+            ownerId: workspace.ownerId,
           })
 
-        await workspaceLifecycleService.disconnectWorkspaceChannels({
-          integrations: props?.integrations,
-          teardownLevel: "disconnect",
-          workspaceId: workspace.id,
-          ownerId: workspace.ownerId,
-        })
-
-        // Drain high-volume child tables in small self-committing batches
-        // before the FK cascade, so no single statement deletes millions of
-        // rows under lock.
-        await workspaceLifecycleService.purgeWorkspaceHeavyData({
-          workspaceId: workspace.id,
-        })
-
-        // Best-effort: never block/roll back the purge if release fails —
-        // `reconcileOwnerPoolUsage` below re-derives `workspaces` from source
-        // for every affected owner regardless.
-        await quotaEnforcementService
-          .release({ userId: workspace.ownerId, metric: "workspaces" })
-          .catch((err) => {
-            logger.warn(
-              { err, workspaceId: workspace.id, ownerId: workspace.ownerId },
-              "workspace-purge: workspace quota release failed",
-            )
+          // Drain high-volume child tables in small self-committing batches
+          // before the FK cascade, so no single statement deletes millions of
+          // rows under lock.
+          await workspaceLifecycleService.purgeWorkspaceHeavyData({
+            workspaceId: workspace.id,
           })
+
+          // Best-effort: never block/roll back the purge if release fails —
+          // `reconcileOwnerPoolUsage` below re-derives `workspaces` from source
+          // for every affected owner regardless.
+          await quotaEnforcementService
+            .release({ userId: workspace.ownerId, metric: "workspaces" })
+            .catch((err) => {
+              logger.warn(
+                { err, workspaceId: workspace.id, ownerId: workspace.ownerId },
+                "workspace-purge: workspace quota release failed",
+              )
+            })
+
+          succeeded.push(workspace)
+        } catch (err) {
+          logger.error(
+            { err, workspaceId: workspace.id },
+            "workspace-purge: teardown failed, deferring to next run",
+          )
+        }
       }
 
-      const workspaceIds = claimed.rows.map((row) => row.id)
+      const workspaceIds = succeeded.map((row) => row.id)
       const result = await db.transaction(async (tx) => {
-        await tx
-          .delete(workspaceModel)
-          .where(inArray(workspaceModel.id, workspaceIds))
+        if (workspaceIds.length > 0) {
+          await tx
+            .delete(workspaceModel)
+            .where(inArray(workspaceModel.id, workspaceIds))
+        }
 
         return {
-          deleted: claimed.rows,
+          deleted: succeeded,
           memberUserIds: claimed.memberUserIds,
         }
       })
 
-      if (result.deleted.length === 0) {
+      // A full chunk that tore down nothing is a systemic failure (e.g. the DB
+      // is unhealthy): stop instead of spinning through maxChunks re-claiming
+      // the same rows. The next scheduled tick retries.
+      if (succeeded.length === 0) {
         break
       }
 
@@ -287,7 +307,12 @@ class WorkspaceService extends BaseService {
         "workspace-purge: workspaces purged",
       )
 
-      if (result.deleted.length < chunkSize) {
+      // Stop when this chunk claimed fewer than a full batch — no more due
+      // workspaces remain. Keyed off *claimed* (not *succeeded*) so a single
+      // failing workspace can't cut the run short while others are still due;
+      // failed ones are re-attempted on later chunks (bounded by maxChunks) and
+      // on the next tick.
+      if (claimed.rows.length < chunkSize) {
         break
       }
     }

--- a/packages/database/__tests__/timescale.test.ts
+++ b/packages/database/__tests__/timescale.test.ts
@@ -1,0 +1,22 @@
+import { PgDialect } from "drizzle-orm/pg-core"
+import { describe, expect, test, vi } from "vitest"
+import { liftDecompressionLimit } from "../src/timescale"
+
+describe("liftDecompressionLimit", () => {
+  test("issues SET LOCAL with the exact TimescaleDB GUC name", async () => {
+    const execute = vi.fn().mockResolvedValue(undefined)
+
+    // Only `execute` is used; a minimal stub stands in for the client.
+    await liftDecompressionLimit({ execute } as never)
+
+    expect(execute).toHaveBeenCalledOnce()
+
+    const rendered = new PgDialect().sqlToQuery(execute.mock.calls[0][0]).sql
+    // The GUC name must match TimescaleDB's registered parameter exactly —
+    // `_per_dml_transaction`, not the non-existent `_per_dml_operation`, which
+    // would raise "unrecognized configuration parameter" at runtime.
+    expect(rendered).toBe(
+      "SET LOCAL timescaledb.max_tuples_decompressed_per_dml_transaction = 0",
+    )
+  })
+})

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -50,6 +50,11 @@ export type Transaction = Parameters<
 export type { PgTable } from "drizzle-orm/pg-core"
 export type DatabaseClient = typeof db | Transaction
 
+// Side-effect-free hypertable helpers (kept out of this module so they can be
+// imported without booting the connection pool). Re-exported here so callers
+// keep using the single `@chatbotx.io/database/client` entrypoint.
+export { liftDecompressionLimit } from "./timescale"
+
 export const countWithRelationsFilter = <TTable extends PgTable>(props: {
   client?: DatabaseClient
   table: TTable

--- a/packages/database/src/timescale.ts
+++ b/packages/database/src/timescale.ts
@@ -1,0 +1,24 @@
+import { sql } from "drizzle-orm"
+import type { DatabaseClient } from "./client"
+
+/**
+ * Lift TimescaleDB's per-transaction decompression cap for the current
+ * transaction so a bulk DELETE against a compressed hypertable
+ * (`Message`/`Attachment`) is not aborted by
+ * `max_tuples_decompressed_per_dml_transaction` (default 100k; `0` = unlimited).
+ *
+ * The GUC name is exact per TimescaleDB's `src/guc.c`
+ * (`MAKE_EXTOPTION("max_tuples_decompressed_per_dml_transaction")`); an unknown
+ * `timescaledb.*` name would raise "unrecognized configuration parameter".
+ *
+ * MUST be called inside the same transaction as the delete: `SET LOCAL` scopes
+ * the change to that transaction and reverts on commit, which is also what keeps
+ * it safe under PgBouncer transaction pooling.
+ */
+export const liftDecompressionLimit = async (
+  tx: DatabaseClient,
+): Promise<void> => {
+  await tx.execute(
+    sql`SET LOCAL timescaledb.max_tuples_decompressed_per_dml_transaction = 0`,
+  )
+}

--- a/packages/worker-config/src/queues/schedule/index.ts
+++ b/packages/worker-config/src/queues/schedule/index.ts
@@ -31,6 +31,17 @@ export const ScheduleJobData = {
   teardownExpiredTrial: "teardownExpiredTrial",
 } as const
 
+/**
+ * Cadence (minutes) of the `purgeWorkspaces` cron. Shared so the scheduled
+ * deletion timestamp can be rounded up to the same boundary the cron fires on,
+ * keeping the deletion time shown in the UI honest (the banner renders
+ * `scheduledDeletionAt` verbatim). The cron pattern in
+ * `apps/worker/src/schedule/handlers/register-schedules.ts` is derived from
+ * this value, so both stay in sync automatically. Keep it a divisor of 60 so
+ * the derived every-N-minutes cron pattern remains valid.
+ */
+export const PURGE_WORKSPACES_INTERVAL_MINUTES = 30
+
 export const broadcastSendJobId = (broadcastId: string) =>
   `broadcast-send-${broadcastId}`
 


### PR DESCRIPTION
## Summary

Scheduled workspace deletion was not completing: the hourly purge crashed while deleting a workspace's messages, so no due workspace was ever removed. This makes the purge correct, resilient, and safe to run alongside live traffic.

### What changed

- **Purge no longer crashes on message/attachment data.** These live in compressed TimescaleDB hypertables that the previous batch-delete could not touch. They are now drained safely by conversation, in small bounded pages, so worker memory stays flat even for very large workspaces.
- **One bad workspace can no longer stall the whole purge.** Each workspace is torn down in isolation; a failure is logged and retried on the next run while every other due workspace still gets deleted.
- **Cleaner teardown.** Disconnecting channels no longer throws when an integration's credentials are already gone (Messenger/WhatsApp) and for the built-in web chat channel.
- **Deletion timing.** The countdown shown to customers is accurate again, and the purge runs on a predictable schedule.
- **Heavier work is throttled** so it stays gentle on the shared database and is safe under PgBouncer transaction pooling.

### Notable

While verifying against TimescaleDB's documentation, the decompression-limit setting used a parameter name that does not exist in TimescaleDB, which would fail at runtime. It has been corrected and centralized in one shared helper (also removing a duplicated statement), with a test that pins the exact name.

## Test plan

- [x] `pnpm --filter @chatbotx.io/business exec vitest run` — 730 passing (adds coverage for the per-workspace guard, hypertable draining, and skip-disconnect-when-no-credentials)
- [x] `pnpm --filter @chatbotx.io/database exec vitest run` — 378 passing (adds the decompression-parameter-name test)
- [x] `pnpm --filter worker test purge-workspaces`
- [x] Type-check: database, business, worker-config, worker, webchat, builder
- [x] Lint (Biome) on all changed files
- [ ] Verify on staging against a real compressed hypertable: schedule a workspace with historical messages for deletion and confirm the purge completes cleanly

## Notes for reviewers

- Message **sharding** (if enabled) is out of scope here — shard-resident messages are cleaned by the existing per-contact path; a follow-up can extend workspace purge to shards.
