### PR TITLE
feat(auth): add sign-in method switcher and reorder SSO providers

### DIFF
--- a/apps/builder/messages/ar.json
+++ b/apps/builder/messages/ar.json
@@ -2900,6 +2900,8 @@
     "orContinueWith": "أو المتابعة باستخدام",
     "continueWithFacebook": "المتابعة باستخدام Facebook",
     "continueWithGoogle": "المتابعة باستخدام Google",
+    "continueWithEmail": "المتابعة باستخدام البريد الإلكتروني",
+    "continueWithMagicLink": "المتابعة باستخدام رابط سحري",
     "dontHaveAnAccount": "ليس لديك حساب؟",
     "alreadyHaveAnAccount": "لديك حساب بالفعل؟",
     "signUp": "إنشاء حساب",

--- a/apps/builder/messages/da.json
+++ b/apps/builder/messages/da.json
@@ -2893,6 +2893,8 @@
     "orContinueWith": "Eller fortsæt med",
     "continueWithFacebook": "Fortsæt med Facebook",
     "continueWithGoogle": "Fortsæt med Google",
+    "continueWithEmail": "Fortsæt med e-mail",
+    "continueWithMagicLink": "Fortsæt med magisk link",
     "dontHaveAnAccount": "Don't har an konto?",
     "alreadyHaveAnAccount": "Allerede har an konto?",
     "signUp": "Log up",

--- a/apps/builder/messages/de.json
+++ b/apps/builder/messages/de.json
@@ -2251,6 +2251,8 @@
     "orContinueWith": "Oder fortfahren mit",
     "continueWithFacebook": "Mit Facebook fortfahren",
     "continueWithGoogle": "Mit Google fortfahren",
+    "continueWithEmail": "Mit E-Mail fortfahren",
+    "continueWithMagicLink": "Mit Magic Link fortfahren",
     "dontHaveAnAccount": "Noch kein Konto?",
     "alreadyHaveAnAccount": "Bereits ein Konto?",
     "signUp": "Registrieren",

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -2900,6 +2900,8 @@
     "orContinueWith": "Or continue with",
     "continueWithFacebook": "Continue with Facebook",
     "continueWithGoogle": "Continue with Google",
+    "continueWithEmail": "Continue with Email",
+    "continueWithMagicLink": "Continue with Magic Link",
     "dontHaveAnAccount": "Don't have an account?",
     "alreadyHaveAnAccount": "Already have an account?",
     "signUp": "Sign up",

--- a/apps/builder/messages/es.json
+++ b/apps/builder/messages/es.json
@@ -2893,6 +2893,8 @@
     "orContinueWith": "O continuar con",
     "continueWithFacebook": "Continue con Facebook",
     "continueWithGoogle": "Continuar con Google",
+    "continueWithEmail": "Continuar con correo electrónico",
+    "continueWithMagicLink": "Continuar con enlace mágico",
     "dontHaveAnAccount": "Don't tiene un cuenta?",
     "alreadyHaveAnAccount": "Already tiene un cuenta?",
     "signUp": "Registrarse",

--- a/apps/builder/messages/fi.json
+++ b/apps/builder/messages/fi.json
@@ -2893,6 +2893,8 @@
     "orContinueWith": "Tai jatka käyttäen",
     "continueWithFacebook": "Jatka Facebookilla",
     "continueWithGoogle": "Jatka Googlella",
+    "continueWithEmail": "Jatka sähköpostilla",
+    "continueWithMagicLink": "Jatka taikalinkillä",
     "dontHaveAnAccount": "Eikö sinulla ole tiliä?",
     "alreadyHaveAnAccount": "Onko sinulla jo tili?",
     "signUp": "Rekisteröidy",

--- a/apps/builder/messages/fr.json
+++ b/apps/builder/messages/fr.json
@@ -2280,6 +2280,8 @@
     "orContinueWith": "Ou continuer avec",
     "continueWithFacebook": "Continuer avec Facebook",
     "continueWithGoogle": "Continuer avec Google",
+    "continueWithEmail": "Continuer avec l'e-mail",
+    "continueWithMagicLink": "Continuer avec le lien magique",
     "dontHaveAnAccount": "Vous n’avez pas de compte ?",
     "alreadyHaveAnAccount": "Vous avez déjà un compte ?",
     "signUp": "S’inscrire",

--- a/apps/builder/messages/he.json
+++ b/apps/builder/messages/he.json
@@ -1194,6 +1194,8 @@
     "orContinueWith": "או המשך באמצעות",
     "continueWithFacebook": "המשך באמצעות Facebook",
     "continueWithGoogle": "המשך באמצעות Google",
+    "continueWithEmail": "המשך באמצעות אימייל",
+    "continueWithMagicLink": "המשך באמצעות קישור קסם",
     "dontHaveAnAccount": "אין לכם חשבון?",
     "alreadyHaveAnAccount": "כבר יש לכם חשבון?",
     "signUp": "הרשמה",

--- a/apps/builder/messages/id.json
+++ b/apps/builder/messages/id.json
@@ -2893,6 +2893,8 @@
     "orContinueWith": "Atau lanjutkan dengan",
     "continueWithFacebook": "Lanjutkan dengan Facebook",
     "continueWithGoogle": "Lanjutkan dengan Google",
+    "continueWithEmail": "Lanjutkan dengan Email",
+    "continueWithMagicLink": "Lanjutkan dengan Magic Link",
     "dontHaveAnAccount": "Belum memiliki akun?",
     "alreadyHaveAnAccount": "Sudah memiliki akun?",
     "signUp": "Daftar",

--- a/apps/builder/messages/it.json
+++ b/apps/builder/messages/it.json
@@ -2639,6 +2639,8 @@
     "orContinueWith": "Oppure continua con",
     "continueWithFacebook": "Continua con Facebook",
     "continueWithGoogle": "Continua con Google",
+    "continueWithEmail": "Continua con Email",
+    "continueWithMagicLink": "Continua con Magic Link",
     "dontHaveAnAccount": "Non hai un account?",
     "alreadyHaveAnAccount": "Hai già un account?",
     "signUp": "Registrati",

--- a/apps/builder/messages/ja.json
+++ b/apps/builder/messages/ja.json
@@ -2880,6 +2880,8 @@
     "orContinueWith": "または次の方法で続行",
     "continueWithFacebook": "Facebookで続行",
     "continueWithGoogle": "Googleで続行",
+    "continueWithEmail": "メールで続行",
+    "continueWithMagicLink": "マジックリンクで続行",
     "dontHaveAnAccount": "アカウントをお持ちでないですか？",
     "alreadyHaveAnAccount": "すでにアカウントをお持ちですか？",
     "signUp": "新規登録",

--- a/apps/builder/messages/nl.json
+++ b/apps/builder/messages/nl.json
@@ -2893,6 +2893,8 @@
     "orContinueWith": "Of ga verder met",
     "continueWithFacebook": "Doorgaan met Facebook",
     "continueWithGoogle": "Doorgaan met Google",
+    "continueWithEmail": "Doorgaan met e-mail",
+    "continueWithMagicLink": "Doorgaan met magische link",
     "dontHaveAnAccount": "Heb je nog geen account?",
     "alreadyHaveAnAccount": "Heb je al een account?",
     "signUp": "Registreren",

--- a/apps/builder/messages/pt-BR.json
+++ b/apps/builder/messages/pt-BR.json
@@ -2880,6 +2880,8 @@
     "orContinueWith": "Ou continue com",
     "continueWithFacebook": "Continuar com o Facebook",
     "continueWithGoogle": "Continuar com o Google",
+    "continueWithEmail": "Continuar com o e-mail",
+    "continueWithMagicLink": "Continuar com o link mágico",
     "dontHaveAnAccount": "Não tem uma conta?",
     "alreadyHaveAnAccount": "Já tem uma conta?",
     "signUp": "Cadastre-se",

--- a/apps/builder/messages/pt-PT.json
+++ b/apps/builder/messages/pt-PT.json
@@ -2893,6 +2893,8 @@
     "orContinueWith": "Ou continue com",
     "continueWithFacebook": "Continuar com o Facebook",
     "continueWithGoogle": "Continuar com o Google",
+    "continueWithEmail": "Continuar com o e-mail",
+    "continueWithMagicLink": "Continuar com a ligação mágica",
     "dontHaveAnAccount": "Não tem uma conta?",
     "alreadyHaveAnAccount": "Já tem uma conta?",
     "signUp": "Registar",

--- a/apps/builder/messages/ro.json
+++ b/apps/builder/messages/ro.json
@@ -2893,6 +2893,8 @@
     "orContinueWith": "Sau continuă cu",
     "continueWithFacebook": "Continuă cu Facebook",
     "continueWithGoogle": "Continuă cu Google",
+    "continueWithEmail": "Continuă cu e-mail",
+    "continueWithMagicLink": "Continuă cu link magic",
     "dontHaveAnAccount": "Nu ai un cont?",
     "alreadyHaveAnAccount": "Ai deja un cont?",
     "signUp": "Înregistrare",

--- a/apps/builder/messages/sv.json
+++ b/apps/builder/messages/sv.json
@@ -330,6 +330,8 @@
     "checkYourEmail": "Kontrollera din e-post",
     "continueWithFacebook": "Fortsätt med Facebook",
     "continueWithGoogle": "Fortsätt med Google",
+    "continueWithEmail": "Fortsätt med e-post",
+    "continueWithMagicLink": "Fortsätt med magisk länk",
     "didNotReceiveEmail": "Fick du inget e-postmeddelande? Kontrollera skräppostmappen.",
     "dontHaveAnAccount": "Har du inget konto?",
     "forgotPassword": "Glömt lösenordet?",

--- a/apps/builder/messages/tr.json
+++ b/apps/builder/messages/tr.json
@@ -2893,6 +2893,8 @@
     "orContinueWith": "Veya şununla devam et",
     "continueWithFacebook": "Facebook ile devam et",
     "continueWithGoogle": "Google ile devam et",
+    "continueWithEmail": "E-posta ile devam et",
+    "continueWithMagicLink": "Sihirli Bağlantıyla devam et",
     "dontHaveAnAccount": "Hesabınız yok mu?",
     "alreadyHaveAnAccount": "Zaten bir hesabınız var mı?",
     "signUp": "Kaydol",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -2900,6 +2900,8 @@
     "orContinueWith": "Hoặc tiếp tục với",
     "continueWithFacebook": "Tiếp tục với Facebook",
     "continueWithGoogle": "Tiếp tục với Google",
+    "continueWithEmail": "Tiếp tục với Email",
+    "continueWithMagicLink": "Tiếp tục với Magic Link",
     "dontHaveAnAccount": "Chưa có tài khoản?",
     "alreadyHaveAnAccount": "Đã có tài khoản?",
     "signUp": "Đăng ký",

--- a/apps/builder/src/components/workspace-switcher.tsx
+++ b/apps/builder/src/components/workspace-switcher.tsx
@@ -22,7 +22,7 @@ import {
   useSidebar,
 } from "@chatbotx.io/ui/components/ui/sidebar"
 import { cn } from "@chatbotx.io/ui/lib/utils"
-import { ChevronsUpDown, PlusCircle } from "lucide-react"
+import { ChevronDown, PlusCircle } from "lucide-react"
 import Link from "next/link"
 import { useTranslations } from "next-intl"
 import { useEffect, useState } from "react"
@@ -73,7 +73,7 @@ export function WorkspaceSwitcher({
                   </span>
                   {/* <span className="truncate text-xs">{activeWorkspace?.plan}</span> */}
                 </div>
-                <ChevronsUpDown className="ms-auto" />
+                <ChevronDown className="ms-auto" />
               </SidebarMenuButton>
             }
           />

--- a/apps/builder/src/features/auth/sign-in.tsx
+++ b/apps/builder/src/features/auth/sign-in.tsx
@@ -1,13 +1,16 @@
 "use client"
 
 import type { SocialProvider } from "@chatbotx.io/auth/server"
+import { Button } from "@chatbotx.io/ui/components/ui/button"
 import {
   Card,
   CardContent,
   CardHeader,
 } from "@chatbotx.io/ui/components/ui/card"
+import { ArrowLeftIcon, LinkIcon, MailIcon } from "lucide-react"
 import Link from "next/link"
 import { useTranslations } from "next-intl"
+import { useState } from "react"
 import { isCommunity } from "@/env"
 import SSOSignIn from "@/features/auth/sso-sign-in"
 import { useTenantSettings } from "../tenant"
@@ -18,6 +21,8 @@ import {
   AuthHeader,
   OrSeparator,
 } from "./components/shared"
+
+type SignInMethod = "email" | "magicLink"
 
 export type SignInFormProps = {
   callbackUrl?: string
@@ -32,6 +37,7 @@ export const SignInForm = ({
 }: SignInFormProps) => {
   const t = useTranslations()
   const { name, policyUrl, termsOfServiceUrl } = useTenantSettings()
+  const [activeMethod, setActiveMethod] = useState<SignInMethod | null>(null)
 
   return (
     <div className="flex flex-col gap-6" {...props}>
@@ -42,16 +48,52 @@ export const SignInForm = ({
 
         <CardContent>
           <div className="grid gap-6">
-            <EmailPasswordSignIn />
-
-            <OrSeparator />
-
-            <MagicLinkSignIn />
-
-            {!isCommunity() && enabledProviders.length > 0 && (
+            {activeMethod ? (
               <>
-                <OrSeparator />
-                <SSOSignIn providers={enabledProviders} />
+                {activeMethod === "email" ? (
+                  <EmailPasswordSignIn />
+                ) : (
+                  <MagicLinkSignIn />
+                )}
+
+                <Button
+                  className="w-fit text-foreground/60"
+                  onClick={() => setActiveMethod(null)}
+                  type="button"
+                  variant="ghost"
+                >
+                  <ArrowLeftIcon className="size-4 rtl:rotate-180" />
+                  {t("actions.back")}
+                </Button>
+              </>
+            ) : (
+              <>
+                {!isCommunity() && enabledProviders.length > 0 && (
+                  <>
+                    <SSOSignIn providers={enabledProviders} />
+                    <OrSeparator />
+                  </>
+                )}
+
+                <Button
+                  className="w-full"
+                  onClick={() => setActiveMethod("email")}
+                  type="button"
+                  variant="outline"
+                >
+                  <MailIcon />
+                  {t("auth.continueWithEmail")}
+                </Button>
+
+                <Button
+                  className="w-full"
+                  onClick={() => setActiveMethod("magicLink")}
+                  type="button"
+                  variant="outline"
+                >
+                  <LinkIcon />
+                  {t("auth.continueWithMagicLink")}
+                </Button>
               </>
             )}
 

--- a/apps/builder/src/features/auth/sso-sign-in.tsx
+++ b/apps/builder/src/features/auth/sso-sign-in.tsx
@@ -62,6 +62,20 @@ export default function SSOSignIn({ providers }: SSOSignInProps) {
 
   return (
     <div className="flex flex-col items-center gap-3">
+      {providers.includes("facebook") && (
+        <Button
+          aria-label={t("auth.continueWithFacebook")}
+          className="w-full bg-[#1877F2] text-white hover:bg-[#0F6FE5]"
+          onClick={async () => {
+            await signInWith("facebook")
+          }}
+          type="button"
+        >
+          <FacebookIcon />
+          {t("auth.continueWithFacebook")}
+        </Button>
+      )}
+
       {providers.includes("google") && (
         <Button
           aria-label={t("auth.continueWithGoogle")}
@@ -74,20 +88,6 @@ export default function SSOSignIn({ providers }: SSOSignInProps) {
         >
           <GoogleIcon />
           {t("auth.continueWithGoogle")}
-        </Button>
-      )}
-
-      {providers.includes("facebook") && (
-        <Button
-          aria-label={t("auth.continueWithFacebook")}
-          className="w-full bg-[#1877F2] text-white hover:bg-[#0F6FE5]"
-          onClick={async () => {
-            await signInWith("facebook")
-          }}
-          type="button"
-        >
-          <FacebookIcon />
-          {t("auth.continueWithFacebook")}
         </Button>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Sign-in now opens on a method-picker screen (SSO / email / magic link) instead of showing every method at once, with a back button to return to the picker.
- Facebook is listed before Google in the SSO button order, matching its priority as the primary SSO provider.
- Adds `auth.continueWithEmail` and `auth.continueWithMagicLink` translation keys across all 18 locales.

## Changes
- `apps/builder/src/features/auth/sign-in.tsx` — method switcher UI with `activeMethod` state and back button
- `apps/builder/src/features/auth/sso-sign-in.tsx` — reorder Facebook before Google
- `apps/builder/src/components/workspace-switcher.tsx` — swap `ChevronsUpDown` for `ChevronDown`
- `apps/builder/messages/*.json` — new translation keys in all locales

## Test plan
- [x] pnpm lint (via lefthook pre-commit)
- [x] pnpm check-types (via lefthook pre-commit, all packages)
- [ ] manual verification of sign-in flow (method picker, back button, SSO order) in the browser