### PR TITLE
feat(workspace): add logo editor and store avatars as storage paths

### DIFF
--- a/apps/builder/__tests__/presigned-upload-route.test.ts
+++ b/apps/builder/__tests__/presigned-upload-route.test.ts
@@ -106,6 +106,7 @@ describe("POST /api/presigned-upload", () => {
       fileId: "file-1",
       presignedPostUrl: "https://upload.example.com/signed",
       publicUrl: "https://cdn.example.com/workspaces/1/logo.png",
+      path: "workspaces/1/logo.png",
     })
   })
 

--- a/apps/builder/messages/ar.json
+++ b/apps/builder/messages/ar.json
@@ -2572,6 +2572,9 @@
     "noWorkspaces": "ليس لديك أي مساحات عمل بعد.",
     "owner": "المالك"
   },
+  "editProfile": {
+    "title": "تعديل الملف الشخصي"
+  },
   "messages": {
     "moveFeature": "نقل {feature}",
     "poweredBy": "مدعوم من {name}",

--- a/apps/builder/messages/da.json
+++ b/apps/builder/messages/da.json
@@ -2503,6 +2503,9 @@
     "noWorkspaces": "Du don't have vilkårlig arbejdsområder yet.",
     "owner": "Owner"
   },
+  "editProfile": {
+    "title": "Rediger profil"
+  },
   "channels": {
     "title": "Kanaler",
     "duplicated": {

--- a/apps/builder/messages/de.json
+++ b/apps/builder/messages/de.json
@@ -1871,6 +1871,9 @@
     "noWorkspaces": "Sie haben noch keine Arbeitsbereiche.",
     "owner": "Inhaber"
   },
+  "editProfile": {
+    "title": "Profil bearbeiten"
+  },
   "channels": {
     "title": "Kanäle",
     "duplicated": {

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -2572,6 +2572,9 @@
     "noWorkspaces": "You don't have any workspaces yet.",
     "owner": "Owner"
   },
+  "editProfile": {
+    "title": "Edit Profile"
+  },
   "messages": {
     "moveFeature": "Move {feature}",
     "poweredBy": "Powered by {name}",

--- a/apps/builder/messages/es.json
+++ b/apps/builder/messages/es.json
@@ -2567,6 +2567,9 @@
     "noWorkspaces": "You don't tiene cualquier espacio de trabajos yet.",
     "owner": "Propietario"
   },
+  "editProfile": {
+    "title": "Editar perfil"
+  },
   "messages": {
     "moveFeature": "Mover {feature}",
     "poweredBy": "Con tecnología de {name}",

--- a/apps/builder/messages/fi.json
+++ b/apps/builder/messages/fi.json
@@ -2503,6 +2503,9 @@
     "noWorkspaces": "Sinulla ei ole vielä työtiloja.",
     "owner": "Omistaja"
   },
+  "editProfile": {
+    "title": "Muokkaa profiilia"
+  },
   "channels": {
     "title": "Kanavat",
     "duplicated": {

--- a/apps/builder/messages/fr.json
+++ b/apps/builder/messages/fr.json
@@ -1900,6 +1900,9 @@
     "noWorkspaces": "Vous n’avez pas encore d’espace de travail.",
     "owner": "Propriétaire"
   },
+  "editProfile": {
+    "title": "Modifier le profil"
+  },
   "channels": {
     "title": "Canaux",
     "duplicated": {

--- a/apps/builder/messages/he.json
+++ b/apps/builder/messages/he.json
@@ -823,6 +823,9 @@
     "noWorkspaces": "אין לכם עדיין סביבות עבודה.",
     "owner": "בעלים"
   },
+  "editProfile": {
+    "title": "עריכת פרופיל"
+  },
   "channels": {
     "title": "ערוצים",
     "duplicated": {

--- a/apps/builder/messages/id.json
+++ b/apps/builder/messages/id.json
@@ -2503,6 +2503,9 @@
     "noWorkspaces": "Anda belum memiliki ruang kerja.",
     "owner": "Pemilik"
   },
+  "editProfile": {
+    "title": "Edit Profil"
+  },
   "channels": {
     "title": "Saluran",
     "duplicated": {

--- a/apps/builder/messages/it.json
+++ b/apps/builder/messages/it.json
@@ -2249,6 +2249,9 @@
     "noWorkspaces": "Non hai ancora alcuna area di lavoro.",
     "owner": "Proprietario"
   },
+  "editProfile": {
+    "title": "Modifica profilo"
+  },
   "channels": {
     "title": "Canali",
     "duplicated": {

--- a/apps/builder/messages/ja.json
+++ b/apps/builder/messages/ja.json
@@ -3847,6 +3847,9 @@
     "noWorkspaces": "ワークスペースはまだありません。",
     "owner": "所有者"
   },
+  "editProfile": {
+    "title": "プロフィールを編集"
+  },
   "ecommerce": {
     "title": "Eコマース",
     "description": "Eコマースストアを作成・管理します。"

--- a/apps/builder/messages/nl.json
+++ b/apps/builder/messages/nl.json
@@ -2503,6 +2503,9 @@
     "noWorkspaces": "Je hebt nog geen workspaces.",
     "owner": "Eigenaar"
   },
+  "editProfile": {
+    "title": "Profiel bewerken"
+  },
   "channels": {
     "title": "Kanalen",
     "duplicated": {

--- a/apps/builder/messages/pt-BR.json
+++ b/apps/builder/messages/pt-BR.json
@@ -3847,6 +3847,9 @@
     "noWorkspaces": "Você ainda não tem nenhum espaço de trabalho.",
     "owner": "Proprietário"
   },
+  "editProfile": {
+    "title": "Editar perfil"
+  },
   "ecommerce": {
     "title": "Comércio eletrônico",
     "description": "Crie e gerencie sua loja virtual."

--- a/apps/builder/messages/pt-PT.json
+++ b/apps/builder/messages/pt-PT.json
@@ -2503,6 +2503,9 @@
     "noWorkspaces": "Ainda não tem espaços de trabalho.",
     "owner": "Proprietário"
   },
+  "editProfile": {
+    "title": "Editar perfil"
+  },
   "channels": {
     "title": "Canais",
     "duplicated": {

--- a/apps/builder/messages/ro.json
+++ b/apps/builder/messages/ro.json
@@ -558,6 +558,9 @@
     "noWorkspaces": "Nu aveți încă niciun spațiu de lucru.",
     "owner": "Proprietar"
   },
+  "editProfile": {
+    "title": "Editează profilul"
+  },
   "actions": {
     "copy": "Copiază",
     "copyUrl": "Copiază adresa URL",

--- a/apps/builder/messages/sv.json
+++ b/apps/builder/messages/sv.json
@@ -2746,6 +2746,9 @@
     "subtitle": "Välj en arbetsyta för att fortsätta där du slutade, eller skapa en ny.",
     "welcomeBack": "Välkommen tillbaka, {name}"
   },
+  "editProfile": {
+    "title": "Redigera profil"
+  },
   "inboxTeams": {
     "title": "Inkorgsteam"
   },

--- a/apps/builder/messages/tr.json
+++ b/apps/builder/messages/tr.json
@@ -2567,6 +2567,9 @@
     "noWorkspaces": "Henüz hiç çalışma alanınız yok.",
     "owner": "Sahip"
   },
+  "editProfile": {
+    "title": "Profili Düzenle"
+  },
   "messages": {
     "moveFeature": "{feature} Taşı",
     "poweredBy": "{name} tarafından desteklenmektedir",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -2572,6 +2572,9 @@
     "noWorkspaces": "Bạn chưa có không gian làm việc nào.",
     "owner": "Chủ sở hữu"
   },
+  "editProfile": {
+    "title": "Chỉnh sửa hồ sơ"
+  },
   "messages": {
     "moveFeature": "Di chuyển {feature}",
     "poweredBy": "Được cung cấp bởi {name}",

--- a/apps/builder/src/app/api/presigned-upload/route.ts
+++ b/apps/builder/src/app/api/presigned-upload/route.ts
@@ -56,9 +56,24 @@ export async function POST(req: NextRequest) {
           { status: 400 },
         )
       }
-      const user = await getCurrentUser()
-      if (!(user && (await isPlatformAdmin(user)))) {
-        return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+
+      // A user's own avatar is scoped to their own storage namespace by
+      // genericHandler (public/platform/${userId}/...), so any authenticated
+      // user may upload one without the platform-admin gate that otherwise
+      // protects workspace-less uploads (e.g. platform branding assets).
+      const isOwnAvatarUpload = input.path?.startsWith("avatar/")
+      if (isOwnAvatarUpload) {
+        if (!input.mimeType.startsWith("image/")) {
+          return NextResponse.json(
+            { error: "Avatar uploads must be an image" },
+            { status: 400 },
+          )
+        }
+      } else {
+        const user = await getCurrentUser()
+        if (!(user && (await isPlatformAdmin(user)))) {
+          return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+        }
       }
       const domain = await getDomainFromHeader()
       ;({ storageUrl } = await resolveTenantSettingsByDomain(domain))
@@ -101,6 +116,7 @@ export async function POST(req: NextRequest) {
       fileId,
       presignedPostUrl,
       publicUrl,
+      path,
     })
   } catch (error) {
     return serverErrorHandler(error)

--- a/apps/builder/src/components/avatar-upload-field.tsx
+++ b/apps/builder/src/components/avatar-upload-field.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@chatbotx.io/ui/components/ui/avatar"
+import { Button } from "@chatbotx.io/ui/components/ui/button"
+import { DirectUploadButton } from "@chatbotx.io/ui/components/uploader/direct-upload-button"
+import { cn } from "@chatbotx.io/ui/lib/utils"
+import { useRef } from "react"
+import { toast } from "sonner"
+
+type AvatarUploadFieldProps = {
+  previewUrl: string | undefined
+  alt: string
+  fallbackText: string
+  uploadPath: string
+  workspaceId?: string
+  uploadLabel: string
+  onUploaded: (path: string) => void
+  shape: "circle" | "rounded"
+}
+
+export function AvatarUploadField({
+  previewUrl,
+  alt,
+  fallbackText,
+  uploadPath,
+  workspaceId,
+  uploadLabel,
+  onUploaded,
+  shape,
+}: AvatarUploadFieldProps) {
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+
+  return (
+    <>
+      <DirectUploadButton
+        accept="image/*"
+        className="hidden"
+        label={uploadLabel}
+        maxSize={10_485_760}
+        multiple={false}
+        onUploadError={(error) => {
+          toast.error(error.message)
+        }}
+        onUploadSuccess={(filePath) => {
+          onUploaded(filePath)
+        }}
+        triggerRef={triggerRef}
+        uploadPath={uploadPath}
+        workspaceId={workspaceId}
+      />
+      <Button
+        className={cn(
+          "relative size-16",
+          shape === "circle" && "rounded-full p-0",
+        )}
+        onClick={() => triggerRef.current?.click()}
+        type="button"
+        variant="ghost"
+      >
+        <Avatar
+          className={cn("size-16", shape === "rounded" && "rounded-lg border")}
+        >
+          <AvatarImage alt={alt} src={previewUrl ?? ""} />
+          <AvatarFallback className="text-sm">{fallbackText}</AvatarFallback>
+        </Avatar>
+      </Button>
+    </>
+  )
+}

--- a/apps/builder/src/components/nav-user.tsx
+++ b/apps/builder/src/components/nav-user.tsx
@@ -33,6 +33,8 @@ import { useState } from "react"
 import { UpgradePlanDialog } from "@/enterprise/features/billing/upgrade-plan-dialog"
 import { isCloud } from "@/env"
 import { SignOut } from "@/features/auth/sign-out"
+import { EditProfileDialog } from "@/features/workspaces/components/edit-profile-dialog"
+import { useUserAvatarUrl } from "@/lib/auth/avatar"
 import { LangSelector } from "./lang-selector"
 import { ThemeSwitcher } from "./theme-switcher"
 
@@ -54,6 +56,7 @@ export function NavUser({
   const { isMobile } = useSidebar()
   const t = useTranslations()
   const [upgradeOpen, setUpgradeOpen] = useState(false)
+  const avatarUrl = useUserAvatarUrl(user.avatar)
 
   return (
     <SidebarMenu>
@@ -69,7 +72,7 @@ export function NavUser({
                 size="lg"
               >
                 <Avatar className="h-8 w-8 rounded-lg">
-                  <AvatarImage alt={user.name} src={user.avatar} />
+                  <AvatarImage alt={user.name} src={avatarUrl ?? ""} />
                   <AvatarFallback className="rounded-lg">
                     {user.name.slice(0, 2) || "  "}
                   </AvatarFallback>
@@ -94,7 +97,7 @@ export function NavUser({
               <DropdownMenuLabel className="p-0 font-normal">
                 <div className="flex items-center gap-2 px-1 py-1.5 text-start text-sm">
                   <Avatar className="h-8 w-8 rounded-lg">
-                    <AvatarImage alt={user.name} src={user.avatar} />
+                    <AvatarImage alt={user.name} src={avatarUrl ?? ""} />
                     <AvatarFallback className="rounded-lg">
                       {user.name.slice(0, 2) || "  "}
                     </AvatarFallback>
@@ -105,6 +108,14 @@ export function NavUser({
                       {user.email}
                     </span>
                   </div>
+                  <EditProfileDialog
+                    className="ms-auto shrink-0"
+                    user={{
+                      name: user.name,
+                      email: user.email,
+                      image: user.avatar,
+                    }}
+                  />
                 </div>
               </DropdownMenuLabel>
             </DropdownMenuGroup>

--- a/apps/builder/src/enterprise/features/audit-logs/audit-logs-table-columns.tsx
+++ b/apps/builder/src/enterprise/features/audit-logs/audit-logs-table-columns.tsx
@@ -13,7 +13,37 @@ import {
 } from "@chatbotx.io/ui/components/ui/tooltip"
 import type { ColumnDef } from "@tanstack/react-table"
 import { format } from "date-fns"
+import { useUserAvatarUrl } from "@/lib/auth/avatar"
 import type { AuditLogResource } from "./schemas"
+
+function AuditUserCell({
+  user,
+}: {
+  user: NonNullable<AuditLogResource["user"]>
+}) {
+  const avatarUrl = useUserAvatarUrl(user.image)
+
+  return (
+    <div className="flex items-center gap-2">
+      <Avatar className="size-6">
+        <AvatarImage alt="userImage" src={avatarUrl ?? ""} />
+        <AvatarFallback>{user.name?.[0]}</AvatarFallback>
+      </Avatar>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <div className="inline-block max-w-[200px] truncate">
+              {user.name}
+            </div>
+          }
+        />
+        <TooltipContent>
+          <p>{user.name}</p>
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  )
+}
 
 export function getAuditColumns(): ColumnDef<AuditLogResource>[] {
   return [
@@ -25,27 +55,7 @@ export function getAuditColumns(): ColumnDef<AuditLogResource>[] {
       cell: ({ row }) => (
         <div>
           {row.original.user ? (
-            <div className="flex items-center gap-2">
-              <Avatar className="size-6">
-                <AvatarImage
-                  alt="userImage"
-                  src={row.original.user.image || undefined}
-                />
-                <AvatarFallback>{row.original.user.name?.[0]}</AvatarFallback>
-              </Avatar>
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <div className="inline-block max-w-[200px] truncate">
-                      {row.original.user.name}
-                    </div>
-                  }
-                />
-                <TooltipContent>
-                  <p>{row.original.user.name}</p>
-                </TooltipContent>
-              </Tooltip>
-            </div>
+            <AuditUserCell user={row.original.user} />
           ) : null}
         </div>
       ),

--- a/apps/builder/src/features/conversations/conversation-item.tsx
+++ b/apps/builder/src/features/conversations/conversation-item.tsx
@@ -24,6 +24,7 @@ import { useTranslations } from "next-intl"
 import { useAction } from "next-safe-action/hooks"
 import { useEffect, useMemo } from "react"
 import { toast } from "sonner"
+import { useUserAvatarUrl } from "@/lib/auth/avatar"
 import { useChatStore } from "../chat/store/chat-store-provider"
 import { useAvatarUrl } from "../contacts/utils"
 import { InboxIcon } from "../inboxes/components/inbox-icon"
@@ -36,14 +37,17 @@ type ConversationItemProps = {
   onSelect: () => void
 }
 
-const assignedIcon = (conversation: ListConversationItemResource) => {
+const assignedIcon = (
+  conversation: ListConversationItemResource,
+  assignedAvatarUrl: string | undefined,
+) => {
   if (conversation.assignedUserId) {
     return (
       <Tooltip>
         <TooltipTrigger
           render={
             <Avatar className="size-4">
-              <AvatarImage src={conversation.assignedUser?.image ?? ""} />
+              <AvatarImage src={assignedAvatarUrl ?? ""} />
 
               <AvatarFallback className="text-[0.5rem]">
                 {conversation.assignedUser?.name?.slice(0, 2) ?? " "}
@@ -80,6 +84,7 @@ export default function ConversationItem({
   const isActive = conversation.id === activeConversationId
   const isComment = conversation.messages?.[0]?.type === "comment"
   const avatarUrl = useAvatarUrl(conversation.contact)
+  const assignedAvatarUrl = useUserAvatarUrl(conversation.assignedUser?.image)
   const previewText = resolveLastMessagePreview(conversation.messages?.[0], t)
   const isUnread = Boolean(
     conversation.agentLastReadAt &&
@@ -144,7 +149,7 @@ export default function ConversationItem({
         <div className="relative">
           {contactAvatar}
           <div className="absolute start-0 bottom-0 transform">
-            {assignedIcon(conversation)}
+            {assignedIcon(conversation, assignedAvatarUrl)}
           </div>
           <div className="absolute end-0 bottom-0 transform">
             {conversation.contactInboxes?.map((contactInbox) => (

--- a/apps/builder/src/features/tenant/utils.ts
+++ b/apps/builder/src/features/tenant/utils.ts
@@ -2,9 +2,10 @@ import {
   resolveTenantSettingsByDomain,
   type TenantSettings,
 } from "@chatbotx.io/business"
+import { cache } from "react"
 import { getDomainFromHeader } from "@/lib/domain"
 
-export const getTenantSettings = async (): Promise<TenantSettings> => {
+export const getTenantSettings = cache(async (): Promise<TenantSettings> => {
   const domain = await getDomainFromHeader()
   return resolveTenantSettingsByDomain(domain)
-}
+})

--- a/apps/builder/src/features/workspace-members/workspace-members-table.tsx
+++ b/apps/builder/src/features/workspace-members/workspace-members-table.tsx
@@ -31,6 +31,7 @@ import {
 } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { use, useMemo, useState } from "react"
+import { useUserAvatarUrl } from "@/lib/auth/avatar"
 import { DeleteWorkspaceMemberDialog } from "./components/delete-workspace-member"
 import { InviteWorkspaceMemberDialog } from "./components/invite-workspace-member"
 import { UpdateWorkspaceMemberDialog } from "./components/update-workspace-member"
@@ -40,6 +41,38 @@ import type { ListWorkspaceMembersResponse } from "./schema/query"
 type WorkspaceMembersTableProps = {
   promises: Promise<[Awaited<ReturnType<typeof listWorkspaceMembers>>]>
   teamMembersAtLimit?: boolean
+}
+
+function MemberNameCell({
+  member,
+}: {
+  member: ListWorkspaceMembersResponse["data"][number]
+}) {
+  const avatarUrl = useUserAvatarUrl(member.user.image)
+
+  return (
+    <div className="flex items-center gap-2">
+      <Avatar className="size-7 justify-items-center">
+        <AvatarImage alt="avatar" src={avatarUrl ?? ""} />
+        <AvatarFallback>
+          {(member.user.name || "").charAt(0).toUpperCase()}
+        </AvatarFallback>
+      </Avatar>
+
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <div className="inline-block max-w-[200px] truncate">
+              {member.user.name}
+            </div>
+          }
+        />
+        <TooltipContent>
+          <p>{member.user.name}</p>
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  )
 }
 
 const renderPermissionCell = (enabled: boolean) =>
@@ -104,32 +137,7 @@ export function WorkspaceMembersTable({
             title={t("fields.name.label")}
           />
         ),
-        cell: ({ row }) => (
-          <div className="flex items-center gap-2">
-            <Avatar className="size-7 justify-items-center">
-              <AvatarImage
-                alt="avatar"
-                src={row.original.user.image ?? undefined}
-              />
-              <AvatarFallback>
-                {(row.original.user.name || "").charAt(0).toUpperCase()}
-              </AvatarFallback>
-            </Avatar>
-
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <div className="inline-block max-w-[200px] truncate">
-                    {row.original.user.name}
-                  </div>
-                }
-              />
-              <TooltipContent>
-                <p>{row.original.user.name}</p>
-              </TooltipContent>
-            </Tooltip>
-          </div>
-        ),
+        cell: ({ row }) => <MemberNameCell member={row.original} />,
         enableHiding: false,
       },
       {

--- a/apps/builder/src/features/workspaces/components/account-rail.tsx
+++ b/apps/builder/src/features/workspaces/components/account-rail.tsx
@@ -12,8 +12,11 @@ import { UsageBars } from "@/components/usage-bars"
 import { UpgradePlanButton } from "@/enterprise/features/billing/upgrade-plan-dialog"
 import { isCloud } from "@/env"
 import { SignOut } from "@/features/auth/sign-out"
+import { getTenantSettings } from "@/features/tenant/utils"
+import { getUserAvatarUrl } from "@/lib/auth/avatar"
 import { buildPlanNotice, buildUsageLabels } from "@/lib/quota-metrics"
 import { resolveTrialMessage, trialMessageClassName } from "@/lib/trial-message"
+import { EditProfileDialog } from "./edit-profile-dialog"
 
 type AccountRailProps = {
   user: {
@@ -39,19 +42,23 @@ export const AccountRail = async ({
   isSuperAdmin = false,
   isPlatformAdmin = false,
 }: AccountRailProps) => {
-  const t = await getTranslations()
+  const [t, { storageUrl }] = await Promise.all([
+    getTranslations(),
+    getTenantSettings(),
+  ])
   const cloud = isCloud()
   const notice = buildPlanNotice(planStatus, trialEndsAt)
   const displayName = user.name?.trim() || user.email
   const initials = displayName.slice(0, 2).toUpperCase()
+  const avatarUrl = getUserAvatarUrl(user.image, storageUrl)
 
   const usageLabels = buildUsageLabels(t)
 
   return (
     <aside className="flex w-full shrink-0 flex-col gap-2 rounded-xl border bg-card p-6 md:w-72">
-      <div className="flex items-center gap-3">
+      <div className="relative flex items-center gap-3">
         <Avatar className="size-11">
-          <AvatarImage alt={displayName} src={user.image ?? ""} />
+          <AvatarImage alt={displayName} src={avatarUrl ?? ""} />
           <AvatarFallback className="rounded-full text-sm">
             {initials}
           </AvatarFallback>
@@ -62,6 +69,7 @@ export const AccountRail = async ({
             {user.email}
           </span>
         </div>
+        <EditProfileDialog className="absolute inset-e-0 top-0" user={user} />
       </div>
 
       {cloud && (

--- a/apps/builder/src/features/workspaces/components/edit-profile-dialog.tsx
+++ b/apps/builder/src/features/workspaces/components/edit-profile-dialog.tsx
@@ -1,0 +1,155 @@
+"use client"
+
+import { InputField } from "@chatbotx.io/ui/components/form/input-field"
+import { Button } from "@chatbotx.io/ui/components/ui/button"
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@chatbotx.io/ui/components/ui/dialog"
+import { Form } from "@chatbotx.io/ui/components/ui/form"
+import { Label } from "@chatbotx.io/ui/components/ui/label"
+import { cn } from "@chatbotx.io/ui/lib/utils"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Loader2Icon, PencilIcon } from "lucide-react"
+import { useRouter } from "next/navigation"
+import { useTranslations } from "next-intl"
+import { useState } from "react"
+import { useForm } from "react-hook-form"
+import { toast } from "sonner"
+import { z } from "zod"
+import { AvatarUploadField } from "@/components/avatar-upload-field"
+import { authClient } from "@/lib/auth/auth-client"
+import { useUserAvatarUrl } from "@/lib/auth/avatar"
+
+const editProfileSchema = z.object({
+  name: z.string().trim().min(1),
+  image: z.string().nullable(),
+})
+
+type EditProfileDialogProps = {
+  user: { name: string | null; email: string; image: string | null }
+  className?: string
+  triggerClassName?: string
+}
+
+export function EditProfileDialog({
+  user,
+  className,
+  triggerClassName,
+}: EditProfileDialogProps) {
+  const t = useTranslations()
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+
+  const form = useForm({
+    resolver: zodResolver(editProfileSchema),
+    defaultValues: {
+      name: user.name ?? "",
+      image: user.image,
+    },
+  })
+
+  const image = form.watch("image")
+  const avatarUrl = useUserAvatarUrl(image)
+  const displayName = form.watch("name")?.trim() || user.email
+  const initials = displayName.slice(0, 2).toUpperCase()
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    const { error } = await authClient.updateUser({
+      name: values.name,
+      image: values.image,
+    })
+
+    if (error) {
+      toast.error(error.message)
+      return
+    }
+
+    toast.success(
+      t("messages.updatedSuccess", { feature: t("editProfile.title") }),
+    )
+    setOpen(false)
+    router.refresh()
+  })
+
+  return (
+    <Dialog
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen)
+        if (nextOpen) {
+          form.reset({ name: user.name ?? "", image: user.image })
+        }
+      }}
+      open={open}
+    >
+      <DialogTrigger
+        render={
+          <Button
+            className={cn(className, triggerClassName)}
+            size="icon"
+            variant="outline"
+          >
+            <PencilIcon aria-hidden className="size-4" />
+            <span className="sr-only">{t("actions.edit")}</span>
+          </Button>
+        }
+      />
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("editProfile.title")}</DialogTitle>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form className="flex flex-col gap-4" onSubmit={onSubmit}>
+            <div className="flex flex-col items-center gap-2">
+              <AvatarUploadField
+                alt={displayName}
+                fallbackText={initials}
+                onUploaded={(filePath) => {
+                  form.setValue("image", filePath, { shouldDirty: true })
+                }}
+                previewUrl={avatarUrl}
+                shape="circle"
+                uploadLabel={t("actions.uploadFile")}
+                uploadPath="avatar"
+              />
+              <Label className="text-muted-foreground text-xs">
+                {t("fields.avatar.label")}
+              </Label>
+            </div>
+
+            <InputField
+              label={t("fields.name.label")}
+              name="name"
+              placeholder={t("fields.name.placeholder")}
+            />
+
+            <div className="flex items-center justify-end gap-2">
+              <DialogClose
+                render={
+                  <Button size="sm" type="button" variant="ghost">
+                    {t("actions.cancel")}
+                  </Button>
+                }
+              />
+              <Button
+                disabled={form.formState.isSubmitting}
+                size="sm"
+                type="submit"
+              >
+                {form.formState.isSubmitting && (
+                  <Loader2Icon className="animate-spin" />
+                )}
+                {t("actions.save")}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/builder/src/features/workspaces/helpers.ts
+++ b/apps/builder/src/features/workspaces/helpers.ts
@@ -1,4 +1,5 @@
 import { SMART_RESPONSE_DELAY_OPTIONS } from "@chatbotx.io/database/partials"
+import { getPublicFileUrl } from "@chatbotx.io/utils"
 import type { useTranslations } from "next-intl"
 import { useTenantSettings } from "@/features/tenant"
 import type { WorkspaceResource } from "./schema/resource"
@@ -17,7 +18,7 @@ export function getWorkspaceLogoUrl(
   storageUrl: string,
 ): string | undefined {
   return workspace?.logo
-    ? new URL(workspace.logo, storageUrl).toString()
+    ? getPublicFileUrl(workspace.logo, storageUrl)
     : undefined
 }
 

--- a/apps/builder/src/features/workspaces/schema/update-workspace-schema.ts
+++ b/apps/builder/src/features/workspaces/schema/update-workspace-schema.ts
@@ -33,6 +33,7 @@ const smartResponseDelaySecondsSchema = z
 
 export const updateWorkspaceBasicRequest = z.object({
   name: z.string().min(1).max(255),
+  logo: z.string().nullish(),
 })
 export type UpdateWorkspaceBasicRequest = z.infer<
   typeof updateWorkspaceBasicRequest

--- a/apps/builder/src/features/workspaces/update-workspace-basic-form.tsx
+++ b/apps/builder/src/features/workspaces/update-workspace-basic-form.tsx
@@ -12,10 +12,13 @@ import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { toast } from "sonner"
 import { useCopyToClipboard } from "usehooks-ts"
+import { AvatarUploadField } from "@/components/avatar-upload-field"
 import { SettingRow } from "@/components/setting-row"
+import { useTenantSettings } from "@/features/tenant"
 import type { WorkspaceResource } from "@/features/workspaces/schema/resource"
 import { authClient } from "@/lib/auth/auth-client"
 import { updateWorkspaceBasicAction } from "./actions/update-workspace-action"
+import { getWorkspaceLogoUrl } from "./helpers"
 import { updateWorkspaceBasicRequest } from "./schema/update-workspace-schema"
 
 export function UpdateWorkspaceBasicForm({
@@ -27,6 +30,7 @@ export function UpdateWorkspaceBasicForm({
   const router = useRouter()
 
   const session = authClient.useSession()
+  const { storageUrl } = useTenantSettings()
 
   const [_, copyToClipboard] = useCopyToClipboard()
   const onCopy = (value: string) => {
@@ -58,11 +62,18 @@ export function UpdateWorkspaceBasicForm({
         mode: "onChange",
         defaultValues: {
           name: workspace.name,
+          logo: workspace.logo,
         },
       },
       errorMapProps: {},
     },
   )
+
+  const nameValue = form.watch("name")
+  const logoPath = form.watch("logo")
+  const logoUrl = getWorkspaceLogoUrl({ logo: logoPath ?? null }, storageUrl)
+  const displayName = nameValue?.trim() || workspace.name
+  const initials = displayName.slice(0, 2).toUpperCase()
 
   return (
     <Card>
@@ -106,6 +117,23 @@ export function UpdateWorkspaceBasicForm({
 
             <SettingRow description={""} label={t("fields.name.label")}>
               <InputField name="name" />
+            </SettingRow>
+
+            <SettingRow description={""} label={t("fields.logo.label")}>
+              <div className="flex items-center gap-3">
+                <AvatarUploadField
+                  alt={displayName}
+                  fallbackText={initials}
+                  onUploaded={(filePath) => {
+                    form.setValue("logo", filePath, { shouldDirty: true })
+                  }}
+                  previewUrl={logoUrl}
+                  shape="rounded"
+                  uploadLabel={t("actions.uploadFile")}
+                  uploadPath={`public/space/${workspace.id}/logos`}
+                  workspaceId={workspace.id}
+                />
+              </div>
             </SettingRow>
 
             <div className="flex justify-start">

--- a/apps/builder/src/lib/auth/avatar.ts
+++ b/apps/builder/src/lib/auth/avatar.ts
@@ -1,0 +1,16 @@
+import { getPublicFileUrl } from "@chatbotx.io/utils"
+import { useTenantSettings } from "@/features/tenant"
+
+export function getUserAvatarUrl(
+  image: string | null | undefined,
+  storageUrl: string,
+): string | undefined {
+  return image ? getPublicFileUrl(image, storageUrl) : undefined
+}
+
+export function useUserAvatarUrl(
+  image: string | null | undefined,
+): string | undefined {
+  const { storageUrl } = useTenantSettings()
+  return getUserAvatarUrl(image, storageUrl)
+}

--- a/packages/ui/src/components/uploader/direct-upload-button.tsx
+++ b/packages/ui/src/components/uploader/direct-upload-button.tsx
@@ -108,7 +108,11 @@ export function DirectUploadButton({
               xhr.addEventListener("load", () => {
                 if (xhr.status >= 200 && xhr.status < 300) {
                   onSuccess(file)
-                  onUploadSuccess?.(filePath, file, presignedPost.publicUrl)
+                  onUploadSuccess?.(
+                    presignedPost.path,
+                    file,
+                    presignedPost.publicUrl,
+                  )
                   resolve()
                 } else {
                   const error = new Error(


### PR DESCRIPTION
## Summary
- Adds a workspace logo upload field to workspace settings (next to the workspace name field), reusing the existing presigned-upload flow.
- Refactors both workspace logo and user avatar storage to keep a relative storage path in the DB, resolved to a full URL only at render time (`getUserAvatarUrl`/`getWorkspaceLogoUrl`), so the storage backend can change later without a data migration. Legacy rows already storing a full URL keep working unchanged.
- Folds in fixes surfaced by a `/code-review high` pass on this change: a broken test, a presigned-upload security gap, a stale-draft dialog bug, duplicated picker UI, and a redundant tenant-settings lookup.

## Changes
- `apps/builder/src/features/workspaces/update-workspace-basic-form.tsx` / `schema/update-workspace-schema.ts` / `actions` — new `logo` field on the workspace basic-settings form.
- `apps/builder/src/lib/auth/avatar.ts` (new) — `getUserAvatarUrl`/`useUserAvatarUrl`, mirroring the existing workspace-logo helper pattern.
- `apps/builder/src/features/workspaces/components/edit-profile-dialog.tsx` (new/refactored), `apps/builder/src/components/avatar-upload-field.tsx` (new) — shared avatar/logo upload-picker component; dialog now resets its form when reopened so a cancelled draft doesn't reappear.
- Display sites updated to resolve avatar paths at render time instead of storing/reading full URLs: `nav-user.tsx`, `account-rail.tsx`, `conversation-item.tsx`, `workspace-members-table.tsx`, `audit-logs-table-columns.tsx`.
- `apps/builder/src/app/api/presigned-upload/route.ts` — now returns the server-resolved `path` (previously declared in the response schema but never sent, so `DirectUploadButton` had to guess it client-side — wrong for the one upload path that gets server-side rewritten); the avatar-upload exemption from the platform-admin gate now also requires an image mimeType.
- `apps/builder/src/features/tenant/utils.ts` — `getTenantSettings` memoized per-request via React `cache()`, since `AccountRail` now calls it in addition to the root layout.
- `packages/ui/src/components/uploader/direct-upload-button.tsx` — `onUploadSuccess`'s first argument is now the real server-resolved path.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [x] `pnpm --filter @chatbotx.io/ui check-types`
- [x] `apps/builder/__tests__/presigned-upload-route.test.ts` passes
- [ ] Manual: workspace settings → upload a logo, save, reload, confirm it persists and renders
- [ ] Manual: sidebar avatar menu → edit profile, upload avatar, Cancel, reopen — confirm original avatar/name shown, not the discarded draft
- [ ] Manual: confirm a presigned-upload POST for an avatar path with a non-image mimeType is rejected with 400