### PR TITLE
fix(worker): use correct schema field for addContactNotes step

### DIFF
--- a/apps/worker/src/integration/handlers/contact.ts
+++ b/apps/worker/src/integration/handlers/contact.ts
@@ -19,8 +19,8 @@ import {
   emitTagRemoved,
 } from "@chatbotx.io/events"
 import type {
+  AddContactNotesStepSchema,
   AddContactTagStepSchema,
-  AddNotesStepSchema,
   ClearCustomFieldStepSchema,
   DeleteContactStepSchema,
   MarkEmailVerifiedStepSchema,
@@ -86,10 +86,10 @@ export async function clearContactCustomField({
 export async function addContactNotes({
   conversation,
   step,
-}: ExecuteStepProps<AddNotesStepSchema>) {
+}: ExecuteStepProps<AddContactNotesStepSchema>) {
   await db.insert(contactNoteModel).values({
     contactId: conversation.contactId,
-    text: step.text,
+    text: step.content,
     id: createId(),
   })
 }


### PR DESCRIPTION
## Summary
- `addContactNotes` (registered for `stepTypes.enum.addContactNotes` in `apps/worker/src/integration/handlers/step.ts`) was typed against `AddNotesStepSchema`, the legacy `addNotes` step, and read `step.text`.
- The builder actually creates `AddContactNotesStepSchema` objects (field `content`) when a button's "add note" action is used, so `step.text` resolved to `undefined`.
- Drizzle wrote SQL `DEFAULT` for the missing value, violating the NOT NULL constraint on `ContactNote.text` and failing the job — confirmed against a real failed job log.

## Changes
- `apps/worker/src/integration/handlers/contact.ts`: switch `addContactNotes`'s prop type to `AddContactNotesStepSchema` and read `step.content` instead of `step.text`.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter worker check-types`
- [ ] manual verification: trigger a button with an "add note" action attached and confirm the note is saved without job failure