### PR TITLE
fix(flow): resolve button/quickReply target when continuing multi-step chain

### DIFF
--- a/apps/worker/src/integration/handlers/flow.ts
+++ b/apps/worker/src/integration/handlers/flow.ts
@@ -157,19 +157,46 @@ export const runFlowNode = async (props: IntegrationJobRunFlowNode["data"]) => {
     workspaceId: conversation.workspaceId,
   })
 
-  // Process to find start node. Try to find by nodeId first, if not found, try to find by isStartNode.
-  let targetNode: FlowNode | null | undefined = null
-  if (props.nodeId) {
-    targetNode = (flowVersion.nodes as unknown as FlowNode[]).find(
-      (n) => n.id === props.nodeId,
-    )
+  const nodes = flowVersion.nodes as unknown as FlowNode[]
+
+  // A re-dispatched job continuing a button/quickReply's own multi-step chain
+  // (executeMultipleStepsGenerator's one-step-per-job loop) carries its target
+  // explicitly. Resolving by nodeId alone would land on the containing node's
+  // details instead of the button/quickReply's, and startFromStepId would
+  // never match one of the node's own step ids.
+  let details: ExecuteStepsAndQuickRepliesProps["details"]
+  let targetType: ExecuteStepsAndQuickRepliesProps["targetType"]
+  let targetId: string
+  let targetNodeId: string
+
+  if (
+    props.targetType === flowActionTargetTypes.button ||
+    props.targetType === flowActionTargetTypes.quickReply
+  ) {
+    const resolved = props.targetId
+      ? resolveFlowActionTarget(nodes, props.targetId)
+      : null
+    if (!resolved) {
+      throw new SdkException(
+        "FlowVersion does not contain the button/quickReply target",
+      )
+    }
+    details = resolved.details
+    targetType = resolved.targetType
+    targetId = resolved.details.id
+    targetNodeId = resolved.nodeId ?? props.nodeId ?? ""
   } else {
-    targetNode = (flowVersion.nodes as unknown as FlowNode[]).find(
-      (n) => n.data.isStartNode,
-    )
-  }
-  if (!targetNode) {
-    throw new SdkException("FlowVersion does not contain start node")
+    // Process to find start node. Try to find by nodeId first, if not found, try to find by isStartNode.
+    const targetNode = props.nodeId
+      ? nodes.find((n) => n.id === props.nodeId)
+      : nodes.find((n) => n.data.isStartNode)
+    if (!targetNode) {
+      throw new SdkException("FlowVersion does not contain start node")
+    }
+    details = targetNode.data.details
+    targetType = "node"
+    targetId = targetNode.id
+    targetNodeId = targetNode.id
   }
 
   try {
@@ -178,10 +205,10 @@ export const runFlowNode = async (props: IntegrationJobRunFlowNode["data"]) => {
       contactInbox,
       flowVersion,
       useLatestFlowVersion,
-      details: targetNode.data.details,
-      targetType: "node",
-      targetId: targetNode.id,
-      targetNodeId: targetNode.id,
+      details,
+      targetType,
+      targetId,
+      targetNodeId,
       startFromStepId: props.startFromStepId,
       ctx: {
         variables: initVariables(),
@@ -354,6 +381,14 @@ export async function runStepsAndQuickReplies(
             ? undefined
             : flowVersion.id,
           nodeId: props.targetNodeId,
+          targetType:
+            targetType === "button" || targetType === "quickReply"
+              ? targetType
+              : undefined,
+          targetId:
+            targetType === "button" || targetType === "quickReply"
+              ? targetId
+              : undefined,
           startFromStepId: nextStep.id,
           metadata: props.metadata,
           trackingContext: props.trackingContext,

--- a/packages/worker-config/src/queues/integration/index.ts
+++ b/packages/worker-config/src/queues/integration/index.ts
@@ -2,7 +2,10 @@ import type {
   ContactInboxModel,
   ConversationModel,
 } from "@chatbotx.io/database/types"
-import type { MetadataPayload } from "@chatbotx.io/flow-config"
+import type {
+  FlowActionTargetType,
+  MetadataPayload,
+} from "@chatbotx.io/flow-config"
 import type { CommentAnchor, OutgoingMessage } from "@chatbotx.io/sdk"
 import { Queue } from "bullmq"
 import {
@@ -124,6 +127,15 @@ export type IntegrationJobRunFlowNode = {
     flowVersionId?: string
     nodeId?: string
     startFromStepId?: string
+    /**
+     * Set when this job resumes a button/quickReply's own multi-step chain
+     * (one step per job) rather than a node's. Without it, resolving by
+     * `nodeId` alone lands on the containing node's details instead of the
+     * button/quickReply's, and `startFromStepId` never matches — see
+     * `runFlowNode`.
+     */
+    targetType?: FlowActionTargetType
+    targetId?: string
     nodeVisits?: NodeVisits
     trackingContext?: BotResponseTrackingContext
     metadata?: MetadataPayload


### PR DESCRIPTION
## Summary
- Tapping a button (e.g. "Bắt đầu nút khác" / `startAnotherNode`) with 2+ action steps attached (add tag, set field, subscribe sequence, ...) silently stopped executing and never advanced to the next node. A button with 0-1 steps worked fine.
- Root cause: `executeMultipleStepsGenerator` dispatches one `sendFlow` BullMQ job per remaining step, but the re-dispatch only carried `nodeId`. `runFlowNode` resolved the target purely by `nodeId`, landing on the **containing node's** `details` instead of the **button/quickReply's own** `details` — correct for a node's own multi-step chain, wrong for a button/quickReply's. `startFromStepId` then never matched any id in the (wrong) steps array, and `runStepsAndQuickReplies` returned early before ever reaching the edge-follow that advances to the next node.

## Changes
- `packages/worker-config/src/queues/integration/index.ts`: add optional `targetType`/`targetId` to `IntegrationJobRunFlowNode["data"]`.
- `apps/worker/src/integration/handlers/flow.ts`: `runFlowNode` now resolves the target via the existing `resolveFlowActionTarget` helper when the job carries `targetType: "button" | "quickReply"`, instead of assuming `nodeId` always points at a node. The re-dispatch call site passes these two fields through when continuing a button/quickReply's own step chain.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter worker check-types`
- [ ] manual verification: tap a `startAnotherNode` button with 2+ action steps attached and confirm all steps run and the flow advances to the next node