### PR TITLE
fix(messenger): normalize missing workspaceId to undefined in connect route

### DIFF
--- a/apps/builder/src/app/(no-sidebar)/channels/create/messenger/route.ts
+++ b/apps/builder/src/app/(no-sidebar)/channels/create/messenger/route.ts
@@ -27,7 +27,7 @@ import {
  * guards itself since it's a public GET endpoint, not just an internal helper.
  */
 export async function GET(req: NextRequest) {
-  const workspaceId = req.nextUrl.searchParams.get("workspaceId")
+  const workspaceId = req.nextUrl.searchParams.get("workspaceId") ?? undefined
 
   if (workspaceId) {
     await requireWorkspacePermission(workspaceId, "superAdmin")


### PR DESCRIPTION
## Summary
- Onboarding Messenger connect (new workspace, no `workspaceId` yet) 404'd right after Facebook redirected back with the OAuth code.
- Root cause: `/channels/create/messenger/route.ts` read `workspaceId` via `req.nextUrl.searchParams.get("workspaceId")`, which returns `null` (not `undefined`) when the param is absent. `null` survives `JSON.stringify` into the OAuth `state` param (`"workspaceId":null`), while every other channel (Instagram, Zalo, TikTok, ...) builds this value through `getIdFromParams`, which yields `undefined` — dropped entirely by `stringify`. The callback's state schema only allowed the field to be *omitted*, so an explicit `null` failed validation and the callback returned `notFound()`.
- Fix: normalize the missing param to `undefined` at the read site (`?? undefined`), matching the pattern already used by every other channel's create route. Scoped to the Messenger route only — no change to the shared OAuth callback validation.

## Test plan
- [x] `pnpm --filter builder check-types`
- [ ] Manually verify: create a brand-new workspace, choose Messenger, complete the Facebook OAuth flow, confirm it lands on the Page picker instead of 404