### PR TITLE
fix(conversations): show assigned name in tooltip instead of raw text

### DIFF
--- a/apps/builder/messages/ar.json
+++ b/apps/builder/messages/ar.json
@@ -156,7 +156,8 @@
     "assignConversation": "إسناد المحادثة",
     "assignedToMe": "مسندة إليّ",
     "assignedTo": "مسندة إلى {name}",
-    "unAssigned": "غير مسندة"
+    "unAssigned": "غير مسندة",
+    "user": "مستخدم"
   },
   "aiAgent": {
     "defaultAgent": "الوكيل الافتراضي",

--- a/apps/builder/messages/da.json
+++ b/apps/builder/messages/da.json
@@ -156,7 +156,8 @@
     "assignConversation": "Tildel samtale",
     "assignedToMe": "Tildelt mig",
     "assignedTo": "Tildelt til {name}",
-    "unAssigned": "Ikke tildelt"
+    "unAssigned": "Ikke tildelt",
+    "user": "Bruger"
   },
   "aiAgent": {
     "defaultAgent": "Standardagent",

--- a/apps/builder/messages/de.json
+++ b/apps/builder/messages/de.json
@@ -150,7 +150,8 @@
     "assignConversation": "Unterhaltung zuweisen",
     "assignedToMe": "Mir zugewiesen",
     "assignedTo": "{name} zugewiesen",
-    "unAssigned": "Nicht zugewiesen"
+    "unAssigned": "Nicht zugewiesen",
+    "user": "Benutzer"
   },
   "aiAgent": {
     "defaultAgent": "Standard-Agent",

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -156,7 +156,8 @@
     "assignConversation": "Assign conversation",
     "assignedToMe": "Assigned to me",
     "assignedTo": "Assigned to {name}",
-    "unAssigned": "Unassigned"
+    "unAssigned": "Unassigned",
+    "user": "User"
   },
   "aiAgent": {
     "defaultAgent": "Default Agent",

--- a/apps/builder/messages/es.json
+++ b/apps/builder/messages/es.json
@@ -156,7 +156,8 @@
     "assignConversation": "Asignar conversación",
     "assignedToMe": "Asignada a mí",
     "assignedTo": "Asignada a {name}",
-    "unAssigned": "Sin asignar"
+    "unAssigned": "Sin asignar",
+    "user": "Usuario"
   },
   "aiAgent": {
     "defaultAgent": "Agente predeterminado",

--- a/apps/builder/messages/fi.json
+++ b/apps/builder/messages/fi.json
@@ -156,7 +156,8 @@
     "assignConversation": "Määritä keskustelu",
     "assignedToMe": "Määritetty minulle",
     "assignedTo": "Määritetty käyttäjälle {name}",
-    "unAssigned": "Ei määritetty"
+    "unAssigned": "Ei määritetty",
+    "user": "Käyttäjä"
   },
   "aiAgent": {
     "defaultAgent": "Oletusagentti",

--- a/apps/builder/messages/fr.json
+++ b/apps/builder/messages/fr.json
@@ -156,7 +156,8 @@
     "assignConversation": "Attribuer la conversation",
     "assignedToMe": "Attribuée à moi",
     "assignedTo": "Attribuée à {name}",
-    "unAssigned": "Non attribuée"
+    "unAssigned": "Non attribuée",
+    "user": "Utilisateur"
   },
   "aiAgent": {
     "defaultAgent": "Agent par défaut",

--- a/apps/builder/messages/he.json
+++ b/apps/builder/messages/he.json
@@ -156,7 +156,8 @@
     "assignConversation": "הקצאת שיחה",
     "assignedToMe": "הוקצה לי",
     "assignedTo": "הוקצה אל {name}",
-    "unAssigned": "לא הוקצה"
+    "unAssigned": "לא הוקצה",
+    "user": "משתמש"
   },
   "aiAgent": {
     "defaultAgent": "סוכן ברירת מחדל",

--- a/apps/builder/messages/id.json
+++ b/apps/builder/messages/id.json
@@ -156,7 +156,8 @@
     "assignConversation": "Tetapkan percakapan",
     "assignedToMe": "Ditugaskan kepada saya",
     "assignedTo": "Ditugaskan kepada {name}",
-    "unAssigned": "Belum ditugaskan"
+    "unAssigned": "Belum ditugaskan",
+    "user": "Pengguna"
   },
   "aiAgent": {
     "defaultAgent": "Agen Default",

--- a/apps/builder/messages/it.json
+++ b/apps/builder/messages/it.json
@@ -1253,7 +1253,8 @@
     "assignConversation": "Assegna conversazione",
     "assignedToMe": "Assegnata a me",
     "assignedTo": "Assegnata a {name}",
-    "unAssigned": "Non assegnata"
+    "unAssigned": "Non assegnata",
+    "user": "Utente"
   },
   "aiAgent": {
     "defaultAgent": "Agente predefinito",

--- a/apps/builder/messages/ja.json
+++ b/apps/builder/messages/ja.json
@@ -156,7 +156,8 @@
     "assignConversation": "会話を割り当て",
     "assignedToMe": "自分に割り当て済み",
     "assignedTo": "{name}に割り当て済み",
-    "unAssigned": "未割り当て"
+    "unAssigned": "未割り当て",
+    "user": "ユーザー"
   },
   "aiAgent": {
     "defaultAgent": "デフォルトエージェント",

--- a/apps/builder/messages/nl.json
+++ b/apps/builder/messages/nl.json
@@ -156,7 +156,8 @@
     "assignConversation": "Gesprek toewijzen",
     "assignedToMe": "Aan mij toegewezen",
     "assignedTo": "Toegewezen aan {name}",
-    "unAssigned": "Niet toegewezen"
+    "unAssigned": "Niet toegewezen",
+    "user": "Gebruiker"
   },
   "aiAgent": {
     "defaultAgent": "Standaardagent",

--- a/apps/builder/messages/pt-BR.json
+++ b/apps/builder/messages/pt-BR.json
@@ -156,7 +156,8 @@
     "assignConversation": "Atribuir conversa",
     "assignedToMe": "Atribuída a mim",
     "assignedTo": "Atribuída a {name}",
-    "unAssigned": "Não atribuída"
+    "unAssigned": "Não atribuída",
+    "user": "Usuário"
   },
   "aiAgent": {
     "defaultAgent": "Agente padrão",

--- a/apps/builder/messages/pt-PT.json
+++ b/apps/builder/messages/pt-PT.json
@@ -156,7 +156,8 @@
     "assignConversation": "Atribuir conversa",
     "assignedToMe": "Atribuída a mim",
     "assignedTo": "Atribuída a {name}",
-    "unAssigned": "Não atribuída"
+    "unAssigned": "Não atribuída",
+    "user": "Utilizador"
   },
   "aiAgent": {
     "defaultAgent": "Agente predefinido",

--- a/apps/builder/messages/ro.json
+++ b/apps/builder/messages/ro.json
@@ -718,7 +718,8 @@
     "assignConversation": "Atribuie conversația",
     "assignedToMe": "Atribuită mie",
     "assignedTo": "Atribuită lui {name}",
-    "unAssigned": "Neatribuită"
+    "unAssigned": "Neatribuită",
+    "user": "Utilizator"
   },
   "aiAgent": {
     "defaultAgent": "Agent implicit",

--- a/apps/builder/messages/sv.json
+++ b/apps/builder/messages/sv.json
@@ -316,7 +316,8 @@
     "assignConversation": "Tilldela konversation",
     "assignedTo": "Tilldelad till {name}",
     "assignedToMe": "Tilldelad till mig",
-    "unAssigned": "Ej tilldelad"
+    "unAssigned": "Ej tilldelad",
+    "user": "Användare"
   },
   "auditLogs": {
     "title": "Granskningsloggar"

--- a/apps/builder/messages/tr.json
+++ b/apps/builder/messages/tr.json
@@ -156,7 +156,8 @@
     "assignConversation": "Görüşmeyi ata",
     "assignedToMe": "Bana atandı",
     "assignedTo": "{name} adlı kişiye atandı",
-    "unAssigned": "Atanmamış"
+    "unAssigned": "Atanmamış",
+    "user": "Kullanıcı"
   },
   "aiAgent": {
     "defaultAgent": "Varsayılan Temsilci",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -156,7 +156,8 @@
     "assignConversation": "Gán cuộc trò chuyện",
     "assignedToMe": "Đã gán cho tôi",
     "assignedTo": "Đã gán cho {name}",
-    "unAssigned": "Chưa gán"
+    "unAssigned": "Chưa gán",
+    "user": "Người dùng"
   },
   "aiAgent": {
     "defaultAgent": "Agent mặc định",

--- a/apps/builder/src/features/conversations/conversation-item.tsx
+++ b/apps/builder/src/features/conversations/conversation-item.tsx
@@ -40,8 +40,14 @@ type ConversationItemProps = {
 const assignedIcon = (
   conversation: ListConversationItemResource,
   assignedAvatarUrl: string | undefined,
+  t: ReturnType<typeof useTranslations>,
 ) => {
   if (conversation.assignedUserId) {
+    const assignedUserName =
+      conversation.assignedUser?.name ||
+      conversation.assignedUser?.email ||
+      t("assignAdmin.user")
+
     return (
       <Tooltip>
         <TooltipTrigger
@@ -56,18 +62,28 @@ const assignedIcon = (
           }
         />
         <TooltipContent align="center" side="bottom">
-          {conversation.assignedUser?.name ||
-            conversation.assignedUser?.email ||
-            "User"}
+          {t("assignAdmin.assignedTo", { name: assignedUserName })}
         </TooltipContent>
       </Tooltip>
     )
   }
   if (conversation.assignedInboxTeamId) {
     return (
-      <div className="overflow-hidden rounded-full border border-zinc-600 bg-secondary">
-        <UsersRoundIcon size={16} strokeWidth={1} />
-      </div>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <div className="overflow-hidden rounded-full border border-zinc-600 bg-secondary">
+              <UsersRoundIcon size={16} strokeWidth={1} />
+            </div>
+          }
+        />
+        <TooltipContent align="center" side="bottom">
+          {t("assignAdmin.assignedTo", {
+            name:
+              conversation.assignedInboxTeam?.name ?? t("fields.team.label"),
+          })}
+        </TooltipContent>
+      </Tooltip>
     )
   }
   return
@@ -149,7 +165,7 @@ export default function ConversationItem({
         <div className="relative">
           {contactAvatar}
           <div className="absolute start-0 bottom-0 transform">
-            {assignedIcon(conversation, assignedAvatarUrl)}
+            {assignedIcon(conversation, assignedAvatarUrl, t)}
           </div>
           <div className="absolute end-0 bottom-0 transform">
             {conversation.contactInboxes?.map((contactInbox) => (


### PR DESCRIPTION
## Summary
- Tooltip for the assigned-conversation icon now renders the localized "Assigned to {name}" string instead of the bare user name, so it reads correctly when the user has no avatar/short name.
- Added a tooltip to the "assigned to team" icon (previously showed no tooltip at all), reusing the same "Assigned to {name}" pattern with the team's name.
- Replaced the hardcoded `"User"` fallback with a new `assignAdmin.user` translation key, added to all 18 locale files.

## Changes
- `apps/builder/src/features/conversations/conversation-item.tsx`
- `apps/builder/messages/*.json` (all 18 locales — new `assignAdmin.user` key)

## Test plan
- [x] pnpm lint
- [x] pnpm --filter builder check-types
- [ ] manual verification in browser