### PR TITLE
fix(auth): link facebook sso to existing account on matching email

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -468,6 +468,22 @@ export function createAuth(config: AuthConfig) {
       // better-auth's `parseGenericState`) plus the origin allowlist in
       // `oauth-referer.ts`, so the cookie check is safe to skip here.
       skipStateCookieCheck: true,
+      accountLinking: {
+        enabled: true,
+        // Trust our own social providers' email claims. Google's id token
+        // always carries an accurate `email_verified`, but Facebook's Graph
+        // API never returns one at all — better-auth's link-account guard
+        // then falls back to treating the email as unverified and refuses to
+        // link, so ANY existing account (password, magic link, or the other
+        // social provider) sharing that email hits "account not linked" on
+        // every Facebook sign-in. Both providers gate signup on owning the
+        // mailbox, so trusting them here is safe; `requireLocalEmailVerified`
+        // (default true, left untouched below) still requires the *local*
+        // side of the match to be a verified account before linking, which is
+        // what keeps this from being an account-takeover vector via an
+        // unverified placeholder signup.
+        trustedProviders: [...SOCIAL_PROVIDERS],
+      },
       additionalFields: {
         tenantId: {
           type: "string",


### PR DESCRIPTION
## Summary
- Facebook Graph API never returns an `email_verified` claim, so better-auth's implicit account-linking guard always treated the Facebook email as unverified and refused to link — every Facebook sign-in against an already-existing account (password, magic link, or Google) failed with "account not linked".
- Add `google`/`facebook` to `account.accountLinking.trustedProviders` in `createAuth()` so the provider's email claim is trusted for linking purposes. Both providers gate signup on owning the mailbox, so this is safe.
- `requireLocalEmailVerified` is left at its default (`true`): the local account being linked into must still be a verified account, which prevents an unverified placeholder signup from being used as an account-takeover vector.

## Changes
- `packages/auth/src/server.ts` — add `accountLinking: { enabled: true, trustedProviders: [...SOCIAL_PROVIDERS] }` to the `account` block passed to `betterAuth()`.

## Test plan
- [x] `pnpm lint` (via pre-commit hook)
- [x] `pnpm --filter builder check-types` (via pre-commit hook, full workspace typecheck)
- [ ] Manual verification: sign up with email/password, verify email, then sign in with Facebook using the same email — should log into the existing account instead of erroring