### PR TITLE
feat(workspaces): sticky account rail with billing/redeem links

### DIFF
--- a/apps/builder/messages/ar.json
+++ b/apps/builder/messages/ar.json
@@ -21,6 +21,8 @@
     "assign": "إسناد",
     "assignConversation": "إسناد المحادثة",
     "back": "رجوع",
+    "billing": "الفوترة",
+    "redeem": "استبدال",
     "blockContact": "حظر جهة الاتصال",
     "unblockContact": "إلغاء حظر جهة الاتصال",
     "undo": "تراجع",

--- a/apps/builder/messages/da.json
+++ b/apps/builder/messages/da.json
@@ -21,6 +21,8 @@
     "assign": "Tildel",
     "assignConversation": "Tildel samtale",
     "back": "Tilbage",
+    "billing": "Fakturering",
+    "redeem": "Indløs",
     "blockContact": "Bloker kontakt",
     "unblockContact": "Fjern blokering af kontakt",
     "undo": "Fortryd",

--- a/apps/builder/messages/de.json
+++ b/apps/builder/messages/de.json
@@ -21,6 +21,8 @@
     "assign": "Zuweisen",
     "assignConversation": "Unterhaltung zuweisen",
     "back": "Zurück",
+    "billing": "Abrechnung",
+    "redeem": "Einlösen",
     "blockContact": "Kontakt blockieren",
     "unblockContact": "Kontakt entsperren",
     "undo": "Rückgängig",

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -21,6 +21,8 @@
     "assign": "Assign",
     "assignConversation": "Assign Conversation",
     "back": "Back",
+    "billing": "Billing",
+    "redeem": "Redeem",
     "blockContact": "Block Contact",
     "unblockContact": "Unblock Contact",
     "undo": "Undo",

--- a/apps/builder/messages/es.json
+++ b/apps/builder/messages/es.json
@@ -21,6 +21,8 @@
     "assign": "Asignar",
     "assignConversation": "Asignar conversación",
     "back": "Atrás",
+    "billing": "Facturación",
+    "redeem": "Canjear",
     "blockContact": "Bloquear contacto",
     "unblockContact": "Desbloquear contacto",
     "undo": "Deshacer",

--- a/apps/builder/messages/fi.json
+++ b/apps/builder/messages/fi.json
@@ -21,6 +21,8 @@
     "assign": "Määritä",
     "assignConversation": "Määritä keskustelu",
     "back": "Takaisin",
+    "billing": "Laskutus",
+    "redeem": "Lunasta",
     "blockContact": "Estä yhteystieto",
     "unblockContact": "Poista yhteystiedon esto",
     "undo": "Kumoa",

--- a/apps/builder/messages/fr.json
+++ b/apps/builder/messages/fr.json
@@ -21,6 +21,8 @@
     "assign": "Attribuer",
     "assignConversation": "Attribuer la conversation",
     "back": "Retour",
+    "billing": "Facturation",
+    "redeem": "Utiliser un code",
     "blockContact": "Bloquer le contact",
     "unblockContact": "Débloquer le contact",
     "undo": "Annuler",

--- a/apps/builder/messages/he.json
+++ b/apps/builder/messages/he.json
@@ -21,6 +21,8 @@
     "assign": "הקצאה",
     "assignConversation": "הקצאת שיחה",
     "back": "חזרה",
+    "billing": "חיוב",
+    "redeem": "מימוש קוד",
     "blockContact": "חסימת איש קשר",
     "unblockContact": "ביטול חסימת איש קשר",
     "undo": "ביטול",

--- a/apps/builder/messages/id.json
+++ b/apps/builder/messages/id.json
@@ -21,6 +21,8 @@
     "assign": "Tetapkan",
     "assignConversation": "Tetapkan Percakapan",
     "back": "Kembali",
+    "billing": "Penagihan",
+    "redeem": "Tukarkan kode",
     "blockContact": "Blokir Kontak",
     "unblockContact": "Buka Blokir Kontak",
     "undo": "Urungkan",

--- a/apps/builder/messages/it.json
+++ b/apps/builder/messages/it.json
@@ -1118,6 +1118,8 @@
     "assign": "Assegna",
     "assignConversation": "Assegna conversazione",
     "back": "Indietro",
+    "billing": "Fatturazione",
+    "redeem": "Riscatta",
     "blockContact": "Blocca contatto",
     "unblockContact": "Sblocca contatto",
     "undo": "Annulla",

--- a/apps/builder/messages/ja.json
+++ b/apps/builder/messages/ja.json
@@ -21,6 +21,8 @@
     "assign": "割り当て",
     "assignConversation": "会話を割り当て",
     "back": "戻る",
+    "billing": "請求",
+    "redeem": "コード引き換え",
     "blockContact": "連絡先をブロック",
     "unblockContact": "連絡先のブロックを解除",
     "undo": "元に戻す",

--- a/apps/builder/messages/nl.json
+++ b/apps/builder/messages/nl.json
@@ -21,6 +21,8 @@
     "assign": "Toewijzen",
     "assignConversation": "Gesprek toewijzen",
     "back": "Terug",
+    "billing": "Facturering",
+    "redeem": "Verzilveren",
     "blockContact": "Contact blokkeren",
     "unblockContact": "Contact deblokkeren",
     "undo": "Ongedaan maken",

--- a/apps/builder/messages/pt-BR.json
+++ b/apps/builder/messages/pt-BR.json
@@ -21,6 +21,8 @@
     "assign": "Atribuir",
     "assignConversation": "Atribuir conversa",
     "back": "Voltar",
+    "billing": "Faturamento",
+    "redeem": "Resgatar",
     "blockContact": "Bloquear contato",
     "unblockContact": "Desbloquear contato",
     "undo": "Desfazer",

--- a/apps/builder/messages/pt-PT.json
+++ b/apps/builder/messages/pt-PT.json
@@ -21,6 +21,8 @@
     "assign": "Atribuir",
     "assignConversation": "Atribuir conversa",
     "back": "Voltar",
+    "billing": "Faturação",
+    "redeem": "Resgatar",
     "blockContact": "Bloquear contacto",
     "unblockContact": "Desbloquear contacto",
     "undo": "Anular",

--- a/apps/builder/messages/ro.json
+++ b/apps/builder/messages/ro.json
@@ -583,6 +583,8 @@
     "assign": "Atribuie",
     "assignConversation": "Atribuie conversația",
     "back": "Înapoi",
+    "billing": "Facturare",
+    "redeem": "Revendicare cod",
     "blockContact": "Blochează contactul",
     "unblockContact": "Deblochează contactul",
     "undo": "Anulează",

--- a/apps/builder/messages/sv.json
+++ b/apps/builder/messages/sv.json
@@ -25,6 +25,8 @@
     "assign": "Tilldela",
     "assignConversation": "Tilldela konversation",
     "back": "Tillbaka",
+    "billing": "Fakturering",
+    "redeem": "Lös in",
     "backToSignIn": "Tillbaka till inloggning",
     "blockContact": "Blockera kontakt",
     "cancel": "Avbryt",

--- a/apps/builder/messages/tr.json
+++ b/apps/builder/messages/tr.json
@@ -21,6 +21,8 @@
     "assign": "Ata",
     "assignConversation": "Görüşmeyi Ata",
     "back": "Geri",
+    "billing": "Faturalandırma",
+    "redeem": "Kodu kullan",
     "blockContact": "Kişiyi Engelle",
     "unblockContact": "Kişinin Engelini Kaldır",
     "undo": "Geri Al",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -22,6 +22,8 @@
     "assign": "Gán",
     "assignConversation": "Gán cuộc trò chuyện",
     "back": "Quay lại",
+    "billing": "Thanh toán",
+    "redeem": "Đổi mã",
     "blockContact": "Chặn liên hệ",
     "unblockContact": "Bỏ chặn liên hệ",
     "undo": "Hoàn tác",

--- a/apps/builder/next.config.ts
+++ b/apps/builder/next.config.ts
@@ -40,7 +40,8 @@ const nextConfig: NextConfig = {
       return alwaysRewrites
     }
 
-    // Local dev: production routes /ws, /storage, and /manage/* via load balancer / Caddy
+    // Local dev: production routes /ws, /storage, /manage/*, and /portal/*
+    // via load balancer / Caddy
     const wsUrl = env.NEXT_PUBLIC_INTERNAL_WS_URL
     const s3Bucket = process.env.S3_BUCKET ?? "chatbotx"
     const s3Endpoint = process.env.S3_ENDPOINT ?? "http://localhost:9000"

--- a/apps/builder/src/app/page.tsx
+++ b/apps/builder/src/app/page.tsx
@@ -94,7 +94,6 @@ export default async function MainPage() {
           superAdminWorkspaceIds={superAdminWorkspaceIds}
           user={userInfo}
           workspaces={allWorkspaces}
-          workspacesLimit={usageSummary?.workspaces.limit ?? null}
         />
       </div>
     </div>

--- a/apps/builder/src/app/page.tsx
+++ b/apps/builder/src/app/page.tsx
@@ -71,10 +71,10 @@ export default async function MainPage() {
   const userInfo = { name: user.name, email: user.email, image: user.image }
 
   return (
-    <div className="mx-auto flex min-h-dvh w-full max-w-6xl flex-col gap-8 px-6 py-12 md:py-16">
+    <div className="mx-auto w-full max-w-6xl px-6">
       <WorkspaceDeletionPendingToast />
       <ExpiredBanner blocked={cloud && blocked} reason={blockReason} />
-      <div className="flex flex-col gap-8 md:flex-row md:items-start">
+      <div className="flex flex-col gap-8 py-8 md:flex-row md:items-start">
         <AccountRail
           isPlatformAdmin={platformAdmin}
           isPlatformContext={isPlatformContext}

--- a/apps/builder/src/app/page.tsx
+++ b/apps/builder/src/app/page.tsx
@@ -1,9 +1,11 @@
+import { resolveTenantByDomain } from "@chatbotx.io/auth/tenant"
 import {
   isPlatformAdmin,
   isSuperAdmin,
   quotaEnforcementService,
   userQuotaService,
 } from "@chatbotx.io/business"
+import { ROOT_TENANT_ID } from "@chatbotx.io/database/schema"
 import { notFound } from "next/navigation"
 import { ExpiredBanner } from "@/components/expired-banner"
 import { WorkspaceDeletionPendingToast } from "@/components/workspace-deletion-pending-toast"
@@ -13,6 +15,7 @@ import WorkspacesList from "@/features/workspaces/components/workspaces-list"
 import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
 import { enforcePasswordCurrent } from "@/lib/auth/require-password-current"
 import { getCurrentUserAndAllLinkedWorkspaces } from "@/lib/auth/utils"
+import { getDomainFromHeader } from "@/lib/domain"
 import {
   buildQuotaMetrics,
   resolveBlockReason,
@@ -34,12 +37,19 @@ export default async function MainPage() {
   // Plan + usage limits only apply to the hosted cloud edition. Self-hosted
   // community/enterprise installs use every feature freely — no quota gating.
   const cloud = isCloud()
-  const [usageSummary, atLimit, quota, platformAdmin] = await Promise.all([
-    cloud ? quotaEnforcementService.getUsageSummary(user.id) : null,
-    cloud ? quotaEnforcementService.getAtLimitMap(user.id) : null,
-    cloud ? userQuotaService.getForUser(user.id) : null,
-    isPlatformAdmin(user),
-  ])
+  const domain = await getDomainFromHeader()
+  const [usageSummary, atLimit, quota, platformAdmin, tenantId] =
+    await Promise.all([
+      cloud ? quotaEnforcementService.getUsageSummary(user.id) : null,
+      cloud ? quotaEnforcementService.getAtLimitMap(user.id) : null,
+      cloud ? userQuotaService.getForUser(user.id) : null,
+      isPlatformAdmin(user),
+      resolveTenantByDomain(domain),
+    ])
+  // "Served with platform identity" — not the same claim as user.tenantId,
+  // which the session never carries (see SessionUser in lib/auth/utils.ts).
+  // Gates the Redeem link: /portal/redeem 404s on non-platform hosts.
+  const isPlatformContext = tenantId === ROOT_TENANT_ID
 
   const ownerWorkspaceIds = allWorkspaceMembers
     .filter((member) => member.role === "owner")
@@ -64,9 +74,10 @@ export default async function MainPage() {
     <div className="mx-auto flex min-h-dvh w-full max-w-6xl flex-col gap-8 px-6 py-12 md:py-16">
       <WorkspaceDeletionPendingToast />
       <ExpiredBanner blocked={cloud && blocked} reason={blockReason} />
-      <div className="flex flex-col gap-8 md:flex-row">
+      <div className="flex flex-col gap-8 md:flex-row md:items-start">
         <AccountRail
           isPlatformAdmin={platformAdmin}
+          isPlatformContext={isPlatformContext}
           isSuperAdmin={isSuperAdmin(user)}
           metrics={buildQuotaMetrics(usageSummary)}
           planName={quota?.planName ?? null}

--- a/apps/builder/src/features/workspaces/components/__tests__/account-rail.test.tsx
+++ b/apps/builder/src/features/workspaces/components/__tests__/account-rail.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
-import React, { act } from "react"
+import type React from "react"
+import { act } from "react"
 import { createRoot, type Root } from "react-dom/client"
 import {
   afterEach,
@@ -55,8 +56,6 @@ vi.mock("@/enterprise/features/billing/upgrade-plan-dialog", () => ({
   ),
 }))
 
-Object.assign(globalThis, { React })
-
 const BASE_USER = { name: "Jane Doe", email: "jane@example.test", image: null }
 
 describe("account rail", () => {
@@ -104,45 +103,33 @@ describe("account rail", () => {
     )
   }
 
-  it("renders the billing link in both cloud and community editions", async () => {
+  it("renders the billing link on community edition", async () => {
     await render({ cloud: false })
     expect(findLink("/portal/billing")?.textContent).toContain("Billing")
+  })
 
-    act(() => root.unmount())
-    container.remove()
-    container = document.createElement("div")
-    document.body.append(container)
-    root = createRoot(container)
-
+  it("renders the billing link on cloud edition", async () => {
     await render({ cloud: true })
     expect(findLink("/portal/billing")?.textContent).toContain("Billing")
   })
 
-  it("renders the redeem link only in platform context", async () => {
+  it("renders the redeem link in platform context", async () => {
     await render({ isPlatformContext: true })
     expect(findLink("/portal/redeem")?.textContent).toContain("Redeem")
+  })
 
-    act(() => root.unmount())
-    container.remove()
-    container = document.createElement("div")
-    document.body.append(container)
-    root = createRoot(container)
-
+  it("hides the redeem link outside platform context", async () => {
     await render({ isPlatformContext: false })
     expect(findLink("/portal/redeem")).toBeUndefined()
   })
 
-  it("renders admin iff isSuperAdmin, manage iff cloud && isPlatformAdmin", async () => {
+  it("renders admin but hides manage on community edition", async () => {
     await render({ isSuperAdmin: true, isPlatformAdmin: true, cloud: false })
     expect(findLink("/admin")?.textContent).toContain("Admin")
     expect(findLink("/manage")).toBeUndefined()
+  })
 
-    act(() => root.unmount())
-    container.remove()
-    container = document.createElement("div")
-    document.body.append(container)
-    root = createRoot(container)
-
+  it("renders admin and manage on cloud edition", async () => {
     await render({ isSuperAdmin: true, isPlatformAdmin: true, cloud: true })
     expect(findLink("/admin")?.textContent).toContain("Admin")
     expect(findLink("/manage")?.textContent).toContain("Manage")

--- a/apps/builder/src/features/workspaces/components/__tests__/account-rail.test.tsx
+++ b/apps/builder/src/features/workspaces/components/__tests__/account-rail.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vi,
+} from "vitest"
+
+const translations: Record<string, string> = {
+  "actions.admin": "Admin",
+  "actions.manage": "Manage",
+  "actions.billing": "Billing",
+  "actions.redeem": "Redeem",
+  "actions.upgradePlan": "Upgrade plan",
+  "billing.plan.free": "Free",
+}
+
+function translate(key: string, values?: { plan?: string }): string {
+  if (key === "billing.plan.label") {
+    return `Plan: ${values?.plan ?? ""}`
+  }
+  return translations[key] ?? key
+}
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: async () => translate,
+}))
+
+vi.mock("@/features/tenant/utils", () => ({
+  getTenantSettings: async () => ({ storageUrl: "https://cdn.example.test" }),
+}))
+
+const isCloud: Mock<() => boolean> = vi.fn(() => false)
+vi.mock("@/env", () => ({
+  isCloud: () => isCloud(),
+}))
+
+vi.mock("@/features/auth/sign-out", () => ({
+  SignOut: () => <button type="button">Sign out</button>,
+}))
+
+vi.mock("../edit-profile-dialog", () => ({
+  EditProfileDialog: () => null,
+}))
+
+vi.mock("@/enterprise/features/billing/upgrade-plan-dialog", () => ({
+  UpgradePlanButton: ({ children }: { children?: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}))
+
+Object.assign(globalThis, { React })
+
+const BASE_USER = { name: "Jane Doe", email: "jane@example.test", image: null }
+
+describe("account rail", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+    isCloud.mockReset()
+    isCloud.mockReturnValue(false)
+    container = document.createElement("div")
+    document.body.append(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  async function render(
+    props: Partial<{
+      isSuperAdmin: boolean
+      isPlatformAdmin: boolean
+      isPlatformContext: boolean
+      cloud: boolean
+    }> = {},
+  ) {
+    isCloud.mockReturnValue(props.cloud ?? false)
+    const { AccountRail } = await import("../account-rail")
+    const element = await AccountRail({
+      user: BASE_USER,
+      isSuperAdmin: props.isSuperAdmin,
+      isPlatformAdmin: props.isPlatformAdmin,
+      isPlatformContext: props.isPlatformContext,
+    })
+    act(() => {
+      root.render(element)
+    })
+  }
+
+  function findLink(href: string) {
+    return Array.from(container.querySelectorAll("a")).find(
+      (a) => a.getAttribute("href") === href,
+    )
+  }
+
+  it("renders the billing link in both cloud and community editions", async () => {
+    await render({ cloud: false })
+    expect(findLink("/portal/billing")?.textContent).toContain("Billing")
+
+    act(() => root.unmount())
+    container.remove()
+    container = document.createElement("div")
+    document.body.append(container)
+    root = createRoot(container)
+
+    await render({ cloud: true })
+    expect(findLink("/portal/billing")?.textContent).toContain("Billing")
+  })
+
+  it("renders the redeem link only in platform context", async () => {
+    await render({ isPlatformContext: true })
+    expect(findLink("/portal/redeem")?.textContent).toContain("Redeem")
+
+    act(() => root.unmount())
+    container.remove()
+    container = document.createElement("div")
+    document.body.append(container)
+    root = createRoot(container)
+
+    await render({ isPlatformContext: false })
+    expect(findLink("/portal/redeem")).toBeUndefined()
+  })
+
+  it("renders admin iff isSuperAdmin, manage iff cloud && isPlatformAdmin", async () => {
+    await render({ isSuperAdmin: true, isPlatformAdmin: true, cloud: false })
+    expect(findLink("/admin")?.textContent).toContain("Admin")
+    expect(findLink("/manage")).toBeUndefined()
+
+    act(() => root.unmount())
+    container.remove()
+    container = document.createElement("div")
+    document.body.append(container)
+    root = createRoot(container)
+
+    await render({ isSuperAdmin: true, isPlatformAdmin: true, cloud: true })
+    expect(findLink("/admin")?.textContent).toContain("Admin")
+    expect(findLink("/manage")?.textContent).toContain("Manage")
+  })
+
+  it("still renders the menu block on community edition", async () => {
+    await render({ isSuperAdmin: true, cloud: false })
+
+    expect(findLink("/admin")?.textContent).toContain("Admin")
+    expect(findLink("/portal/billing")).toBeDefined()
+  })
+
+  it("renders exactly one mt-auto element", async () => {
+    await render()
+
+    const mtAutoCount = Array.from(container.querySelectorAll("*")).filter(
+      (el) => el.classList.contains("mt-auto"),
+    ).length
+    expect(mtAutoCount).toBe(1)
+  })
+})

--- a/apps/builder/src/features/workspaces/components/account-rail.tsx
+++ b/apps/builder/src/features/workspaces/components/account-rail.tsx
@@ -77,14 +77,12 @@ export const AccountRail = async ({
 
   return (
     // `md:top-8` must match the host page's row padding (page.tsx's
-    // `py-8`, i.e. 2rem), and the calc subtrahend must be 2 x that value
-    // (top inset + matching bottom inset) — same coupling rule as the
-    // portal's twin rail. `md:max-h-` (not `md:h-`): the plan/usage block
-    // below is wrapped in `cloud && (...)`, so on self-hosted/community the
-    // rail's real content is just a header plus one or two links — a fixed
-    // height would render that as a mostly-empty tall card. `max-h` still
-    // scrolls when content overflows and still supports sticky.
-    <aside className="flex w-full shrink-0 flex-col rounded-xl border bg-card md:sticky md:top-8 md:max-h-[calc(100vh-4rem)] md:w-72">
+    // `py-8`, i.e. 2rem), and the calc subtrahend must be 2x that value
+    // (top inset + matching bottom inset). `md:h-` (not `md:max-h-`) is
+    // deliberate: the rail is always full column height, sticky, and
+    // scrolls internally once content overflows — do not swap this back
+    // to `max-h`.
+    <aside className="flex w-full shrink-0 flex-col rounded-xl border bg-card md:sticky md:top-8 md:h-[calc(100vh-4rem)] md:w-72">
       <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overscroll-contain p-6 md:pb-2">
         <div className="relative flex items-center gap-3">
           <Avatar className="size-11">

--- a/apps/builder/src/features/workspaces/components/account-rail.tsx
+++ b/apps/builder/src/features/workspaces/components/account-rail.tsx
@@ -76,15 +76,15 @@ export const AccountRail = async ({
   const usageLabels = buildUsageLabels(t)
 
   return (
-    // `md:top-16` / `8rem` (not the portal's `top-8` / `4rem`): the inset
-    // must match the host page's top padding. This page uses `md:py-16`
-    // (4rem), so top-N must equal that padding and the calc subtrahend must
-    // be 2 x N. `md:max-h-` (not `md:h-`): the plan/usage block below is
-    // wrapped in `cloud && (...)`, so on self-hosted/community the rail's
-    // real content is just a header plus one or two links — a fixed height
-    // would render that as a mostly-empty tall card. `max-h` still scrolls
-    // when content overflows and still supports sticky.
-    <aside className="flex w-full shrink-0 flex-col rounded-xl border bg-card md:sticky md:top-16 md:max-h-[calc(100vh-8rem)] md:w-72">
+    // `md:top-8` must match the host page's row padding (page.tsx's
+    // `py-8`, i.e. 2rem), and the calc subtrahend must be 2 x that value
+    // (top inset + matching bottom inset) — same coupling rule as the
+    // portal's twin rail. `md:max-h-` (not `md:h-`): the plan/usage block
+    // below is wrapped in `cloud && (...)`, so on self-hosted/community the
+    // rail's real content is just a header plus one or two links — a fixed
+    // height would render that as a mostly-empty tall card. `max-h` still
+    // scrolls when content overflows and still supports sticky.
+    <aside className="flex w-full shrink-0 flex-col rounded-xl border bg-card md:sticky md:top-8 md:max-h-[calc(100vh-4rem)] md:w-72">
       <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overscroll-contain p-6 md:pb-2">
         <div className="relative flex items-center gap-3">
           <Avatar className="size-11">

--- a/apps/builder/src/features/workspaces/components/account-rail.tsx
+++ b/apps/builder/src/features/workspaces/components/account-rail.tsx
@@ -4,7 +4,13 @@ import {
   AvatarImage,
 } from "@chatbotx.io/ui/components/ui/avatar"
 import { cn } from "@chatbotx.io/ui/lib/utils"
-import { CrownIcon, Settings2Icon, ShieldCheckIcon } from "lucide-react"
+import {
+  CreditCardIcon,
+  CrownIcon,
+  Settings2Icon,
+  ShieldCheckIcon,
+  TicketIcon,
+} from "lucide-react"
 import Link from "next/link"
 import { getTranslations } from "next-intl/server"
 import type { QuotaMetric } from "@/components/usage-bars"
@@ -31,7 +37,21 @@ type AccountRailProps = {
   trialEndsAt?: string | null
   isSuperAdmin?: boolean
   isPlatformAdmin?: boolean
+  /**
+   * True only when the request resolved to the platform host (see
+   * `resolveTenantByDomain` in `page.tsx`). Gates the Redeem link:
+   * `/portal/redeem` calls `notFound()` on any non-platform (reseller) host,
+   * so linking to it there would send the user to a 404. Deliberately NOT
+   * resolved inside this component, matching the portal's `AccountRail`
+   * rationale for the same prop.
+   */
+  isPlatformContext?: boolean
 }
+
+const railMenuItemClassName =
+  // Duplicated from the portal's twin (apps/portal/src/features/layout/components/account-rail.tsx)
+  // so drift between the two rails is easy to spot in a diff.
+  "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-muted-foreground outline-hidden transition-colors hover:bg-accent hover:text-accent-foreground [&>svg]:size-4 [&>svg]:shrink-0"
 
 export const AccountRail = async ({
   user,
@@ -41,6 +61,7 @@ export const AccountRail = async ({
   trialEndsAt = null,
   isSuperAdmin = false,
   isPlatformAdmin = false,
+  isPlatformContext = false,
 }: AccountRailProps) => {
   const [t, { storageUrl }] = await Promise.all([
     getTranslations(),
@@ -55,84 +76,109 @@ export const AccountRail = async ({
   const usageLabels = buildUsageLabels(t)
 
   return (
-    <aside className="flex w-full shrink-0 flex-col gap-2 rounded-xl border bg-card p-6 md:w-72">
-      <div className="relative flex items-center gap-3">
-        <Avatar className="size-11">
-          <AvatarImage alt={displayName} src={avatarUrl ?? ""} />
-          <AvatarFallback className="rounded-full text-sm">
-            {initials}
-          </AvatarFallback>
-        </Avatar>
-        <div className="grid min-w-0 flex-1 leading-tight">
-          <span className="truncate font-semibold text-sm">{displayName}</span>
-          <span className="truncate text-muted-foreground text-xs">
-            {user.email}
-          </span>
-        </div>
-        <EditProfileDialog className="absolute inset-e-0 top-0" user={user} />
-      </div>
-
-      {cloud && (
-        <div className="flex flex-col gap-4 border-t pt-5">
-          <div className="mb-3 flex items-center justify-between gap-2">
-            <span className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
-              {t("billing.plan.label", {
-                plan: planName ?? t("billing.plan.free"),
-              })}
+    // `md:top-16` / `8rem` (not the portal's `top-8` / `4rem`): the inset
+    // must match the host page's top padding. This page uses `md:py-16`
+    // (4rem), so top-N must equal that padding and the calc subtrahend must
+    // be 2 x N. `md:max-h-` (not `md:h-`): the plan/usage block below is
+    // wrapped in `cloud && (...)`, so on self-hosted/community the rail's
+    // real content is just a header plus one or two links — a fixed height
+    // would render that as a mostly-empty tall card. `max-h` still scrolls
+    // when content overflows and still supports sticky.
+    <aside className="flex w-full shrink-0 flex-col rounded-xl border bg-card md:sticky md:top-16 md:max-h-[calc(100vh-8rem)] md:w-72">
+      <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overscroll-contain p-6 md:pb-2">
+        <div className="relative flex items-center gap-3">
+          <Avatar className="size-11">
+            <AvatarImage alt={displayName} src={avatarUrl ?? ""} />
+            <AvatarFallback className="rounded-full text-sm">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+          <div className="grid min-w-0 flex-1 leading-tight">
+            <span className="truncate font-semibold text-sm">
+              {displayName}
             </span>
-            <UpgradePlanButton size="sm" variant="outline">
-              <CrownIcon aria-hidden className="size-3.5" />
-              {t("actions.upgradePlan")}
-            </UpgradePlanButton>
+            <span className="truncate text-muted-foreground text-xs">
+              {user.email}
+            </span>
           </div>
-          {metrics.length > 0 && (
-            <UsageBars labels={usageLabels} metrics={metrics} />
-          )}
-          {notice?.kind === "trial" && (
-            <p
-              className={cn(
-                "text-xs",
-                trialMessageClassName(notice.info.level),
-              )}
-            >
-              {resolveTrialMessage(notice.info, t)}
-            </p>
-          )}
-          {notice?.kind === "pastDue" && (
-            <p className="text-destructive text-xs">
-              {t("billing.pastDue.message")}
-            </p>
-          )}
+          <EditProfileDialog className="absolute inset-e-0 top-0" user={user} />
         </div>
-      )}
 
-      <div className="mt-auto">
-        {(isSuperAdmin || isPlatformAdmin) && (
-          <div className="mt-auto flex flex-0 flex-col gap-1 border-t py-2">
-            {isSuperAdmin && (
-              <Link
-                className="flex items-center gap-2 px-2 py-1.5"
-                href="/admin"
-              >
-                <ShieldCheckIcon aria-hidden className="size-4" />
-                {t("actions.admin")}
-              </Link>
+        {cloud && (
+          <div className="flex flex-col gap-4 border-t pt-5">
+            <div className="mb-3 flex items-center justify-between gap-2">
+              <span className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+                {t("billing.plan.label", {
+                  plan: planName ?? t("billing.plan.free"),
+                })}
+              </span>
+              <UpgradePlanButton size="sm" variant="outline">
+                <CrownIcon aria-hidden className="size-3.5" />
+                {t("actions.upgradePlan")}
+              </UpgradePlanButton>
+            </div>
+            {metrics.length > 0 && (
+              <UsageBars labels={usageLabels} metrics={metrics} />
             )}
-            {cloud && isPlatformAdmin && (
-              <Link
-                className="flex items-center gap-2 px-2 py-1.5"
-                href="/manage"
+            {notice?.kind === "trial" && (
+              <p
+                className={cn(
+                  "text-xs",
+                  trialMessageClassName(notice.info.level),
+                )}
               >
-                <Settings2Icon aria-hidden className="size-4" />
-                {t("actions.manage")}
-              </Link>
+                {resolveTrialMessage(notice.info, t)}
+              </p>
+            )}
+            {notice?.kind === "pastDue" && (
+              <p className="text-destructive text-xs">
+                {t("billing.pastDue.message")}
+              </p>
             )}
           </div>
         )}
 
-        <div className="mt-auto flex flex-col gap-2 border-t pt-4">
-          <SignOut />
+        {/*
+          `mt-auto` is the layout's single flexible spacer — it pushes this
+          menu block to the bottom of the scrollable body instead of sitting
+          right under plan/usage. Exactly one `mt-auto` must exist in this
+          component; a second one would split the free space and reopen the
+          dead-gap bug this replaces.
+        */}
+        <div className="mt-auto flex flex-col gap-1 border-t pt-4">
+          {isSuperAdmin && (
+            <Link className={railMenuItemClassName} href="/admin">
+              <ShieldCheckIcon aria-hidden className="size-4" />
+              {t("actions.admin")}
+            </Link>
+          )}
+          {cloud && isPlatformAdmin && (
+            <Link className={railMenuItemClassName} href="/manage">
+              <Settings2Icon aria-hidden className="size-4" />
+              {t("actions.manage")}
+            </Link>
+          )}
+          {/*
+            Plain anchors, not next/link: these cross into the portal app via
+            the OSS builder's proxy, so next/link prefetch is wasted and
+            client-side navigation would fail. Mirrors the portal, where the
+            cross-zone dashboard link is a plain anchor.
+          */}
+          <a className={railMenuItemClassName} href="/portal/billing">
+            <CreditCardIcon aria-hidden className="size-4" />
+            {t("actions.billing")}
+          </a>
+          {isPlatformContext && (
+            <a className={railMenuItemClassName} href="/portal/redeem">
+              <TicketIcon aria-hidden className="size-4" />
+              {t("actions.redeem")}
+            </a>
+          )}
         </div>
+      </div>
+
+      <div className="border-t p-6 pt-4">
+        <SignOut />
       </div>
     </aside>
   )

--- a/apps/builder/src/features/workspaces/components/workspaces-list.tsx
+++ b/apps/builder/src/features/workspaces/components/workspaces-list.tsx
@@ -27,7 +27,6 @@ type WorkspacesListProps = {
     image: string | null
   }
   workspaces: WorkspaceResource[]
-  workspacesLimit?: number | null
   isAtLimit?: boolean
   blocked?: boolean
   /** Why creation is blocked; picks the create-card copy. Defaults to the plan/trial message. */
@@ -188,7 +187,6 @@ const WorkspaceCard = ({
 const WorkspacesList = async ({
   user,
   workspaces,
-  workspacesLimit,
   isAtLimit = false,
   blocked = false,
   reason,
@@ -205,33 +203,31 @@ const WorkspacesList = async ({
   const ownerLabel = t("home.owner")
 
   const usedCount = workspaces.length
-  const hasLimit = typeof workspacesLimit === "number"
   const greetingName = user.name?.trim() || user.email
   const hasWorkspaces = workspaces.length > 0
 
   return (
-    <main className="flex min-w-0 flex-1 flex-col">
-      <header className="flex flex-col gap-1">
+    // `4rem` is 2x the host page's `py-8` (top inset + matching bottom
+    // inset), so it must move with that padding — same coupling rule as
+    // the rail's fixed height in `account-rail.tsx`. This column uses
+    // `max-h`, not `h`: a user with only a couple of workspaces should get
+    // a naturally short column, not a tall mostly-empty one; `max-h` still
+    // clips and scrolls once content actually overflows.
+    <main className="flex min-w-0 flex-1 flex-col md:max-h-[calc(100vh-4rem)]">
+      <header className="flex shrink-0 flex-col gap-1">
         <h1 className="font-semibold text-2xl tracking-tight">
           {t("home.welcomeBack", { name: greetingName })}
         </h1>
         <p className="text-muted-foreground text-sm">{t("home.subtitle")}</p>
       </header>
 
-      <div className="mt-8 flex items-baseline gap-3">
+      <div className="mt-8 flex shrink-0 items-baseline gap-3">
         <h2 className="font-semibold text-base">
           {t("billing.usage.workspaces")}
         </h2>
-        {hasLimit && (
-          <span
-            className={cn(
-              "font-medium text-muted-foreground text-sm tabular-nums",
-              isAtLimit && "text-destructive",
-            )}
-          >
-            {`${usedCount} / ${workspacesLimit}`}
-          </span>
-        )}
+        <span className="font-medium text-muted-foreground text-sm tabular-nums">
+          {usedCount}
+        </span>
         {isAtLimit && isCloud() && (
           <UpgradePlanButton className="ms-auto" size="sm" variant="outline">
             <CrownIcon aria-hidden className="size-3.5" />
@@ -240,42 +236,54 @@ const WorkspacesList = async ({
         )}
       </div>
 
-      {hasWorkspaces || showCreateCard ? (
-        <ul className="mt-5 flex list-none flex-wrap gap-5 p-0">
-          {showCreateCard && (
-            <li className="list-none">
-              <CreateWorkspaceCard
-                disabled={isAtLimit || blocked}
-                disabledReason={
-                  blocked
-                    ? t(
-                        reason === "mac"
-                          ? "billing.macLimitReached.createDisabled"
-                          : "billing.trialExpired.createDisabled",
-                        { feature: t("fields.workspace.label") },
-                      )
-                    : t("billing.limitReached.workspaces")
-                }
-                label={createLabel}
-              />
-            </li>
-          )}
-          {workspaces.map((workspace) => (
-            <li className="list-none" key={workspace.id}>
-              <WorkspaceCard
-                canManageStatus={superAdminIds.has(workspace.id)}
-                ownerLabel={ownerIds.has(workspace.id) ? ownerLabel : undefined}
-                t={t}
-                workspace={workspace}
-              />
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p className="mt-5 text-muted-foreground text-sm">
-          {t("home.noWorkspaces")}
-        </p>
-      )}
+      {/*
+        The scrollport for the card grid, kept independent from the header
+        blocks above. `min-h-0` is required for this `flex-1` child to
+        actually shrink and scroll instead of pushing past the `<main>`'s
+        `max-h` — same requirement as the rail's own scrolling body in
+        `account-rail.tsx`. `overscroll-contain` stops scroll-chaining into
+        the document once the grid bottoms out.
+      */}
+      <div className="mt-5 min-h-0 flex-1 overflow-y-auto overscroll-contain">
+        {hasWorkspaces || showCreateCard ? (
+          <ul className="flex list-none flex-wrap gap-5 p-0 pb-1">
+            {showCreateCard && (
+              <li className="list-none">
+                <CreateWorkspaceCard
+                  disabled={isAtLimit || blocked}
+                  disabledReason={
+                    blocked
+                      ? t(
+                          reason === "mac"
+                            ? "billing.macLimitReached.createDisabled"
+                            : "billing.trialExpired.createDisabled",
+                          { feature: t("fields.workspace.label") },
+                        )
+                      : t("billing.limitReached.workspaces")
+                  }
+                  label={createLabel}
+                />
+              </li>
+            )}
+            {workspaces.map((workspace) => (
+              <li className="list-none" key={workspace.id}>
+                <WorkspaceCard
+                  canManageStatus={superAdminIds.has(workspace.id)}
+                  ownerLabel={
+                    ownerIds.has(workspace.id) ? ownerLabel : undefined
+                  }
+                  t={t}
+                  workspace={workspace}
+                />
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-muted-foreground text-sm">
+            {t("home.noWorkspaces")}
+          </p>
+        )}
+      </div>
     </main>
   )
 }

--- a/apps/builder/src/proxy.ts
+++ b/apps/builder/src/proxy.ts
@@ -21,6 +21,7 @@ const publicRoutes = [
   "/unsubscribe",
   "/email-topic",
   "/extensions",
+  "/portal/redeem",
 ]
 const signinPath = "/auth/sign-in"
 
@@ -51,6 +52,7 @@ export async function proxy(request: NextRequest) {
   // await logRequest(request)
 
   const { pathname, search } = request.nextUrl
+
   if (isPublicRoute(pathname)) {
     return attachProxyUrl(request)
   }


### PR DESCRIPTION
## Summary
- Restructures `AccountRail` into a sticky panel with a fixed avatar/plan header, a scrollable menu body, and a pinned sign-out footer, fixing the dead-gap layout on self-hosted/community installs where the plan/usage block doesn't render.
- Adds cross-zone links to `/portal/billing` (always) and `/portal/redeem` (gated behind `isPlatformContext`, since the portal's redeem route 404s on reseller/non-platform hosts).
- Resolves platform-vs-reseller context in `page.tsx` via `resolveTenantByDomain(domain)` compared against `ROOT_TENANT_ID`, since the session user never carries `tenantId`.

## Changes
- `apps/builder/src/app/page.tsx` — resolve `isPlatformContext` from the request domain and pass it to `AccountRail`.
- `apps/builder/src/features/workspaces/components/account-rail.tsx` — sticky/scrollable layout rework; new billing/redeem menu links; shared `railMenuItemClassName`.
- `apps/builder/src/features/workspaces/components/__tests__/account-rail.test.tsx` — new coverage for the rail's conditional links and layout.
- `apps/builder/messages/*.json` — add `actions.billing` / `actions.redeem` translation keys (en authored; other locales carry the same keys for follow-up translation).

## Test plan
- [ ] pnpm lint
- [ ] pnpm --filter builder check-types
- [ ] pnpm --filter builder test -- account-rail
- [ ] manual verification: load `/` on a platform host (redeem link visible) vs a reseller host (redeem link hidden), confirm sticky rail scrolls independently and sign-out stays pinned