### PR TITLE
fix(worker): prevent scheduled workspace purge from failing on overlapping runs

### DIFF
--- a/apps/worker/__tests__/purge-workspaces.test.ts
+++ b/apps/worker/__tests__/purge-workspaces.test.ts
@@ -4,14 +4,19 @@ const purgeDueScheduled = vi.fn()
 const runExclusive = vi.fn(async ({ fn }: { fn: () => Promise<unknown> }) =>
   fn(),
 )
+const lockExists = vi.fn()
 const info = vi.fn()
+const warn = vi.fn()
 
 vi.mock("@chatbotx.io/business", () => ({
   workspaceService: { purgeDueScheduled },
 }))
-vi.mock("@chatbotx.io/redis", () => ({ distributedLock: { runExclusive } }))
+vi.mock("@chatbotx.io/redis", () => ({
+  distributedLock: { runExclusive },
+  distributedStore: { exists: lockExists },
+}))
 vi.mock("@chatbotx.io/logger", () => ({
-  getChildLogger: () => ({ info }),
+  getChildLogger: () => ({ info, warn }),
 }))
 vi.mock("../src/services/integrations", () => ({
   allIntegrations: ["integration"],
@@ -24,7 +29,10 @@ const { purgeWorkspaces } = await import(
 beforeEach(() => {
   purgeDueScheduled.mockReset()
   runExclusive.mockClear()
+  lockExists.mockReset()
+  lockExists.mockResolvedValue(false)
   info.mockReset()
+  warn.mockReset()
   purgeDueScheduled.mockResolvedValue(0)
 })
 
@@ -34,7 +42,8 @@ describe("purgeWorkspaces", () => {
     expect(runExclusive).toHaveBeenCalledWith(
       expect.objectContaining({
         key: "schedule:purge-workspaces",
-        timeoutInSeconds: 55,
+        retryTimeoutInSeconds: 5,
+        timeoutInSeconds: 10_800,
       }),
     )
     expect(purgeDueScheduled).toHaveBeenCalledWith({
@@ -49,5 +58,62 @@ describe("purgeWorkspaces", () => {
       { deleted: 2 },
       "purgeWorkspaces: workspaces purged",
     )
+  })
+
+  test("skips successfully when another purge still holds the lock", async () => {
+    const err = Object.assign(new Error("lock held"), {
+      name: "LockAcquisitionError",
+      code: "LOCK_ACQUISITION_FAILED",
+      key: "schedule:purge-workspaces",
+    })
+    runExclusive.mockRejectedValueOnce(err)
+    lockExists.mockResolvedValueOnce(true)
+
+    await expect(purgeWorkspaces()).resolves.toBeUndefined()
+    expect(lockExists).toHaveBeenCalledWith("schedule:purge-workspaces")
+    expect(purgeDueScheduled).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith(
+      { err },
+      "purgeWorkspaces: skipped because another purge still holds the lock",
+    )
+  })
+
+  test("rethrows lock acquisition failures when the lock key is not held", async () => {
+    const err = Object.assign(new Error("redis unavailable"), {
+      name: "LockAcquisitionError",
+      code: "LOCK_ACQUISITION_FAILED",
+      key: "schedule:purge-workspaces",
+    })
+    runExclusive.mockRejectedValueOnce(err)
+    lockExists.mockResolvedValueOnce(false)
+
+    await expect(purgeWorkspaces()).rejects.toBe(err)
+    expect(purgeDueScheduled).not.toHaveBeenCalled()
+    expect(warn).not.toHaveBeenCalledWith(
+      { err },
+      "purgeWorkspaces: skipped because another purge still holds the lock",
+    )
+  })
+
+  test("skips immediately when a local purge is already running", async () => {
+    let resolvePurge: (() => void) | undefined
+    purgeDueScheduled.mockImplementationOnce(
+      () =>
+        new Promise<number>((resolve) => {
+          resolvePurge = () => resolve(0)
+        }),
+    )
+
+    const firstRun = purgeWorkspaces()
+    await Promise.resolve()
+    await expect(purgeWorkspaces()).resolves.toBeUndefined()
+
+    expect(runExclusive).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledWith(
+      "purgeWorkspaces: skipped because a local purge is still running",
+    )
+
+    resolvePurge?.()
+    await firstRun
   })
 })

--- a/apps/worker/src/schedule/handlers/purge-workspaces.ts
+++ b/apps/worker/src/schedule/handlers/purge-workspaces.ts
@@ -1,23 +1,64 @@
 import { workspaceService } from "@chatbotx.io/business"
 import { getChildLogger } from "@chatbotx.io/logger"
-import { distributedLock } from "@chatbotx.io/redis"
+import { distributedLock, distributedStore } from "@chatbotx.io/redis"
 import { allIntegrations } from "../../services/integrations"
 
+const LOCK_KEY = "schedule:purge-workspaces"
 const log = getChildLogger("purge-workspaces")
-const LOCK_TTL_SECONDS = 55
+const LOCK_TTL_SECONDS = 3 * 60 * 60
+const LOCK_ACQUIRE_RETRY_SECONDS = 5
+let isPurgeWorkspacesRunning = false
 
 export async function purgeWorkspaces(): Promise<void> {
-  await distributedLock.runExclusive({
-    key: "schedule:purge-workspaces",
-    timeoutInSeconds: LOCK_TTL_SECONDS,
-    fn: async () => {
-      const deleted = await workspaceService.purgeDueScheduled({
-        integrations: allIntegrations,
-      })
+  if (isPurgeWorkspacesRunning) {
+    log.warn("purgeWorkspaces: skipped because a local purge is still running")
+    return
+  }
 
-      if (deleted > 0) {
-        log.info({ deleted }, "purgeWorkspaces: workspaces purged")
-      }
-    },
-  })
+  isPurgeWorkspacesRunning = true
+  try {
+    await distributedLock.runExclusive({
+      key: LOCK_KEY,
+      timeoutInSeconds: LOCK_TTL_SECONDS,
+      retryTimeoutInSeconds: LOCK_ACQUIRE_RETRY_SECONDS,
+      fn: async () => {
+        const deleted = await workspaceService.purgeDueScheduled({
+          integrations: allIntegrations,
+        })
+
+        if (deleted > 0) {
+          log.info({ deleted }, "purgeWorkspaces: workspaces purged")
+        }
+      },
+    })
+  } catch (err) {
+    if (isLockAcquisitionFailure(err) && (await isPurgeLockHeld())) {
+      log.warn(
+        { err },
+        "purgeWorkspaces: skipped because another purge still holds the lock",
+      )
+      return
+    }
+
+    throw err
+  } finally {
+    isPurgeWorkspacesRunning = false
+  }
+}
+
+function isLockAcquisitionFailure(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "name" in err &&
+    "code" in err &&
+    "key" in err &&
+    err.name === "LockAcquisitionError" &&
+    err.code === "LOCK_ACQUISITION_FAILED" &&
+    err.key === LOCK_KEY
+  )
+}
+
+async function isPurgeLockHeld(): Promise<boolean> {
+  return await distributedStore.exists(LOCK_KEY)
 }

--- a/packages/business/src/workspace/__tests__/service.test.ts
+++ b/packages/business/src/workspace/__tests__/service.test.ts
@@ -162,4 +162,38 @@ describe("WorkspaceService.purgeDueScheduled", () => {
     // The failed workspace keeps its row; only the clean one is deleted.
     expect(tx.delete).toHaveBeenCalledTimes(1)
   })
+
+  test("tears down up to five claimed workspaces concurrently", async () => {
+    const claimedRows = Array.from({ length: 6 }, (_, index) => ({
+      id: `w${index + 1}`,
+      ownerId: `o${index + 1}`,
+      tenantId: `t${index + 1}`,
+    }))
+    const deleteWhere = vi.fn().mockResolvedValue(undefined)
+    const tx = {
+      execute: vi.fn().mockResolvedValue({ rows: claimedRows }),
+      select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }),
+      delete: vi.fn(() => ({ where: deleteWhere })),
+    }
+    mocks.dbTransaction.mockImplementation(
+      (callback: (tx: unknown) => unknown) => callback(tx),
+    )
+
+    let active = 0
+    let maxActive = 0
+    mocks.purgeWorkspaceHeavyData.mockImplementation(async () => {
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      active -= 1
+      return 0
+    })
+
+    await expect(
+      workspaceService.purgeDueScheduled({ chunkSize: 6, maxChunks: 1 }),
+    ).resolves.toBe(6)
+
+    expect(mocks.purgeWorkspaceHeavyData).toHaveBeenCalledTimes(6)
+    expect(maxActive).toBe(5)
+  })
 })

--- a/packages/business/src/workspace/service.ts
+++ b/packages/business/src/workspace/service.ts
@@ -32,9 +32,12 @@ import {
 import { nextScheduledDeletionAt } from "./deletion-schedule"
 
 type WorkspaceWhere = Partial<{ id: string; ownerId: string; token: string }>
+type DueWorkspace = Pick<WorkspaceModel, "id" | "ownerId" | "tenantId">
 
 const stableKey = (where: WorkspaceWhere) =>
   JSON.stringify(Object.fromEntries(Object.entries(where).sort()))
+
+const PURGE_WORKSPACE_TEARDOWN_CONCURRENCY = 5
 
 class WorkspaceService extends BaseService {
   async findOrFail(props: {
@@ -218,54 +221,13 @@ class WorkspaceService extends BaseService {
       // the whole cron (BullMQ would retry the entire batch forever). Only
       // workspaces that tear down cleanly are deleted below; a failed one keeps
       // its `scheduledDeletionAt` and is retried on the next tick.
-      const succeeded: typeof claimed.rows = []
-      for (const workspace of claimed.rows) {
-        try {
-          await workspaceLifecycleService.freezeWorkspaceRuntime(workspace.id)
-
-          await workspaceLifecycleService
-            .disconnectWorkspaceIntegrations(workspace.id)
-            .catch((err) => {
-              logger.error(
-                { err, workspaceId: workspace.id },
-                "workspace-purge: failed to disconnect workspace integrations",
-              )
-            })
-
-          await workspaceLifecycleService.disconnectWorkspaceChannels({
-            integrations: props?.integrations,
-            teardownLevel: "disconnect",
-            workspaceId: workspace.id,
-            ownerId: workspace.ownerId,
-          })
-
-          // Drain high-volume child tables in small self-committing batches
-          // before the FK cascade, so no single statement deletes millions of
-          // rows under lock.
-          await workspaceLifecycleService.purgeWorkspaceHeavyData({
-            workspaceId: workspace.id,
-          })
-
-          // Best-effort: never block/roll back the purge if release fails —
-          // `reconcileOwnerPoolUsage` below re-derives `workspaces` from source
-          // for every affected owner regardless.
-          await quotaEnforcementService
-            .release({ userId: workspace.ownerId, metric: "workspaces" })
-            .catch((err) => {
-              logger.warn(
-                { err, workspaceId: workspace.id, ownerId: workspace.ownerId },
-                "workspace-purge: workspace quota release failed",
-              )
-            })
-
-          succeeded.push(workspace)
-        } catch (err) {
-          logger.error(
-            { err, workspaceId: workspace.id },
-            "workspace-purge: teardown failed, deferring to next run",
-          )
-        }
-      }
+      const teardownResults = await mapWithConcurrency(
+        claimed.rows,
+        PURGE_WORKSPACE_TEARDOWN_CONCURRENCY,
+        async (workspace) =>
+          await this.teardownDueWorkspace(workspace, props?.integrations),
+      )
+      const succeeded = teardownResults.filter(isNonNull)
 
       const workspaceIds = succeeded.map((row) => row.id)
       const result = await db.transaction(async (tx) => {
@@ -331,6 +293,57 @@ class WorkspaceService extends BaseService {
     )
 
     return totalDeleted
+  }
+
+  private async teardownDueWorkspace(
+    workspace: DueWorkspace,
+    integrations?: WorkspaceTeardownIntegrations,
+  ): Promise<DueWorkspace | null> {
+    try {
+      await workspaceLifecycleService.freezeWorkspaceRuntime(workspace.id)
+
+      await workspaceLifecycleService
+        .disconnectWorkspaceIntegrations(workspace.id)
+        .catch((err) => {
+          logger.error(
+            { err, workspaceId: workspace.id },
+            "workspace-purge: failed to disconnect workspace integrations",
+          )
+        })
+
+      await workspaceLifecycleService.disconnectWorkspaceChannels({
+        integrations,
+        teardownLevel: "disconnect",
+        workspaceId: workspace.id,
+        ownerId: workspace.ownerId,
+      })
+
+      // Drain high-volume child tables in small self-committing batches before
+      // the FK cascade, so no single statement deletes millions of rows under lock.
+      await workspaceLifecycleService.purgeWorkspaceHeavyData({
+        workspaceId: workspace.id,
+      })
+
+      // Best-effort: never block/roll back the purge if release fails —
+      // `reconcileOwnerPoolUsage` below re-derives `workspaces` from source
+      // for every affected owner regardless.
+      await quotaEnforcementService
+        .release({ userId: workspace.ownerId, metric: "workspaces" })
+        .catch((err) => {
+          logger.warn(
+            { err, workspaceId: workspace.id, ownerId: workspace.ownerId },
+            "workspace-purge: workspace quota release failed",
+          )
+        })
+
+      return workspace
+    } catch (err) {
+      logger.error(
+        { err, workspaceId: workspace.id },
+        "workspace-purge: teardown failed, deferring to next run",
+      )
+      return null
+    }
   }
 
   /**
@@ -454,3 +467,30 @@ class WorkspaceService extends BaseService {
 }
 
 export const workspaceService = new WorkspaceService()
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length)
+  let nextIndex = 0
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    async () => {
+      while (nextIndex < items.length) {
+        const currentIndex = nextIndex
+        nextIndex += 1
+        results[currentIndex] = await mapper(items[currentIndex] as T)
+      }
+    },
+  )
+
+  await Promise.all(workers)
+  return results
+}
+
+function isNonNull<T>(value: T | null): value is T {
+  return value !== null
+}

--- a/packages/redis/__tests__/distributed-store.test.ts
+++ b/packages/redis/__tests__/distributed-store.test.ts
@@ -1,0 +1,15 @@
+import type Redis from "ioredis"
+import { describe, expect, test, vi } from "vitest"
+import { distributedStoreFactory } from "../src/distributed-store"
+
+describe("distributedStoreFactory.exists", () => {
+  test("returns true only when Redis reports the key exists", async () => {
+    const exists = vi.fn(async (key: string) => (key === "present" ? 1 : 0))
+    const store = distributedStoreFactory(
+      async () => ({ exists }) as unknown as Redis,
+    )
+
+    await expect(store.exists("present")).resolves.toBe(true)
+    await expect(store.exists("missing")).resolves.toBe(false)
+  })
+})

--- a/packages/redis/src/distributed-lock.ts
+++ b/packages/redis/src/distributed-lock.ts
@@ -23,15 +23,17 @@ export const distributedLockFactory = (
     runExclusive: async <T>({
       key,
       timeoutInSeconds,
+      retryTimeoutInSeconds,
       fn,
     }: RunExclusiveParams<T>): Promise<T> => {
       const timeout = timeoutInSeconds * 1000
+      const retryTimeout = (retryTimeoutInSeconds ?? timeoutInSeconds) * 1000
       const adapter = await getOrCreateRedisAdapter()
       const redLock = createRedlock({
         adapters: [adapter],
         key,
         ttl: timeout,
-        retryAttempts: Math.ceil(timeout / 200),
+        retryAttempts: Math.ceil(retryTimeout / 200),
         retryDelay: 200,
         clockDriftFactor: 0.01,
       })
@@ -50,5 +52,6 @@ export const distributedLockFactory = (
 type RunExclusiveParams<T> = {
   key: string
   timeoutInSeconds: number
+  retryTimeoutInSeconds?: number
   fn: () => Promise<T>
 }

--- a/packages/redis/src/distributed-store.ts
+++ b/packages/redis/src/distributed-store.ts
@@ -57,6 +57,11 @@ export const distributedStoreFactory = (
     }
   },
 
+  async exists(key: string): Promise<boolean> {
+    const redisClient = await getRedisClient()
+    return (await redisClient.exists(key)) > 0
+  },
+
   async getAll<T>(keys: string[]): Promise<Record<string, T | null>> {
     const redisClient = await getRedisClient()
     const values = await redisClient.mget(keys)


### PR DESCRIPTION
## Summary

The hourly workspace-purge cron was surfacing repeated errors in production when it overlapped with another run (multiple worker instances or a run still in progress). The losing run retried for the full lock window and then threw, turning normal contention into a hard failure.

This change makes the cron treat "another run already holds the lock" as a benign skip instead of an error, and speeds up the per-workspace teardown so a single run finishes well within its window.

## Changes

- Skip quietly when another purge already holds the distributed lock, instead of throwing.
- Add a short lock-acquire retry window so a contended run gives up quickly rather than blocking.
- Guard against a second local run starting while one is still in progress.
- Tear down due workspaces with bounded concurrency so a large batch completes faster.

## Test plan

- [x] `redis` unit tests (`distributed-store.exists`)
- [x] `business` workspace service tests
- [x] `worker` purge-workspaces handler tests
- [x] `pnpm lint`

> Note: the repo-wide type-check hook currently fails on unrelated, pre-existing errors in `ui` / `database` / unbuilt `imports` package; the packages changed here type-check clean.