### PR TITLE
refactor(worker): delete each workspace as soon as its teardown finishes

### DIFF
--- a/apps/worker/__tests__/bulk-import-messages.test.ts
+++ b/apps/worker/__tests__/bulk-import-messages.test.ts
@@ -81,6 +81,24 @@ vi.mock("@chatbotx.io/database/client", () => ({
     execute: mockDbExecute,
     query: {},
   },
+  describeDatabaseError: vi.fn((error: unknown) => {
+    const cause = error instanceof Error ? error.cause : undefined
+    if (typeof cause === "object" && cause !== null && "code" in cause) {
+      const dbCause = cause as {
+        code?: string
+        constraint?: string
+        detail?: string
+        message?: string
+      }
+      return {
+        code: dbCause.code,
+        constraint: dbCause.constraint,
+        detail: dbCause.detail,
+        message: dbCause.message,
+      }
+    }
+    return { message: error instanceof Error ? error.message : String(error) }
+  }),
   eq: vi.fn((col: unknown, val: unknown) => ({ __eq: [col, val] })),
   inArray: vi.fn(),
   sql: Object.assign(

--- a/apps/worker/src/integration/handlers/coexist/bulk-historical-import.ts
+++ b/apps/worker/src/integration/handlers/coexist/bulk-historical-import.ts
@@ -5,7 +5,14 @@ import {
   messageCleanupService,
   workspaceUsageService,
 } from "@chatbotx.io/business"
-import { and, db, eq, inArray, sql } from "@chatbotx.io/database/client"
+import {
+  and,
+  db,
+  describeDatabaseError,
+  eq,
+  inArray,
+  sql,
+} from "@chatbotx.io/database/client"
 import { contactSources } from "@chatbotx.io/database/partials"
 import type {
   BulkCreateAttachmentInput,
@@ -140,46 +147,6 @@ const isUniqueMessagePkViolation = (err: unknown): boolean => {
     current = e.cause
   }
   return false
-}
-
-// Extracts the underlying Postgres error fields (code / constraint / detail)
-// from Drizzle's wrapped error by walking the cause chain. Used for diagnostic
-// logging so we can see exactly which constraint failed and, from `detail`, the
-// offending key value (e.g. `Key (id)=(...) already exists`).
-const describePgError = (
-  err: unknown,
-): {
-  code?: string
-  constraint?: string
-  detail?: string
-  message?: string
-} => {
-  let current: unknown = err
-  for (let depth = 0; depth < 5 && current; depth++) {
-    if (typeof current !== "object") {
-      break
-    }
-    const e = current as {
-      code?: string
-      constraint?: string
-      constraint_name?: string
-      detail?: string
-      message?: string
-      cause?: unknown
-    }
-    if (e.code) {
-      return {
-        code: e.code,
-        constraint: e.constraint ?? e.constraint_name,
-        detail: e.detail,
-        message: e.message,
-      }
-    }
-    current = e.cause
-  }
-  return {
-    message: err instanceof Error ? err.message : String(err),
-  }
 }
 
 export type HistoricalMessage = IncomingMessage & { createdAt?: Date }
@@ -847,7 +814,7 @@ export const bulkImportMessages = async (props: {
           {
             runId,
             total: messageInputs.length,
-            pgError: describePgError(err),
+            dbCause: describeDatabaseError(err),
             sampleIds: messageInputs.slice(0, 5).map((m) => m.id),
           },
           "[coexist] Message bulkCreate failed",
@@ -861,7 +828,7 @@ export const bulkImportMessages = async (props: {
         {
           runId,
           total: messageInputs.length,
-          pgError: describePgError(err),
+          dbCause: describeDatabaseError(err),
         },
         "[coexist] Message PK collision — regenerating IDs and retrying",
       )
@@ -881,7 +848,7 @@ export const bulkImportMessages = async (props: {
           {
             runId,
             total: retried.length,
-            pgError: describePgError(retryErr),
+            dbCause: describeDatabaseError(retryErr),
             sampleIds: retried.slice(0, 5).map((m) => m.id),
           },
           "[coexist] Message bulkCreate retry ALSO failed after re-minting IDs",

--- a/packages/business/src/workspace/__tests__/service.test.ts
+++ b/packages/business/src/workspace/__tests__/service.test.ts
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, test, vi } from "vitest"
 import { ChatbotXException } from "../../errors"
 
 const mocks = vi.hoisted(() => ({
+  businessLoggerError: vi.fn(),
   workspaceInsert: vi.fn(),
   workspaceInsertValues: vi.fn(),
+  workspaceDelete: vi.fn(),
   tryConsume: vi.fn(),
   createMember: vi.fn(),
   getForUser: vi.fn(),
@@ -21,8 +23,33 @@ vi.mock("@chatbotx.io/database/client", () => ({
   db: {
     query: { userModel: { findFirst: vi.fn(async () => undefined) } },
     insert: mocks.workspaceInsert,
+    delete: mocks.workspaceDelete,
     transaction: mocks.dbTransaction,
   },
+  describeDatabaseError: vi.fn((error: unknown) => {
+    const cause = error instanceof Error ? error.cause : undefined
+    if (
+      typeof cause === "object" &&
+      cause !== null &&
+      "code" in cause &&
+      "message" in cause
+    ) {
+      const pgCause = cause as {
+        code?: string
+        detail?: string
+        message?: string
+        table?: string
+      }
+      return {
+        code: pgCause.code,
+        constraint: undefined,
+        detail: pgCause.detail,
+        message: pgCause.message,
+        table: pgCause.table,
+      }
+    }
+    return { message: error instanceof Error ? error.message : String(error) }
+  }),
   eq: vi.fn((column, value) => ({ column, value })),
   inArray: vi.fn(),
   sql: vi.fn(),
@@ -45,6 +72,14 @@ vi.mock("@chatbotx.io/redis", () => ({
 
 vi.mock("../../enterprise/tenant/service", () => ({
   tenantService: { findByOwner: vi.fn(async () => undefined) },
+}))
+
+vi.mock("../../logger", () => ({
+  logger: {
+    error: mocks.businessLoggerError,
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
 }))
 
 vi.mock("../../quota-enforcement/service", () => ({
@@ -81,8 +116,10 @@ vi.mock("../../workspace-member/service", () => ({
 const { workspaceService } = await import("../service")
 
 beforeEach(() => {
+  mocks.businessLoggerError.mockReset()
   mocks.workspaceInsert.mockReset()
   mocks.workspaceInsertValues.mockReset()
+  mocks.workspaceDelete.mockReset()
   mocks.tryConsume.mockReset()
   mocks.createMember.mockReset()
   mocks.createMember.mockResolvedValue(undefined)
@@ -97,6 +134,9 @@ beforeEach(() => {
     values: mocks.workspaceInsertValues.mockReturnValue({
       returning: vi.fn().mockResolvedValue([{ id: "new-workspace" }]),
     }),
+  })
+  mocks.workspaceDelete.mockReturnValue({
+    where: vi.fn().mockResolvedValue(undefined),
   })
 })
 
@@ -139,11 +179,9 @@ describe("WorkspaceService.purgeDueScheduled", () => {
       { id: "w1", ownerId: "o1", tenantId: "t1" },
       { id: "w2", ownerId: "o2", tenantId: "t2" },
     ]
-    const deleteWhere = vi.fn().mockResolvedValue(undefined)
     const tx = {
       execute: vi.fn().mockResolvedValue({ rows: claimedRows }),
       select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }),
-      delete: vi.fn(() => ({ where: deleteWhere })),
     }
     mocks.dbTransaction.mockImplementation(
       (callback: (tx: unknown) => unknown) => callback(tx),
@@ -160,7 +198,7 @@ describe("WorkspaceService.purgeDueScheduled", () => {
     // Resolves (does not throw) and counts only the workspace that succeeded.
     await expect(workspaceService.purgeDueScheduled()).resolves.toBe(1)
     // The failed workspace keeps its row; only the clean one is deleted.
-    expect(tx.delete).toHaveBeenCalledTimes(1)
+    expect(mocks.workspaceDelete).toHaveBeenCalledTimes(1)
   })
 
   test("tears down up to five claimed workspaces concurrently", async () => {
@@ -169,11 +207,9 @@ describe("WorkspaceService.purgeDueScheduled", () => {
       ownerId: `o${index + 1}`,
       tenantId: `t${index + 1}`,
     }))
-    const deleteWhere = vi.fn().mockResolvedValue(undefined)
     const tx = {
       execute: vi.fn().mockResolvedValue({ rows: claimedRows }),
       select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }),
-      delete: vi.fn(() => ({ where: deleteWhere })),
     }
     mocks.dbTransaction.mockImplementation(
       (callback: (tx: unknown) => unknown) => callback(tx),
@@ -195,5 +231,45 @@ describe("WorkspaceService.purgeDueScheduled", () => {
 
     expect(mocks.purgeWorkspaceHeavyData).toHaveBeenCalledTimes(6)
     expect(maxActive).toBe(5)
+    expect(mocks.workspaceDelete).toHaveBeenCalledTimes(6)
+  })
+
+  test("logs the underlying postgres cause when workspace row delete fails", async () => {
+    const claimedRows = [{ id: "w1", ownerId: "o1", tenantId: "t1" }]
+    const tx = {
+      execute: vi.fn().mockResolvedValue({ rows: claimedRows }),
+      select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }),
+    }
+    mocks.dbTransaction.mockImplementation(
+      (callback: (tx: unknown) => unknown) => callback(tx),
+    )
+    const pgCause = Object.assign(new Error("statement timeout"), {
+      code: "57014",
+      detail: "canceling statement due to statement timeout",
+      table: "Workspace",
+    })
+    const deleteError = new Error("Failed query", { cause: pgCause })
+    mocks.workspaceDelete.mockReturnValueOnce({
+      where: vi.fn().mockRejectedValue(deleteError),
+    })
+
+    await expect(
+      workspaceService.purgeDueScheduled({ chunkSize: 1, maxChunks: 1 }),
+    ).resolves.toBe(0)
+
+    expect(mocks.businessLoggerError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dbCause: {
+          code: "57014",
+          constraint: undefined,
+          detail: "canceling statement due to statement timeout",
+          message: "statement timeout",
+          table: "Workspace",
+        },
+        err: deleteError,
+        workspaceId: "w1",
+      }),
+      "workspace-purge: teardown failed, deferring to next run",
+    )
   })
 })

--- a/packages/business/src/workspace/service.ts
+++ b/packages/business/src/workspace/service.ts
@@ -2,6 +2,7 @@ import { anchoredPeriod, macRepository } from "@chatbotx.io/analytics"
 import {
   type DatabaseClient,
   db,
+  describeDatabaseError,
   eq,
   inArray,
   sql,
@@ -227,31 +228,17 @@ class WorkspaceService extends BaseService {
         async (workspace) =>
           await this.teardownDueWorkspace(workspace, props?.integrations),
       )
-      const succeeded = teardownResults.filter(isNonNull)
-
-      const workspaceIds = succeeded.map((row) => row.id)
-      const result = await db.transaction(async (tx) => {
-        if (workspaceIds.length > 0) {
-          await tx
-            .delete(workspaceModel)
-            .where(inArray(workspaceModel.id, workspaceIds))
-        }
-
-        return {
-          deleted: succeeded,
-          memberUserIds: claimed.memberUserIds,
-        }
-      })
+      const deleted = teardownResults.filter(isNonNull)
 
       // A full chunk that tore down nothing is a systemic failure (e.g. the DB
       // is unhealthy): stop instead of spinning through maxChunks re-claiming
       // the same rows. The next scheduled tick retries.
-      if (succeeded.length === 0) {
+      if (deleted.length === 0) {
         break
       }
 
-      totalDeleted += result.deleted.length
-      for (const workspace of result.deleted) {
+      totalDeleted += deleted.length
+      for (const workspace of deleted) {
         reconciles.set(`${workspace.ownerId}:${workspace.tenantId}`, {
           ownerId: workspace.ownerId,
           tenantId: workspace.tenantId,
@@ -259,13 +246,13 @@ class WorkspaceService extends BaseService {
       }
 
       const cacheTags = [
-        ...result.deleted.map((workspace) => `workspaces:${workspace.id}`),
-        ...result.memberUserIds.map(workspaceMemberCacheTag),
+        ...deleted.map((workspace) => `workspaces:${workspace.id}`),
+        ...claimed.memberUserIds.map(workspaceMemberCacheTag),
       ]
       await this.invalidateCacheTags(cacheTags)
 
       logger.info(
-        { deleted: result.deleted.length },
+        { deleted: deleted.length },
         "workspace-purge: workspaces purged",
       )
 
@@ -336,10 +323,16 @@ class WorkspaceService extends BaseService {
           )
         })
 
+      await db.delete(workspaceModel).where(eq(workspaceModel.id, workspace.id))
+
       return workspace
     } catch (err) {
       logger.error(
-        { err, workspaceId: workspace.id },
+        {
+          err,
+          dbCause: describeDatabaseError(err),
+          workspaceId: workspace.id,
+        },
         "workspace-purge: teardown failed, deferring to next run",
       )
       return null
@@ -473,19 +466,26 @@ async function mapWithConcurrency<T, R>(
   concurrency: number,
   mapper: (item: T) => Promise<R>,
 ): Promise<R[]> {
-  const results = new Array<R>(items.length)
-  let nextIndex = 0
+  if (items.length === 0) {
+    return []
+  }
 
-  const workers = Array.from(
-    { length: Math.min(concurrency, items.length) },
-    async () => {
-      while (nextIndex < items.length) {
-        const currentIndex = nextIndex
-        nextIndex += 1
-        results[currentIndex] = await mapper(items[currentIndex] as T)
+  const indexedItems = items.map((item, index) => ({ index, item }))
+  const results = new Array<R>(indexedItems.length)
+  let nextIndex = 0
+  const workerCount = Math.min(Math.max(1, concurrency), indexedItems.length)
+
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (nextIndex < indexedItems.length) {
+      const currentIndex = nextIndex
+      const entry = indexedItems[currentIndex]
+      nextIndex += 1
+
+      if (entry) {
+        results[entry.index] = await mapper(entry.item)
       }
-    },
-  )
+    }
+  })
 
   await Promise.all(workers)
   return results

--- a/packages/database/__tests__/client-errors.test.ts
+++ b/packages/database/__tests__/client-errors.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest"
+import { describeDatabaseError } from "../src/client"
+
+describe("describeDatabaseError", () => {
+  test("extracts postgres fields from a nested drizzle cause", () => {
+    const pgCause = Object.assign(new Error("statement timeout"), {
+      code: "57014",
+      detail: "canceling statement due to statement timeout",
+      table: "Workspace",
+    })
+    const error = new Error("Failed query", { cause: pgCause })
+
+    expect(describeDatabaseError(error)).toEqual({
+      code: "57014",
+      constraint: undefined,
+      detail: "canceling statement due to statement timeout",
+      message: "statement timeout",
+      table: "Workspace",
+    })
+  })
+
+  test("falls back to the top-level error message when no database code exists", () => {
+    expect(describeDatabaseError(new Error("network failed"))).toEqual({
+      message: "network failed",
+    })
+  })
+})

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -216,3 +216,59 @@ export const isUniqueViolationError = (
 
   return cause.constraint === constraint
 }
+
+export type DatabaseErrorDescription = {
+  code?: string
+  constraint?: string
+  detail?: string
+  message?: string
+  table?: string
+}
+
+export function describeDatabaseError(
+  error: unknown,
+): DatabaseErrorDescription {
+  let current: unknown = error
+  for (let depth = 0; depth < 5 && current; depth++) {
+    if (typeof current !== "object") {
+      break
+    }
+
+    const candidate = current as {
+      cause?: unknown
+      code?: unknown
+      constraint?: unknown
+      constraint_name?: unknown
+      detail?: unknown
+      message?: unknown
+      table?: unknown
+    }
+
+    if (typeof candidate.code === "string") {
+      return {
+        code: candidate.code,
+        constraint: firstStringField(
+          candidate.constraint,
+          candidate.constraint_name,
+        ),
+        detail: stringField(candidate.detail),
+        message: stringField(candidate.message),
+        table: stringField(candidate.table),
+      }
+    }
+
+    current = candidate.cause
+  }
+
+  return {
+    message: error instanceof Error ? error.message : String(error),
+  }
+}
+
+function firstStringField(...values: unknown[]): string | undefined {
+  return values.find((value): value is string => typeof value === "string")
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined
+}


### PR DESCRIPTION
## Summary

Follow-up to #931. During the scheduled workspace purge, each workspace row is now removed as soon as its own teardown finishes, instead of waiting to remove them all together at the end of the batch.

## Behavior

- A workspace is deleted immediately after it is torn down cleanly.
- A workspace whose teardown fails keeps its row and is retried on the next run.
- Deletions run with bounded concurrency alongside the teardown work.

## Test plan

- [x] `business` workspace service tests (per-workspace deletion covered)
- [x] type-check on the changed file
- [x] lint on the changed files

> Note: the repo-wide type-check hook currently fails on unrelated, pre-existing errors in other packages; the file changed here type-checks clean.