### PR TITLE
feat(contacts): import column auto-mapping and template download

### DIFF
--- a/apps/builder/__tests__/contacts-import-template-route.test.ts
+++ b/apps/builder/__tests__/contacts-import-template-route.test.ts
@@ -1,31 +1,29 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
-const { mockRequireContactsAccess, mockFindById, mockNotFound } = vi.hoisted(
+const { mockGetUserAndWorkspace, mockCanAccessContactsSection } = vi.hoisted(
   () => ({
-    mockRequireContactsAccess: vi.fn(),
-    mockFindById: vi.fn(),
-    mockNotFound: vi.fn(() => {
-      throw new Error("not found")
-    }),
+    mockGetUserAndWorkspace: vi.fn(),
+    mockCanAccessContactsSection: vi.fn(),
   }),
 )
 
-vi.mock("@/lib/auth/require-workspace-permission", () => ({
-  requireContactsAccess: mockRequireContactsAccess,
+vi.mock("@/lib/auth/utils", () => ({
+  getCurrentUserAndTargetWorkspace: mockGetUserAndWorkspace,
 }))
 
-vi.mock("@chatbotx.io/business", () => ({
-  workspaceService: {
-    findById: mockFindById,
-  },
-}))
-
-vi.mock("next/navigation", () => ({
-  notFound: mockNotFound,
+vi.mock("@/features/contacts/permissions", () => ({
+  canAccessContactsSection: mockCanAccessContactsSection,
 }))
 
 const UTF8_BOM_BYTES = [0xef, 0xbb, 0xbf]
+
+const EN_TEMPLATE =
+  '"Contact ID","Phone number","Email","First name","Last name"\n' +
+  '"1234567890","+14155550100","john.doe@example.com","John","Doe"\n'
+const VI_TEMPLATE =
+  '"ID Liên hệ","Số điện thoại","Email","Tên","Họ"\n' +
+  '"1234567890","+84155550100","an.nguyen@example.com","An","Nguyễn"\n'
 
 const { GET } = await import(
   "../src/app/(no-sidebar)/space/[workspaceId]/contacts/import/template/route"
@@ -36,6 +34,11 @@ const callRoute = (workspaceId: string) =>
     params: Promise.resolve({ workspaceId }),
   })
 
+const workspaceWithLanguage = (language: string) => ({
+  targetWorkspace: { language },
+  targetWorkspaceMember: { permissions: {} },
+})
+
 // `Response.text()` decodes as UTF-8 and strips a leading BOM per the WHATWG
 // spec, so BOM presence must be asserted on the raw bytes instead.
 const readRawBytes = async (res: Response) =>
@@ -44,11 +47,11 @@ const readRawBytes = async (res: Response) =>
 describe("contacts import template download route", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockRequireContactsAccess.mockResolvedValue(undefined)
+    mockCanAccessContactsSection.mockReturnValue(true)
   })
 
-  test("returns an English-header CSV attachment for a non-Vietnamese workspace", async () => {
-    mockFindById.mockResolvedValue({ language: "en" })
+  test("returns an English CSV attachment for a non-Vietnamese workspace", async () => {
+    mockGetUserAndWorkspace.mockResolvedValue(workspaceWithLanguage("en"))
 
     const res = await callRoute("ws-1")
     const bytes = await readRawBytes(res)
@@ -59,36 +62,45 @@ describe("contacts import template download route", () => {
       'attachment; filename="contacts-import-template.csv"',
     )
     expect([...bytes.subarray(0, 3)]).toEqual(UTF8_BOM_BYTES)
-    expect(bytes.subarray(3).toString("utf-8")).toBe(
-      '"Contact ID","Phone number","Email","First name","Last name"\n',
-    )
-    expect(mockRequireContactsAccess).toHaveBeenCalledWith("ws-1")
-    expect(mockFindById).toHaveBeenCalledWith({ id: "ws-1" })
+    expect(bytes.subarray(3).toString("utf-8")).toBe(EN_TEMPLATE)
+    expect(mockGetUserAndWorkspace).toHaveBeenCalledWith("ws-1")
   })
 
-  test("returns a Vietnamese-header CSV attachment for a Vietnamese workspace", async () => {
-    mockFindById.mockResolvedValue({ language: "vi" })
+  test("returns a Vietnamese CSV attachment for a Vietnamese workspace", async () => {
+    mockGetUserAndWorkspace.mockResolvedValue(workspaceWithLanguage("vi"))
 
     const res = await callRoute("ws-1")
     const bytes = await readRawBytes(res)
 
     expect(res.status).toBe(200)
     expect([...bytes.subarray(0, 3)]).toEqual(UTF8_BOM_BYTES)
-    expect(bytes.subarray(3).toString("utf-8")).toBe(
-      '"ID Liên hệ","Số điện thoại","Email","Tên","Họ"\n',
-    )
+    expect(bytes.subarray(3).toString("utf-8")).toBe(VI_TEMPLATE)
   })
 
-  test("propagates the access-denied rejection without loading the workspace", async () => {
-    mockRequireContactsAccess.mockRejectedValue(new Error("not found"))
+  test("404s when the caller is not a member of the workspace", async () => {
+    mockGetUserAndWorkspace.mockResolvedValue(null)
 
-    await expect(callRoute("ws-1")).rejects.toThrow("not found")
-    expect(mockFindById).not.toHaveBeenCalled()
+    const res = await callRoute("ws-1")
+
+    expect(res.status).toBe(404)
+    expect(await res.text()).toBe("")
+    expect(mockCanAccessContactsSection).not.toHaveBeenCalled()
   })
 
-  test("404s without checking access or loading the workspace when workspaceId is missing", async () => {
-    await expect(callRoute("")).rejects.toThrow("not found")
-    expect(mockRequireContactsAccess).not.toHaveBeenCalled()
-    expect(mockFindById).not.toHaveBeenCalled()
+  test("404s when the caller lacks contacts access", async () => {
+    mockGetUserAndWorkspace.mockResolvedValue(workspaceWithLanguage("en"))
+    mockCanAccessContactsSection.mockReturnValue(false)
+
+    const res = await callRoute("ws-1")
+
+    expect(res.status).toBe(404)
+    expect(await res.text()).toBe("")
+  })
+
+  test("404s without checking access when workspaceId is missing", async () => {
+    const res = await callRoute("")
+
+    expect(res.status).toBe(404)
+    expect(mockGetUserAndWorkspace).not.toHaveBeenCalled()
   })
 })

--- a/apps/builder/__tests__/contacts-import-template-route.test.ts
+++ b/apps/builder/__tests__/contacts-import-template-route.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockRequireContactsAccess, mockFindById, mockNotFound } = vi.hoisted(
+  () => ({
+    mockRequireContactsAccess: vi.fn(),
+    mockFindById: vi.fn(),
+    mockNotFound: vi.fn(() => {
+      throw new Error("not found")
+    }),
+  }),
+)
+
+vi.mock("@/lib/auth/require-workspace-permission", () => ({
+  requireContactsAccess: mockRequireContactsAccess,
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  workspaceService: {
+    findById: mockFindById,
+  },
+}))
+
+vi.mock("next/navigation", () => ({
+  notFound: mockNotFound,
+}))
+
+const UTF8_BOM_BYTES = [0xef, 0xbb, 0xbf]
+
+const { GET } = await import(
+  "../src/app/(no-sidebar)/space/[workspaceId]/contacts/import/template/route"
+)
+
+const callRoute = (workspaceId: string) =>
+  GET(new Request("http://localhost/space/ws-1/contacts/import/template"), {
+    params: Promise.resolve({ workspaceId }),
+  })
+
+// `Response.text()` decodes as UTF-8 and strips a leading BOM per the WHATWG
+// spec, so BOM presence must be asserted on the raw bytes instead.
+const readRawBytes = async (res: Response) =>
+  Buffer.from(await res.arrayBuffer())
+
+describe("contacts import template download route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRequireContactsAccess.mockResolvedValue(undefined)
+  })
+
+  test("returns an English-header CSV attachment for a non-Vietnamese workspace", async () => {
+    mockFindById.mockResolvedValue({ language: "en" })
+
+    const res = await callRoute("ws-1")
+    const bytes = await readRawBytes(res)
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toBe("text/csv; charset=utf-8")
+    expect(res.headers.get("content-disposition")).toBe(
+      'attachment; filename="contacts-import-template.csv"',
+    )
+    expect([...bytes.subarray(0, 3)]).toEqual(UTF8_BOM_BYTES)
+    expect(bytes.subarray(3).toString("utf-8")).toBe(
+      '"Contact ID","Phone number","Email","First name","Last name"\n',
+    )
+    expect(mockRequireContactsAccess).toHaveBeenCalledWith("ws-1")
+    expect(mockFindById).toHaveBeenCalledWith({ id: "ws-1" })
+  })
+
+  test("returns a Vietnamese-header CSV attachment for a Vietnamese workspace", async () => {
+    mockFindById.mockResolvedValue({ language: "vi" })
+
+    const res = await callRoute("ws-1")
+    const bytes = await readRawBytes(res)
+
+    expect(res.status).toBe(200)
+    expect([...bytes.subarray(0, 3)]).toEqual(UTF8_BOM_BYTES)
+    expect(bytes.subarray(3).toString("utf-8")).toBe(
+      '"ID Liên hệ","Số điện thoại","Email","Tên","Họ"\n',
+    )
+  })
+
+  test("propagates the access-denied rejection without loading the workspace", async () => {
+    mockRequireContactsAccess.mockRejectedValue(new Error("not found"))
+
+    await expect(callRoute("ws-1")).rejects.toThrow("not found")
+    expect(mockFindById).not.toHaveBeenCalled()
+  })
+
+  test("404s without checking access or loading the workspace when workspaceId is missing", async () => {
+    await expect(callRoute("")).rejects.toThrow("not found")
+    expect(mockRequireContactsAccess).not.toHaveBeenCalled()
+    expect(mockFindById).not.toHaveBeenCalled()
+  })
+})

--- a/apps/builder/__tests__/contacts-import-template.test.ts
+++ b/apps/builder/__tests__/contacts-import-template.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+import { describe, expect, test } from "vitest"
+import {
+  buildContactsImportTemplateCsv,
+  CONTACTS_IMPORT_TEMPLATE_COLUMNS,
+  CONTACTS_IMPORT_TEMPLATE_FILENAME,
+} from "@/features/contacts/lib/contacts-import-template"
+
+const UTF8_BOM = "﻿"
+
+describe("buildContactsImportTemplateCsv", () => {
+  test("returns quoted English headers with a UTF-8 BOM for the en language", () => {
+    const csv = buildContactsImportTemplateCsv("en")
+
+    expect(csv.startsWith(UTF8_BOM)).toBe(true)
+    expect(csv.slice(UTF8_BOM.length)).toBe(
+      '"Contact ID","Phone number","Email","First name","Last name"\n',
+    )
+  })
+
+  test("returns quoted Vietnamese headers for the vi language", () => {
+    const csv = buildContactsImportTemplateCsv("vi")
+
+    expect(csv.slice(UTF8_BOM.length)).toBe(
+      '"ID Liên hệ","Số điện thoại","Email","Tên","Họ"\n',
+    )
+  })
+
+  test("falls back to English headers for any language other than vi", () => {
+    const fr = buildContactsImportTemplateCsv("fr")
+    const empty = buildContactsImportTemplateCsv("")
+
+    const englishHeaderRow =
+      '"Contact ID","Phone number","Email","First name","Last name"\n'
+    expect(fr.slice(UTF8_BOM.length)).toBe(englishHeaderRow)
+    expect(empty.slice(UTF8_BOM.length)).toBe(englishHeaderRow)
+  })
+
+  test("resolves regional variants to their base language", () => {
+    // "vi-VN" must resolve like "vi"; en-* variants (and unmapped locales) fall
+    // back to English — this guards the resolveLocale() delegation.
+    const csv = buildContactsImportTemplateCsv("vi-VN")
+
+    expect(csv.slice(UTF8_BOM.length)).toBe(
+      '"ID Liên hệ","Số điện thoại","Email","Tên","Họ"\n',
+    )
+  })
+
+  test("emits exactly the documented column count and order", () => {
+    const csv = buildContactsImportTemplateCsv("en")
+    const [headerLine] = csv.slice(UTF8_BOM.length).trimEnd().split("\n")
+
+    expect(CONTACTS_IMPORT_TEMPLATE_COLUMNS).toEqual([
+      "contactId",
+      "phoneNumber",
+      "email",
+      "firstName",
+      "lastName",
+    ])
+    expect(headerLine.split(",")).toHaveLength(
+      CONTACTS_IMPORT_TEMPLATE_COLUMNS.length,
+    )
+  })
+
+  test("exposes a stable download filename", () => {
+    expect(CONTACTS_IMPORT_TEMPLATE_FILENAME).toBe(
+      "contacts-import-template.csv",
+    )
+  })
+})

--- a/apps/builder/__tests__/contacts-import-template.test.ts
+++ b/apps/builder/__tests__/contacts-import-template.test.ts
@@ -9,31 +9,32 @@ import {
 const UTF8_BOM = "﻿"
 
 describe("buildContactsImportTemplateCsv", () => {
-  test("returns quoted English headers with a UTF-8 BOM for the en language", () => {
+  const EN_TEMPLATE =
+    '"Contact ID","Phone number","Email","First name","Last name"\n' +
+    '"1234567890","+14155550100","john.doe@example.com","John","Doe"\n'
+  const VI_TEMPLATE =
+    '"ID Liên hệ","Số điện thoại","Email","Tên","Họ"\n' +
+    '"1234567890","+84155550100","an.nguyen@example.com","An","Nguyễn"\n'
+
+  test("returns quoted English headers and an example row with a UTF-8 BOM for the en language", () => {
     const csv = buildContactsImportTemplateCsv("en")
 
     expect(csv.startsWith(UTF8_BOM)).toBe(true)
-    expect(csv.slice(UTF8_BOM.length)).toBe(
-      '"Contact ID","Phone number","Email","First name","Last name"\n',
-    )
+    expect(csv.slice(UTF8_BOM.length)).toBe(EN_TEMPLATE)
   })
 
-  test("returns quoted Vietnamese headers for the vi language", () => {
+  test("returns quoted Vietnamese headers and example row for the vi language", () => {
     const csv = buildContactsImportTemplateCsv("vi")
 
-    expect(csv.slice(UTF8_BOM.length)).toBe(
-      '"ID Liên hệ","Số điện thoại","Email","Tên","Họ"\n',
-    )
+    expect(csv.slice(UTF8_BOM.length)).toBe(VI_TEMPLATE)
   })
 
-  test("falls back to English headers for any language other than vi", () => {
+  test("falls back to the English template for any language other than vi", () => {
     const fr = buildContactsImportTemplateCsv("fr")
     const empty = buildContactsImportTemplateCsv("")
 
-    const englishHeaderRow =
-      '"Contact ID","Phone number","Email","First name","Last name"\n'
-    expect(fr.slice(UTF8_BOM.length)).toBe(englishHeaderRow)
-    expect(empty.slice(UTF8_BOM.length)).toBe(englishHeaderRow)
+    expect(fr.slice(UTF8_BOM.length)).toBe(EN_TEMPLATE)
+    expect(empty.slice(UTF8_BOM.length)).toBe(EN_TEMPLATE)
   })
 
   test("resolves regional variants to their base language", () => {
@@ -41,14 +42,12 @@ describe("buildContactsImportTemplateCsv", () => {
     // back to English — this guards the resolveLocale() delegation.
     const csv = buildContactsImportTemplateCsv("vi-VN")
 
-    expect(csv.slice(UTF8_BOM.length)).toBe(
-      '"ID Liên hệ","Số điện thoại","Email","Tên","Họ"\n',
-    )
+    expect(csv.slice(UTF8_BOM.length)).toBe(VI_TEMPLATE)
   })
 
-  test("emits exactly the documented column count and order", () => {
+  test("emits a header row and exactly one example data row", () => {
     const csv = buildContactsImportTemplateCsv("en")
-    const [headerLine] = csv.slice(UTF8_BOM.length).trimEnd().split("\n")
+    const rows = csv.slice(UTF8_BOM.length).trimEnd().split("\n")
 
     expect(CONTACTS_IMPORT_TEMPLATE_COLUMNS).toEqual([
       "contactId",
@@ -57,9 +56,12 @@ describe("buildContactsImportTemplateCsv", () => {
       "firstName",
       "lastName",
     ])
-    expect(headerLine.split(",")).toHaveLength(
-      CONTACTS_IMPORT_TEMPLATE_COLUMNS.length,
-    )
+    expect(rows).toHaveLength(2)
+    for (const row of rows) {
+      expect(row.split(",")).toHaveLength(
+        CONTACTS_IMPORT_TEMPLATE_COLUMNS.length,
+      )
+    }
   })
 
   test("exposes a stable download filename", () => {

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -43,6 +43,7 @@
     "disableBot": "Disable Bot",
     "disconnect": "Disconnect",
     "download": "Download",
+    "downloadTemplate": "Download template",
     "edit": "Edit",
     "editFeature": "Edit {feature}",
     "enableBot": "Enable Bot",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -43,6 +43,7 @@
     "disableBot": "Tắt bot",
     "disconnect": "Ngắt kết nối",
     "download": "Tải xuống",
+    "downloadTemplate": "Tải mẫu",
     "edit": "Chỉnh sửa",
     "editFeature": "Chỉnh sửa {feature}",
     "enableBot": "Bật bot",

--- a/apps/builder/src/app/(no-sidebar)/space/[workspaceId]/contacts/import/template/route.ts
+++ b/apps/builder/src/app/(no-sidebar)/space/[workspaceId]/contacts/import/template/route.ts
@@ -1,11 +1,10 @@
-import { workspaceService } from "@chatbotx.io/business"
 import { getIdFromParams } from "@chatbotx.io/utils"
-import { notFound } from "next/navigation"
 import {
   buildContactsImportTemplateCsv,
   CONTACTS_IMPORT_TEMPLATE_FILENAME,
 } from "@/features/contacts/lib/contacts-import-template"
-import { requireContactsAccess } from "@/lib/auth/require-workspace-permission"
+import { canAccessContactsSection } from "@/features/contacts/permissions"
+import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
 
 export const runtime = "nodejs"
 
@@ -15,14 +14,27 @@ export async function GET(
 ) {
   const workspaceId = getIdFromParams(await params, "workspaceId")
   if (!workspaceId) {
-    notFound()
+    return new Response(null, { status: 404 })
   }
 
-  // Throws (renders 404) when the caller lacks contacts access.
-  await requireContactsAccess(workspaceId)
+  // A route handler must return an explicit Response on the deny path.
+  // `notFound()` renders an HTML error page here (the browser saved it as
+  // "template.html") instead of a real 404 for this download.
+  const userAndWorkspace = await getCurrentUserAndTargetWorkspace(workspaceId)
+  if (
+    !(
+      userAndWorkspace &&
+      canAccessContactsSection(
+        userAndWorkspace.targetWorkspaceMember.permissions,
+      )
+    )
+  ) {
+    return new Response(null, { status: 404 })
+  }
 
-  const workspace = await workspaceService.findById({ id: workspaceId })
-  const csv = buildContactsImportTemplateCsv(workspace.language)
+  const csv = buildContactsImportTemplateCsv(
+    userAndWorkspace.targetWorkspace.language,
+  )
 
   return new Response(csv, {
     headers: {

--- a/apps/builder/src/app/(no-sidebar)/space/[workspaceId]/contacts/import/template/route.ts
+++ b/apps/builder/src/app/(no-sidebar)/space/[workspaceId]/contacts/import/template/route.ts
@@ -1,0 +1,34 @@
+import { workspaceService } from "@chatbotx.io/business"
+import { getIdFromParams } from "@chatbotx.io/utils"
+import { notFound } from "next/navigation"
+import {
+  buildContactsImportTemplateCsv,
+  CONTACTS_IMPORT_TEMPLATE_FILENAME,
+} from "@/features/contacts/lib/contacts-import-template"
+import { requireContactsAccess } from "@/lib/auth/require-workspace-permission"
+
+export const runtime = "nodejs"
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ workspaceId: string }> },
+) {
+  const workspaceId = getIdFromParams(await params, "workspaceId")
+  if (!workspaceId) {
+    notFound()
+  }
+
+  // Throws (renders 404) when the caller lacks contacts access.
+  await requireContactsAccess(workspaceId)
+
+  const workspace = await workspaceService.findById({ id: workspaceId })
+  const csv = buildContactsImportTemplateCsv(workspace.language)
+
+  return new Response(csv, {
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${CONTACTS_IMPORT_TEMPLATE_FILENAME}"`,
+      "Cache-Control": "no-store",
+    },
+  })
+}

--- a/apps/builder/src/features/contacts/import-contact-form.tsx
+++ b/apps/builder/src/features/contacts/import-contact-form.tsx
@@ -20,6 +20,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hooks"
 import {
   ArrowRightIcon,
+  DownloadIcon,
   HistoryIcon,
   Loader2Icon,
   Trash2Icon,
@@ -112,7 +113,15 @@ export function ImportContactsForm({ workspaceId }: { workspaceId: string }) {
 
   return (
     <>
-      <div className="flex justify-end">
+      <div className="flex justify-end gap-4">
+        <a
+          className="inline-flex items-center gap-1 text-blue-600 text-sm hover:underline"
+          download
+          href={`/space/${workspaceId}/contacts/import/template`}
+        >
+          <DownloadIcon size={16} />
+          {t("actions.downloadTemplate")}
+        </a>
         <Link
           className="inline-flex items-center gap-1 text-blue-600 text-sm hover:underline"
           href={`/space/${workspaceId}/contacts/import/histories`}

--- a/apps/builder/src/features/contacts/import-contact-form.tsx
+++ b/apps/builder/src/features/contacts/import-contact-form.tsx
@@ -2,9 +2,11 @@
 
 import {
   channelTypes,
+  contactImportFields,
   importTypes,
   uploadTypes,
 } from "@chatbotx.io/database/partials"
+import { matchContactImportHeaders } from "@chatbotx.io/imports"
 import { InputField } from "@chatbotx.io/ui/components/form/input-field"
 import { SelectField } from "@chatbotx.io/ui/components/form/select-field"
 import {
@@ -111,6 +113,18 @@ export function ImportContactsForm({ workspaceId }: { workspaceId: string }) {
     }
   }, [timezone, form.setValue])
 
+  // Set the column mapping from a file's headers. Done in the same event
+  // handler that updates `csvHeaders` (never a later effect) so each Select
+  // sees its new value and new options in one commit — otherwise Base UI
+  // Select briefly holds the previous file's value against the new options,
+  // fires `onValueChange(null)`, and overwrites the mapping with null.
+  const applyHeaderMapping = (headers: string[]) => {
+    const columnByField = matchContactImportHeaders(headers)
+    for (const field of contactImportFields.options) {
+      form.setValue(field, columnByField[field], { shouldValidate: true })
+    }
+  }
+
   return (
     <>
       <div className="flex justify-end gap-4">
@@ -134,10 +148,12 @@ export function ImportContactsForm({ workspaceId }: { workspaceId: string }) {
         onCleared={() => {
           setFileId("")
           setCsvHeaders([])
+          applyHeaderMapping([])
         }}
         onUploaded={(result, headers) => {
           setFileId(result.fileId)
           setCsvHeaders(headers)
+          applyHeaderMapping(headers)
         }}
         onUploadingChange={setIsUploading}
         subType={importTypes.enum.contacts}
@@ -264,8 +280,13 @@ function HeaderConnectField({
   return (
     <div className="flex items-center gap-4">
       <div className="flex-1">
+        {/* Remount the Select when the header set changes so it re-renders
+            from the current form value instead of keeping the previous file's
+            label (Base UI Select does not clear a stale label when its options
+            change out from under it). */}
         <SelectField
           allowClear={allowClear}
+          key={csvHeaders.join("")}
           name={name}
           options={csvHeaders.map((col) => ({ label: col, value: col }))}
         />

--- a/apps/builder/src/features/contacts/lib/contacts-import-template.ts
+++ b/apps/builder/src/features/contacts/lib/contacts-import-template.ts
@@ -44,6 +44,28 @@ const resolveColumnLabel = (
   )
 }
 
+// A single filled-in row so users see the expected format for each column
+// rather than an empty template.
+const TEMPLATE_EXAMPLE_ROW: Record<
+  TemplateLocale,
+  Record<ContactsImportTemplateColumn, string>
+> = {
+  en: {
+    contactId: "1234567890",
+    phoneNumber: "+14155550100",
+    email: "john.doe@example.com",
+    firstName: "John",
+    lastName: "Doe",
+  },
+  vi: {
+    contactId: "1234567890",
+    phoneNumber: "+84155550100",
+    email: "an.nguyen@example.com",
+    firstName: "An",
+    lastName: "Nguyễn",
+  },
+}
+
 // Always quotes and doubles embedded quotes, mirroring the `escapeCsvValue`
 // convention used by the worker's CSV export handlers
 // (apps/worker/src/default/handlers/export-contacts.ts and export-coupons.ts).
@@ -52,16 +74,27 @@ const resolveColumnLabel = (
 const escapeCsvValue = (value: string): string =>
   `"${value.replace(/"/g, '""')}"`
 
+const buildCsvRow = (values: readonly string[]): string =>
+  values.map(escapeCsvValue).join(",")
+
 /**
- * Builds the contacts-import CSV template: a single localized header row
- * covering every channel's import columns, prefixed with a UTF-8 BOM so
- * spreadsheet apps (Excel, Sheets) render non-ASCII labels correctly.
+ * Builds the contacts-import CSV template: a localized header row covering
+ * every channel's import columns followed by one example data row, prefixed
+ * with a UTF-8 BOM so spreadsheet apps (Excel, Sheets) render non-ASCII
+ * labels correctly.
  */
 export const buildContactsImportTemplateCsv = (language: string): string => {
   const locale = resolveTemplateLocale(language)
-  const headerRow = CONTACTS_IMPORT_TEMPLATE_COLUMNS.map((column) =>
-    escapeCsvValue(resolveColumnLabel(locale, column)),
-  ).join(",")
+  const example = TEMPLATE_EXAMPLE_ROW[locale]
 
-  return `﻿${headerRow}\n`
+  const headerRow = buildCsvRow(
+    CONTACTS_IMPORT_TEMPLATE_COLUMNS.map((column) =>
+      resolveColumnLabel(locale, column),
+    ),
+  )
+  const exampleRow = buildCsvRow(
+    CONTACTS_IMPORT_TEMPLATE_COLUMNS.map((column) => example[column]),
+  )
+
+  return `﻿${headerRow}\n${exampleRow}\n`
 }

--- a/apps/builder/src/features/contacts/lib/contacts-import-template.ts
+++ b/apps/builder/src/features/contacts/lib/contacts-import-template.ts
@@ -1,0 +1,67 @@
+import { resolveLocale } from "@/i18n/config"
+import { messagesByLocale } from "@/i18n/messages"
+
+export const CONTACTS_IMPORT_TEMPLATE_FILENAME = "contacts-import-template.csv"
+
+/**
+ * The CSV columns for the contacts-import template: the union of every
+ * channel's column-map targets (see `ContactImportColumnMap` and the worker's
+ * `extractRowData`). WhatsApp does not read `contactId` (its identity comes
+ * from the phone number) and only WhatsApp requires `phoneNumber`, but a
+ * single combined template covers every channel's mapping dropdown.
+ */
+export const CONTACTS_IMPORT_TEMPLATE_COLUMNS = [
+  "contactId",
+  "phoneNumber",
+  "email",
+  "firstName",
+  "lastName",
+] as const
+
+type ContactsImportTemplateColumn =
+  (typeof CONTACTS_IMPORT_TEMPLATE_COLUMNS)[number]
+
+// Only Vietnamese and English template headers are supported today.
+const TEMPLATE_LOCALES = ["vi", "en"] as const
+type TemplateLocale = (typeof TEMPLATE_LOCALES)[number]
+
+const resolveTemplateLocale = (language: string): TemplateLocale =>
+  resolveLocale(language) === "vi" ? "vi" : "en"
+
+type FieldLabelMessages = {
+  fields?: Partial<Record<ContactsImportTemplateColumn, { label?: string }>>
+}
+
+const resolveColumnLabel = (
+  locale: TemplateLocale,
+  column: ContactsImportTemplateColumn,
+): string => {
+  const localizedFields = (messagesByLocale[locale] as FieldLabelMessages)
+    .fields
+  const englishFields = (messagesByLocale.en as FieldLabelMessages).fields
+  return (
+    localizedFields?.[column]?.label ?? englishFields?.[column]?.label ?? column
+  )
+}
+
+// Always quotes and doubles embedded quotes, mirroring the `escapeCsvValue`
+// convention used by the worker's CSV export handlers
+// (apps/worker/src/default/handlers/export-contacts.ts and export-coupons.ts).
+// There is no shared CSV package yet, so this mirrors — rather than imports —
+// that convention for consistency across the codebase.
+const escapeCsvValue = (value: string): string =>
+  `"${value.replace(/"/g, '""')}"`
+
+/**
+ * Builds the contacts-import CSV template: a single localized header row
+ * covering every channel's import columns, prefixed with a UTF-8 BOM so
+ * spreadsheet apps (Excel, Sheets) render non-ASCII labels correctly.
+ */
+export const buildContactsImportTemplateCsv = (language: string): string => {
+  const locale = resolveTemplateLocale(language)
+  const headerRow = CONTACTS_IMPORT_TEMPLATE_COLUMNS.map((column) =>
+    escapeCsvValue(resolveColumnLabel(locale, column)),
+  ).join(",")
+
+  return `﻿${headerRow}\n`
+}

--- a/packages/database/src/partials/import.ts
+++ b/packages/database/src/partials/import.ts
@@ -17,6 +17,15 @@ export type ImportStatus = z.infer<typeof importStatuses>
 
 const bigintAsStringSchema = z.string().regex(/^\d+$/)
 
+export const contactImportFields = z.enum([
+  "contactId",
+  "phoneNumber",
+  "email",
+  "firstName",
+  "lastName",
+])
+export type ContactImportField = z.infer<typeof contactImportFields>
+
 export const contactImportColumnMapSchema = z
   .object({
     contactId: z.string().optional(),

--- a/packages/imports/__tests__/contacts-header-match.test.ts
+++ b/packages/imports/__tests__/contacts-header-match.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "vitest"
+import {
+  matchContactImportHeaders,
+  normalizeContactHeader,
+} from "../src/modules/contacts/header-match"
+
+describe("contact import header matching", () => {
+  test.each([
+    ["Contact ID", "contactId"],
+    ["ID Liên hệ", "contactId"],
+    ["Phone number", "phoneNumber"],
+    ["Số điện thoại", "phoneNumber"],
+    ["SĐT", "phoneNumber"],
+    ["Email", "email"],
+    ["E-mail Address", "email"],
+    ["First name", "firstName"],
+    ["Tên", "firstName"],
+    ["Last name", "lastName"],
+    ["Họ", "lastName"],
+  ])("maps %s to %s", (header, field) => {
+    expect(matchContactImportHeaders([header])).toHaveProperty(field, header)
+  })
+
+  test("maps a full localized template row to every field", () => {
+    expect(
+      matchContactImportHeaders([
+        "ID Liên hệ",
+        "Số điện thoại",
+        "Email",
+        "Tên",
+        "Họ",
+      ]),
+    ).toEqual({
+      contactId: "ID Liên hệ",
+      phoneNumber: "Số điện thoại",
+      email: "Email",
+      firstName: "Tên",
+      lastName: "Họ",
+    })
+  })
+
+  test("keeps first and last name headers from colliding", () => {
+    expect(matchContactImportHeaders(["Last name", "First name"])).toEqual({
+      firstName: "First name",
+      lastName: "Last name",
+    })
+  })
+
+  test("does not guess an unsupported header", () => {
+    expect(matchContactImportHeaders(["Ghi chú", "Extension"])).toEqual({})
+  })
+
+  test("returns nothing for an empty header list", () => {
+    expect(matchContactImportHeaders([])).toEqual({})
+  })
+
+  test("uses a duplicate source header only once", () => {
+    const mapping = matchContactImportHeaders(["Email", "Email"])
+    expect(Object.values(mapping)).toEqual(["Email"])
+  })
+
+  test.each([
+    ["đ", "d"],
+    ["Đ", "d"],
+    ["Số điện thoại", "sodienthoai"],
+  ])("normalizes Vietnamese variants in %s", (header, normalized) => {
+    expect(normalizeContactHeader(header)).toBe(normalized)
+  })
+})

--- a/packages/imports/src/index.ts
+++ b/packages/imports/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./file-validation"
+export * from "./modules/contacts/header-match"
 export * from "./modules/products"
 export * from "./registry"
 export type { ImportConfig, ImportEntry, ImportHandler } from "./types"

--- a/packages/imports/src/modules/contacts/header-match.ts
+++ b/packages/imports/src/modules/contacts/header-match.ts
@@ -1,0 +1,61 @@
+import {
+  type ContactImportColumnMap,
+  type ContactImportField,
+  contactImportFields,
+} from "@chatbotx.io/database/partials"
+
+export const normalizeContactHeader = (raw: string): string =>
+  raw
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/đ/gi, "d")
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "")
+
+// Candidate headers per field, covering English, Vietnamese, our downloadable
+// template labels, and common export column names. Values are matched after
+// `normalizeContactHeader`, so accents/separators/casing here are irrelevant.
+const HEADER_CANDIDATES = {
+  contactId: ["contactid", "id", "idlienhe", "subscriberid", "psid", "uid"],
+  phoneNumber: [
+    "phonenumber",
+    "phone",
+    "mobile",
+    "mobilephone",
+    "tel",
+    "telephone",
+    "sodienthoai",
+    "sdt",
+    "dienthoai",
+  ],
+  email: ["email", "emailaddress", "mail", "diachiemail"],
+  firstName: ["firstname", "givenname", "ten"],
+  lastName: ["lastname", "surname", "familyname", "ho"],
+} as const satisfies Record<ContactImportField, readonly string[]>
+
+const normalizedCandidates = Object.fromEntries(
+  contactImportFields.options.map((field) => [
+    field,
+    new Set(HEADER_CANDIDATES[field].map(normalizeContactHeader)),
+  ]),
+) as Record<ContactImportField, Set<string>>
+
+export const matchContactImportHeaders = (
+  headers: readonly string[],
+): Partial<ContactImportColumnMap> => {
+  const matchedColumns = new Set<string>()
+  const result: Partial<ContactImportColumnMap> = {}
+
+  for (const field of contactImportFields.options) {
+    const match = headers.find(
+      (header) =>
+        !matchedColumns.has(header) &&
+        normalizedCandidates[field].has(normalizeContactHeader(header)),
+    )
+    if (match) {
+      result[field] = match
+      matchedColumns.add(match)
+    }
+  }
+  return result
+}

--- a/packages/imports/src/modules/contacts/index.ts
+++ b/packages/imports/src/modules/contacts/index.ts
@@ -2,6 +2,8 @@ import { createId } from "@chatbotx.io/utils"
 import type { ImportHandler } from "../../types"
 import { replaceTemplate } from "../../utils"
 
+export * from "./header-match"
+
 export const handler: ImportHandler<"contacts"> = {
   buildPath: (input, entry) => {
     const extension = input.fileName.split(".").pop() || "txt"


### PR DESCRIPTION
## Summary

Adds contacts import UX improvements:

- **Download template** button returns a localized CSV (workspace language) with a header row and one example data row.
- **Auto-maps the column dropdowns** from the uploaded file's headers, so users don't have to match every field by hand. Re-uploading a file re-runs the mapping and clears the previous file's selections.

Header matching reuses the existing shared pattern from the products import (`@chatbotx.io/imports`), with the field set derived from the contacts import model.

## Test plan

Automated:

- [x] `@chatbotx.io/imports` unit tests (header matching: EN/VI/template labels, unsupported headers, duplicates, normalization)
- [x] builder tests for the template CSV builder and download route
- [x] type checks pass for `database`, `imports`, and `builder`

Manual (please verify before merge):

- [ ] Download template → opens a CSV with localized headers + one example row
- [ ] Upload a file whose headers match → dropdowns auto-fill
- [ ] Upload a second file with different headers → mapping resets; only matching columns are filled, the rest are cleared; no validation errors
- [ ] Confirm import still works end to end

## Notes

- The auto-map UI behavior is not covered by automated tests yet (the builder app has no React component test setup). Manual verification is needed for the upload/re-upload flow.
