### PR TITLE
feat(webchat): add branding, avatars, and widget CSS hardening

### DIFF
--- a/apps/builder/__tests__/message-item-avatar.test.tsx
+++ b/apps/builder/__tests__/message-item-avatar.test.tsx
@@ -1,0 +1,113 @@
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, describe, expect, test, vi } from "vitest"
+import { MessageItem } from "@/features/messages/components/message-item"
+import type { MessageResourceWithRelations } from "@/features/messages/schema/resource"
+
+/** Echoes the key back so assertions never depend on the English copy. */
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+// Base UI's Avatar.Image only mounts once the underlying <img> actually
+// fires a load/error event (see useImageLoadingStatus), which jsdom never
+// dispatches for a src that isn't really fetched. Mock it down to plain
+// markup so this test stays about MessageItem's own avatar-gating logic
+// (variant + avatarUrl), not Base UI's async image-loading state machine —
+// same approach as add-channel-button.test.tsx for the Tooltip primitives.
+vi.mock("@chatbotx.io/ui/components/ui/avatar", () => ({
+  Avatar: ({ children }: { children: React.ReactNode }) => (
+    <span data-slot="avatar">{children}</span>
+  ),
+  AvatarImage: ({ src, alt }: { src: string; alt: string }) => (
+    // biome-ignore lint/performance/noImgElement: test double for next/image-less Avatar primitive
+    <img alt={alt} data-slot="avatar-image" height={24} src={src} width={24} />
+  ),
+  AvatarFallback: ({ children }: { children: React.ReactNode }) => (
+    <span data-slot="avatar-fallback">{children}</span>
+  ),
+}))
+
+let container: HTMLDivElement | null = null
+let root: Root | null = null
+
+function renderComponent(ui: React.ReactElement) {
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => {
+    root?.render(ui)
+  })
+  return container
+}
+
+afterEach(() => {
+  if (root) {
+    act(() => {
+      root?.unmount()
+    })
+  }
+  container?.remove()
+  container = null
+  root = null
+})
+
+const AVATAR_URL = "https://cdn.example.com/logo.png"
+
+const makeMessage = (overrides: Partial<MessageResourceWithRelations> = {}) =>
+  ({
+    id: "msg-1",
+    workspaceId: "ws-1",
+    conversationId: "conv-1",
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    messageType: "outgoing",
+    type: "message",
+    text: "Hello from the bot",
+    deletedAt: null,
+    attributes: null,
+    contentAttributes: null,
+    attachments: [],
+    ...overrides,
+  }) as unknown as MessageResourceWithRelations
+
+describe("MessageItem avatar (guest widget showLogo)", () => {
+  test("does not render an avatar when avatarUrl is omitted", () => {
+    // This is the agent-inbox call shape: no avatarUrl prop at all. Guards
+    // against a future change accidentally making the avatar show up (or the
+    // gutter reserve) for inbox users, who never pass this prop.
+    const el = renderComponent(
+      <MessageItem guestDisplay={false} message={makeMessage()} />,
+    )
+
+    expect(el.querySelector("img")).toBeNull()
+    expect(el.querySelector('[data-slot="avatar"]')).toBeNull()
+  })
+
+  test("renders the workspace logo beside an agent/bot bubble in the guest widget", () => {
+    const el = renderComponent(
+      <MessageItem
+        avatarUrl={AVATAR_URL}
+        guestDisplay={true}
+        message={makeMessage({ messageType: "outgoing" })}
+      />,
+    )
+
+    const avatar = el.querySelector('[data-slot="avatar-image"]')
+    expect(avatar).not.toBeNull()
+  })
+
+  test("never renders an avatar on the visitor's own (incoming) bubble", () => {
+    // Under guestDisplay, "incoming" maps to variant "right" — the visitor's
+    // own messages. avatarUrl must be ignored there even if passed, since the
+    // caller (webchat-message-list.tsx) only means it for the agent/bot side.
+    const el = renderComponent(
+      <MessageItem
+        avatarUrl={AVATAR_URL}
+        guestDisplay={true}
+        message={makeMessage({ messageType: "incoming" })}
+      />,
+    )
+
+    expect(el.querySelector('[data-slot="avatar-image"]')).toBeNull()
+  })
+})

--- a/apps/builder/__tests__/update-webchat-action-permission.test.ts
+++ b/apps/builder/__tests__/update-webchat-action-permission.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment node
+
+import { beforeEach, expect, test, vi } from "vitest"
+
+const mockHasWorkspacePermission = vi.fn()
+const mockFindOrFail = vi.fn()
+const mockDbTransaction = vi.fn()
+const SUPER_ADMIN_ERROR_RE = /super admin/i
+
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, unknown> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.inputSchema = () => chain
+  chain.action = (fn: unknown) => fn
+  return {
+    workspaceActionClient: chain,
+  }
+})
+
+vi.mock("@/lib/auth/permission-routes", () => ({
+  hasWorkspacePermission: mockHasWorkspacePermission,
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: { transaction: mockDbTransaction },
+  eq: vi.fn(),
+  findOrFail: mockFindOrFail,
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  integrationWebchatModel: { id: "id-column" },
+}))
+
+const { updateWebchatAction } = await import(
+  "../src/features/integration-webchat/actions/update-webchat.action"
+)
+
+// The action reads the caller's permissions from the middleware ctx
+// (workspaceActionClient already loads the member row), so no user/member
+// fetch happens inside the action itself.
+const makeInput = (permissions: Record<string, unknown>) => ({
+  bindArgsParsedInputs: ["workspace-1", "webchat-1"],
+  parsedInput: {
+    name: "Support",
+    brandColor: "#007bff",
+    hideHeader: false,
+    showLogo: true,
+    hideMessageInput: false,
+  },
+  ctx: { workspaceMemberPermissions: permissions },
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFindOrFail.mockResolvedValue({ id: "webchat-1" })
+  mockDbTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+    fn({
+      update: () => ({ set: () => ({ where: vi.fn() }) }),
+    }),
+  )
+})
+
+test("rejects a workspace member without superAdmin permission", async () => {
+  mockHasWorkspacePermission.mockReturnValue(false)
+
+  await expect(
+    (updateWebchatAction as (props: unknown) => Promise<unknown>)(
+      makeInput({}),
+    ),
+  ).rejects.toThrow(SUPER_ADMIN_ERROR_RE)
+
+  // The permission check must short-circuit before any write is attempted —
+  // this is the guard that closes the bypass of the edit page's
+  // requireWorkspacePermission(workspaceId, "superAdmin") gate.
+  expect(mockFindOrFail).not.toHaveBeenCalled()
+  expect(mockDbTransaction).not.toHaveBeenCalled()
+})
+
+test("gates on the permissions supplied by the middleware ctx", async () => {
+  mockHasWorkspacePermission.mockReturnValue(false)
+
+  await expect(
+    (updateWebchatAction as (props: unknown) => Promise<unknown>)(
+      makeInput({ superAdmin: false }),
+    ),
+  ).rejects.toThrow(SUPER_ADMIN_ERROR_RE)
+
+  expect(mockHasWorkspacePermission).toHaveBeenCalledWith(
+    { superAdmin: false },
+    "superAdmin",
+  )
+  expect(mockDbTransaction).not.toHaveBeenCalled()
+})
+
+test("proceeds to update when the caller is a superAdmin", async () => {
+  mockHasWorkspacePermission.mockReturnValue(true)
+
+  await (updateWebchatAction as (props: unknown) => Promise<unknown>)(
+    makeInput({ superAdmin: true }),
+  )
+
+  expect(mockFindOrFail).toHaveBeenCalledWith(
+    expect.objectContaining({
+      where: { id: "webchat-1", workspaceId: "workspace-1" },
+    }),
+  )
+  expect(mockDbTransaction).toHaveBeenCalled()
+})

--- a/apps/builder/__tests__/webchat-brand-color.test.ts
+++ b/apps/builder/__tests__/webchat-brand-color.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest"
+import {
+  getRelativeLuminance,
+  readableForeground,
+} from "@/features/integration-webchat/lib/brand-color"
+
+describe("getRelativeLuminance", () => {
+  test("returns 0 for black", () => {
+    expect(getRelativeLuminance("#000000")).toBe(0)
+  })
+
+  test("returns 1 for white", () => {
+    expect(getRelativeLuminance("#ffffff")).toBeCloseTo(1, 5)
+  })
+
+  test("accepts uppercase and lowercase hex digits", () => {
+    expect(getRelativeLuminance("#FFFFFF")).toBeCloseTo(
+      getRelativeLuminance("#ffffff") as number,
+      10,
+    )
+  })
+
+  test("returns undefined for a malformed value", () => {
+    expect(getRelativeLuminance("not-a-color")).toBeUndefined()
+    expect(getRelativeLuminance("#fff")).toBeUndefined()
+    expect(getRelativeLuminance("#gggggg")).toBeUndefined()
+  })
+})
+
+describe("readableForeground", () => {
+  test("picks near-black text on a light brand color", () => {
+    // This is the exact failure mode this helper exists to fix: without it,
+    // --primary-foreground stays the theme's near-white default and a light
+    // brandColor like this yellow produces unreadable white-on-yellow text.
+    expect(readableForeground("#ffe600")).toBe("#0a0a0a")
+  })
+
+  test("picks near-white text on a dark brand color", () => {
+    expect(readableForeground("#007bff")).toBe("#ffffff")
+  })
+
+  test("falls back to white when the color can't be parsed", () => {
+    expect(readableForeground("not-a-color")).toBe("#ffffff")
+  })
+})

--- a/apps/builder/__tests__/webchat-page-guards.test.tsx
+++ b/apps/builder/__tests__/webchat-page-guards.test.tsx
@@ -47,6 +47,12 @@ vi.mock("@/lib/domain", () => ({
   getDomainFromHeader: mockGetDomainFromHeader,
 }))
 
+vi.mock("@/features/tenant/utils", () => ({
+  getTenantSettings: vi.fn().mockResolvedValue({
+    storageUrl: "https://storage.example.com/",
+  }),
+}))
+
 vi.mock("next-intl/server", () => ({
   getTranslations: vi.fn((namespace?: string) => {
     const messages: Record<string, string> = {

--- a/apps/builder/__tests__/webchat-widget-css.test.ts
+++ b/apps/builder/__tests__/webchat-widget-css.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest"
+import { sanitizeWidgetCss } from "@/features/integration-webchat/lib/widget-css"
+
+describe("sanitizeWidgetCss", () => {
+  test("leaves ordinary CSS untouched", () => {
+    const css = "body { background: #111; } .foo { color: red; }"
+    expect(sanitizeWidgetCss(css)).toBe(css)
+  })
+
+  test("neutralizes a closing style tag so it can't break out of the element", () => {
+    const malicious = "body{}</style><script>alert(1)</script>"
+    const sanitized = sanitizeWidgetCss(malicious)
+
+    expect(sanitized).not.toContain("</style>")
+    expect(sanitized).toContain("\\3C /style")
+  })
+
+  test("neutralizes a case-insensitive and repeated closing tag", () => {
+    const malicious = "a{}</STYLE>b{}</Style >c{}</style>"
+    const sanitized = sanitizeWidgetCss(malicious)
+
+    expect(sanitized.toLowerCase()).not.toContain("</style")
+  })
+})

--- a/apps/builder/messages/ar.json
+++ b/apps/builder/messages/ar.json
@@ -289,6 +289,7 @@
     "title": "الفوترة",
     "plan": {
       "label": "الخطة: {plan}",
+      "currentLabel": "الخطة الحالية",
       "free": "مجانية"
     },
     "usage": {

--- a/apps/builder/messages/da.json
+++ b/apps/builder/messages/da.json
@@ -289,6 +289,7 @@
     "title": "Fakturering",
     "plan": {
       "label": "Plan: {plan}",
+      "currentLabel": "Nuværende plan",
       "free": "Gratis"
     },
     "usage": {

--- a/apps/builder/messages/de.json
+++ b/apps/builder/messages/de.json
@@ -274,7 +274,11 @@
   },
   "billing": {
     "title": "Abrechnung",
-    "plan": { "label": "Tarif: {plan}", "free": "Kostenlos" },
+    "plan": {
+      "label": "Tarif: {plan}",
+      "currentLabel": "Aktueller Tarif",
+      "free": "Kostenlos"
+    },
     "usage": {
       "contacts": "Kontakte",
       "mac": "Monatlich aktive Kontakte",

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -290,6 +290,7 @@
     "title": "Billing",
     "plan": {
       "label": "Plan: {plan}",
+      "currentLabel": "Current plan",
       "free": "Free"
     },
     "usage": {

--- a/apps/builder/messages/es.json
+++ b/apps/builder/messages/es.json
@@ -289,6 +289,7 @@
     "title": "Facturación",
     "plan": {
       "label": "Plan: {plan}",
+      "currentLabel": "Plan actual",
       "free": "Gratis"
     },
     "usage": {

--- a/apps/builder/messages/fi.json
+++ b/apps/builder/messages/fi.json
@@ -289,6 +289,7 @@
     "title": "Laskutus",
     "plan": {
       "label": "Tilaus: {plan}",
+      "currentLabel": "Nykyinen tilaus",
       "free": "Ilmainen"
     },
     "usage": {

--- a/apps/builder/messages/fr.json
+++ b/apps/builder/messages/fr.json
@@ -289,6 +289,7 @@
     "title": "Facturation",
     "plan": {
       "label": "Forfait : {plan}",
+      "currentLabel": "Forfait actuel",
       "free": "Gratuit"
     },
     "usage": {

--- a/apps/builder/messages/he.json
+++ b/apps/builder/messages/he.json
@@ -3934,6 +3934,7 @@
     "title": "חיוב",
     "plan": {
       "label": "תוכנית: {plan}",
+      "currentLabel": "התוכנית הנוכחית",
       "free": "חינם"
     },
     "usage": {

--- a/apps/builder/messages/id.json
+++ b/apps/builder/messages/id.json
@@ -289,6 +289,7 @@
     "title": "Penagihan",
     "plan": {
       "label": "Paket: {plan}",
+      "currentLabel": "Paket saat ini",
       "free": "Gratis"
     },
     "usage": {

--- a/apps/builder/messages/it.json
+++ b/apps/builder/messages/it.json
@@ -1386,6 +1386,7 @@
     "title": "Fatturazione",
     "plan": {
       "label": "Piano: {plan}",
+      "currentLabel": "Piano attuale",
       "free": "Gratuito"
     },
     "usage": {

--- a/apps/builder/messages/ja.json
+++ b/apps/builder/messages/ja.json
@@ -289,6 +289,7 @@
     "title": "請求",
     "plan": {
       "label": "プラン：{plan}",
+      "currentLabel": "現在のプラン",
       "free": "無料"
     },
     "usage": {

--- a/apps/builder/messages/nl.json
+++ b/apps/builder/messages/nl.json
@@ -289,6 +289,7 @@
     "title": "Facturering",
     "plan": {
       "label": "Abonnement: {plan}",
+      "currentLabel": "Huidig abonnement",
       "free": "Gratis"
     },
     "usage": {

--- a/apps/builder/messages/pt-BR.json
+++ b/apps/builder/messages/pt-BR.json
@@ -289,6 +289,7 @@
     "title": "Faturamento",
     "plan": {
       "label": "Plano: {plan}",
+      "currentLabel": "Plano atual",
       "free": "Grátis"
     },
     "usage": {

--- a/apps/builder/messages/pt-PT.json
+++ b/apps/builder/messages/pt-PT.json
@@ -289,6 +289,7 @@
     "title": "Faturação",
     "plan": {
       "label": "Plano: {plan}",
+      "currentLabel": "Plano atual",
       "free": "Gratuito"
     },
     "usage": {

--- a/apps/builder/messages/ro.json
+++ b/apps/builder/messages/ro.json
@@ -851,6 +851,7 @@
     "title": "Facturare",
     "plan": {
       "label": "Plan: {plan}",
+      "currentLabel": "Plan curent",
       "free": "Gratuit"
     },
     "usage": {

--- a/apps/builder/messages/sv.json
+++ b/apps/builder/messages/sv.json
@@ -396,6 +396,7 @@
     },
     "plan": {
       "free": "Kostnadsfritt",
+      "currentLabel": "Nuvarande abonnemang",
       "label": "Abonnemang: {plan}"
     },
     "title": "Fakturering",

--- a/apps/builder/messages/tr.json
+++ b/apps/builder/messages/tr.json
@@ -289,6 +289,7 @@
     "title": "Faturalandırma",
     "plan": {
       "label": "Plan: {plan}",
+      "currentLabel": "Mevcut plan",
       "free": "Ücretsiz"
     },
     "usage": {

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -290,6 +290,7 @@
     "title": "Thanh toán",
     "plan": {
       "label": "Gói: {plan}",
+      "currentLabel": "Gói hiện tại",
       "free": "Miễn phí"
     },
     "usage": {

--- a/apps/builder/messages/zh-TW.json
+++ b/apps/builder/messages/zh-TW.json
@@ -1789,6 +1789,7 @@
     "title": "計費",
     "plan": {
       "label": "方案：{plan}",
+      "currentLabel": "目前方案",
       "free": "免費"
     },
     "usage": {

--- a/apps/builder/public/chat-widget/plugin.css
+++ b/apps/builder/public/chat-widget/plugin.css
@@ -83,7 +83,7 @@
   overflow: hidden;
   pointer-events: none;
   background: white;
-  border: none;
+  border: 1px solid rgba(0, 0, 0, 0.08);
   border-radius: 20px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
   opacity: 0;

--- a/apps/builder/src/app/(no-sidebar)/webchat/page.tsx
+++ b/apps/builder/src/app/(no-sidebar)/webchat/page.tsx
@@ -15,9 +15,12 @@ import {
 } from "@/features/integration-webchat/lib/authorized-domain"
 import { createGuestConversationId } from "@/features/integration-webchat/lib/guest-conversation-id"
 import { createWebchatAccessToken } from "@/features/integration-webchat/lib/webchat-access-token"
+import { CustomWidgetStyle } from "@/features/integration-webchat/lib/widget-css"
 import { GuestSessionStoreProvider } from "@/features/integration-webchat/providers/store/guest-session-provider"
 import { toWebchatClientConfig } from "@/features/integration-webchat/providers/store/lib/webchat-client-config"
 import { WebchatWrapper } from "@/features/integration-webchat/webchat-wrapper"
+import { getTenantSettings } from "@/features/tenant/utils"
+import { getWorkspaceLogoUrl } from "@/features/workspaces/helpers"
 import { getDomainFromHeader } from "@/lib/domain"
 
 type WebchatPageProps = {
@@ -120,12 +123,23 @@ export default async function WebchatPage(props: WebchatPageProps) {
     workspaceId: targetWebchat.workspaceId,
   })
 
+  // Gated server-side so a showLogo=false widget never even receives a URL,
+  // rather than shipping one and relying on the client to hide it.
+  const { storageUrl } = await getTenantSettings()
+  const workspaceLogoUrl = targetWebchat.showLogo
+    ? getWorkspaceLogoUrl(workspace, storageUrl)
+    : undefined
+
   return (
     <GuestSessionStoreProvider
       accessToken={accessToken}
       config={toWebchatClientConfig(targetWebchat)}
       serverGuestConversationId={guestConversationId}
+      workspaceLogoUrl={workspaceLogoUrl}
     >
+      {targetWebchat.customCss && (
+        <CustomWidgetStyle css={targetWebchat.customCss} />
+      )}
       <WebchatWrapper parentOrigin={embeddingOrigin} referral={data.ref} />
     </GuestSessionStoreProvider>
   )

--- a/apps/builder/src/features/inboxes/components/add-channel-button.tsx
+++ b/apps/builder/src/features/inboxes/components/add-channel-button.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Button } from "@chatbotx.io/ui/components/ui/button"
+import { Button, buttonVariants } from "@chatbotx.io/ui/components/ui/button"
 import {
   Tooltip,
   TooltipContent,
@@ -74,8 +74,11 @@ export function AddChannelButton({
   }
 
   return (
-    <Button render={<Link href={href ?? "#"} />} size="sm" variant="secondary">
+    <Link
+      className={buttonVariants({ size: "sm", variant: "secondary" })}
+      href={href ?? "#"}
+    >
       {content}
-    </Button>
+    </Link>
   )
 }

--- a/apps/builder/src/features/integration-webchat/actions/update-webchat.action.ts
+++ b/apps/builder/src/features/integration-webchat/actions/update-webchat.action.ts
@@ -3,6 +3,7 @@
 import { db, eq, findOrFail } from "@chatbotx.io/database/client"
 import { integrationWebchatModel } from "@chatbotx.io/database/schema"
 import { zodBigintAsString } from "@chatbotx.io/utils"
+import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
 import { workspaceActionClient } from "@/lib/safe-action"
 import { updateWebchatRequest } from "../schema/mutation"
 
@@ -13,8 +14,19 @@ export const updateWebchatAction = workspaceActionClient
     const {
       bindArgsParsedInputs: [workspaceId, id],
       parsedInput,
+      ctx,
     } = props
     const { authorizedDomains, welcomeFlowId, ...rest } = parsedInput
+
+    // The edit page gates entry with requireWorkspacePermission(workspaceId,
+    // "superAdmin"), but workspaceActionClient only verifies membership — a
+    // member could otherwise call this action directly, bypassing the page,
+    // and set fields like customCss that render inside the public widget.
+    // Permissions come from the middleware ctx (already loaded), so this gate
+    // adds no extra round-trip.
+    if (!hasWorkspacePermission(ctx.workspaceMemberPermissions, "superAdmin")) {
+      throw new Error("You need to be a super admin to update this webchat")
+    }
 
     const integration = await findOrFail({
       table: integrationWebchatModel,

--- a/apps/builder/src/features/integration-webchat/components/authorized-domain-field.tsx
+++ b/apps/builder/src/features/integration-webchat/components/authorized-domain-field.tsx
@@ -42,7 +42,10 @@ export default function AuthorizedDomainField() {
       </p>
       {authorizedDomains.map((field, index) => (
         <div className="flex gap-2" key={field.id}>
-          <InputField name={`authorizedDomains.${index}.value`} />
+          <InputField
+            name={`authorizedDomains.${index}.value`}
+            placeholder="example.com"
+          />
 
           <Button
             aria-label={t("actions.delete")}

--- a/apps/builder/src/features/integration-webchat/dialogs/embed-code-dialog.tsx
+++ b/apps/builder/src/features/integration-webchat/dialogs/embed-code-dialog.tsx
@@ -35,10 +35,7 @@ export function EmbedCodeDialog({ webchat, children }: EmbedCodeDialogProps) {
   type="module" onload="window.csmChatWidget?.init({
     webchatId: '${webchat.id}',
     workspaceId: '${webchat.workspaceId}',
-    brandColor: '${webchat.brandColor}',
-    hideHeader: ${webchat.hideHeader},
-    showLogo: ${webchat.showLogo},
-    hideMessageInput: true
+    brandColor: '${webchat.brandColor}'
   });"></script>`
 
   return (

--- a/apps/builder/src/features/integration-webchat/lib/brand-color.ts
+++ b/apps/builder/src/features/integration-webchat/lib/brand-color.ts
@@ -1,0 +1,66 @@
+const HEX_COLOR_REGEX = /^#([0-9a-fA-F]{6})$/
+
+const SRGB_CHANNEL_MAX = 255
+const GAMMA_THRESHOLD = 0.039_28
+const GAMMA_LINEAR_DIVISOR = 12.92
+const GAMMA_OFFSET = 0.055
+const GAMMA_SCALE = 1.055
+const GAMMA_EXPONENT = 2.4
+const LUMINANCE_WEIGHT_RED = 0.2126
+const LUMINANCE_WEIGHT_GREEN = 0.7152
+const LUMINANCE_WEIGHT_BLUE = 0.0722
+const LUMINANCE_THRESHOLD = 0.5
+
+const WHITE_FOREGROUND = "#ffffff"
+const BLACK_FOREGROUND = "#0a0a0a"
+
+/**
+ * Converts one sRGB channel (0-255) to its linear-light value, per the
+ * WCAG relative luminance formula.
+ */
+const toLinearChannel = (channel: number): number => {
+  const normalized = channel / SRGB_CHANNEL_MAX
+  return normalized <= GAMMA_THRESHOLD
+    ? normalized / GAMMA_LINEAR_DIVISOR
+    : ((normalized + GAMMA_OFFSET) / GAMMA_SCALE) ** GAMMA_EXPONENT
+}
+
+/**
+ * Relative luminance of a `#RRGGBB` hex color, per WCAG 2.x. Returns
+ * `undefined` for anything that isn't a strict 6-digit hex string so callers
+ * can fall back safely instead of rendering on a garbage value.
+ */
+export const getRelativeLuminance = (hexColor: string): number | undefined => {
+  const match = HEX_COLOR_REGEX.exec(hexColor)
+  if (!match) {
+    return
+  }
+
+  const value = match[1]
+  const red = Number.parseInt(value.slice(0, 2), 16)
+  const green = Number.parseInt(value.slice(2, 4), 16)
+  const blue = Number.parseInt(value.slice(4, 6), 16)
+
+  return (
+    LUMINANCE_WEIGHT_RED * toLinearChannel(red) +
+    LUMINANCE_WEIGHT_GREEN * toLinearChannel(green) +
+    LUMINANCE_WEIGHT_BLUE * toLinearChannel(blue)
+  )
+}
+
+/**
+ * Picks a readable near-black or near-white foreground for a given
+ * `brandColor` background. `webchat-wrapper.tsx` overrides the `--primary`
+ * design token with the admin's brand color, but `--primary-foreground` is
+ * hardcoded near-white in every theme (see packages/ui/src/styles/default.css)
+ * — on a light brand color that produces unreadable white-on-yellow text.
+ * Falls back to white (the existing default) when the color can't be parsed.
+ */
+export const readableForeground = (hexColor: string): string => {
+  const luminance = getRelativeLuminance(hexColor)
+  if (luminance === undefined) {
+    return WHITE_FOREGROUND
+  }
+
+  return luminance > LUMINANCE_THRESHOLD ? BLACK_FOREGROUND : WHITE_FOREGROUND
+}

--- a/apps/builder/src/features/integration-webchat/lib/widget-css.tsx
+++ b/apps/builder/src/features/integration-webchat/lib/widget-css.tsx
@@ -1,0 +1,36 @@
+const STYLE_CLOSE_TAG_REGEX = /<\/style/gi
+
+/**
+ * Neutralizes a literal `</style` in admin-authored widget CSS before it is
+ * injected via `dangerouslySetInnerHTML` by `CustomWidgetStyle` below.
+ * `customCss` is superAdmin-authored, but `dangerouslySetInnerHTML` does no
+ * escaping of its own — without this, `</style><script>...` in a saved value
+ * would close the style element and inject arbitrary markup, turning a
+ * CSS-only feature into stored XSS on the builder's own origin.
+ *
+ * `\3C` is the CSS escape sequence for `<`, so the replacement stays valid,
+ * inert CSS rather than truncating the value.
+ */
+export const sanitizeWidgetCss = (css: string): string =>
+  css.replace(STYLE_CLOSE_TAG_REGEX, "\\3C /style")
+
+/**
+ * Renders `IntegrationWebchat.customCss` as a scoped, server-rendered
+ * `<style>` tag so it applies before first paint (no flash of unstyled
+ * content, unlike the tenant-level equivalent in `tenant-settings-provider.tsx`,
+ * which injects client-side via a `useEffect`).
+ *
+ * Security: `customCss` is gated by `requireWorkspacePermission(workspaceId,
+ * "superAdmin")` on the edit page and by the matching check inside
+ * `updateWebchatAction`. The widget itself renders in a cross-origin iframe,
+ * so this CSS cannot execute script or reach the embedding page — the
+ * residual risk (background-image exfiltration, chrome-spoofing overlays) is
+ * accepted as part of letting a workspace admin style their own widget. It is
+ * kept out of `WebchatClientConfig` deliberately: that DTO's allow-listed key
+ * set is asserted by a test, and `customCss` is write-only data no component
+ * reads, so it doesn't belong in client-held state.
+ */
+export const CustomWidgetStyle = ({ css }: { css: string }) => (
+  // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized superAdmin-authored widget CSS, see module doc above
+  <style dangerouslySetInnerHTML={{ __html: sanitizeWidgetCss(css) }} />
+)

--- a/apps/builder/src/features/integration-webchat/providers/store/guest-session-provider.tsx
+++ b/apps/builder/src/features/integration-webchat/providers/store/guest-session-provider.tsx
@@ -25,6 +25,8 @@ export type GuestSessionStoreProviderProps = {
   config: WebchatClientConfig
   accessToken?: string | null
   serverGuestConversationId: string
+  /** Resolved server-side; see GuestSessionState.workspaceLogoUrl. */
+  workspaceLogoUrl?: string
 }
 
 export const GuestSessionStoreProvider = ({
@@ -32,10 +34,15 @@ export const GuestSessionStoreProvider = ({
   config,
   accessToken = null,
   serverGuestConversationId,
+  workspaceLogoUrl,
 }: GuestSessionStoreProviderProps) => {
   const storeRef = useRef<GuestSessionStoreApi>(null)
   if (!storeRef.current) {
-    storeRef.current = createGuestSessionStore(config, accessToken)
+    storeRef.current = createGuestSessionStore(
+      config,
+      accessToken,
+      workspaceLogoUrl,
+    )
   }
 
   useEffect(() => {

--- a/apps/builder/src/features/integration-webchat/providers/store/guest-sesssion-store.ts
+++ b/apps/builder/src/features/integration-webchat/providers/store/guest-sesssion-store.ts
@@ -24,6 +24,14 @@ export type GuestSessionState = {
   guestConversationId: string | null
   isNewGuestSession: boolean
   accessToken: string | null
+  /**
+   * Resolved workspace logo URL, already gated server-side on
+   * `config.showLogo` (undefined when the flag is off or no logo is set).
+   * Kept as separate store state rather than a `WebchatClientConfig` field
+   * so the DTO's allow-listed key set — asserted by
+   * webchat-guest-session.test.ts — stays unchanged.
+   */
+  workspaceLogoUrl?: string
   user: UserResource | null
   config: WebchatClientConfig
 
@@ -58,12 +66,14 @@ export type GuestSessionStore = GuestSessionState & GuestSessionActions
 export const createGuestSessionStore = (
   props: WebchatClientConfig,
   accessToken: string | null = null,
+  workspaceLogoUrl?: string,
 ) => {
   return createStore<GuestSessionStore>((set, get) => ({
     // default state
     guestConversationId: null,
     isNewGuestSession: false,
     accessToken,
+    workspaceLogoUrl,
     user: null,
     config: props,
 

--- a/apps/builder/src/features/integration-webchat/schema/mutation.ts
+++ b/apps/builder/src/features/integration-webchat/schema/mutation.ts
@@ -20,7 +20,7 @@ export const createWebchatRequest = z.object({
   hideHeader: z.boolean().default(false),
   showLogo: z.boolean().default(true),
   hideMessageInput: z.boolean().default(false),
-  customCss: z.string().optional(),
+  customCss: z.string().max(20_000).optional(),
   enable: z.boolean().default(true),
 })
 export type CreateWebchatRequest = z.infer<typeof createWebchatRequest>

--- a/apps/builder/src/features/integration-webchat/webchat-message-list.tsx
+++ b/apps/builder/src/features/integration-webchat/webchat-message-list.tsx
@@ -1,6 +1,12 @@
 "use client"
 
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@chatbotx.io/ui/components/ui/avatar"
 import { Skeleton } from "@chatbotx.io/ui/components/ui/skeleton"
+import { BotIcon } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import {
   type GridComponents,
@@ -25,6 +31,7 @@ export function WebchatMessageList() {
     guestConversationId,
     sendPostback,
     isTyping,
+    workspaceLogoUrl,
   } = useGuestSessionStore((state) => state)
 
   const virtuosoRef = useRef<VirtuosoHandle>(null)
@@ -65,9 +72,10 @@ export function WebchatMessageList() {
         initialTopMostItemIndex={{ index: "LAST" }}
         itemContent={(_, item) =>
           item.id === TYPING_INDICATOR_ID ? (
-            <TypingIndicator />
+            <TypingIndicator avatarUrl={workspaceLogoUrl} />
           ) : (
             <MessageItem
+              avatarUrl={workspaceLogoUrl}
               guestDisplay={true}
               key={item.id}
               message={item as MessageResourceWithRelations}
@@ -96,8 +104,16 @@ const MessageComponentHeader: GridComponents["Header"] = () => {
   ) : null
 }
 
-const TypingIndicator = () => (
+const TypingIndicator = ({ avatarUrl }: { avatarUrl?: string }) => (
   <MessageBubble variant="left">
+    {avatarUrl && (
+      <Avatar className="mt-auto size-6 self-start">
+        <AvatarImage alt="" src={avatarUrl} />
+        <AvatarFallback>
+          <BotIcon aria-hidden className="size-3.5" />
+        </AvatarFallback>
+      </Avatar>
+    )}
     <div className="mx-3 flex min-h-11 items-center gap-1 rounded-xl bg-secondary px-4 py-3">
       <span
         aria-hidden

--- a/apps/builder/src/features/integration-webchat/webchat-wrapper.tsx
+++ b/apps/builder/src/features/integration-webchat/webchat-wrapper.tsx
@@ -1,6 +1,8 @@
 "use client"
 
+import type { CSSProperties } from "react"
 import WebchatRef from "./components/webchat-ref"
+import { readableForeground } from "./lib/brand-color"
 import { useGuestSessionStore } from "./providers/store/guest-session-provider"
 import { WebchatHeader } from "./webchat-header"
 import { WebchatMessageInput } from "./webchat-message-input"
@@ -18,8 +20,13 @@ export const WebchatWrapper = ({
     (state) => state,
   )
 
+  const brandColorStyle = {
+    "--primary": config.brandColor,
+    "--primary-foreground": readableForeground(config.brandColor),
+  } as CSSProperties
+
   return (
-    <div className="flex h-screen w-screen flex-col">
+    <div className="flex h-screen w-screen flex-col" style={brandColorStyle}>
       {!config.hideHeader && <WebchatHeader />}
       <WebchatMessageList />
       {!config.hideMessageInput && (

--- a/apps/builder/src/features/messages/components/message-item.tsx
+++ b/apps/builder/src/features/messages/components/message-item.tsx
@@ -5,6 +5,11 @@ import type {
   MessageStoryReplyEntity,
   MessageTemplateEntity,
 } from "@chatbotx.io/sdk"
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@chatbotx.io/ui/components/ui/avatar"
 import { Button, buttonVariants } from "@chatbotx.io/ui/components/ui/button"
 import { Card, CardContent } from "@chatbotx.io/ui/components/ui/card"
 import {
@@ -17,6 +22,7 @@ import {
 import { cn } from "@chatbotx.io/ui/lib/utils"
 import { format } from "date-fns"
 import {
+  BotIcon,
   ExternalLinkIcon,
   ImageIcon,
   PaperclipIcon,
@@ -36,6 +42,13 @@ import { MessageBubble } from "./message-bubble"
 type MessageItemProps = {
   message: MessageResourceWithRelations
   guestDisplay?: boolean
+  /**
+   * Workspace logo shown beside agent/bot bubbles in the guest widget when
+   * `IntegrationWebchat.showLogo` is on. Deliberately opt-in and unused by
+   * the agent inbox, which renders this same component — passing it only
+   * from `webchat-message-list.tsx` keeps inbox rendering unchanged.
+   */
+  avatarUrl?: string
   onChangeHide?: () => void
   onChangeLike?: () => void
   onDelete?: () => void
@@ -58,6 +71,7 @@ export const MessageItem = (props: MessageItemProps) => {
   const {
     message,
     guestDisplay = false,
+    avatarUrl,
     onChangeLike,
     onChangeHide,
     onReply,
@@ -103,6 +117,14 @@ export const MessageItem = (props: MessageItemProps) => {
       title={format(new Date(message.createdAt), "yyyy/MM/dd HH:mm:ss")}
       variant={variant}
     >
+      {variant === "left" && avatarUrl && (
+        <Avatar className="mt-auto size-6 self-start">
+          <AvatarImage alt="" src={avatarUrl} />
+          <AvatarFallback>
+            <BotIcon aria-hidden className="size-3.5" />
+          </AvatarFallback>
+        </Avatar>
+      )}
       <div className="flex min-h-11 max-w-[70%] flex-col gap-1">
         {storyReply && <StoryReplyContext story={storyReply.story} />}
         {isComment ? (

--- a/apps/builder/src/features/messages/components/message-item.tsx
+++ b/apps/builder/src/features/messages/components/message-item.tsx
@@ -118,7 +118,7 @@ export const MessageItem = (props: MessageItemProps) => {
       variant={variant}
     >
       {variant === "left" && avatarUrl && (
-        <Avatar className="mt-auto size-6 self-start">
+        <Avatar className="mt-2 size-7 self-start">
           <AvatarImage alt="" src={avatarUrl} />
           <AvatarFallback>
             <BotIcon aria-hidden className="size-3.5" />

--- a/apps/builder/src/features/workspaces/components/__tests__/account-rail.test.tsx
+++ b/apps/builder/src/features/workspaces/components/__tests__/account-rail.test.tsx
@@ -20,6 +20,7 @@ const translations: Record<string, string> = {
   "actions.redeem": "Redeem",
   "actions.upgradePlan": "Upgrade plan",
   "billing.plan.free": "Free",
+  "billing.plan.currentLabel": "Current plan",
 }
 
 function translate(key: string, values?: { plan?: string }): string {
@@ -48,6 +49,14 @@ vi.mock("@/features/auth/sign-out", () => ({
 
 vi.mock("../edit-profile-dialog", () => ({
   EditProfileDialog: () => null,
+}))
+
+// Severs the server-action import chain (refresh action → @/lib/safe-action →
+// @chatbotx.io/business → database/client), which otherwise touches a
+// server-only env var at import time and crashes the whole file before any
+// test body runs.
+vi.mock("../refresh-all-channel-tokens-button", () => ({
+  RefreshAllChannelTokensButton: () => null,
 }))
 
 vi.mock("@/enterprise/features/billing/upgrade-plan-dialog", () => ({
@@ -82,6 +91,7 @@ describe("account rail", () => {
       isPlatformAdmin: boolean
       isPlatformContext: boolean
       cloud: boolean
+      planName: string | null
     }> = {},
   ) {
     isCloud.mockReturnValue(props.cloud ?? false)
@@ -91,6 +101,7 @@ describe("account rail", () => {
       isSuperAdmin: props.isSuperAdmin,
       isPlatformAdmin: props.isPlatformAdmin,
       isPlatformContext: props.isPlatformContext,
+      planName: props.planName,
     })
     act(() => {
       root.render(element)
@@ -101,6 +112,10 @@ describe("account rail", () => {
     return Array.from(container.querySelectorAll("a")).find(
       (a) => a.getAttribute("href") === href,
     )
+  }
+
+  function planNameText() {
+    return container.textContent ?? ""
   }
 
   it("renders the billing link on community edition", async () => {
@@ -149,5 +164,21 @@ describe("account rail", () => {
       (el) => el.classList.contains("mt-auto"),
     ).length
     expect(mtAutoCount).toBe(1)
+  })
+
+  it("renders the current plan label and name on cloud edition", async () => {
+    await render({ cloud: true, planName: "Pro" })
+
+    const text = planNameText()
+    expect(text).toContain("Current plan")
+    expect(text).toContain("Pro")
+  })
+
+  it("falls back to the free plan label when no plan name is set", async () => {
+    await render({ cloud: true, planName: null })
+
+    const text = planNameText()
+    expect(text).toContain("Current plan")
+    expect(text).toContain("Free")
   })
 })

--- a/apps/builder/src/features/workspaces/components/__tests__/workspace-deletion-card.test.tsx
+++ b/apps/builder/src/features/workspaces/components/__tests__/workspace-deletion-card.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const translations: Record<string, string> = {
+  "workspace.deletion.title": "Delete workspace",
+  "workspace.deletion.description": "Permanently delete this workspace.",
+  "workspace.deletion.schedule": "Delete workspace",
+  "workspace.deletion.confirmTitle": "Delete this workspace?",
+  "workspace.deletion.confirmDescription": "This cannot be undone.",
+  "actions.undo": "Undo",
+  "actions.cancel": "Cancel",
+  "actions.delete": "Delete",
+}
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => translations[key] ?? key,
+  useLocale: () => "en",
+}))
+
+const capturedOptions: Record<string, { onSuccess?: () => void }> = {}
+
+vi.mock("next-safe-action/hooks", () => ({
+  useAction: (
+    action: { __name: string },
+    options: { onSuccess?: () => void },
+  ) => {
+    capturedOptions[action.__name] = options
+    return { execute: vi.fn(), isPending: false }
+  },
+}))
+
+vi.mock("../../actions/schedule-workspace-deletion-action", () => ({
+  scheduleWorkspaceDeletionAction: {
+    __name: "schedule",
+    bind: () => ({ __name: "schedule" }),
+  },
+}))
+
+vi.mock("../../actions/cancel-workspace-deletion-action", () => ({
+  cancelWorkspaceDeletionAction: {
+    __name: "cancel",
+    bind: () => ({ __name: "cancel" }),
+  },
+}))
+
+const WORKSPACE_ID = "ws_123"
+
+describe("WorkspaceDeletionCard", () => {
+  let container: HTMLDivElement
+  let root: Root
+  let reloadMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+    container = document.createElement("div")
+    document.body.append(container)
+    root = createRoot(container)
+
+    reloadMock = vi.fn()
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { reload: reloadMock },
+    })
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  async function render(scheduledDeletionAt: string | null = null) {
+    const { WorkspaceDeletionCard } = await import("../workspace-deletion-card")
+    act(() => {
+      root.render(
+        <WorkspaceDeletionCard
+          workspace={{ id: WORKSPACE_ID, scheduledDeletionAt }}
+        />,
+      )
+    })
+  }
+
+  it("does a full page reload after scheduling deletion succeeds", async () => {
+    await render(null)
+
+    capturedOptions.schedule?.onSuccess?.()
+
+    expect(reloadMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("does a full page reload after canceling deletion succeeds", async () => {
+    await render(new Date().toISOString())
+
+    capturedOptions.cancel?.onSuccess?.()
+
+    expect(reloadMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/builder/src/features/workspaces/components/account-rail.tsx
+++ b/apps/builder/src/features/workspaces/components/account-rail.tsx
@@ -105,13 +105,22 @@ export const AccountRail = async ({
 
         {cloud && (
           <div className="flex flex-col gap-4 border-t pt-5">
-            <div className="mb-3 flex items-center justify-between gap-2">
-              <span className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
-                {t("billing.plan.label", {
-                  plan: planName ?? t("billing.plan.free"),
-                })}
-              </span>
-              <UpgradePlanButton size="sm" variant="outline">
+            <div className="flex flex-col gap-3">
+              <div className="grid gap-0.5">
+                <span className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+                  {t("billing.plan.currentLabel")}
+                </span>
+                {/*
+                  `wrap-break-word` rather than `truncate`: the rail is only
+                  18rem wide and a plan name is the one string here the user
+                  must be able to read in full, so it wraps to a second line
+                  instead of being clipped with an ellipsis.
+                */}
+                <span className="wrap-break-word font-semibold text-base leading-tight">
+                  {planName ?? t("billing.plan.free")}
+                </span>
+              </div>
+              <UpgradePlanButton className="w-full" size="sm" variant="outline">
                 <CrownIcon aria-hidden className="size-3.5" />
                 {t("actions.upgradePlan")}
               </UpgradePlanButton>

--- a/apps/builder/src/features/workspaces/components/account-rail.tsx
+++ b/apps/builder/src/features/workspaces/components/account-rail.tsx
@@ -121,7 +121,7 @@ export const AccountRail = async ({
                 </span>
               </div>
               <UpgradePlanButton className="w-full" size="sm" variant="outline">
-                <CrownIcon aria-hidden className="size-3.5" />
+                <CrownIcon aria-hidden className="size-4" />
                 {t("actions.upgradePlan")}
               </UpgradePlanButton>
             </div>

--- a/apps/builder/src/features/workspaces/components/workspace-deletion-card.tsx
+++ b/apps/builder/src/features/workspaces/components/workspace-deletion-card.tsx
@@ -16,11 +16,9 @@ import { Card, CardContent } from "@chatbotx.io/ui/components/ui/card"
 import { formatDate } from "@chatbotx.io/ui/lib/format"
 import { formatDistanceToNowStrict } from "date-fns"
 import { AlertTriangleIcon, Loader2Icon, Trash2Icon } from "lucide-react"
-import { useRouter } from "next/navigation"
 import { useLocale, useTranslations } from "next-intl"
 import { useAction } from "next-safe-action/hooks"
 import { useEffect, useState } from "react"
-import { toast } from "sonner"
 import { safeActionErrorHandler } from "@/lib/errors/safe-action-error-handler"
 import { cancelWorkspaceDeletionAction } from "../actions/cancel-workspace-deletion-action"
 import { scheduleWorkspaceDeletionAction } from "../actions/schedule-workspace-deletion-action"
@@ -73,7 +71,6 @@ export function WorkspaceDeletionCard({
 }) {
   const t = useTranslations()
   const locale = useLocale()
-  const router = useRouter()
   const countdown = useCountdown(workspace.scheduledDeletionAt)
   const deletionDate = formatDate(workspace.scheduledDeletionAt ?? undefined, {
     hour: "numeric",
@@ -81,9 +78,14 @@ export function WorkspaceDeletionCard({
     locale,
   })
 
+  const reloadPage = () => {
+    window.location.reload()
+  }
+
   const { execute: scheduleDeletion, isPending: isScheduling } = useAction(
     scheduleWorkspaceDeletionAction.bind(null, workspace.id),
     {
+      onSuccess: reloadPage,
       onError: safeActionErrorHandler,
     },
   )
@@ -91,10 +93,7 @@ export function WorkspaceDeletionCard({
   const { execute: cancelDeletion, isPending: isCancelling } = useAction(
     cancelWorkspaceDeletionAction.bind(null, workspace.id),
     {
-      onSuccess: () => {
-        toast.success(t("workspace.deletion.undone"))
-        router.refresh()
-      },
+      onSuccess: reloadPage,
       onError: safeActionErrorHandler,
     },
   )

--- a/apps/builder/src/lib/safe-action.ts
+++ b/apps/builder/src/lib/safe-action.ts
@@ -90,13 +90,26 @@ export const workspaceActionClientAllowExpired = authActionClient.use(
       throw new Error("Workspace not found")
     }
 
-    const { workspaces } = await getAllWorkspaceMembers(user.id)
+    const { workspaceMembers, workspaces } = await getAllWorkspaceMembers(
+      user.id,
+    )
     const workspace = workspaces.find((c) => c.id === workspaceId)
-    if (!workspace) {
+    const member = workspaceMembers.find((m) => m.workspaceId === workspaceId)
+    if (!(workspace && member)) {
       throw new Error("Workspace not found")
     }
 
-    return next({ ctx: { workspaceId: workspace.id, workspace } })
+    // `permissions` is exposed so actions can gate on it (e.g. superAdmin)
+    // without a second user+member round-trip — the same rows are already
+    // loaded here. The `permissions` jsonb defaults to `{}`, so callers must
+    // fail closed on missing keys (see `hasWorkspacePermission`).
+    return next({
+      ctx: {
+        workspaceId: workspace.id,
+        workspace,
+        workspaceMemberPermissions: member.permissions,
+      },
+    })
   },
 )
 


### PR DESCRIPTION
## Summary
- Auto-contrast the widget's foreground text against the admin-chosen `brandColor` instead of a hardcoded white, and show the workspace logo beside bot/agent bubbles (gated server-side on `showLogo`).
- Sanitize `IntegrationWebchat.customCss` against `</style>` injection before it's rendered via `dangerouslySetInnerHTML`, and cap its length at 20k characters.
- Close a privilege gap: `updateWebchatAction` only checked workspace membership, so any member (not just superAdmin, as the edit page requires) could set `customCss` served to the public widget — now gated on `superAdmin` via a new `workspaceMemberPermissions` field on the action ctx.
- Small unrelated fixes bundled from the same working session: reload instead of toast+`router.refresh()` after workspace deletion actions, an account-rail plan label/layout tweak, and an `add-channel-button` anchor-instead-of-button fix.

## Changes
- `apps/builder/src/features/integration-webchat/lib/brand-color.ts` (new) — WCAG relative luminance + readable foreground helpers
- `apps/builder/src/features/integration-webchat/lib/widget-css.tsx` (new) — `sanitizeWidgetCss` + `CustomWidgetStyle` server component
- `apps/builder/src/features/integration-webchat/actions/update-webchat.action.ts`, `apps/builder/src/lib/safe-action.ts` — superAdmin permission gate on the action, `workspaceMemberPermissions` exposed on ctx
- `apps/builder/src/features/integration-webchat/schema/mutation.ts` — `customCss` max length
- `apps/builder/src/app/(no-sidebar)/webchat/page.tsx`, `webchat-wrapper.tsx`, `webchat-message-list.tsx`, `guest-session-provider.tsx`, `guest-sesssion-store.ts` — wire brand color + workspace logo through to the guest widget
- `apps/builder/src/features/messages/components/message-item.tsx` — optional `avatarUrl` prop for agent/bot bubbles
- `apps/builder/src/features/integration-webchat/dialogs/embed-code-dialog.tsx`, `components/authorized-domain-field.tsx` — trim unused embed snippet options, add domain field placeholder
- `apps/builder/src/features/workspaces/components/{account-rail,workspace-deletion-card}.tsx`, `apps/builder/src/features/inboxes/components/add-channel-button.tsx` — unrelated small fixes
- Translation keys added across all `apps/builder/messages/*.json` locales
- New/updated tests under `apps/builder/__tests__/` and `apps/builder/src/features/workspaces/components/__tests__/`

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types` (required fixing an unrelated stale workspace link for `@chatbotx.io/integration-instagram-facebook` via `CI=true pnpm install --no-frozen-lockfile`)
- [ ] Manual verification: load a webchat widget with a light `brandColor` and confirm header/button text stays readable; toggle `showLogo` and confirm the avatar appears/disappears; attempt `updateWebchatAction` as a non-superAdmin member and confirm it's rejected