### PR TITLE
feat(channels): show token refresh error warning icon in channel settings

### DIFF
--- a/apps/builder/__tests__/whatsapp-verification-actions.test.ts
+++ b/apps/builder/__tests__/whatsapp-verification-actions.test.ts
@@ -21,7 +21,7 @@ type VerifyCodeActionHandler = (args: {
 
 const {
   claimVerificationCodeSlotMock,
-  findWorkspaceIntegrationMock,
+  findByIdForWorkspaceMock,
   loggerErrorMock,
   recordRegistrationOutcomeMock,
   registerPhoneNumberMock,
@@ -31,7 +31,7 @@ const {
   verifyCodeMock,
 } = vi.hoisted(() => ({
   claimVerificationCodeSlotMock: vi.fn(),
-  findWorkspaceIntegrationMock: vi.fn(),
+  findByIdForWorkspaceMock: vi.fn(),
   loggerErrorMock: vi.fn(),
   recordRegistrationOutcomeMock: vi.fn(),
   registerPhoneNumberMock: vi.fn(),
@@ -56,7 +56,7 @@ vi.mock("@/lib/safe-action", () => {
 vi.mock("@chatbotx.io/business", () => ({
   integrationWhatsappService: {
     claimVerificationCodeSlot: claimVerificationCodeSlotMock,
-    findWorkspaceIntegration: findWorkspaceIntegrationMock,
+    findByIdForWorkspace: findByIdForWorkspaceMock,
     recordRegistrationOutcome: recordRegistrationOutcomeMock,
     releaseVerificationCodeSlot: releaseVerificationCodeSlotMock,
   },
@@ -168,7 +168,7 @@ const metaRefusedError = () =>
 describe("Whatsapp verification actions", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    findWorkspaceIntegrationMock.mockResolvedValue(integration)
+    findByIdForWorkspaceMock.mockResolvedValue(integration)
     releaseVerificationCodeSlotMock.mockResolvedValue(undefined)
     claimVerificationCodeSlotMock.mockResolvedValue({
       status: "claimed",
@@ -408,7 +408,7 @@ describe("Whatsapp verification actions", () => {
   })
 
   test("does not call register after OTP for coexist integrations", async () => {
-    findWorkspaceIntegrationMock.mockResolvedValueOnce({
+    findByIdForWorkspaceMock.mockResolvedValueOnce({
       ...integration,
       isCoexist: true,
     })

--- a/apps/builder/src/components/token-refresh-error-icon.tsx
+++ b/apps/builder/src/components/token-refresh-error-icon.tsx
@@ -1,0 +1,19 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@chatbotx.io/ui/components/ui/tooltip"
+import { TriangleAlertIcon } from "lucide-react"
+
+export function TokenRefreshErrorIcon({ message }: { message: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger>
+        <TriangleAlertIcon className="text-destructive" size={16} />
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>{message}</p>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/apps/builder/src/features/integration-instagram/components/instagram-manage.tsx
+++ b/apps/builder/src/features/integration-instagram/components/instagram-manage.tsx
@@ -13,6 +13,7 @@ import {
 import Link from "next/link"
 import { useTranslations } from "next-intl"
 import { use } from "react"
+import { TokenRefreshErrorIcon } from "@/components/token-refresh-error-icon"
 import { useChannelDuplicatedError } from "@/hooks/use-channel-duplicated-error"
 import { useChannelReconnectResult } from "@/hooks/use-channel-reconnect-result"
 import type { listIntegrationInstagrams } from "../queries"
@@ -66,7 +67,16 @@ export function InstagramManage({
           <TableBody>
             {integrationInstagrams.map((integrationInstagram) => (
               <TableRow key={integrationInstagram.id}>
-                <TableCell>{integrationInstagram.name}</TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    {integrationInstagram.tokenRefreshError && (
+                      <TokenRefreshErrorIcon
+                        message={integrationInstagram.tokenRefreshError}
+                      />
+                    )}
+                    {integrationInstagram.name}
+                  </div>
+                </TableCell>
                 <TableCell className="flex w-50 justify-end gap-2">
                   <InstagramReconnect
                     integrationInstagram={integrationInstagram}

--- a/apps/builder/src/features/integration-messenger/messenger-manage.tsx
+++ b/apps/builder/src/features/integration-messenger/messenger-manage.tsx
@@ -13,6 +13,7 @@ import {
 import Link from "next/link"
 import { useTranslations } from "next-intl"
 import { use } from "react"
+import { TokenRefreshErrorIcon } from "@/components/token-refresh-error-icon"
 import { AddChannelButton } from "@/features/inboxes/components/add-channel-button"
 import { useChannelDuplicatedError } from "@/hooks/use-channel-duplicated-error"
 import { useChannelReconnectResult } from "@/hooks/use-channel-reconnect-result"
@@ -69,7 +70,16 @@ export function MessengerManage({
           <TableBody>
             {integrationMessengers.map((integrationMessenger) => (
               <TableRow key={integrationMessenger.id}>
-                <TableCell>{integrationMessenger.name}</TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    {integrationMessenger.tokenRefreshError && (
+                      <TokenRefreshErrorIcon
+                        message={integrationMessenger.tokenRefreshError}
+                      />
+                    )}
+                    {integrationMessenger.name}
+                  </div>
+                </TableCell>
                 <TableCell className="flex w-50 justify-end gap-2">
                   <MessengerReconnect
                     integrationMessenger={integrationMessenger}

--- a/apps/builder/src/features/integration-tiktok/tiktok-manage.tsx
+++ b/apps/builder/src/features/integration-tiktok/tiktok-manage.tsx
@@ -10,6 +10,7 @@ import {
 } from "@chatbotx.io/ui/components/ui/table"
 import { useTranslations } from "next-intl"
 import { use } from "react"
+import { TokenRefreshErrorIcon } from "@/components/token-refresh-error-icon"
 import { AddChannelButton } from "@/features/inboxes/components/add-channel-button"
 import { useChannelDuplicatedError } from "@/hooks/use-channel-duplicated-error"
 import { TiktokDisconnect } from "./components/tiktok-disconnect"
@@ -65,7 +66,16 @@ export function TiktokManage({
           <TableBody>
             {integrationTiktoks.map((integrationTiktok) => (
               <TableRow key={integrationTiktok.id}>
-                <TableCell>{integrationTiktok.name}</TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    {integrationTiktok.tokenRefreshError && (
+                      <TokenRefreshErrorIcon
+                        message={integrationTiktok.tokenRefreshError}
+                      />
+                    )}
+                    {integrationTiktok.name}
+                  </div>
+                </TableCell>
                 <TableCell className="flex w-50 justify-end gap-2">
                   <TiktokRefreshToken integrationTiktok={integrationTiktok} />
                   <TiktokDisconnect integrationTiktok={integrationTiktok} />

--- a/apps/builder/src/features/integration-whatsapp/verification/actions.ts
+++ b/apps/builder/src/features/integration-whatsapp/verification/actions.ts
@@ -88,12 +88,10 @@ async function getWorkspaceIntegration(input: {
   integrationId: string
   notFoundMessage: string
 }) {
-  const integration = await integrationWhatsappService.findWorkspaceIntegration(
-    {
-      id: input.integrationId,
-      workspaceId: input.workspaceId,
-    },
-  )
+  const integration = await integrationWhatsappService.findByIdForWorkspace({
+    id: input.integrationId,
+    workspaceId: input.workspaceId,
+  })
 
   if (!integration) {
     throw new ChatbotXException(input.notFoundMessage)

--- a/apps/builder/src/features/integration-whatsapp/whatsapp-manage.tsx
+++ b/apps/builder/src/features/integration-whatsapp/whatsapp-manage.tsx
@@ -12,6 +12,7 @@ import {
 import Link from "next/link"
 import { useTranslations } from "next-intl"
 import { use } from "react"
+import { TokenRefreshErrorIcon } from "@/components/token-refresh-error-icon"
 import { AddChannelButton } from "@/features/inboxes/components/add-channel-button"
 import { useChannelDuplicatedError } from "@/hooks/use-channel-duplicated-error"
 import type { listIntegrationWhatsapps } from "./queries"
@@ -66,7 +67,16 @@ export function WhatsappManage({
           <TableBody>
             {integrationWhatsapps.map((integrationWhatsapp) => (
               <TableRow key={integrationWhatsapp.id}>
-                <TableCell>{integrationWhatsapp.inbox?.name}</TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    {integrationWhatsapp.tokenRefreshError && (
+                      <TokenRefreshErrorIcon
+                        message={integrationWhatsapp.tokenRefreshError}
+                      />
+                    )}
+                    {integrationWhatsapp.inbox?.name}
+                  </div>
+                </TableCell>
                 <TableCell className="flex w-[200px] justify-end gap-2">
                   <Button size="sm" variant="secondary">
                     <Link

--- a/apps/builder/src/features/integration-zalo/zalo-manage.tsx
+++ b/apps/builder/src/features/integration-zalo/zalo-manage.tsx
@@ -10,6 +10,7 @@ import {
 } from "@chatbotx.io/ui/components/ui/table"
 import { useTranslations } from "next-intl"
 import { use } from "react"
+import { TokenRefreshErrorIcon } from "@/components/token-refresh-error-icon"
 import { AddChannelButton } from "@/features/inboxes/components/add-channel-button"
 import { useChannelDuplicatedError } from "@/hooks/use-channel-duplicated-error"
 import { ZaloDisconnect } from "./components/zalo-disconnect"
@@ -65,7 +66,16 @@ export function ZaloManage({
           <TableBody>
             {integrationZalos.map((integrationZalo) => (
               <TableRow key={integrationZalo.id}>
-                <TableCell>{integrationZalo.name}</TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    {integrationZalo.tokenRefreshError && (
+                      <TokenRefreshErrorIcon
+                        message={integrationZalo.tokenRefreshError}
+                      />
+                    )}
+                    {integrationZalo.name}
+                  </div>
+                </TableCell>
                 <TableCell className="flex w-50 justify-end gap-2">
                   <ZaloRefreshPermissions integrationZalo={integrationZalo} />
                   <ZaloDisconnect integrationZalo={integrationZalo} />

--- a/apps/builder/src/features/workspaces/actions/refresh-all-channel-tokens.action.ts
+++ b/apps/builder/src/features/workspaces/actions/refresh-all-channel-tokens.action.ts
@@ -2,6 +2,7 @@
 
 import {
   instagramIntegrationService,
+  integrationWhatsappService,
   isWorkspaceScheduledForDeletion,
   messengerIntegrationService,
   tiktokIntegrationService,
@@ -19,6 +20,10 @@ import {
 import type { TiktokAuthValue } from "@chatbotx.io/integration-tiktok"
 import { refreshAccessToken as refreshTiktokAccessToken } from "@chatbotx.io/integration-tiktok/apis/auth"
 import { buildTokenTimestamps } from "@chatbotx.io/integration-tiktok/lib/token-utils"
+import {
+  integration as integrationWhatsapp,
+  type WhatsappAuthValue,
+} from "@chatbotx.io/integration-whatsapp"
 import {
   calculateExpiresAt,
   refreshAccessToken as refreshZaloAccessToken,
@@ -339,6 +344,64 @@ async function refreshMessengerIntegrations(
   return toSummary(results)
 }
 
+async function refreshOneWhatsapp(
+  id: string,
+  workspaceId: string,
+): Promise<RefreshResult> {
+  if (!integrationWhatsapp.refreshAuth) {
+    return "skipped"
+  }
+
+  return await distributedLock.runExclusive({
+    key: `auth:refresh:whatsapp:${id}`,
+    timeoutInSeconds: REFRESH_LOCK_TIMEOUT_SECONDS,
+    fn: async () => {
+      try {
+        const integration =
+          await integrationWhatsappService.findByIdForWorkspace({
+            id,
+            workspaceId,
+          })
+        if (!integration) {
+          return "skipped"
+        }
+
+        const auth = integration.auth as WhatsappAuthValue
+        if (auth.metadata.isManual) {
+          return "skipped"
+        }
+
+        const newAuth = await integrationWhatsapp.refreshAuth?.({ auth })
+        await integrationWhatsappService.updateAuth({
+          id,
+          workspaceId,
+          auth: newAuth as WhatsappAuthValue,
+        })
+        return "refreshed"
+      } catch (error) {
+        await integrationWhatsappService.markTokenRefreshError(
+          id,
+          error instanceof Error ? error.message : String(error),
+        )
+        return "failed"
+      }
+    },
+  })
+}
+
+async function refreshWhatsappIntegrations(
+  workspaceIds: string[],
+): Promise<RefreshSummary> {
+  const integrations =
+    await integrationWhatsappService.findForTokenRefreshByWorkspaceIds(
+      workspaceIds,
+    )
+  const results = await runInBatches(integrations, (integration) =>
+    refreshOneWhatsapp(integration.id, integration.workspaceId),
+  )
+  return toSummary(results)
+}
+
 /**
  * Excludes workspaces mid-deletion-grace-window or blocked for trial/quota
  * reasons (AGENTS.md invariant #14) from the bulk refresh, matching the gates
@@ -383,6 +446,7 @@ export const refreshAllChannelTokensAction = authActionClient.action(
       refreshInstagramIntegrations(workspaceIds),
       refreshInstagramFacebookIntegrations(workspaceIds),
       refreshMessengerIntegrations(workspaceIds),
+      refreshWhatsappIntegrations(workspaceIds),
     ])
 
     return sumSummaries(summaries)

--- a/apps/worker/src/schedule/handlers/refresh-channel-tokens.ts
+++ b/apps/worker/src/schedule/handlers/refresh-channel-tokens.ts
@@ -1,0 +1,50 @@
+import type { ChannelType } from "@chatbotx.io/database/partials"
+import { logger } from "../../lib/logger"
+import { refreshInstagramFacebookTokens } from "./refresh-instagram-facebook-tokens"
+import { refreshInstagramTokens } from "./refresh-instagram-tokens"
+import { refreshMessengerTokens } from "./refresh-messenger-tokens"
+import { refreshTiktokTokens } from "./refresh-tiktok-tokens"
+import { refreshWhatsappTokens } from "./refresh-whatsapp-tokens"
+import { refreshZaloTokens } from "./refresh-zalo-tokens"
+
+async function refreshInstagramAndFacebookTokens(): Promise<void> {
+  await Promise.all([
+    refreshInstagramTokens(),
+    refreshInstagramFacebookTokens(),
+  ])
+}
+
+const refreshTokenAdapter: Record<
+  ChannelType,
+  (() => Promise<void>) | undefined
+> = {
+  zalo: refreshZaloTokens,
+  tiktok: refreshTiktokTokens,
+  instagram: refreshInstagramAndFacebookTokens,
+  messenger: refreshMessengerTokens,
+  whatsapp: refreshWhatsappTokens,
+  omnichannel: undefined,
+  webchat: undefined,
+  smtp: undefined,
+  telegram: undefined,
+}
+
+export async function refreshChannelTokens(): Promise<void> {
+  const entries = Object.entries(refreshTokenAdapter).filter(
+    (entry): entry is [ChannelType, () => Promise<void>] =>
+      entry[1] !== undefined,
+  )
+
+  const results = await Promise.allSettled(
+    entries.map(([channel, refresh]) =>
+      refresh().catch((error) => {
+        logger.error(error, `[refreshChannelTokens] channel=${channel} failed`)
+        throw error
+      }),
+    ),
+  )
+  const failed = results.filter((r) => r.status === "rejected").length
+  if (failed > 0) {
+    logger.warn(`[refreshChannelTokens] ${failed} channel(s) failed to run`)
+  }
+}

--- a/apps/worker/src/schedule/handlers/refresh-whatsapp-tokens.ts
+++ b/apps/worker/src/schedule/handlers/refresh-whatsapp-tokens.ts
@@ -1,0 +1,71 @@
+import { integrationWhatsappService } from "@chatbotx.io/business"
+import {
+  integration as integrationWhatsapp,
+  type WhatsappAuthValue,
+} from "@chatbotx.io/integration-whatsapp"
+import { distributedLock } from "@chatbotx.io/redis"
+import { logger } from "../../lib/logger"
+
+const BATCH_SIZE = 50
+const REFRESH_LOCK_TIMEOUT_SECONDS = 10
+
+async function refreshOne(integration: {
+  id: string
+  workspaceId: string
+}): Promise<void> {
+  if (!integrationWhatsapp.refreshAuth) {
+    return
+  }
+
+  await distributedLock.runExclusive({
+    key: `auth:refresh:whatsapp:${integration.id}`,
+    timeoutInSeconds: REFRESH_LOCK_TIMEOUT_SECONDS,
+    fn: async () => {
+      try {
+        const current = await integrationWhatsappService.findByIdForWorkspace({
+          id: integration.id,
+          workspaceId: integration.workspaceId,
+        })
+        if (!current) {
+          return
+        }
+
+        const auth = current.auth as WhatsappAuthValue
+        if (auth.metadata.isManual) {
+          return
+        }
+
+        const newAuth = await integrationWhatsapp.refreshAuth?.({ auth })
+
+        await integrationWhatsappService.updateAuth({
+          id: integration.id,
+          workspaceId: integration.workspaceId,
+          auth: newAuth as WhatsappAuthValue,
+        })
+      } catch (error) {
+        logger.error(
+          error,
+          `[refreshWhatsappTokens] id=${integration.id} failed`,
+        )
+        await integrationWhatsappService.markTokenRefreshError(
+          integration.id,
+          error instanceof Error ? error.message : String(error),
+        )
+      }
+    },
+  })
+}
+
+export async function refreshWhatsappTokens(): Promise<void> {
+  if (!integrationWhatsapp.refreshAuth) {
+    logger.warn("[refreshWhatsappTokens] integration does not support refresh")
+    return
+  }
+
+  const integrations = await integrationWhatsappService.findAllForTokenRefresh()
+
+  for (let i = 0; i < integrations.length; i += BATCH_SIZE) {
+    const batch = integrations.slice(i, i + BATCH_SIZE)
+    await Promise.all(batch.map(refreshOne))
+  }
+}

--- a/apps/worker/src/schedule/handlers/register-schedules.ts
+++ b/apps/worker/src/schedule/handlers/register-schedules.ts
@@ -229,70 +229,14 @@ export const registerSchedules = async () => {
   )
 
   await scheduleQueue.upsertJobScheduler(
-    ScheduleJobData.refreshZaloTokens,
+    ScheduleJobData.refreshChannelTokens,
     {
       pattern: "0 2 * * *",
     },
     {
-      name: ScheduleJobData.refreshZaloTokens,
+      name: ScheduleJobData.refreshChannelTokens,
       data: {
-        type: ScheduleJobData.refreshZaloTokens,
-        data: {},
-      },
-    },
-  )
-
-  await scheduleQueue.upsertJobScheduler(
-    ScheduleJobData.refreshTiktokTokens,
-    {
-      pattern: "15 2 * * *",
-    },
-    {
-      name: ScheduleJobData.refreshTiktokTokens,
-      data: {
-        type: ScheduleJobData.refreshTiktokTokens,
-        data: {},
-      },
-    },
-  )
-
-  await scheduleQueue.upsertJobScheduler(
-    ScheduleJobData.refreshInstagramTokens,
-    {
-      pattern: "30 2 * * *",
-    },
-    {
-      name: ScheduleJobData.refreshInstagramTokens,
-      data: {
-        type: ScheduleJobData.refreshInstagramTokens,
-        data: {},
-      },
-    },
-  )
-
-  await scheduleQueue.upsertJobScheduler(
-    ScheduleJobData.refreshMessengerTokens,
-    {
-      pattern: "45 2 * * *",
-    },
-    {
-      name: ScheduleJobData.refreshMessengerTokens,
-      data: {
-        type: ScheduleJobData.refreshMessengerTokens,
-        data: {},
-      },
-    },
-  )
-
-  await scheduleQueue.upsertJobScheduler(
-    ScheduleJobData.refreshInstagramFacebookTokens,
-    {
-      pattern: "5 3 * * *",
-    },
-    {
-      name: ScheduleJobData.refreshInstagramFacebookTokens,
-      data: {
-        type: ScheduleJobData.refreshInstagramFacebookTokens,
+        type: ScheduleJobData.refreshChannelTokens,
         data: {},
       },
     },

--- a/apps/worker/src/schedule/worker.ts
+++ b/apps/worker/src/schedule/worker.ts
@@ -27,11 +27,7 @@ import { purgeWorkspaces } from "./handlers/purge-workspaces"
 import { reconcileBroadcasts } from "./handlers/reconcile-broadcasts"
 import { reconcileMetaCatalogSyncs } from "./handlers/reconcile-meta-catalog-syncs"
 import { reconcileTenants } from "./handlers/reconcile-tenants"
-import { refreshInstagramFacebookTokens } from "./handlers/refresh-instagram-facebook-tokens"
-import { refreshInstagramTokens } from "./handlers/refresh-instagram-tokens"
-import { refreshMessengerTokens } from "./handlers/refresh-messenger-tokens"
-import { refreshTiktokTokens } from "./handlers/refresh-tiktok-tokens"
-import { refreshZaloTokens } from "./handlers/refresh-zalo-tokens"
+import { refreshChannelTokens } from "./handlers/refresh-channel-tokens"
 import { registerSchedules } from "./handlers/register-schedules"
 import { scanCoexistRuns } from "./handlers/scan-coexist-runs"
 import { scanSmartDelay } from "./handlers/scan-smart-delay"
@@ -134,24 +130,8 @@ async function startScheduleWorker() {
           await purgeWorkspaces()
           return
 
-        case ScheduleJobData.refreshZaloTokens:
-          await refreshZaloTokens()
-          return
-
-        case ScheduleJobData.refreshTiktokTokens:
-          await refreshTiktokTokens()
-          return
-
-        case ScheduleJobData.refreshInstagramTokens:
-          await refreshInstagramTokens()
-          return
-
-        case ScheduleJobData.refreshMessengerTokens:
-          await refreshMessengerTokens()
-          return
-
-        case ScheduleJobData.refreshInstagramFacebookTokens:
-          await refreshInstagramFacebookTokens()
+        case ScheduleJobData.refreshChannelTokens:
+          await refreshChannelTokens()
           return
 
         case ScheduleJobData.unsubscribeExpiredTrials:

--- a/integrations/whatsapp/src/api/auth.ts
+++ b/integrations/whatsapp/src/api/auth.ts
@@ -57,6 +57,27 @@ export const exchangeAccessToken = (
   )
 }
 
+export const exchangeLongLivedToken = (
+  settings: { clientId: string; clientSecret: string },
+  accessToken: string,
+): Promise<string> =>
+  rescue(async () => {
+    const result = await ky
+      .get<ExchangeAccessTokenResponse>(
+        `${API_URL}/${DEFAULT_API_VERSION}/oauth/access_token`,
+        {
+          searchParams: {
+            grant_type: "fb_exchange_token",
+            client_id: settings.clientId,
+            client_secret: settings.clientSecret,
+            fb_exchange_token: accessToken,
+          },
+        },
+      )
+      .json()
+    return result.access_token
+  })
+
 export async function debugToken(
   accessToken: string,
   debugAccessToken = accessToken,

--- a/integrations/whatsapp/src/integration.ts
+++ b/integrations/whatsapp/src/integration.ts
@@ -4,6 +4,7 @@ import {
   type IntegrationDefinition,
   SdkException,
 } from "@chatbotx.io/sdk"
+import { exchangeLongLivedToken } from "./api/auth"
 import { getFlowAssets } from "./api/flow"
 import {
   findConversationalAutomation,
@@ -64,6 +65,19 @@ const config: IntegrationDefinition<
   },
   disconnect: async (auth: WhatsappAuthValue): Promise<void> => {
     await unsubscribeWebhook({ auth })
+  },
+  refreshAuth: async ({ auth }) => {
+    const accessToken = await exchangeLongLivedToken(
+      { clientId: auth.clientId, clientSecret: auth.clientSecret },
+      auth.tokens.accessToken,
+    )
+    return {
+      ...auth,
+      tokens: {
+        ...auth.tokens,
+        accessToken,
+      },
+    }
   },
 }
 

--- a/packages/business/src/integration-whatsapp/schema.ts
+++ b/packages/business/src/integration-whatsapp/schema.ts
@@ -16,6 +16,7 @@ export const integrationWhatsappResource = createSelectSchema(
   name: true,
   inboxId: true,
   displayPhoneNumber: true,
+  tokenRefreshError: true,
 })
 
 export type IntegrationWhatsappResource = z.infer<

--- a/packages/business/src/integration-whatsapp/service.ts
+++ b/packages/business/src/integration-whatsapp/service.ts
@@ -228,10 +228,34 @@ class IntegrationWhatsappService extends BaseService {
     })
   }
 
-  findWorkspaceIntegration(
+  findByIdForWorkspace(
     input: FindWorkspaceIntegrationInput,
   ): Promise<IntegrationWhatsappModel | null> {
-    return integrationWhatsappRepository.findWorkspaceIntegration(input)
+    return integrationWhatsappRepository.findByIdForWorkspace(input)
+  }
+
+  findAllForTokenRefresh() {
+    return integrationWhatsappRepository.findAllForTokenRefresh()
+  }
+
+  findForTokenRefreshByWorkspaceIds(workspaceIds: string[]) {
+    return integrationWhatsappRepository.findForTokenRefreshByWorkspaceIds(
+      workspaceIds,
+    )
+  }
+
+  /**
+   * Replace the stored OAuth credentials after a token refresh. Scoped by
+   * workspace so a forged integration id can never touch another tenant's row.
+   */
+  updateAuth(
+    input: FindWorkspaceIntegrationInput & { auth: Record<string, unknown> },
+  ): Promise<void> {
+    return integrationWhatsappRepository.updateAuth(input)
+  }
+
+  markTokenRefreshError(id: string, error: string): Promise<void> {
+    return integrationWhatsappRepository.markTokenRefreshError(id, error)
   }
 
   /**

--- a/packages/business/src/integration/service.ts
+++ b/packages/business/src/integration/service.ts
@@ -14,6 +14,7 @@ import {
   integrationMetaCatalogModel,
   integrationModel,
   integrationTiktokModel,
+  integrationWhatsappModel,
   integrationZaloModel,
 } from "@chatbotx.io/database/schema"
 import type { IntegrationModel } from "@chatbotx.io/database/types"
@@ -25,6 +26,7 @@ export type TokenRefreshErrorChannel =
   | "instagram"
   | "instagramFacebook"
   | "messenger"
+  | "whatsapp"
 
 export type TokenRefreshErrorIntegration = {
   id: string
@@ -71,61 +73,75 @@ class IntegrationService extends BaseService {
   async findTokenRefreshErrorsByWorkspaceId(
     workspaceId: string,
   ): Promise<TokenRefreshErrorIntegration[]> {
-    const [zalos, tiktoks, instagrams, messengers] = await Promise.all([
-      db
-        .select({
-          id: integrationZaloModel.id,
-          name: integrationZaloModel.name,
-          error: integrationZaloModel.tokenRefreshError,
-        })
-        .from(integrationZaloModel)
-        .where(
-          and(
-            eq(integrationZaloModel.workspaceId, workspaceId),
-            isNotNull(integrationZaloModel.tokenRefreshError),
+    const [zalos, tiktoks, instagrams, messengers, whatsapps] =
+      await Promise.all([
+        db
+          .select({
+            id: integrationZaloModel.id,
+            name: integrationZaloModel.name,
+            error: integrationZaloModel.tokenRefreshError,
+          })
+          .from(integrationZaloModel)
+          .where(
+            and(
+              eq(integrationZaloModel.workspaceId, workspaceId),
+              isNotNull(integrationZaloModel.tokenRefreshError),
+            ),
           ),
-        ),
-      db
-        .select({
-          id: integrationTiktokModel.id,
-          name: integrationTiktokModel.name,
-          error: integrationTiktokModel.tokenRefreshError,
-        })
-        .from(integrationTiktokModel)
-        .where(
-          and(
-            eq(integrationTiktokModel.workspaceId, workspaceId),
-            isNotNull(integrationTiktokModel.tokenRefreshError),
+        db
+          .select({
+            id: integrationTiktokModel.id,
+            name: integrationTiktokModel.name,
+            error: integrationTiktokModel.tokenRefreshError,
+          })
+          .from(integrationTiktokModel)
+          .where(
+            and(
+              eq(integrationTiktokModel.workspaceId, workspaceId),
+              isNotNull(integrationTiktokModel.tokenRefreshError),
+            ),
           ),
-        ),
-      db
-        .select({
-          id: integrationInstagramModel.id,
-          name: integrationInstagramModel.name,
-          error: integrationInstagramModel.tokenRefreshError,
-          type: integrationInstagramModel.type,
-        })
-        .from(integrationInstagramModel)
-        .where(
-          and(
-            eq(integrationInstagramModel.workspaceId, workspaceId),
-            isNotNull(integrationInstagramModel.tokenRefreshError),
+        db
+          .select({
+            id: integrationInstagramModel.id,
+            name: integrationInstagramModel.name,
+            error: integrationInstagramModel.tokenRefreshError,
+            type: integrationInstagramModel.type,
+          })
+          .from(integrationInstagramModel)
+          .where(
+            and(
+              eq(integrationInstagramModel.workspaceId, workspaceId),
+              isNotNull(integrationInstagramModel.tokenRefreshError),
+            ),
           ),
-        ),
-      db
-        .select({
-          id: integrationMessengerModel.id,
-          name: integrationMessengerModel.name,
-          error: integrationMessengerModel.tokenRefreshError,
-        })
-        .from(integrationMessengerModel)
-        .where(
-          and(
-            eq(integrationMessengerModel.workspaceId, workspaceId),
-            isNotNull(integrationMessengerModel.tokenRefreshError),
+        db
+          .select({
+            id: integrationMessengerModel.id,
+            name: integrationMessengerModel.name,
+            error: integrationMessengerModel.tokenRefreshError,
+          })
+          .from(integrationMessengerModel)
+          .where(
+            and(
+              eq(integrationMessengerModel.workspaceId, workspaceId),
+              isNotNull(integrationMessengerModel.tokenRefreshError),
+            ),
           ),
-        ),
-    ])
+        db
+          .select({
+            id: integrationWhatsappModel.id,
+            name: integrationWhatsappModel.name,
+            error: integrationWhatsappModel.tokenRefreshError,
+          })
+          .from(integrationWhatsappModel)
+          .where(
+            and(
+              eq(integrationWhatsappModel.workspaceId, workspaceId),
+              isNotNull(integrationWhatsappModel.tokenRefreshError),
+            ),
+          ),
+      ])
 
     return [
       ...zalos.map((row) => ({
@@ -152,6 +168,12 @@ class IntegrationService extends BaseService {
       ...messengers.map((row) => ({
         id: row.id,
         channel: "messenger" as const,
+        name: row.name,
+        error: row.error as string,
+      })),
+      ...whatsapps.map((row) => ({
+        id: row.id,
+        channel: "whatsapp" as const,
         name: row.name,
         error: row.error as string,
       })),

--- a/packages/database/drizzle/20260802015339_add-ig-story-automation/snapshot.json
+++ b/packages/database/drizzle/20260802015339_add-ig-story-automation/snapshot.json
@@ -2,10 +2,7 @@
   "version": "8",
   "dialect": "postgres",
   "id": "4881e2af-9436-4814-8630-f7a554b2002b",
-  "prevIds": [
-    "97b85b04-2745-4f90-bde9-54c43794a33d",
-    "cf9e3f5e-62c4-4d0c-accc-360cfec6a3bb"
-  ],
+  "prevIds": ["cf9e3f5e-62c4-4d0c-accc-360cfec6a3bb"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],

--- a/packages/database/drizzle/20260806173000_instagram_coexist/snapshot.json
+++ b/packages/database/drizzle/20260806173000_instagram_coexist/snapshot.json
@@ -2,7 +2,7 @@
   "version": "8",
   "dialect": "postgres",
   "id": "9976c2d4-70d6-4228-8165-9ca20823699d",
-  "prevIds": ["4881e2af-9436-4814-8630-f7a554b2002b"],
+  "prevIds": ["01064b59-bd6f-4411-b7aa-a156cdcc1ba1"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],

--- a/packages/database/drizzle/20260807093021_add-outbound-automated-response-folder-type/snapshot.json
+++ b/packages/database/drizzle/20260807093021_add-outbound-automated-response-folder-type/snapshot.json
@@ -2,7 +2,7 @@
   "version": "8",
   "dialect": "postgres",
   "id": "92fa1eef-bd97-4879-bf43-a3c2e605ca87",
-  "prevIds": ["01064b59-bd6f-4411-b7aa-a156cdcc1ba1"],
+  "prevIds": ["9976c2d4-70d6-4228-8165-9ca20823699d"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],

--- a/packages/database/drizzle/20260810041827_add_tenant_hidden_channels/snapshot.json
+++ b/packages/database/drizzle/20260810041827_add_tenant_hidden_channels/snapshot.json
@@ -2,10 +2,7 @@
   "version": "8",
   "dialect": "postgres",
   "id": "ec928099-855b-4bb1-bdd3-ec08eefcfb5e",
-  "prevIds": [
-    "92fa1eef-bd97-4879-bf43-a3c2e605ca87",
-    "9976c2d4-70d6-4228-8165-9ca20823699d"
-  ],
+  "prevIds": ["92fa1eef-bd97-4879-bf43-a3c2e605ca87"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],

--- a/packages/database/drizzle/20260810050035_add_token_refresh_error_flag/snapshot.json
+++ b/packages/database/drizzle/20260810050035_add_token_refresh_error_flag/snapshot.json
@@ -2,10 +2,7 @@
   "version": "8",
   "dialect": "postgres",
   "id": "1ffed4d9-b68f-49d7-923d-b43c480f4ba0",
-  "prevIds": [
-    "92fa1eef-bd97-4879-bf43-a3c2e605ca87",
-    "9976c2d4-70d6-4228-8165-9ca20823699d"
-  ],
+  "prevIds": ["ec928099-855b-4bb1-bdd3-ec08eefcfb5e"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],

--- a/packages/database/drizzle/20260811025220_add_whatsapp_token_refresh_error/migration.sql
+++ b/packages/database/drizzle/20260811025220_add_whatsapp_token_refresh_error/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "IntegrationWhatsapp" ADD COLUMN "tokenRefreshError" text;

--- a/packages/database/drizzle/20260811025220_add_whatsapp_token_refresh_error/snapshot.json
+++ b/packages/database/drizzle/20260811025220_add_whatsapp_token_refresh_error/snapshot.json
@@ -1,8 +1,8 @@
 {
   "version": "8",
   "dialect": "postgres",
-  "id": "9d810992-498d-4c59-bb8c-72debb5cbedc",
-  "prevIds": ["97b85b04-2745-4f90-bde9-54c43794a33d"],
+  "id": "9dfc0c5b-fe4d-4460-a095-d233d1d0529a",
+  "prevIds": ["1ffed4d9-b68f-49d7-923d-b43c480f4ba0"],
   "ddl": [
     {
       "values": ["pending", "success", "error", "processing"],
@@ -105,6 +105,12 @@
       "schema": "public"
     },
     {
+      "values": ["inbound", "outbound"],
+      "name": "automatedResponseType",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
       "values": ["now", "future"],
       "name": "broadcastScheduleType",
       "entityType": "enums",
@@ -117,7 +123,7 @@
       "schema": "public"
     },
     {
-      "values": ["whatsapp", "messenger"],
+      "values": ["whatsapp", "messenger", "instagram"],
       "name": "coexistChannel",
       "entityType": "enums",
       "schema": "public"
@@ -189,7 +195,7 @@
       "schema": "public"
     },
     {
-      "values": ["messenger", "instagram"],
+      "values": ["messenger", "instagram", "instagramFacebook"],
       "name": "fbCommentAutomationType",
       "entityType": "enums",
       "schema": "public"
@@ -216,9 +222,18 @@
         "webhook",
         "sequence",
         "emailTopic",
-        "fbComment"
+        "fbComment",
+        "igComment",
+        "igStory",
+        "outboundAutomatedResponse"
       ],
       "name": "folderType",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": ["instagram", "instagramFacebook"],
+      "name": "igStoryAutomationType",
       "entityType": "enums",
       "schema": "public"
     },
@@ -765,6 +780,12 @@
     {
       "isRlsEnabled": false,
       "name": "Folder",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "IgStoryAutomation",
       "entityType": "tables",
       "schema": "public"
     },
@@ -4964,6 +4985,19 @@
       "table": "AutomatedResponse"
     },
     {
+      "type": "automatedResponseType",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'inbound'",
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "AutomatedResponse"
+    },
+    {
       "type": "bigint",
       "typeSchema": null,
       "notNull": true,
@@ -8532,6 +8566,19 @@
       "table": "Tenant"
     },
     {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "hiddenChannels",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Tenant"
+    },
+    {
       "type": "bigint",
       "typeSchema": null,
       "notNull": true,
@@ -8865,6 +8912,32 @@
       "generated": null,
       "identity": null,
       "name": "monthlyBotMessagesUsed",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "UserQuota"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "monthlyBotMessagesPeriodStart",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "UserQuota"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "botMessagesTopUpGranted",
       "entityType": "columns",
       "schema": "public",
       "table": "UserQuota"
@@ -10843,6 +10916,188 @@
       "name": "id",
       "entityType": "columns",
       "schema": "public",
+      "table": "IgStoryAutomation"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IgStoryAutomation"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IgStoryAutomation"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IgStoryAutomation"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspaceId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IgStoryAutomation"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "folderId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IgStoryAutomation"
+    },
+    {
+      "type": "igStoryAutomationType",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IgStoryAutomation"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "isActive",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IgStoryAutomation"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "startTime",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IgStoryAutomation"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "endTime",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IgStoryAutomation"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "repliesCount",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IgStoryAutomation"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{\"type\":\"all\",\"value\":[]}'",
+      "generated": null,
+      "identity": null,
+      "name": "story",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IgStoryAutomation"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{\"type\":\"none\",\"value\":null}'",
+      "generated": null,
+      "identity": null,
+      "name": "reply",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IgStoryAutomation"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{\"type\":\"all\",\"value\":[]}'",
+      "generated": null,
+      "identity": null,
+      "name": "includeKeywords",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IgStoryAutomation"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
       "table": "Import"
     },
     {
@@ -12367,6 +12622,19 @@
       "table": "IntegrationInstagram"
     },
     {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "coexistEnabled",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationInstagram"
+    },
+    {
       "type": "jsonb",
       "typeSchema": null,
       "notNull": true,
@@ -12440,6 +12708,19 @@
       "generated": null,
       "identity": null,
       "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationInstagram"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tokenRefreshError",
       "entityType": "columns",
       "schema": "public",
       "table": "IntegrationInstagram"
@@ -12887,6 +13168,19 @@
       "table": "IntegrationMessenger"
     },
     {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tokenRefreshError",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationMessenger"
+    },
+    {
       "type": "bigint",
       "typeSchema": null,
       "notNull": true,
@@ -12993,7 +13287,7 @@
     {
       "type": "jsonb",
       "typeSchema": null,
-      "notNull": true,
+      "notNull": false,
       "dimensions": 0,
       "default": null,
       "generated": null,
@@ -13038,6 +13332,19 @@
       "generated": null,
       "identity": null,
       "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationMetaCatalog"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deletedAt",
       "entityType": "columns",
       "schema": "public",
       "table": "IntegrationMetaCatalog"
@@ -14109,6 +14416,19 @@
       "table": "IntegrationTiktok"
     },
     {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tokenRefreshError",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationTiktok"
+    },
+    {
       "type": "bigint",
       "typeSchema": null,
       "notNull": true,
@@ -14538,6 +14858,19 @@
       "table": "IntegrationWhatsapp"
     },
     {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tokenRefreshError",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationWhatsapp"
+    },
+    {
       "type": "bigint",
       "typeSchema": null,
       "notNull": true,
@@ -14689,6 +15022,19 @@
       "generated": null,
       "identity": null,
       "name": "syncTagEnabledAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "IntegrationZalo"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tokenRefreshError",
       "entityType": "columns",
       "schema": "public",
       "table": "IntegrationZalo"
@@ -15690,6 +16036,19 @@
       "generated": null,
       "identity": null,
       "name": "handles",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "MetaCatalogSyncRun"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "submissionLeaseId",
       "entityType": "columns",
       "schema": "public",
       "table": "MetaCatalogSyncRun"
@@ -23933,6 +24292,48 @@
           "asc": true,
           "nullsFirst": false,
           "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "IgStoryAutomation_workspaceId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "IgStoryAutomation"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "folderId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "IgStoryAutomation_folderId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "IgStoryAutomation"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspaceId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
         },
         {
           "value": "status",
@@ -24802,6 +25203,27 @@
       "method": "btree",
       "concurrently": false,
       "name": "IntegrationMetaCatalog_workspaceId_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "IntegrationMetaCatalog"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "deletedAt",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "IntegrationMetaCatalog_deletedAt_idx",
       "entityType": "indexes",
       "schema": "public",
       "table": "IntegrationMetaCatalog"
@@ -29419,6 +29841,32 @@
       "columnsTo": ["id"],
       "onUpdate": "CASCADE",
       "onDelete": "CASCADE",
+      "name": "IgStoryAutomation_workspaceId_Workspace_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "IgStoryAutomation"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["folderId"],
+      "schemaTo": "public",
+      "tableTo": "Folder",
+      "columnsTo": ["id"],
+      "onUpdate": "CASCADE",
+      "onDelete": "SET NULL",
+      "name": "IgStoryAutomation_folderId_Folder_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "IgStoryAutomation"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["workspaceId"],
+      "schemaTo": "public",
+      "tableTo": "Workspace",
+      "columnsTo": ["id"],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
       "name": "Import_workspaceId_Workspace_id_fkey",
       "entityType": "fks",
       "schema": "public",
@@ -31861,6 +32309,14 @@
       "name": "Folder_pkey",
       "schema": "public",
       "table": "Folder",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "IgStoryAutomation_pkey",
+      "schema": "public",
+      "table": "IgStoryAutomation",
       "entityType": "pks"
     },
     {

--- a/packages/database/src/repositories/integration-whatsapp/repository.ts
+++ b/packages/database/src/repositories/integration-whatsapp/repository.ts
@@ -126,7 +126,34 @@ class IntegrationWhatsappRepository {
     return new Set(rows.map((row) => row.phoneNumberId))
   }
 
-  async findWorkspaceIntegration(
+  findAllForTokenRefresh(tx: DatabaseClient = db) {
+    return tx
+      .select({
+        id: integrationWhatsappModel.id,
+        workspaceId: integrationWhatsappModel.workspaceId,
+        auth: integrationWhatsappModel.auth,
+      })
+      .from(integrationWhatsappModel)
+  }
+
+  findForTokenRefreshByWorkspaceIds(
+    workspaceIds: string[],
+    tx: DatabaseClient = db,
+  ) {
+    if (workspaceIds.length === 0) {
+      return Promise.resolve([])
+    }
+    return tx
+      .select({
+        id: integrationWhatsappModel.id,
+        workspaceId: integrationWhatsappModel.workspaceId,
+        auth: integrationWhatsappModel.auth,
+      })
+      .from(integrationWhatsappModel)
+      .where(inArray(integrationWhatsappModel.workspaceId, workspaceIds))
+  }
+
+  async findByIdForWorkspace(
     input: WorkspaceIntegrationRef,
     tx: DatabaseClient = db,
   ): Promise<IntegrationWhatsappModel | null> {
@@ -137,6 +164,31 @@ class IntegrationWhatsappRepository {
       .limit(1)
 
     return row ?? null
+  }
+
+  /**
+   * Replace the stored OAuth credentials after a token refresh. Scoped by
+   * workspace so a forged integration id can never touch another tenant's row.
+   */
+  async updateAuth(
+    input: WorkspaceIntegrationRef & { auth: Record<string, unknown> },
+    tx: DatabaseClient = db,
+  ): Promise<void> {
+    await tx
+      .update(integrationWhatsappModel)
+      .set({ auth: input.auth, tokenRefreshError: null })
+      .where(workspaceIntegrationFilter(input))
+  }
+
+  async markTokenRefreshError(
+    id: string,
+    error: string,
+    tx: DatabaseClient = db,
+  ): Promise<void> {
+    await tx
+      .update(integrationWhatsappModel)
+      .set({ tokenRefreshError: error })
+      .where(eq(integrationWhatsappModel.id, id))
   }
 
   async findVerificationCodeRequestedAt(

--- a/packages/database/src/schema/integration-whatsapp.ts
+++ b/packages/database/src/schema/integration-whatsapp.ts
@@ -63,6 +63,7 @@ export const integrationWhatsappModel = pgTable(
       .default("pending_verification"),
     registrationError: jsonb().$type<IntegrationWhatsappRegistrationError>(),
     verificationCodeRequestedAt: timestamp(timestampConfig),
+    tokenRefreshError: text(),
     workspaceId: bigintAsString()
       .notNull()
       .references(() => workspaceModel.id, {

--- a/packages/worker-config/src/queues/schedule/index.ts
+++ b/packages/worker-config/src/queues/schedule/index.ts
@@ -26,11 +26,7 @@ export const ScheduleJobData = {
   purgeCoexistStaging: "purgeCoexistStaging",
   purgeWhatsappSignupSessions: "purgeWhatsappSignupSessions",
   purgeWorkspaces: "purgeWorkspaces",
-  refreshZaloTokens: "refreshZaloTokens",
-  refreshTiktokTokens: "refreshTiktokTokens",
-  refreshInstagramTokens: "refreshInstagramTokens",
-  refreshMessengerTokens: "refreshMessengerTokens",
-  refreshInstagramFacebookTokens: "refreshInstagramFacebookTokens",
+  refreshChannelTokens: "refreshChannelTokens",
   unsubscribeExpiredTrials: "unsubscribeExpiredTrials",
   teardownExpiredTrial: "teardownExpiredTrial",
 } as const
@@ -153,28 +149,8 @@ export type ScheduleJobPurgeWorkspaces = {
   data: Record<string, never>
 }
 
-export type ScheduleJobRefreshZaloTokens = {
-  type: typeof ScheduleJobData.refreshZaloTokens
-  data: Record<string, never>
-}
-
-export type ScheduleJobRefreshTiktokTokens = {
-  type: typeof ScheduleJobData.refreshTiktokTokens
-  data: Record<string, never>
-}
-
-export type ScheduleJobRefreshInstagramTokens = {
-  type: typeof ScheduleJobData.refreshInstagramTokens
-  data: Record<string, never>
-}
-
-export type ScheduleJobRefreshMessengerTokens = {
-  type: typeof ScheduleJobData.refreshMessengerTokens
-  data: Record<string, never>
-}
-
-export type ScheduleJobRefreshInstagramFacebookTokens = {
-  type: typeof ScheduleJobData.refreshInstagramFacebookTokens
+export type ScheduleJobRefreshChannelTokens = {
+  type: typeof ScheduleJobData.refreshChannelTokens
   data: Record<string, never>
 }
 
@@ -208,11 +184,7 @@ export type ScheduleJobData =
   | ScheduleJobPurgeCoexistStaging
   | ScheduleJobPurgeWhatsappSignupSessions
   | ScheduleJobPurgeWorkspaces
-  | ScheduleJobRefreshZaloTokens
-  | ScheduleJobRefreshTiktokTokens
-  | ScheduleJobRefreshInstagramTokens
-  | ScheduleJobRefreshMessengerTokens
-  | ScheduleJobRefreshInstagramFacebookTokens
+  | ScheduleJobRefreshChannelTokens
   | ScheduleJobUnsubscribeExpiredTrials
   | ScheduleJobTeardownExpiredTrial
 


### PR DESCRIPTION
## Summary
- Shows a red warning icon before the integration name on the `settings/channels` manage tables (Zalo, TikTok, Instagram, Messenger, WhatsApp) whenever `tokenRefreshError` is set on that integration
- Hovering the icon shows the actual `tokenRefreshError` message in a tooltip
- Exposes `tokenRefreshError` on `IntegrationWhatsappResource`, which previously only picked `id/name/inboxId/displayPhoneNumber` and would have hidden the field from the WhatsApp manage table

## Changes
- `apps/builder/src/components/token-refresh-error-icon.tsx` (new): shared `TriangleAlertIcon` + `Tooltip` component
- `apps/builder/src/features/integration-{zalo,tiktok,messenger}/*-manage.tsx`, `integration-instagram/components/instagram-manage.tsx`, `integration-whatsapp/whatsapp-manage.tsx`: wire the icon into each channel's name cell
- `packages/business/src/integration-whatsapp/schema.ts`: add `tokenRefreshError` to the picked resource fields

Note: this branch is stacked on `feat/whatsapp-token-refresh` (#937) since the WhatsApp `tokenRefreshError` column/field only exists there — this PR's diff will include #937's changes until that one merges first.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [x] `pnpm --filter @chatbotx.io/business check-types`
- [ ] Manual: seed a `tokenRefreshError` on an integration row and confirm the icon + tooltip render correctly at `/space/:workspaceId/settings/channels` without breaking the table row layout (fixed an earlier `display:flex`-on-`<td>` regression before this PR)