### PR TITLE
fix(workspaces): drop unusable serverside redirect after scheduling deletion

### DIFF
--- a/apps/builder/__tests__/schedule-workspace-deletion-action.test.ts
+++ b/apps/builder/__tests__/schedule-workspace-deletion-action.test.ts
@@ -6,9 +6,6 @@ const mockGetCurrentUserAndTargetWorkspace = vi.fn()
 const mockHasWorkspacePermission = vi.fn()
 const mockScheduleDeletion = vi.fn()
 const mockFreezeWorkspaceRuntime = vi.fn()
-const mockRedirect = vi.fn(() => {
-  throw new Error("redirect")
-})
 
 vi.mock("@/lib/safe-action", () => {
   const chain: Record<string, unknown> = {}
@@ -18,10 +15,6 @@ vi.mock("@/lib/safe-action", () => {
     workspaceActionClientAllowExpired: chain,
   }
 })
-
-vi.mock("next/navigation", () => ({
-  redirect: mockRedirect,
-}))
 
 vi.mock("@/lib/auth/utils", () => ({
   getCurrentUserAndTargetWorkspace: mockGetCurrentUserAndTargetWorkspace,
@@ -56,16 +49,13 @@ beforeEach(() => {
   mockFreezeWorkspaceRuntime.mockResolvedValue(undefined)
 })
 
-test("schedules deletion then freezes the workspace runtime before redirecting", async () => {
-  await expect(
-    (scheduleWorkspaceDeletionAction as (props: unknown) => Promise<unknown>)({
-      bindArgsParsedInputs: ["workspace-1"],
-    }),
-  ).rejects.toThrow("redirect")
+test("schedules deletion then freezes the workspace runtime", async () => {
+  await (
+    scheduleWorkspaceDeletionAction as (props: unknown) => Promise<unknown>
+  )({
+    bindArgsParsedInputs: ["workspace-1"],
+  })
 
   expect(mockScheduleDeletion).toHaveBeenCalledWith({ id: "workspace-1" })
   expect(mockFreezeWorkspaceRuntime).toHaveBeenCalledWith("workspace-1")
-  expect(mockRedirect).toHaveBeenCalledWith(
-    "/space/workspace-1/settings/general",
-  )
 })

--- a/apps/builder/src/features/workspaces/actions/schedule-workspace-deletion-action.ts
+++ b/apps/builder/src/features/workspaces/actions/schedule-workspace-deletion-action.ts
@@ -5,7 +5,6 @@ import {
   workspaceService,
 } from "@chatbotx.io/business"
 import { ChatbotXException } from "@chatbotx.io/business/errors"
-import { redirect } from "next/navigation"
 import {
   type WorkspaceIdRequestParams,
   workspaceIdrequestParams,
@@ -13,7 +12,6 @@ import {
 import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
 import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
 import { workspaceActionClientAllowExpired } from "@/lib/safe-action"
-import { workspaceSettingsGeneralPath } from "@/lib/workspace/settings-paths"
 
 export const scheduleWorkspaceDeletionAction = workspaceActionClientAllowExpired
   .bindArgsSchemas(workspaceIdrequestParams)
@@ -44,7 +42,5 @@ export const scheduleWorkspaceDeletionAction = workspaceActionClientAllowExpired
       })
 
       await workspaceLifecycleService.freezeWorkspaceRuntime(workspaceId)
-
-      redirect(workspaceSettingsGeneralPath(workspaceId))
     },
   )


### PR DESCRIPTION
## Summary
- Removed the server-side `redirect()` in `scheduleWorkspaceDeletionAction` — it targeted the same settings page the client already reloads via `onSuccess`, so it was dead code (the client's `window.location.reload()` takes over before the redirect could matter).
- Kept the client-side `window.location.reload()` in `workspace-deletion-card.tsx` as the single source of truth for refreshing the page after scheduling deletion.
- Updated the action's test to match the new contract (resolves normally instead of throwing `NEXT_REDIRECT`).

## Changes
- `apps/builder/src/features/workspaces/actions/schedule-workspace-deletion-action.ts`
- `apps/builder/__tests__/schedule-workspace-deletion-action.test.ts`

## Test plan
- [x] `pnpm vitest run __tests__/schedule-workspace-deletion-action.test.ts` passes
- [x] `pnpm --filter builder check-types`
- [x] `pnpm lint` (touched files clean; pre-existing unrelated lint findings elsewhere untouched)
- [x] Manual verification: schedule and cancel workspace deletion in the UI, confirm the card refreshes correctly