### PR TITLE
docs: point self-hosters to chatbotx-docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@
 
 To have the project up and running, please follow the [Quick Start Guide](https://chatbotx.io/docs/quickstart).
 
+**Self-hosting ChatbotX without developing on it?** Use **[chatbotx-docker-compose](https://github.com/ChatbotXIO/chatbotx-docker-compose)** — a standalone repo that runs the pre-built `ghcr.io` images with `docker compose up`, no local checkout of this monorepo required. The compose files in this repository (`docker-compose.yml`, `docker-compose.dev.yml`) provision local infrastructure only and expect the apps to run from source via `pnpm dev`.
+
 ## Project Structure
 
 ```text


### PR DESCRIPTION
## Summary
- Add a one-line pointer under Quick Start directing self-hosters who don't want to develop on ChatbotX to the standalone [chatbotx-docker-compose](https://github.com/ChatbotXIO/chatbotx-docker-compose) repo
- Clarifies that this repo's compose files (`docker-compose.yml`, `docker-compose.dev.yml`) are infra-only and expect apps to run from source via `pnpm dev`

Companion to [chatbotx-docker-compose#2](https://github.com/ChatbotXIO/chatbotx-docker-compose/pull/2), which relicenses that repo to MIT and adds the `javascript-executor` service.

## Test plan
- [x] Verified the added link and surrounding markdown render correctly