### PR TITLE
feat(capi): dedup lead events per day only for whatsapp

### DIFF
--- a/apps/worker/__tests__/send-meta-capi-event-step-handler.test.ts
+++ b/apps/worker/__tests__/send-meta-capi-event-step-handler.test.ts
@@ -11,7 +11,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
   enqueueLeadEvent: vi.fn(),
-  formatUtcDay: vi.fn(() => "20260814"),
+  buildLeadSourceKey: vi.fn(() => "flow:step-1:ci-1:key"),
 }))
 
 vi.mock("@chatbotx.io/business", async () => {
@@ -22,7 +22,7 @@ vi.mock("@chatbotx.io/business", async () => {
     ...actual,
     metaConversionsService: {
       enqueueLeadEvent: mocks.enqueueLeadEvent,
-      formatUtcDay: mocks.formatUtcDay,
+      buildLeadSourceKey: mocks.buildLeadSourceKey,
     },
   }
 })
@@ -56,7 +56,7 @@ function props(channel: string, step: typeof baseStep = baseStep) {
 describe("handleSendMetaCapiEventStep", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mocks.formatUtcDay.mockReturnValue("20260814")
+    mocks.buildLeadSourceKey.mockReturnValue("flow:step-1:ci-1:key")
     mocks.enqueueLeadEvent.mockResolvedValue({ id: "mce-1" })
   })
 
@@ -64,16 +64,22 @@ describe("handleSendMetaCapiEventStep", () => {
     "messenger",
     "instagram",
     "whatsapp",
-  ])("enqueues a lead event for supported channel %s with a per-step/day source key", async (channel) => {
+  ])("enqueues a lead event for supported channel %s with a channel-aware source key", async (channel) => {
     const result = await handleSendMetaCapiEventStep(props(channel))
 
+    expect(mocks.buildLeadSourceKey).toHaveBeenCalledWith({
+      scope: "flow",
+      scopeId: "step-1",
+      contactInboxId: "ci-1",
+      channel,
+    })
     expect(mocks.enqueueLeadEvent).toHaveBeenCalledWith({
       workspaceId: "ws-1",
       channel,
       contactInboxId: "ci-1",
       inboxId: "inbox-1",
       source: "flowStep",
-      sourceKey: "flow:step-1:ci-1:20260814",
+      sourceKey: "flow:step-1:ci-1:key",
       value: undefined,
       currency: undefined,
       contentCategory: undefined,

--- a/apps/worker/__tests__/trigger-action-executor-add-tag.test.ts
+++ b/apps/worker/__tests__/trigger-action-executor-add-tag.test.ts
@@ -8,7 +8,7 @@ const mocks = vi.hoisted(() => ({
   enqueueAttach: vi.fn(),
   enqueueTagAppliedEvaluations: vi.fn(),
   enqueueLeadEvent: vi.fn(),
-  formatUtcDay: vi.fn(),
+  buildLeadSourceKey: vi.fn(),
 }))
 
 vi.mock("@chatbotx.io/database/client", () => ({
@@ -57,7 +57,8 @@ vi.mock("@chatbotx.io/business", () => ({
   },
   metaConversionsService: {
     enqueueLeadEvent: (...args: unknown[]) => mocks.enqueueLeadEvent(...args),
-    formatUtcDay: (...args: unknown[]) => mocks.formatUtcDay(...args),
+    buildLeadSourceKey: (...args: unknown[]) =>
+      mocks.buildLeadSourceKey(...args),
   },
 }))
 
@@ -100,7 +101,7 @@ describe("ActionExecutor addTag", () => {
       contactId: "contact-1",
       channel: "messenger",
     })
-    mocks.formatUtcDay.mockReturnValue("20260810")
+    mocks.buildLeadSourceKey.mockReturnValue("trigger:trigger-1:ci-1:key")
   })
 
   test("enqueues tag sync and ads conversion tagApplied evaluation for newly-linked tags", async () => {
@@ -167,13 +168,19 @@ describe("ActionExecutor addTag", () => {
       workspaceId: "ws-1",
     })
 
+    expect(mocks.buildLeadSourceKey).toHaveBeenCalledWith({
+      scope: "trigger",
+      scopeId: "trigger-1",
+      contactInboxId: "ci-1",
+      channel: "messenger",
+    })
     expect(mocks.enqueueLeadEvent).toHaveBeenCalledWith({
       workspaceId: "ws-1",
       channel: "messenger",
       contactInboxId: "ci-1",
       inboxId: "inbox-1",
       source: "triggerAction",
-      sourceKey: "trigger:trigger-1:ci-1:20260810",
+      sourceKey: "trigger:trigger-1:ci-1:key",
     })
   })
 })

--- a/apps/worker/src/integration/handlers/meta-conversions/send-meta-capi-event-step-handler.ts
+++ b/apps/worker/src/integration/handlers/meta-conversions/send-meta-capi-event-step-handler.ts
@@ -39,7 +39,12 @@ export async function handleSendMetaCapiEventStep(
       contactInboxId: contactInbox.id,
       inboxId: contactInbox.inboxId,
       source: "flowStep",
-      sourceKey: `flow:${step.id}:${contactInbox.id}:${metaConversionsService.formatUtcDay(new Date())}`,
+      sourceKey: metaConversionsService.buildLeadSourceKey({
+        scope: "flow",
+        scopeId: step.id,
+        contactInboxId: contactInbox.id,
+        channel: contactInbox.channel,
+      }),
       value: step.value,
       currency: step.currency,
       contentCategory: step.contentCategory,

--- a/apps/worker/src/trigger/services/action-executor.ts
+++ b/apps/worker/src/trigger/services/action-executor.ts
@@ -351,7 +351,12 @@ export class ActionExecutor {
           contactInboxId: recentContactInbox.id,
           inboxId: recentContactInbox.inboxId,
           source: "triggerAction",
-          sourceKey: `trigger:${triggerId}:${recentContactInbox.id}:${metaConversionsService.formatUtcDay(new Date())}`,
+          sourceKey: metaConversionsService.buildLeadSourceKey({
+            scope: "trigger",
+            scopeId: triggerId,
+            contactInboxId: recentContactInbox.id,
+            channel: recentContactInbox.channel,
+          }),
           value,
           currency,
           contentCategory,

--- a/integrations/meta-conversions/__tests__/events.test.ts
+++ b/integrations/meta-conversions/__tests__/events.test.ts
@@ -93,6 +93,7 @@ describe("Meta Conversions events API", () => {
       action_source: "business_messaging",
       messaging_channel: "instagram",
       user_data: {
+        ig_account_id: "ig-business-1",
         instagram_business_account_id: "ig-business-1",
         ig_sid: "ig-sid-1",
       },

--- a/integrations/meta-conversions/src/apis/events.ts
+++ b/integrations/meta-conversions/src/apis/events.ts
@@ -66,15 +66,25 @@ const conversionEventsResponseSchema = z.object({}).passthrough()
 // Verified against Meta Conversions API for Business Messaging docs:
 // https://developers.facebook.com/docs/marketing-api/conversions-api/business-messaging
 // user_data keys: messenger uses page_id + page_scoped_user_id; instagram uses
-// instagram_business_account_id + ig_sid; whatsapp uses
-// whatsapp_business_account_id + ctwa_clid (payload identical to the existing
-// automatic CTWA pipeline in integrations/whatsapp/src/api/conversions.ts).
+// ig_account_id (+ instagram_business_account_id for forward-compat) + ig_sid;
+// whatsapp uses whatsapp_business_account_id + ctwa_clid (payload identical to
+// the existing automatic CTWA pipeline in
+// integrations/whatsapp/src/api/conversions.ts). NOTE: the live IG endpoint
+// requires `ig_account_id` even though the public doc example still shows
+// `instagram_business_account_id` — see the instagram builder below.
 const channelUserDataBuilders = {
   messenger: (event: MetaConversionEventInput) => ({
     page_id: (event as MessengerEventInput).pageId,
     page_scoped_user_id: (event as MessengerEventInput).pageScopedUserId,
   }),
   instagram: (event: MetaConversionEventInput) => ({
+    // Live business_messaging endpoint requires `ig_account_id`; it rejects the
+    // event as "Missing IG account ID parameter" (error_subcode 2804079) when
+    // only `instagram_business_account_id` is sent, even though the public doc
+    // example still lists the latter. We send BOTH (same value): the live API
+    // requires `ig_account_id` and tolerates the doc-named key as unknown, so
+    // this stays correct whichever name Meta consolidates on.
+    ig_account_id: (event as InstagramEventInput).instagramBusinessAccountId,
     instagram_business_account_id: (event as InstagramEventInput)
       .instagramBusinessAccountId,
     ig_sid: (event as InstagramEventInput).igSid,

--- a/packages/business/__tests__/meta-conversions-service.test.ts
+++ b/packages/business/__tests__/meta-conversions-service.test.ts
@@ -870,4 +870,49 @@ describe("MetaConversionsService", () => {
       undefined,
     )
   })
+
+  describe("buildLeadSourceKey", () => {
+    test("whatsapp dedups per contact per UTC day (identical key within a day)", () => {
+      const first = metaConversionsService.buildLeadSourceKey({
+        scope: "flow",
+        scopeId: "s1",
+        contactInboxId: "c1",
+        channel: "whatsapp",
+      })
+      const second = metaConversionsService.buildLeadSourceKey({
+        scope: "flow",
+        scopeId: "s1",
+        contactInboxId: "c1",
+        channel: "whatsapp",
+      })
+
+      expect(first).toBe(second)
+      expect(first).toMatch(/^flow:s1:c1:\d{8}$/)
+    })
+
+    test("messenger and instagram never dedup (a unique key per fire)", () => {
+      const messengerFirst = metaConversionsService.buildLeadSourceKey({
+        scope: "trigger",
+        scopeId: "t1",
+        contactInboxId: "c1",
+        channel: "messenger",
+      })
+      const messengerSecond = metaConversionsService.buildLeadSourceKey({
+        scope: "trigger",
+        scopeId: "t1",
+        contactInboxId: "c1",
+        channel: "messenger",
+      })
+      const instagram = metaConversionsService.buildLeadSourceKey({
+        scope: "flow",
+        scopeId: "s1",
+        contactInboxId: "c1",
+        channel: "instagram",
+      })
+
+      expect(messengerFirst).not.toBe(messengerSecond)
+      expect(instagram).not.toBe(messengerFirst)
+      expect(messengerFirst).toMatch(/^trigger:t1:c1:.+$/)
+    })
+  })
 })

--- a/packages/business/src/meta-conversions/service.ts
+++ b/packages/business/src/meta-conversions/service.ts
@@ -1,6 +1,7 @@
 import { metaCapiEventRepository } from "@chatbotx.io/database/repositories"
 import type { MetaCapiEventModel } from "@chatbotx.io/database/types"
 import { encryptUtils } from "@chatbotx.io/encryption"
+import { createId } from "@chatbotx.io/utils"
 import {
   enqueueIntegrationJob,
   IntegrationJobAction,
@@ -121,6 +122,25 @@ async function enqueueSendMetaCapiEvent(
 class MetaConversionsService extends BaseService {
   formatUtcDay(date: Date): string {
     return formatUtcDay(date)
+  }
+
+  /**
+   * The dedup identity for a lead event, also sent to Meta as `event_id`.
+   *
+   * WhatsApp is capped by Meta at one CAPI event per click-to-WhatsApp ad, so
+   * it dedups per contact per UTC day. Messenger/Instagram have no such cap —
+   * every fire is a distinct conversion, so a unique id is used (BullMQ retries
+   * of the same stored event still reuse its key, so Meta collapses retries).
+   */
+  buildLeadSourceKey(input: {
+    scope: "flow" | "trigger"
+    scopeId: string
+    contactInboxId: string
+    channel: MetaConversionsChannel
+  }): string {
+    const dedupSegment =
+      input.channel === "whatsapp" ? formatUtcDay(new Date()) : createId()
+    return `${input.scope}:${input.scopeId}:${input.contactInboxId}:${dedupSegment}`
   }
 
   async enqueueLeadEvent(


### PR DESCRIPTION
## Summary

WhatsApp deduplicates lead events per contact per day, because Meta caps click-to-WhatsApp ads at one Conversions API event per ad. Messenger and Instagram no longer deduplicate — every fire is a distinct conversion, matching how other platforms behave.

Retries of the same stored event still reuse its id, so Meta collapses those.
