### PR TITLE
fix(builder): show the inbox list on every analytics tab

### DIFF
--- a/apps/builder/__tests__/channel-route-guards.test.ts
+++ b/apps/builder/__tests__/channel-route-guards.test.ts
@@ -220,8 +220,8 @@ vi.mock(
 const { default: CreateChannelPage } = await import(
   "../src/app/(no-sidebar)/channels/create/page"
 )
-const { default: DashboardPage } = await import(
-  "../src/app/space/[workspaceId]/dashboard/contacts/page"
+const { default: DashboardLayout } = await import(
+  "../src/app/space/[workspaceId]/dashboard/layout"
 )
 const { default: MessengerLayout } = await import(
   "../src/app/space/[workspaceId]/messengers/[id]/layout"
@@ -296,7 +296,8 @@ describe("channel route guards", () => {
       },
     })
 
-    const dashboardTree = await DashboardPage({
+    const dashboardTree = await DashboardLayout({
+      children: null,
       params: Promise.resolve({ workspaceId: "ws-1" }),
     })
     renderToStaticMarkup(dashboardTree)
@@ -322,7 +323,8 @@ describe("channel route guards", () => {
       },
     })
 
-    const dashboardTree = await DashboardPage({
+    const dashboardTree = await DashboardLayout({
+      children: null,
       params: Promise.resolve({ workspaceId: "ws-1" }),
     })
     renderToStaticMarkup(dashboardTree)

--- a/apps/builder/src/app/space/[workspaceId]/dashboard/contacts/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/dashboard/contacts/page.tsx
@@ -1,13 +1,9 @@
 import { ContactsDashboard } from "@chatbotx.io/analytics-nextjs/components/contacts-dashboard"
 import { getIdFromParams } from "@chatbotx.io/utils"
 import { notFound } from "next/navigation"
-import { isCloud } from "@/env"
 import { AnalyticsNav } from "@/features/analytics/components/analytics-nav"
-import { InboxCardList } from "@/features/inboxes/components/inbox-card-list"
-import { listInboxes } from "@/features/inboxes/queries"
 import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
 import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
-import { resolveWorkspaceBlockState } from "@/lib/workspace-quota"
 
 export default async function ContactsAnalyticsPage({
   params,
@@ -33,41 +29,17 @@ export default async function ContactsAnalyticsPage({
   }
 
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
-  const cloud = isCloud()
   const { targetWorkspace } = userAndWorkspace
-
-  const [inboxesResult, { blocked, blockReason }] = await Promise.all([
-    listInboxes({ workspaceId, includes: ["integration"] }),
-    resolveWorkspaceBlockState(targetWorkspace.ownerId),
-  ])
-
-  const inboxes = inboxesResult.data.filter((inbox) => inbox.channel !== "smtp")
-
   const isSuperAdmin = hasWorkspacePermission(
     userAndWorkspace.targetWorkspaceMember.permissions,
     "superAdmin",
   )
 
   return (
-    <div className="flex flex-col gap-4">
-      {/* Inbox cards and the filter bar keep the full content width; the
-          Analytics sub-nav renders one row lower, level with the stats. */}
-      <InboxCardList
-        allowAddNew={isSuperAdmin}
-        blocked={cloud && blocked}
-        inboxes={inboxes}
-        reason={cloud ? blockReason : null}
-        workspaceId={workspaceId}
-      />
-
-      <ContactsDashboard
-        defaultSearchParams={{
-          workspaceId,
-          timezone,
-        }}
-        nav={<AnalyticsNav showAds={isSuperAdmin} />}
-        workspaceCreatedAt={targetWorkspace.createdAt}
-      />
-    </div>
+    <ContactsDashboard
+      defaultSearchParams={{ workspaceId, timezone }}
+      nav={<AnalyticsNav showAds={isSuperAdmin} />}
+      workspaceCreatedAt={targetWorkspace.createdAt}
+    />
   )
 }

--- a/apps/builder/src/app/space/[workspaceId]/dashboard/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/dashboard/layout.tsx
@@ -1,0 +1,64 @@
+import { getIdFromParams } from "@chatbotx.io/utils"
+import { notFound } from "next/navigation"
+import type { ReactNode } from "react"
+import { isCloud } from "@/env"
+import { InboxCardList } from "@/features/inboxes/components/inbox-card-list"
+import { listInboxes } from "@/features/inboxes/queries"
+import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
+import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
+import { resolveWorkspaceBlockState } from "@/lib/workspace-quota"
+
+type DashboardLayoutProps = {
+  children: ReactNode
+  params: Promise<{ workspaceId: string }>
+}
+
+export default async function DashboardLayout({
+  children,
+  params,
+}: DashboardLayoutProps) {
+  const workspaceId = getIdFromParams(await params, "workspaceId")
+  if (!workspaceId) {
+    return notFound()
+  }
+
+  const userAndWorkspace = await getCurrentUserAndTargetWorkspace(workspaceId)
+  if (
+    !(
+      userAndWorkspace &&
+      hasWorkspacePermission(
+        userAndWorkspace.targetWorkspaceMember.permissions,
+        "analytics",
+      )
+    )
+  ) {
+    return notFound()
+  }
+
+  const cloud = isCloud()
+  const { targetWorkspace } = userAndWorkspace
+  const [inboxesResult, { blocked, blockReason }] = await Promise.all([
+    listInboxes({ workspaceId, includes: ["integration"] }),
+    resolveWorkspaceBlockState(targetWorkspace.ownerId),
+  ])
+  const inboxes = inboxesResult.data.filter((inbox) => inbox.channel !== "smtp")
+  const isSuperAdmin = hasWorkspacePermission(
+    userAndWorkspace.targetWorkspaceMember.permissions,
+    "superAdmin",
+  )
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Inbox cards are shared across all Analytics sub-pages and stay
+          full-width above each page's filter bar and content. */}
+      <InboxCardList
+        allowAddNew={isSuperAdmin}
+        blocked={cloud && blocked}
+        inboxes={inboxes}
+        reason={cloud ? blockReason : null}
+        workspaceId={workspaceId}
+      />
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

The Analytics section has three sub-pages — **Contacts**, **Conversations**, and **Ads**. The shared inbox card strip only appeared on the Contacts page after the recent navigation split (#960); Conversations and Ads lost it.

This moves the inbox card strip into a shared `dashboard` layout so it renders once, full-width, above every Analytics sub-page. The inbox data is fetched a single time in the layout instead of per page.

## Test plan

- [x] `pnpm lint` passes
- [x] `tsc --noEmit` passes for builder
- [x] builder suite: 247 files / 1531 tests pass
- [ ] Manual: the inbox cards appear on all three tabs (Contacts, Conversations, Ads), full-width above the filter row