### PR TITLE
fix(auth): preserve and validate callbackURL through sign-in flows

### DIFF
--- a/apps/builder/__tests__/safe-callback-url.test.ts
+++ b/apps/builder/__tests__/safe-callback-url.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+
+import { describe, expect, test } from "vitest"
+import {
+  resolveSafeCallbackUrl,
+  withCallbackUrlParam,
+} from "@/lib/safe-callback-url"
+
+const CURRENT_ORIGIN = "https://app.example.com"
+
+describe("resolveSafeCallbackUrl", () => {
+  test("passes through a relative path unchanged", () => {
+    expect(resolveSafeCallbackUrl("/space/1/inbox?tab=x", CURRENT_ORIGIN)).toBe(
+      "/space/1/inbox?tab=x",
+    )
+  })
+
+  test("reduces a same-origin absolute URL to its path, search, and hash", () => {
+    expect(
+      resolveSafeCallbackUrl(
+        `${CURRENT_ORIGIN}/space/1/inbox?tab=x#section`,
+        CURRENT_ORIGIN,
+      ),
+    ).toBe("/space/1/inbox?tab=x#section")
+  })
+
+  test("falls back for a different-origin absolute URL", () => {
+    expect(
+      resolveSafeCallbackUrl("https://evil.example.org/steal", CURRENT_ORIGIN),
+    ).toBe("/")
+  })
+
+  test("falls back for a different-origin URL even with a matching path", () => {
+    expect(
+      resolveSafeCallbackUrl(
+        "https://evil.example.org/space/1/inbox",
+        CURRENT_ORIGIN,
+      ),
+    ).toBe("/")
+  })
+
+  test("falls back for a protocol-relative URL", () => {
+    expect(resolveSafeCallbackUrl("//evil.example.org", CURRENT_ORIGIN)).toBe(
+      "/",
+    )
+  })
+
+  test("falls back for a backslash protocol-relative URL", () => {
+    expect(resolveSafeCallbackUrl("/\\evil.example.org", CURRENT_ORIGIN)).toBe(
+      "/",
+    )
+  })
+
+  test("falls back for a javascript: URL", () => {
+    expect(resolveSafeCallbackUrl("javascript:alert(1)", CURRENT_ORIGIN)).toBe(
+      "/",
+    )
+  })
+
+  test("falls back for null", () => {
+    expect(resolveSafeCallbackUrl(null, CURRENT_ORIGIN)).toBe("/")
+  })
+
+  test("falls back for an empty string", () => {
+    expect(resolveSafeCallbackUrl("", CURRENT_ORIGIN)).toBe("/")
+  })
+
+  test("falls back for an unparseable value", () => {
+    expect(resolveSafeCallbackUrl("not a url", CURRENT_ORIGIN)).toBe("/")
+  })
+
+  test("honors a custom fallback", () => {
+    expect(resolveSafeCallbackUrl(null, CURRENT_ORIGIN, "/manage")).toBe(
+      "/manage",
+    )
+  })
+})
+
+describe("withCallbackUrlParam", () => {
+  test("appends an encoded callbackURL query param when present", () => {
+    expect(withCallbackUrlParam("/auth/sign-up", "/space/1/inbox?tab=x")).toBe(
+      "/auth/sign-up?callbackURL=%2Fspace%2F1%2Finbox%3Ftab%3Dx",
+    )
+  })
+
+  test("returns the path unchanged when callbackURL is null", () => {
+    expect(withCallbackUrlParam("/auth/sign-up", null)).toBe("/auth/sign-up")
+  })
+
+  test("returns the path unchanged when callbackURL is empty", () => {
+    expect(withCallbackUrlParam("/auth/sign-up", "")).toBe("/auth/sign-up")
+  })
+})

--- a/apps/builder/src/features/auth/components/email-password-sign-in.tsx
+++ b/apps/builder/src/features/auth/components/email-password-sign-in.tsx
@@ -12,11 +12,12 @@ import { Input } from "@chatbotx.io/ui/components/ui/input"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { Loader2Icon } from "lucide-react"
 import Link from "next/link"
-import { redirect } from "next/navigation"
+import { useSearchParams } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { useForm } from "react-hook-form"
 import { toast } from "sonner"
 import { authClient } from "@/lib/auth/auth-client"
+import { resolveSafeCallbackUrl } from "@/lib/safe-callback-url"
 import {
   type EmailPasswordSignInRequest,
   emailPasswordSignInRequest,
@@ -24,6 +25,7 @@ import {
 
 export const EmailPasswordSignIn = () => {
   const t = useTranslations()
+  const searchParams = useSearchParams()
 
   const emailPasswordForm = useForm<EmailPasswordSignInRequest>({
     resolver: zodResolver(emailPasswordSignInRequest),
@@ -45,7 +47,14 @@ export const EmailPasswordSignIn = () => {
 
     if (data) {
       toast.success("Signed in successfully")
-      redirect("/")
+      // Full reload (not router.push) so a fresh session re-renders
+      // layout/sidebar state that depends on auth.
+      window.location.assign(
+        resolveSafeCallbackUrl(
+          searchParams.get("callbackURL"),
+          window.location.origin,
+        ),
+      )
     } else {
       toast.error(error.message)
     }

--- a/apps/builder/src/features/auth/components/email-password-sign-up.tsx
+++ b/apps/builder/src/features/auth/components/email-password-sign-up.tsx
@@ -5,11 +5,12 @@ import { Button } from "@chatbotx.io/ui/components/ui/button"
 import { Form } from "@chatbotx.io/ui/components/ui/form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { Loader2Icon } from "lucide-react"
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { useForm } from "react-hook-form"
 import { toast } from "sonner"
 import { authClient } from "@/lib/auth/auth-client"
+import { withCallbackUrlParam } from "@/lib/safe-callback-url"
 import {
   type EmailPasswordSignUpRequest,
   emailPasswordSignUpRequest,
@@ -18,6 +19,7 @@ import {
 export const EmailPasswordSignUp = () => {
   const t = useTranslations()
   const router = useRouter()
+  const searchParams = useSearchParams()
 
   const emailPasswordForm = useForm<EmailPasswordSignUpRequest>({
     resolver: zodResolver(emailPasswordSignUpRequest),
@@ -36,7 +38,9 @@ export const EmailPasswordSignUp = () => {
 
     if (data) {
       toast.success(t("auth.signUpSuccess"))
-      router.push("/auth/sign-in")
+      router.push(
+        withCallbackUrlParam("/auth/sign-in", searchParams.get("callbackURL")),
+      )
     } else {
       toast.error(error.message)
     }

--- a/apps/builder/src/features/auth/components/magic-link-signin.tsx
+++ b/apps/builder/src/features/auth/components/magic-link-signin.tsx
@@ -10,12 +10,12 @@ import { useTranslations } from "next-intl"
 import { useForm } from "react-hook-form"
 import { toast } from "sonner"
 import { authClient } from "@/lib/auth/auth-client"
+import { resolveSafeCallbackUrl } from "@/lib/safe-callback-url"
 import { type MagicLinkRequest, magicLinkRequest } from "../schemas/action"
 
 export const MagicLinkSignIn = () => {
   const t = useTranslations()
   const searchParams = useSearchParams()
-  const callbackURL = searchParams.get("callbackURL")
 
   const magicLinkForm = useForm<MagicLinkRequest>({
     resolver: zodResolver(magicLinkRequest),
@@ -26,9 +26,13 @@ export const MagicLinkSignIn = () => {
   })
 
   const onSubmitMagicLinkForm = async (input: MagicLinkRequest) => {
+    const { origin } = window.location
     const { data, error } = await authClient.signIn.magicLink({
       email: input.email,
-      callbackURL: callbackURL ?? undefined,
+      callbackURL: new URL(
+        resolveSafeCallbackUrl(searchParams.get("callbackURL"), origin),
+        origin,
+      ).toString(),
     })
 
     if (data) {

--- a/apps/builder/src/features/auth/sign-in.tsx
+++ b/apps/builder/src/features/auth/sign-in.tsx
@@ -9,10 +9,12 @@ import {
 } from "@chatbotx.io/ui/components/ui/card"
 import { ArrowLeftIcon, LinkIcon, MailIcon } from "lucide-react"
 import Link from "next/link"
+import { useSearchParams } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { useState } from "react"
 import { isCommunity } from "@/env"
 import SSOSignIn from "@/features/auth/sso-sign-in"
+import { withCallbackUrlParam } from "@/lib/safe-callback-url"
 import { useTenantSettings } from "../tenant"
 import { EmailPasswordSignIn } from "./components/email-password-sign-in"
 import { MagicLinkSignIn } from "./components/magic-link-signin"
@@ -25,19 +27,22 @@ import {
 type SignInMethod = "email" | "magicLink"
 
 export type SignInFormProps = {
-  callbackUrl?: string
   /** Social providers configured for this tenant (own app or platform default). */
   enabledProviders?: SocialProvider[]
 }
 
 export const SignInForm = ({
-  callbackUrl,
   enabledProviders = [],
   ...props
 }: SignInFormProps) => {
   const t = useTranslations()
   const { name, policyUrl, termsOfServiceUrl } = useTenantSettings()
   const [activeMethod, setActiveMethod] = useState<SignInMethod | null>(null)
+  const searchParams = useSearchParams()
+  const signUpHref = withCallbackUrlParam(
+    "/auth/sign-up",
+    searchParams.get("callbackURL"),
+  )
 
   return (
     <div className="flex flex-col gap-6" {...props}>
@@ -101,7 +106,7 @@ export const SignInForm = ({
 
             <div className="text-center font-medium text-foreground/60 text-sm">
               {t("auth.dontHaveAnAccount")}{" "}
-              <Link className="text-foreground underline" href="/auth/sign-up">
+              <Link className="text-foreground underline" href={signUpHref}>
                 {t("auth.signUp")}
               </Link>
             </div>

--- a/apps/builder/src/features/auth/sign-up.tsx
+++ b/apps/builder/src/features/auth/sign-up.tsx
@@ -7,9 +7,11 @@ import {
   CardHeader,
 } from "@chatbotx.io/ui/components/ui/card"
 import Link from "next/link"
+import { useSearchParams } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { isCommunity } from "@/env"
 import SSOSignUp from "@/features/auth/sso-sign-in"
+import { withCallbackUrlParam } from "@/lib/safe-callback-url"
 import { useTenantSettings } from "../tenant"
 import { EmailPasswordSignUp } from "./components/email-password-sign-up"
 import {
@@ -19,18 +21,21 @@ import {
 } from "./components/shared"
 
 export type SignUpFormProps = {
-  callbackUrl?: string
   /** Social providers configured for this tenant (own app or platform default). */
   enabledProviders?: SocialProvider[]
 }
 
 export const SignUpForm = ({
-  callbackUrl,
   enabledProviders = [],
   ...props
 }: SignUpFormProps) => {
   const t = useTranslations()
   const { name, policyUrl, termsOfServiceUrl } = useTenantSettings()
+  const searchParams = useSearchParams()
+  const signInHref = withCallbackUrlParam(
+    "/auth/sign-in",
+    searchParams.get("callbackURL"),
+  )
 
   return (
     <div className="flex flex-col gap-6" {...props}>
@@ -52,7 +57,7 @@ export const SignUpForm = ({
 
             <div className="text-center font-medium text-foreground/60 text-sm">
               {t("auth.alreadyHaveAnAccount")}{" "}
-              <Link className="text-foreground underline" href="/auth/sign-in">
+              <Link className="text-foreground underline" href={signInHref}>
                 {t("auth.signIn")}
               </Link>
             </div>

--- a/apps/builder/src/features/auth/sso-sign-in.tsx
+++ b/apps/builder/src/features/auth/sso-sign-in.tsx
@@ -2,21 +2,32 @@
 
 import type { SocialProvider } from "@chatbotx.io/auth/server"
 import { Button } from "@chatbotx.io/ui/components/ui/button"
+import { useSearchParams } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { authClient } from "@/lib/auth/auth-client"
+import { resolveSafeCallbackUrl } from "@/lib/safe-callback-url"
 
 type SSOSignInProps = {
   /** Providers configured for this tenant (own app or platform default). */
   providers: SocialProvider[]
 }
 
-const signInWith = async (provider: SocialProvider): Promise<void> => {
-  // Carry the current (reseller) origin into the OAuth state so the fixed
-  // platform callback can recover this tenant and relay the user back to their
-  // branded domain. See `resolveTenantFromOAuthState` and the route relay.
+const signInWith = async (
+  provider: SocialProvider,
+  callbackParam: string | null,
+): Promise<void> => {
+  // Carry the current (reseller) origin — and the intended destination path —
+  // into the OAuth state so the fixed platform callback can recover this
+  // tenant and relay the user back to their branded domain at the right path.
+  // See `resolveTenantFromOAuthState` and the route relay. Must stay absolute:
+  // a relative value here would break tenant recovery on the broker callback.
+  const { origin } = window.location
   await authClient.signIn.social({
     provider,
-    callbackURL: window.location.origin,
+    callbackURL: new URL(
+      resolveSafeCallbackUrl(callbackParam, origin),
+      origin,
+    ).toString(),
   })
 }
 
@@ -59,6 +70,8 @@ function GoogleIcon() {
 
 export default function SSOSignIn({ providers }: SSOSignInProps) {
   const t = useTranslations()
+  const searchParams = useSearchParams()
+  const callbackParam = searchParams.get("callbackURL")
 
   return (
     <div className="flex flex-col items-center gap-3">
@@ -67,7 +80,7 @@ export default function SSOSignIn({ providers }: SSOSignInProps) {
           aria-label={t("auth.continueWithFacebook")}
           className="w-full bg-[#1877F2] text-white hover:bg-[#0F6FE5]"
           onClick={async () => {
-            await signInWith("facebook")
+            await signInWith("facebook", callbackParam)
           }}
           type="button"
         >
@@ -81,7 +94,7 @@ export default function SSOSignIn({ providers }: SSOSignInProps) {
           aria-label={t("auth.continueWithGoogle")}
           className="w-full"
           onClick={async () => {
-            await signInWith("google")
+            await signInWith("google", callbackParam)
           }}
           type="button"
           variant="outline"

--- a/apps/builder/src/lib/safe-callback-url.ts
+++ b/apps/builder/src/lib/safe-callback-url.ts
@@ -1,0 +1,59 @@
+const PROTOCOL_RELATIVE_PREFIXES = ["//", "/\\"]
+
+/**
+ * Resolve a `?callbackURL` into a same-origin path safe to redirect to.
+ *
+ * The proxy writes an absolute URL on the current public host
+ * (`proxy.ts` `buildSigninUrl`), so on a white-label custom domain the
+ * callback already points at the domain the user is on. We accept a target
+ * only when its origin matches the page we're currently on: that keeps
+ * white-label domains working (the user stays on their branded host) while
+ * making an attacker-supplied `?callbackURL=` to a foreign origin inert.
+ *
+ * Always returns a path (never an absolute URL), so the eventual redirect is
+ * same-origin by construction regardless of how it's issued.
+ */
+export function resolveSafeCallbackUrl(
+  raw: string | null | undefined,
+  currentOrigin: string,
+  fallback = "/",
+): string {
+  if (!raw) {
+    return fallback
+  }
+
+  if (PROTOCOL_RELATIVE_PREFIXES.some((prefix) => raw.startsWith(prefix))) {
+    return fallback
+  }
+
+  if (raw.startsWith("/")) {
+    return raw
+  }
+
+  try {
+    const target = new URL(raw)
+    if (target.origin !== currentOrigin) {
+      return fallback
+    }
+    return `${target.pathname}${target.search}${target.hash}`
+  } catch {
+    return fallback
+  }
+}
+
+/**
+ * Append a `callbackURL` query param to `path` so it survives a client-side
+ * navigation (e.g. the sign-in ↔ sign-up cross-links). Not a security
+ * boundary — `resolveSafeCallbackUrl` is what sanitizes the value when it's
+ * eventually consumed for a redirect.
+ */
+export function withCallbackUrlParam(
+  path: string,
+  callbackURL: string | null | undefined,
+): string {
+  if (!callbackURL) {
+    return path
+  }
+
+  return `${path}?callbackURL=${encodeURIComponent(callbackURL)}`
+}


### PR DESCRIPTION
## Summary

- Auth entry points dropped the intended destination, so a user deep-linked to a protected page landed on `/` after signing in instead of where they were headed.
- The `?callbackURL=` value was also passed through unvalidated. `resolveSafeCallbackUrl` now accepts a target only when its origin matches the current page and always returns a **path**, so the redirect is same-origin by construction and an attacker-supplied foreign origin is inert.
- White-label custom domains keep working: the proxy writes an absolute URL on the current public host, so the user stays on their branded domain.

## Changes

- **`src/lib/safe-callback-url.ts`** (new) — `resolveSafeCallbackUrl` (sanitizer; rejects protocol-relative `//` and `/\` prefixes and cross-origin absolute URLs) and `withCallbackUrlParam` (forwards the param across the sign-in ↔ sign-up cross-links).
- **`sso-sign-in.tsx` / `magic-link-signin.tsx`** — still send an absolute `callbackURL`, which they require (a relative value breaks tenant recovery on the fixed platform broker callback), but it is now rebuilt from the sanitized path against the current origin.
- **`email-password-sign-in.tsx`** — uses a full reload rather than `redirect()` so a fresh session re-renders layout/sidebar state that depends on auth.
- **`sign-in.tsx` / `sign-up.tsx`** — drop the unused `callbackUrl` prop in favour of reading the param directly; no caller passed it (both `app/auth/*/page.tsx` only pass `enabledProviders`).
- **`__tests__/safe-callback-url.test.ts`** (new) — 14 cases covering same-origin, cross-origin, protocol-relative, malformed, and empty inputs.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [x] `pnpm --filter builder test safe-callback-url` — 14/14 passing
- [x] Manual: visit a protected page while signed out → sign in with email/password → land on the originally requested page, not `/`
- [x] Manual: `?callbackURL=https://evil.example.com` → redirect falls back to `/`
- [x] Manual: sign-in ↔ sign-up cross-links preserve the callback param
- [x] Manual: Google/Facebook SSO and magic-link on a white-label custom domain return to the branded host