### PR TITLE
fix(ci): remove invalid matrix context from release.yml job-level if

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,11 +115,22 @@ jobs:
       - check
     # PRs never push an image (see the "Build image for pull request" step
     # below) and ci.yml already gates types/lint/tests, so the PR run's only
-    # value is a Dockerfile-buildability signal. Keep just the builder leg
-    # for that on `pull_request` — it's the one most likely to break and has
-    # by far the longest build (~16 min vs ~1-2 min for the other four) — and
-    # skip the remaining four legs to cut wasted runner time on every PR.
-    if: github.event_name != 'pull_request' || matrix.label == 'builder'
+    # value is a Dockerfile-buildability signal. Keep just the builder leg for
+    # that on `pull_request` — it's the one most likely to break and has by
+    # far the longest build (~16 min vs ~1-2 min for the other four).
+    #
+    # This gate lives on the "Build image for pull request" step below, NOT
+    # here at job level: `jobs.<job_id>.if` only has access to the `github`,
+    # `needs`, `vars`, and `inputs` contexts — `matrix` isn't expanded yet at
+    # that point, so a job-level `if: matrix.label == 'builder'` is invalid
+    # YAML that fails workflow validation for every trigger, not just this
+    # job (this broke the whole file for several hours — see git blame /
+    # incident notes before changing this again). `runs-on` above CAN see
+    # `matrix` because it's evaluated after matrix expansion; step-level `if`
+    # can too, for the same reason. The other four legs still spin up a
+    # runner on `pull_request` and no-op immediately (all three build steps'
+    # conditions are false), which costs a few seconds each rather than the
+    # full build — not free, but the only place GitHub allows this check.
     strategy:
       fail-fast: false
       matrix:
@@ -215,7 +226,7 @@ jobs:
           # Turbo remote cache secrets omitted — see "Build and push main image".
 
       - name: Build image for pull request
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && matrix.label == 'builder'
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
## Summary
- `release.yml` has been invalid on every trigger (push, PR, tag, dependabot) since #964 merged — GitHub rejects the workflow file at validation time, so **zero jobs** get scheduled and no Docker image has reached GHCR since.
- Root cause: `build-image`'s job-level `if: github.event_name != 'pull_request' || matrix.label == 'builder'` references the `matrix` context, which is not available in `jobs.<job_id>.if` (only `github`/`needs`/`vars`/`inputs` are — matrix isn't expanded yet at that point). This is a file-level validation error, so it takes the entire workflow down, not just this job.
- Confirmed via bisect: last successful run (8 jobs scheduled) is the commit immediately before #964; the first failing run **is** #964, and every run since (17 in a row, including dependabot PRs) reports `jobs.total_count == 0`.

## Changes
- `.github/workflows/release.yml`: removed the illegal job-level `if:` on `build-image`.
- Moved the builder-only PR-leg optimization down to the "Build image for pull request" step, where `matrix` is legal (`if: github.event_name == 'pull_request' && matrix.label == 'builder'`), preserving the original cost-saving intent from #964.
- Expanded the comment to explain the context-availability rule so this doesn't regress the same way again.

## Test plan
- [x] Manually verified: `grep`/awk confirm no remaining job-level `if:` references `matrix` — only step-level does.
- [x] Manually verified: YAML parses cleanly (Ruby `YAML.load_file`).
- [ ] After this PR's own `release.yml` run: confirm `gh api repos/ChatbotXIO/ChatbotX/actions/runs/<id>/jobs --jq '.total_count'` is `> 0` (it is `0` on every current run — this is the actual pass/fail signal for the fix).
- [ ] On the PR run: `prepare-metadata` runs, `check` skips (ci.yml covers PRs), `Build builder` builds without pushing, the other four legs no-op, `output-image-urls` skips.
- [ ] After merge to `main`: confirm all five legs push their `:main` tag and `output-image-urls` prints the five image URLs.