### PR TITLE
fix(contacts): stop prefetching inbox links from the contacts list

### DIFF
--- a/apps/builder/src/features/common/components/stats-contacts-dialog.tsx
+++ b/apps/builder/src/features/common/components/stats-contacts-dialog.tsx
@@ -470,6 +470,7 @@ const SelectableContactItem = memo(function SelectableContactItem({
             <Link
               className="max-w-[200px] truncate text-blue-500"
               href={`/space/${workspaceId}/inbox?conversationId=${contact.conversationId}`}
+              prefetch={false}
               target="_blank"
             >
               <span className="truncate font-medium text-sm leading-tight">

--- a/apps/builder/src/features/contacts/contacts-table.tsx
+++ b/apps/builder/src/features/contacts/contacts-table.tsx
@@ -69,49 +69,65 @@ function NameCell({
   workspaceId: string
 }) {
   const avatarUrl = useAvatarUrl(contact)
-  const inboxHref = `/space/${workspaceId}/inbox?conversationId=${contact.conversation?.id}`
+  const conversationId = contact.conversation?.id
+  const inboxHref = conversationId
+    ? `/space/${workspaceId}/inbox?conversationId=${conversationId}`
+    : null
   const channel = contact.contactInboxes?.[0]?.channel as
     | ChannelType
     | undefined
 
+  const avatarVisual = (
+    <div className="relative">
+      <Avatar className="size-9 shrink-0">
+        <AvatarImage
+          alt={contact.fullName ?? ""}
+          className="object-cover"
+          src={avatarUrl}
+        />
+        <AvatarFallback className="bg-gray-300 text-sm dark:bg-zinc-100 dark:text-zinc-800">
+          {contact.fullName?.slice(0, 2) ?? "?"}
+        </AvatarFallback>
+      </Avatar>
+      {channel && (
+        <div className="absolute end-0 bottom-0 ltr:translate-x-1 rtl:-translate-x-1">
+          <InboxIcon
+            channel={channel}
+            iconClassName="size-3"
+            showLabel={false}
+            size="small"
+          />
+        </div>
+      )}
+    </div>
+  )
+
+  const avatarNode = inboxHref ? (
+    <Link href={inboxHref} prefetch={false} target="_blank">
+      {avatarVisual}
+    </Link>
+  ) : (
+    avatarVisual
+  )
+
+  const nameNode = inboxHref ? (
+    <Link
+      className="truncate font-medium leading-5"
+      href={inboxHref}
+      prefetch={false}
+      target="_blank"
+    >
+      {contact.fullName}
+    </Link>
+  ) : (
+    <span className="truncate font-medium leading-5">{contact.fullName}</span>
+  )
+
   return (
     <div className="flex max-w-56 items-center gap-3">
-      <Link href={inboxHref} target="_blank">
-        <div className="relative">
-          <Avatar className="size-9 shrink-0">
-            <AvatarImage
-              alt={contact.fullName ?? ""}
-              className="object-cover"
-              src={avatarUrl}
-            />
-            <AvatarFallback className="bg-gray-300 text-sm dark:bg-zinc-100 dark:text-zinc-800">
-              {contact.fullName?.slice(0, 2) ?? "?"}
-            </AvatarFallback>
-          </Avatar>
-          {channel && (
-            <div className="absolute end-0 bottom-0 ltr:translate-x-1 rtl:-translate-x-1">
-              <InboxIcon
-                channel={channel}
-                iconClassName="size-3"
-                showLabel={false}
-                size="small"
-              />
-            </div>
-          )}
-        </div>
-      </Link>
+      {avatarNode}
       <Tooltip>
-        <TooltipTrigger
-          render={
-            <Link
-              className="truncate font-medium leading-5"
-              href={inboxHref}
-              target="_blank"
-            >
-              {contact.fullName}
-            </Link>
-          }
-        />
+        <TooltipTrigger render={nameNode} />
         <TooltipContent>
           <p>{contact.fullName}</p>
         </TooltipContent>


### PR DESCRIPTION
## Summary

Opening the contacts list fired a burst of requests to the inbox route (`/space/:id/inbox?conversationId=...`). Each contact row links to its inbox conversation, and Next.js prefetches every in-viewport link on production builds. Because the inbox route is heavy, this flooded the app with prefetch requests whenever the list rendered.

This only appeared on production (Next disables link prefetching in development) and scaled with the number of contacts that have a conversation, which is why some workspaces were affected far more than others.

## Changes

- Disable prefetch (`prefetch={false}`) on the inbox links in the contacts table and the stats contacts dialog. These links open in a new tab, so prefetch never provided any navigation benefit.
- Stop rendering a link for contacts that have no conversation (previously produced a broken `conversationId=undefined` href); the avatar and name render as plain, non-navigable content instead.

## Impact

- The contacts list no longer prefetches the inbox route, sharply reducing request volume on production.
- No API, data, or query changes. Click-to-open behavior is unchanged; contacts without a conversation are simply not clickable.

## Test plan

- [ ] Open the contacts list on a production build and confirm no `/inbox?conversationId=...` prefetch requests fire on load.
- [ ] Click a contact with a conversation and confirm it still opens the inbox in a new tab.
- [ ] Confirm a contact without a conversation renders its name/avatar without a broken link.

_Validation: `pnpm --filter builder check-types` and Biome lint pass._
