### PR TITLE
fix(dynamic-images): make orphaned background cleanup best-effort

### DIFF
--- a/packages/business/src/dynamic-image/service.ts
+++ b/packages/business/src/dynamic-image/service.ts
@@ -15,6 +15,7 @@ import { createId } from "@chatbotx.io/utils"
 import { BaseService } from "../base.service"
 import { contactCustomFieldService } from "../contact-custom-field/service"
 import { notFoundException } from "../errors"
+import { logger } from "../logger"
 import { isSsrfUnsafeUrl } from "../net/ssrf-guard"
 import { resolveTenantSettings } from "../platform/settings"
 import { toPublicStorageUrl } from "../utils"
@@ -55,26 +56,40 @@ function getBackgroundVersion(backgroundUrl: string): string {
   return BACKGROUND_VERSION_RE.exec(backgroundUrl)?.[1] ?? String(Date.now())
 }
 
-/** Deletes every object under `prefix`, paginating through S3's listing. */
+/**
+ * Deletes every object under `prefix`, paginating through S3's listing.
+ * Best-effort: some S3-compatible backends return a client error (e.g.
+ * NoSuchKey) for ListObjectsV2 against a prefix with no matching keys yet,
+ * instead of an empty result. The file(s) this is meant to clean up are
+ * already orphaned and harmless either way, so a failure here must never
+ * abort the save that just succeeded — it's swept again on the next save.
+ */
 async function deleteObjectsByPrefix(
   prefix: string,
   options: { except?: string } = {},
 ): Promise<void> {
-  let continuationToken: string | undefined
-  do {
-    const listed = await uploader.listObjects(prefix, {
-      ContinuationToken: continuationToken,
-    })
-    const keys = (listed.Contents ?? [])
-      .map((object) => object.Key)
-      .filter((key): key is string => Boolean(key) && key !== options.except)
+  try {
+    let continuationToken: string | undefined
+    do {
+      const listed = await uploader.listObjects(prefix, {
+        ContinuationToken: continuationToken,
+      })
+      const keys = (listed.Contents ?? [])
+        .map((object) => object.Key)
+        .filter((key): key is string => Boolean(key) && key !== options.except)
 
-    await Promise.all(keys.map((key) => uploader.deleteObject(key)))
+      await Promise.all(keys.map((key) => uploader.deleteObject(key)))
 
-    continuationToken = listed.IsTruncated
-      ? listed.NextContinuationToken
-      : undefined
-  } while (continuationToken)
+      continuationToken = listed.IsTruncated
+        ? listed.NextContinuationToken
+        : undefined
+    } while (continuationToken)
+  } catch (error) {
+    logger.warn(
+      { prefix, error },
+      "dynamic-image: failed to clean up old files under prefix",
+    )
+  }
 }
 
 type ListInput = {


### PR DESCRIPTION
## Summary
- Production dynamic-image saves were failing outright: `renderAndUploadBackground` uploads a new background then calls `deleteObjectsByPrefix` to remove orphaned old backgrounds, which lists the prefix via S3 `ListObjectsV2`.
- The production S3-compatible storage backend returns a `NoSuchKey` client error for `ListObjectsV2` against a freshly-written prefix instead of the empty result the AWS S3 API contract guarantees, which threw unhandled and crashed the whole `create`/`update` action even though the new background had already uploaded successfully.
- Cleanup of orphaned files is best-effort and non-critical, so it must never abort a save that already succeeded — made it resilient to this failure mode, matching the existing best-effort pattern used elsewhere in `packages/business` (e.g. `smart-delay-cleanup.ts`).

## Changes
- `packages/business/src/dynamic-image/service.ts`: wrap `deleteObjectsByPrefix` in try/catch, log a `logger.warn` on failure instead of throwing.

## Test plan
- [x] `pnpm --filter @chatbotx.io/business check-types`
- [x] lint (via pre-commit `pnpm ultracite fix` + full turbo typecheck, both passed)
- [ ] manual verification: create/update a dynamic image on production and confirm the save succeeds even when the storage backend's `ListObjectsV2` errors