### PR TITLE
fix(ui): stop forcing command item icons to white

### DIFF
--- a/packages/ui/src/components/ui/command.tsx
+++ b/packages/ui/src/components/ui/command.tsx
@@ -149,7 +149,7 @@ function CommandItem({
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-white relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- `CommandItem` forced every lucide icon inside it to `text-white` regardless of theme, making icons invisible against light-mode backgrounds (e.g. combobox field, line ~43).
- Removed the forced color class so icons inherit the item's normal text color in both themes.

## Changes
- `packages/ui/src/components/ui/command.tsx`

## Test plan
- [x] `pnpm --filter @chatbotx.io/ui check-types`
- [ ] Manual verification: open a combobox/command menu in both light and dark mode and confirm icons are visible