### PR TITLE
fix(ci): restore image publishing on merge to main and version tags

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -33,3 +33,12 @@ reports
 **/*.pem
 **/id_ed25519*
 **/id_rsa*
+
+# Drizzle migration snapshots: dev-time-only artifacts of `drizzle-kit generate`
+# (82MB across 148 files vs 768KB of actual migration.sql). Nothing in any image
+# reads them — the container's migration runner uses drizzle-orm's
+# readMigrationFiles(), which globs only `<folder>/migration.sql`, and
+# drizzle-kit is never installed in the image. They MUST stay in git:
+# `drizzle-kit generate` diffs src/schema against the newest snapshot to build
+# the next migration (see packages/database/scripts/check-schema-drift.mjs).
+packages/database/drizzle/*/snapshot.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
     inputs:
       environment:
@@ -29,11 +27,12 @@ jobs:
   # `next build` runs with `typescript.ignoreBuildErrors: true` and the Docker
   # build never runs `check-types`, so without this gate a `v*` tag (or a
   # workflow_dispatch on any branch) could push an image that never
-  # type-checked. ci.yml already gates `pull_request` and push-to-main with
-  # the same (stronger — see the two run steps below) checks, so this job
-  # only needs to re-run for events ci.yml does not cover: a version tag or a
-  # manual dispatch. That keeps the quality gate traveling with the artifact
-  # without duplicating ci.yml's jobs on every PR.
+  # type-checked. This workflow no longer triggers on `pull_request` at all —
+  # ci.yml already runs lint/check-types/test on every PR and push-to-main,
+  # and a Docker build was the only thing this workflow added on a PR, which
+  # duplicated ci.yml's build-buildability signal for no benefit once ci.yml
+  # covers it. So this job only needs to re-run for events ci.yml does not
+  # cover: a version tag or a manual dispatch.
   check:
     name: Type-check, lint, test
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
@@ -102,7 +101,6 @@ jobs:
             ${{ env.DOCKER_REGISTRY }}/${{ steps.image_namespace.outputs.owner_lc }}/chatbotx-javascript-executor
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix={{branch}}-
@@ -113,24 +111,27 @@ jobs:
     needs:
       - prepare-metadata
       - check
-    # PRs never push an image (see the "Build image for pull request" step
-    # below) and ci.yml already gates types/lint/tests, so the PR run's only
-    # value is a Dockerfile-buildability signal. Keep just the builder leg for
-    # that on `pull_request` — it's the one most likely to break and has by
-    # far the longest build (~16 min vs ~1-2 min for the other four).
+    # `check` deliberately does not run on push-to-main (see its `if:` above —
+    # this workflow no longer triggers on `pull_request` at all; ci.yml covers
+    # PRs). A skipped `needs` job skips its dependents by default, which
+    # silently stopped every merge to main from publishing an image between
+    # 2026-08-19 and this fix. This condition lets the build proceed when
+    # `check` is skipped, while still blocking it when `check` actually fails
+    # (tags / workflow_dispatch). NOT `always()` — that would ship images
+    # whose quality gate failed.
     #
-    # This gate lives on the "Build image for pull request" step below, NOT
-    # here at job level: `jobs.<job_id>.if` only has access to the `github`,
-    # `needs`, `vars`, and `inputs` contexts — `matrix` isn't expanded yet at
-    # that point, so a job-level `if: matrix.label == 'builder'` is invalid
-    # YAML that fails workflow validation for every trigger, not just this
-    # job (this broke the whole file for several hours — see git blame /
-    # incident notes before changing this again). `runs-on` above CAN see
-    # `matrix` because it's evaluated after matrix expansion; step-level `if`
-    # can too, for the same reason. The other four legs still spin up a
-    # runner on `pull_request` and no-op immediately (all three build steps'
-    # conditions are false), which costs a few seconds each rather than the
-    # full build — not free, but the only place GitHub allows this check.
+    # Note for any future job-level `if:` edit here: `jobs.<job_id>.if` only
+    # has access to the `github`, `needs`, `vars`, and `inputs` contexts —
+    # `matrix` isn't expanded yet at that point, so a job-level
+    # `if: matrix.label == 'builder'` is invalid YAML that fails workflow
+    # validation for every trigger, not just this job (this broke the whole
+    # file for several hours — see git blame / incident notes before adding
+    # a `matrix` reference here). `runs-on` above CAN see `matrix` because
+    # it's evaluated after matrix expansion; step-level `if` can too.
+    if: >-
+      !cancelled()
+      && needs.prepare-metadata.result == 'success'
+      && needs.check.result != 'failure'
     strategy:
       fail-fast: false
       matrix:
@@ -188,7 +189,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push main image
-        if: github.event_name != 'pull_request' && github.ref_name == 'main'
+        if: github.ref_name == 'main'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -210,7 +211,7 @@ jobs:
           # turborepo-remote-cache is provisioned and TURBO_API is set.
 
       - name: Build and push version image
-        if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -225,25 +226,16 @@ jobs:
           platforms: ${{ env.BUILD_PLATFORMS }}
           # Turbo remote cache secrets omitted — see "Build and push main image".
 
-      - name: Build image for pull request
-        if: github.event_name == 'pull_request' && matrix.label == 'builder'
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          push: false
-          labels: ${{ needs.prepare-metadata.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: ${{ env.BUILD_PLATFORMS }}
-          # Turbo remote cache secrets omitted — see "Build and push main image".
-
   output-image-urls:
     runs-on: ubuntu-latest
     needs:
       - prepare-metadata
       - build-image
-    if: github.event_name != 'pull_request'
+    # Requiring build-image to have succeeded (not just skipped/cancelled)
+    # keeps this job from announcing image URLs for a build that didn't run.
+    if: >-
+      !cancelled()
+      && needs.build-image.result == 'success'
     # Only prints strings computed from `needs` outputs — no registry call.
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,8 +198,15 @@ jobs:
           tags: |
             ${{ env.DOCKER_REGISTRY }}/${{ needs.prepare-metadata.outputs.image_namespace }}/${{ matrix.image }}:main
           labels: ${{ needs.prepare-metadata.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Per-leg scope: the five matrix legs otherwise share one unscoped GHA
+          # cache namespace and evict each other against the 10GB LRU budget.
+          # mode=min (not max): `max` exports every intermediate layer of every
+          # stage — "preparing build cache for export" alone cost 236.8s of a
+          # 340.3s export — while a same-SHA rebuild still ran `pnpm install`
+          # cold and `next build` in full, so the intermediate layers were never
+          # usefully restored. See the phase table in the plan for measurements.
+          cache-from: type=gha,scope=${{ matrix.label }}
+          cache-to: type=gha,scope=${{ matrix.label }},mode=min
           platforms: ${{ env.BUILD_PLATFORMS }}
           # Turbo remote cache: deliberately NOT passed. buildx rejects an
           # empty-valued secret outright, so passing the partial set that exists
@@ -221,8 +228,15 @@ jobs:
             ${{ env.DOCKER_REGISTRY }}/${{ needs.prepare-metadata.outputs.image_namespace }}/${{ matrix.image }}:${{ needs.prepare-metadata.outputs.version }}
             ${{ env.DOCKER_REGISTRY }}/${{ needs.prepare-metadata.outputs.image_namespace }}/${{ matrix.image }}:latest
           labels: ${{ needs.prepare-metadata.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Per-leg scope: the five matrix legs otherwise share one unscoped GHA
+          # cache namespace and evict each other against the 10GB LRU budget.
+          # mode=min (not max): `max` exports every intermediate layer of every
+          # stage — "preparing build cache for export" alone cost 236.8s of a
+          # 340.3s export — while a same-SHA rebuild still ran `pnpm install`
+          # cold and `next build` in full, so the intermediate layers were never
+          # usefully restored. See the phase table in the plan for measurements.
+          cache-from: type=gha,scope=${{ matrix.label }}
+          cache-to: type=gha,scope=${{ matrix.label }},mode=min
           platforms: ${{ env.BUILD_PLATFORMS }}
           # Turbo remote cache secrets omitted — see "Build and push main image".
 


### PR DESCRIPTION
## Summary
- `build-image` depended on `check`, but `check` only runs on `workflow_dispatch` or a `v*` tag. On a push to `main` that dependency was skipped, and GitHub Actions skips dependents of a skipped job by default — so **every merge to `main` since 2026-08-19 published zero Docker images** (confirmed by auditing 8 consecutive push-to-main runs, all with 0 successful build legs; the only images that shipped came from manual `workflow_dispatch` re-fires).
- Guards `build-image` and `output-image-urls` on `needs.check.result != 'failure'` (not `always()`) so a *skipped* check no longer blocks publishing, while a *genuinely failing* check on a tag/dispatch still does.
- Also drops the `pull_request` trigger from this workflow entirely — `ci.yml` already runs lint/check-types/test on every PR, so the Dockerfile-buildability build this workflow added on PRs was duplicate signal, not a real gate. Removed the now-dead PR-only build step, `type=ref,event=pr` tag rule, and the `github.event_name != 'pull_request'` conditions that are always-true now.
- **Follow-up perf work** (measured on run `32355012707`, where the builder leg was the entire 14.7min critical path): the buildx GHA cache export cost 340.3s — 236.8s just "preparing build cache for export" under `mode=max` — yet a same-SHA rebuild 9 minutes later still ran `pnpm install` cold and `next build` in full, so that export bought nothing. Separately, `packages/database/drizzle/*/snapshot.json` (82MB across 148 files, dev-only `drizzle-kit generate` artifacts) shipped into the Docker build context twice despite never being read at runtime.

## Changes
- `.github/workflows/release.yml`:
  - `on:` no longer includes `pull_request`
  - `build-image`: added job-level `if: !cancelled() && needs.prepare-metadata.result == 'success' && needs.check.result != 'failure'`
  - `output-image-urls`: extended `if:` to also require `needs.build-image.result == 'success'`
  - Removed "Build image for pull request" step and the `type=ref,event=pr` metadata tag
  - Simplified the two remaining build steps' `if:` (dropped the now-always-true `pull_request` check)
  - Both remaining build steps: `cache-from`/`cache-to` scoped per matrix leg (`scope=${{ matrix.label }}`) and switched from `mode=max` to `mode=min`, so the five legs stop evicting each other out of the shared 10GB GHA cache budget and stop paying to export intermediate layers that are never usefully restored
- `.dockerignore`: excludes `packages/database/drizzle/*/snapshot.json` from the Docker build context (kept in git — `drizzle-kit generate` still needs it — only excluded from the image, which never reads it)

## Test plan
- [x] YAML parses correctly (verified with `yaml` package)
- [x] `pnpm lint` passes clean
- [x] Snapshot/migration pattern verified exact: `packages/database/drizzle/*/snapshot.json` matches all 148 snapshot files and zero of the 156 `migration.sql` files
- [x] `pnpm --filter @chatbotx.io/database test` — 417/417 pass
- [ ] After merge: confirm the push-to-main run shows all 5 `Build <label>` jobs `success` (not `skipped`) and `output-image-urls` `success`
- [ ] On a future `v*` tag: confirm images publish with both version and `latest` tags
- [ ] Deliberately verify a failing `check` on a tag/dispatch still blocks `build-image` (the property that distinguishes this fix from a bare `always()`)
- [ ] Compare builder leg duration and cache-export phase against the 837s / 340.3s baseline on the next two push-to-main runs (first run re-seeds the new per-scope cache; judge steady-state on the second)
- [ ] Docker build: confirm `snapshot.json` count is 0 and `migration.sql` count is 156 inside `/app/migrate-runner/drizzle`, and that migration SQL is byte-identical (`sha256sum`) to the repo