### PR TITLE
fix(whatsapp): send quick reply templates and route button taps in flows

### DIFF
--- a/apps/builder/messages/ar.json
+++ b/apps/builder/messages/ar.json
@@ -3356,8 +3356,6 @@
       "params": {
         "couponCode": "رمز القسيمة",
         "couponCodePlaceholder": "أدخل رمز القسيمة",
-        "quickReplyPayload": "بيانات الرد السريع",
-        "quickReplyPayloadPlaceholder": "أدخل البيانات (اختياري)",
         "flowToken": "رمز المسار",
         "flowTokenPlaceholder": "أدخل رمز المسار",
         "flowNotSynced": "زامن مسارات واتساب لربط الحقول المُرسلة.",

--- a/apps/builder/messages/da.json
+++ b/apps/builder/messages/da.json
@@ -3356,8 +3356,6 @@
       "params": {
         "couponCode": "Kupon Kode",
         "couponCodePlaceholder": "Indtast kupon kode",
-        "quickReplyPayload": "Quick Svar Payload",
-        "quickReplyPayloadPlaceholder": "Indtast payload (valgfri)",
         "flowToken": "Flow Token",
         "flowTokenPlaceholder": "Indtast flow token",
         "flowNotSynced": "Synkroniser WhatsApp-flows for at knytte indsendte felter.",

--- a/apps/builder/messages/de.json
+++ b/apps/builder/messages/de.json
@@ -3356,8 +3356,6 @@
       "params": {
         "couponCode": "Gutscheincode",
         "couponCodePlaceholder": "Gutscheincode eingeben",
-        "quickReplyPayload": "Schnellantwort-Nutzdaten",
-        "quickReplyPayloadPlaceholder": "Nutzdaten eingeben (optional)",
         "flowToken": "Flow-Token",
         "flowTokenPlaceholder": "Flow-Token eingeben",
         "flowNotSynced": "WhatsApp-Flows synchronisieren, um übermittelte Felder zuzuordnen.",

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -3454,8 +3454,6 @@
       "params": {
         "couponCode": "Coupon Code",
         "couponCodePlaceholder": "Enter coupon code",
-        "quickReplyPayload": "Quick Reply Payload",
-        "quickReplyPayloadPlaceholder": "Enter payload (optional)",
         "flowToken": "Flow Token",
         "flowTokenPlaceholder": "Enter flow token",
         "flowNotSynced": "Sync WhatsApp flows to map submitted fields.",

--- a/apps/builder/messages/es.json
+++ b/apps/builder/messages/es.json
@@ -3356,8 +3356,6 @@
       "params": {
         "couponCode": "Coupon Código",
         "couponCodePlaceholder": "Introduce coupon código",
-        "quickReplyPayload": "Quick Respuesta Payload",
-        "quickReplyPayloadPlaceholder": "Introduce payload (opcional)",
         "flowToken": "Token del flujo",
         "flowTokenPlaceholder": "Introduce flow token",
         "flowNotSynced": "Sincroniza los flujos de WhatsApp para asignar los campos enviados.",

--- a/apps/builder/messages/fi.json
+++ b/apps/builder/messages/fi.json
@@ -3356,8 +3356,6 @@
       "params": {
         "couponCode": "Kuponkikoodi",
         "couponCodePlaceholder": "Kirjoita kuponkikoodi",
-        "quickReplyPayload": "Pikavastauksen tietosisältö",
-        "quickReplyPayloadPlaceholder": "Kirjoita tietosisältö (valinnainen)",
         "flowToken": "Flow-tunnus",
         "flowTokenPlaceholder": "Kirjoita flow-tunnus",
         "flowNotSynced": "Synkronoi WhatsApp-flow't lähetettyjen kenttien yhdistämiseksi.",

--- a/apps/builder/messages/fr.json
+++ b/apps/builder/messages/fr.json
@@ -3356,8 +3356,6 @@
       "params": {
         "couponCode": "Code de coupon",
         "couponCodePlaceholder": "Saisissez le code du coupon",
-        "quickReplyPayload": "Charge utile de la réponse rapide",
-        "quickReplyPayloadPlaceholder": "Saisissez la charge utile (facultatif)",
         "flowToken": "Jeton du flux",
         "flowTokenPlaceholder": "Saisissez le jeton du flux",
         "flowNotSynced": "Synchronisez les flux WhatsApp pour mapper les champs soumis.",

--- a/apps/builder/messages/he.json
+++ b/apps/builder/messages/he.json
@@ -1621,8 +1621,6 @@
       "params": {
         "couponCode": "קוד קופון",
         "couponCodePlaceholder": "הזנת קוד קופון",
-        "quickReplyPayload": "מטען תשובה מהירה",
-        "quickReplyPayloadPlaceholder": "הזנת מטען (אופציונלי)",
         "flowToken": "אסימון תהליך",
         "flowTokenPlaceholder": "הזנת אסימון תהליך",
         "flowNotSynced": "סנכרן תהליכי WhatsApp כדי למפות את השדות שנשלחו.",

--- a/apps/builder/messages/id.json
+++ b/apps/builder/messages/id.json
@@ -3356,8 +3356,6 @@
       "params": {
         "couponCode": "Kode Kupon",
         "couponCodePlaceholder": "Masukkan kode kupon",
-        "quickReplyPayload": "Payload Balasan Cepat",
-        "quickReplyPayloadPlaceholder": "Masukkan payload (opsional)",
         "flowToken": "Token Alur",
         "flowTokenPlaceholder": "Masukkan token alur",
         "flowNotSynced": "Sinkronkan alur WhatsApp untuk memetakan kolom yang dikirim.",

--- a/apps/builder/messages/it.json
+++ b/apps/builder/messages/it.json
@@ -3356,8 +3356,6 @@
       "params": {
         "couponCode": "Codice coupon",
         "couponCodePlaceholder": "Inserisci codice coupon",
-        "quickReplyPayload": "Payload della risposta rapida",
-        "quickReplyPayloadPlaceholder": "Inserisci payload (facoltativo)",
         "flowToken": "Token del flusso",
         "flowTokenPlaceholder": "Inserisci token del flusso",
         "flowNotSynced": "Sincronizza i flussi WhatsApp per mappare i campi inviati.",

--- a/apps/builder/messages/ja.json
+++ b/apps/builder/messages/ja.json
@@ -3335,8 +3335,6 @@
       "params": {
         "couponCode": "クーポンコード",
         "couponCodePlaceholder": "クーポンコードを入力",
-        "quickReplyPayload": "クイック返信のペイロード",
-        "quickReplyPayloadPlaceholder": "ペイロードを入力（任意）",
         "flowToken": "フロートークン",
         "flowTokenPlaceholder": "フロートークンを入力",
         "flowNotSynced": "送信されたフィールドをマッピングするには、WhatsAppフローを同期してください。",

--- a/apps/builder/messages/nl.json
+++ b/apps/builder/messages/nl.json
@@ -3356,8 +3356,6 @@
       "params": {
         "couponCode": "Kortingscode",
         "couponCodePlaceholder": "Voer kortingscode in",
-        "quickReplyPayload": "Payload voor snel antwoord",
-        "quickReplyPayloadPlaceholder": "Voer payload in (optioneel)",
         "flowToken": "Flowtoken",
         "flowTokenPlaceholder": "Voer flowtoken in",
         "flowNotSynced": "Synchroniseer WhatsApp-flows om ingediende velden te koppelen.",

--- a/apps/builder/messages/pt-BR.json
+++ b/apps/builder/messages/pt-BR.json
@@ -3335,8 +3335,6 @@
       "params": {
         "couponCode": "Código do cupom",
         "couponCodePlaceholder": "Insira o código do cupom",
-        "quickReplyPayload": "Carga útil da resposta rápida",
-        "quickReplyPayloadPlaceholder": "Insira a carga útil (opcional)",
         "flowToken": "Token do fluxo",
         "flowTokenPlaceholder": "Insira o token do fluxo",
         "flowNotSynced": "Sincronize os fluxos do WhatsApp para mapear os campos enviados.",

--- a/apps/builder/messages/pt-PT.json
+++ b/apps/builder/messages/pt-PT.json
@@ -3356,8 +3356,6 @@
       "params": {
         "couponCode": "Código do cupão",
         "couponCodePlaceholder": "Introduza o código do cupão",
-        "quickReplyPayload": "Payload da resposta rápida",
-        "quickReplyPayloadPlaceholder": "Introduza o payload (opcional)",
         "flowToken": "Token do fluxo",
         "flowTokenPlaceholder": "Introduza o token do fluxo",
         "flowNotSynced": "Sincronize os fluxos do WhatsApp para mapear os campos submetidos.",

--- a/apps/builder/messages/ro.json
+++ b/apps/builder/messages/ro.json
@@ -3356,8 +3356,6 @@
       "params": {
         "couponCode": "Cod cupon",
         "couponCodePlaceholder": "Introdu codul cuponului",
-        "quickReplyPayload": "Payload răspuns rapid",
-        "quickReplyPayloadPlaceholder": "Introdu payload-ul (opțional)",
         "flowToken": "Token flux",
         "flowTokenPlaceholder": "Introdu tokenul fluxului",
         "flowNotSynced": "Sincronizează fluxurile WhatsApp pentru a asocia câmpurile trimise.",

--- a/apps/builder/messages/sv.json
+++ b/apps/builder/messages/sv.json
@@ -4660,9 +4660,7 @@
         "location": "Plats",
         "locationAddress": "Adress (valfritt)",
         "locationName": "Platsnamn (valfritt)",
-        "longitude": "Longitud",
-        "quickReplyPayload": "Nyttolast för snabbsvar",
-        "quickReplyPayloadPlaceholder": "Ange nyttolast (valfritt)"
+        "longitude": "Longitud"
       },
       "text": {
         "label": "Text"

--- a/apps/builder/messages/tr.json
+++ b/apps/builder/messages/tr.json
@@ -3356,8 +3356,6 @@
       "params": {
         "couponCode": "Kupon Kodu",
         "couponCodePlaceholder": "Kupon kodunu girin",
-        "quickReplyPayload": "Hızlı Yanıt Verisi",
-        "quickReplyPayloadPlaceholder": "Veriyi girin (isteğe bağlı)",
         "flowToken": "Akış Token'ı",
         "flowTokenPlaceholder": "Akış token'ını girin",
         "flowNotSynced": "Gönderilen alanları eşlemek için WhatsApp akışlarını senkronize edin.",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -3356,8 +3356,6 @@
       "params": {
         "couponCode": "Mã giảm giá",
         "couponCodePlaceholder": "Nhập mã giảm giá",
-        "quickReplyPayload": "Payload trả lời nhanh",
-        "quickReplyPayloadPlaceholder": "Nhập payload (tùy chọn)",
         "flowToken": "Flow Token",
         "flowTokenPlaceholder": "Nhập flow token",
         "flowNotSynced": "Đồng bộ luồng WhatsApp để ánh xạ các trường đã gửi.",

--- a/apps/builder/messages/zh-CN.json
+++ b/apps/builder/messages/zh-CN.json
@@ -4653,9 +4653,7 @@
         "location": "位置",
         "locationAddress": "地址（可选）",
         "locationName": "位置名称（可选）",
-        "longitude": "经度",
-        "quickReplyPayload": "快速回复负载",
-        "quickReplyPayloadPlaceholder": "输入酬载（选填）"
+        "longitude": "经度"
       },
       "text": {
         "label": "文本"

--- a/apps/builder/messages/zh-TW.json
+++ b/apps/builder/messages/zh-TW.json
@@ -3389,8 +3389,6 @@
       "params": {
         "couponCode": "優惠券代碼",
         "couponCodePlaceholder": "輸入優惠券代碼",
-        "quickReplyPayload": "快速回覆負載",
-        "quickReplyPayloadPlaceholder": "輸入酬載（選填）",
         "flowToken": "流程代幣",
         "flowTokenPlaceholder": "輸入流權杖",
         "flowNotSynced": "同步WhatsApp 流以映射提交的欄位。",

--- a/apps/builder/src/features/flows/react-flow/steps/base/step-state-handles.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/base/step-state-handles.tsx
@@ -15,6 +15,7 @@ type StateHandleProps = {
   label?: string
   borderClass: string
   fillClass: string
+  labelClassName?: string
 }
 
 export function StateHandle({
@@ -22,6 +23,7 @@ export function StateHandle({
   label,
   borderClass,
   fillClass,
+  labelClassName,
 }: StateHandleProps) {
   const connections = useNodeConnections({
     handleType: "source",
@@ -31,7 +33,7 @@ export function StateHandle({
 
   return (
     <div className="relative flex items-center gap-2 text-xs">
-      {label}
+      <span className={labelClassName}>{label}</span>
       <div
         className={cn(
           "h-4 w-4 rounded-full border-2",

--- a/apps/builder/src/features/flows/react-flow/steps/send-wa-template-message/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-wa-template-message/editor.tsx
@@ -1,22 +1,26 @@
 "use client"
 
 import {
+  type ButtonStepProps,
   extractParameterInfos,
   extractTemplateParams,
   type ParameterInfo,
+  seedWaTemplateStepButtons,
   type TemplateComponent,
+  WA_TEMPLATE_STATUS_BUTTON_COUNT,
 } from "@chatbotx.io/flow-config"
 import { ComboboxField } from "@chatbotx.io/ui/components/form/combobox-field"
 import { SelectField } from "@chatbotx.io/ui/components/form/select-field"
 import { useTranslations } from "next-intl"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { useFormContext } from "react-hook-form"
+import { useFieldArray, useFormContext } from "react-hook-form"
 import { useWhatsappInboxOptions } from "@/features/inboxes/provider/inbox-hook"
 import { TemplateParamsForm } from "@/features/integration-whatsapp/message-templates/components/template-params-form"
 import { TemplatePreview } from "@/features/integration-whatsapp/message-templates/components/template-preview"
 import type { FlowTemplateResource } from "@/features/integration-whatsapp/message-templates/schema/resource"
 import { useFlowTemplate } from "../../stores/flow-template-store-provider"
 import { BaseStepEditor } from "../base/editor"
+import { ButtonStepEditor } from "../button/editor"
 
 type SendWaTemplateMessageStepEditorProps = {
   parentName: string
@@ -27,7 +31,7 @@ function SendWaTemplateMessageStepEditor(
 ) {
   const { parentName } = props
   const t = useTranslations()
-  const { setValue, unregister, watch } = useFormContext()
+  const { control, getValues, setValue, unregister, watch } = useFormContext()
   const [selectedTemplate, setSelectedTemplate] =
     useState<FlowTemplateResource | null>(null)
   const [parameters, setParameters] = useState<ParameterInfo[]>([])
@@ -40,16 +44,59 @@ function SendWaTemplateMessageStepEditor(
   const integrationInboxId = watch(`${parentName}.template.inboxId`)
   const templateId = watch(`${parentName}.template.id`)
   const templateParams = watch(`${parentName}.template.params`) || {}
+  // `fields` only changes on structural mutations (seed/reseed), never on
+  // per-field edits inside a button's dialog — unlike watch(), which would
+  // re-render this whole editor (and the unrelated params form and preview)
+  // on every nested button change.
+  const { fields: stepButtonFields } = useFieldArray({
+    control,
+    name: `${parentName}.buttons`,
+  })
+  const quickReplySlotCount = Math.max(
+    0,
+    stepButtonFields.length - WA_TEMPLATE_STATUS_BUTTON_COUNT,
+  )
+  // Keeps the leading status branches (Delivered/Failed) and reseeds the
+  // quick-reply tail so each template quick reply gets a connectable handle.
+  // Idempotent: seedWaTemplateStepButtons returns unchanged buttons by
+  // reference, so a no-op reseed leaves the form untouched — reopening a
+  // saved step never dirties it or drops edges.
+  const reconcileStepButtons = useCallback(
+    (components: TemplateComponent[]) => {
+      const existingButtons =
+        (getValues(`${parentName}.buttons`) as ButtonStepProps[]) ?? []
+      const seededButtons = seedWaTemplateStepButtons(
+        existingButtons,
+        components,
+      )
+      const isUnchanged =
+        seededButtons.length === existingButtons.length &&
+        seededButtons.every(
+          (button, index) => button === existingButtons[index],
+        )
+      if (isUnchanged) {
+        return
+      }
+      setValue(`${parentName}.buttons`, seededButtons, {
+        shouldDirty: true,
+        shouldValidate: true,
+      })
+    },
+    [getValues, parentName, setValue],
+  )
+
   const resetTemplateParams = useCallback(
     (template: FlowTemplateResource) => {
+      const components = template.components as TemplateComponent[]
       unregister(`${parentName}.template.params`)
       setValue(
         `${parentName}.template.params`,
-        extractTemplateParams(template.components as TemplateComponent[]),
+        extractTemplateParams(components),
         { shouldDirty: true, shouldValidate: true },
       )
+      reconcileStepButtons(components)
     },
-    [parentName, setValue, unregister],
+    [parentName, reconcileStepButtons, setValue, unregister],
   )
 
   useEffect(() => {
@@ -80,6 +127,10 @@ function SendWaTemplateMessageStepEditor(
         setValue(`${parentName}.template.language`, template.language)
         if (hasTemplateChanged) {
           resetTemplateParams(template)
+        } else {
+          // Saved steps predating quick-reply seeding open without a tail;
+          // reconcile on load so their quick replies gain handles too.
+          reconcileStepButtons(template.components as TemplateComponent[])
         }
         const params = extractParameterInfos(
           template.components as TemplateComponent[],
@@ -88,7 +139,14 @@ function SendWaTemplateMessageStepEditor(
       }
     }
     prevTemplateIdRef.current = templateId
-  }, [templateId, whatsappTemplates, parentName, resetTemplateParams, setValue])
+  }, [
+    templateId,
+    whatsappTemplates,
+    parentName,
+    reconcileStepButtons,
+    resetTemplateParams,
+    setValue,
+  ])
 
   const filteredTemplates = useMemo(
     () =>
@@ -164,6 +222,23 @@ function SendWaTemplateMessageStepEditor(
               components={selectedTemplate.components as TemplateComponent[]}
               headerParams={templateParams.header || []}
             />
+          </div>
+        )}
+
+        {quickReplySlotCount > 0 && (
+          <div className="flex flex-col gap-2">
+            {Array.from({ length: quickReplySlotCount }, (_slot, index) => (
+              <ButtonStepEditor
+                editorConfig={{
+                  lockLabel: true,
+                  hiddenButtonTypes: ["openWebsite"],
+                  hideDelete: true,
+                }}
+                // biome-ignore lint/suspicious/noArrayIndexKey: stable seeded list
+                key={index}
+                parentName={`${parentName}.buttons.${WA_TEMPLATE_STATUS_BUTTON_COUNT + index}`}
+              />
+            ))}
           </div>
         )}
       </div>

--- a/apps/builder/src/features/flows/react-flow/steps/send-wa-template-message/viewer.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-wa-template-message/viewer.tsx
@@ -1,20 +1,39 @@
 "use client"
 
 import type { SendWaTemplateMessageStepSchema } from "@chatbotx.io/flow-config"
+import { splitWaTemplateStepButtons } from "@chatbotx.io/flow-config"
 import { Card, CardContent } from "@chatbotx.io/ui/components/ui/card"
-import { cn } from "@chatbotx.io/ui/lib/utils"
-import { Position } from "@xyflow/react"
 import { MessageSquareIcon } from "lucide-react"
-import { BaseHandle } from "@/components/base-handle"
+import { StateHandle } from "../base/step-state-handles"
+import { ButtonStepViewer } from "../button/viewer"
 
 type SendWaTemplateMessageStepViewerProps = {
   data: SendWaTemplateMessageStepSchema
 }
 
+// Delivered/Failed delivery status branches, rendered with the shared labeled
+// connector; every button after them is a template quick reply, rendered like
+// any other step button.
+const statusHandleTones = [
+  {
+    borderClass: "border-green-500",
+    fillClass: "bg-green-500",
+    labelClassName: "font-medium text-green-600 text-sm",
+  },
+  {
+    borderClass: "border-red-500",
+    fillClass: "bg-red-500",
+    labelClassName: "font-medium text-red-600 text-sm",
+  },
+]
+
 export const SendWaTemplateMessageStepViewer = (
   props: SendWaTemplateMessageStepViewerProps,
 ) => {
   const { data } = props
+  const { statusButtons, quickReplyButtons } = splitWaTemplateStepButtons(
+    data.buttons,
+  )
 
   return (
     <Card className="overflow-hidden p-0">
@@ -34,55 +53,21 @@ export const SendWaTemplateMessageStepViewer = (
         </div>
 
         <div className="flex flex-1 flex-col gap-2 bg-gray-100 px-3 py-2 dark:bg-neutral-700">
-          <div
-            className="relative flex items-center justify-end gap-2"
-            key={data.buttons[0].id}
-          >
-            {/* React Flow routes from physical Position.Right, so this offset must stay physical. */}
-            <span className={cn("font-medium text-sm", "text-green-600")}>
-              {data.buttons[0].label}
-            </span>
-            <div
-              className={cn(
-                "h-3 w-3 rounded-full border-2",
-                "border-green-500",
-              )}
-            >
-              <BaseHandle
-                className={cn(
-                  "right-[6px]! h-3! w-3! opacity-0!",
-                  "border-green-500",
-                )}
-                id={data.buttons[0].id}
-                onConnectedClassName={cn("bg-green-500!")}
-                position={Position.Right}
-                type="source"
+          {statusButtons.map((button, buttonIndex) => (
+            <div className="flex justify-end" key={button.id}>
+              <StateHandle
+                borderClass={statusHandleTones[buttonIndex]?.borderClass ?? ""}
+                fillClass={statusHandleTones[buttonIndex]?.fillClass ?? ""}
+                label={button.label}
+                labelClassName={statusHandleTones[buttonIndex]?.labelClassName}
+                stateId={button.id}
               />
             </div>
-          </div>
+          ))}
 
-          <div
-            className="relative flex items-center justify-end gap-2"
-            key={data.buttons[1].id}
-          >
-            <span className={cn("font-medium text-sm", "text-red-600")}>
-              {data.buttons[1].label}
-            </span>
-            <div
-              className={cn("h-3 w-3 rounded-full border-2", "border-red-500")}
-            >
-              <BaseHandle
-                className={cn(
-                  "right-[6px]! h-3! w-3! opacity-0!",
-                  "border-red-500",
-                )}
-                id={data.buttons[1].id}
-                onConnectedClassName={cn("bg-red-500!")}
-                position={Position.Right}
-                type="source"
-              />
-            </div>
-          </div>
+          {quickReplyButtons.map((button) => (
+            <ButtonStepViewer data={button} key={button.id} />
+          ))}
         </div>
       </CardContent>
     </Card>

--- a/apps/builder/src/features/integration-whatsapp/message-templates/components/template-params-form.tsx
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/components/template-params-form.tsx
@@ -38,18 +38,22 @@ type TemplateParamsFormProps = {
 }
 
 function getFieldName(param: ParameterInfo, parentName: string): string {
+  // Button entries are stored densely (only parameterized buttons get an
+  // entry), so fields must write at `paramIndex`; writing at the template's
+  // `buttonIndex` duplicates entries when a static button precedes this one.
+  const buttonSlot = param.paramIndex ?? param.buttonIndex
   if (
     param.type === "button" &&
     param.cardIndex !== undefined &&
     param.buttonIndex !== undefined
   ) {
-    return `${parentName}.carousel[${param.cardIndex}].button[${param.buttonIndex}]`
+    return `${parentName}.carousel[${param.cardIndex}].button[${buttonSlot}]`
   }
   if (param.type === "carousel" && param.cardIndex !== undefined) {
     return `${parentName}.carousel[${param.cardIndex}]`
   }
   if (param.type === "button") {
-    return `${parentName}.button[${param.buttonIndex}]`
+    return `${parentName}.button[${buttonSlot}]`
   }
   if (param.type === "limited_time_offer") {
     return `${parentName}.limited_time_offer`
@@ -78,20 +82,6 @@ function ButtonParamField({
             {...register(`${fieldName}.coupon_code`)}
             placeholder={t(
               "whatsapp.messageTemplate.params.couponCodePlaceholder",
-            )}
-          />
-        </div>
-      )
-    case "quick_reply":
-      return (
-        <div className="space-y-1">
-          <Label className="text-xs">
-            {t("whatsapp.messageTemplate.params.quickReplyPayload")}
-          </Label>
-          <Input
-            {...register(`${fieldName}.payload`)}
-            placeholder={t(
-              "whatsapp.messageTemplate.params.quickReplyPayloadPlaceholder",
             )}
           />
         </div>

--- a/apps/builder/src/features/integration-whatsapp/message-templates/components/template-preview.tsx
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/components/template-preview.tsx
@@ -8,7 +8,20 @@ type TemplatePreviewProps = {
   components: TemplateComponent[]
   headerParams: Array<{ text?: string; image?: { link: string } }>
   bodyParams: Array<{ text?: string }>
-  buttonParams: Array<{ text?: string }>
+  buttonParams: Array<{ text?: string; index?: number }>
+}
+
+// Button param entries are stored densely and carry the template button index
+// in their `index` field, so lookups must match on it (with the array position
+// as a legacy fallback for entries saved without an index).
+function findButtonParam(
+  buttonParams: TemplatePreviewProps["buttonParams"],
+  templateButtonIndex: number,
+): { text?: string; index?: number } | undefined {
+  return (
+    buttonParams?.find((param) => param?.index === templateButtonIndex) ??
+    buttonParams?.[templateButtonIndex]
+  )
 }
 
 export function TemplatePreview({
@@ -90,12 +103,13 @@ export function TemplatePreview({
             <div className="mt-2 space-y-1" key={`buttons-${component.type}`}>
               {component.buttons.map((button, btnIdx) => {
                 let url = button.url || ""
+                const buttonParam = findButtonParam(buttonParams, btnIdx)
                 if (
                   button.type === "URL" &&
                   url.includes("{{1}}") &&
-                  buttonParams?.[btnIdx]?.text
+                  buttonParam?.text
                 ) {
-                  url = url.replace("{{1}}", buttonParams[btnIdx].text)
+                  url = url.replace("{{1}}", buttonParam.text)
                 }
                 return (
                   <div

--- a/apps/worker/__tests__/send-whatsapp-template.test.ts
+++ b/apps/worker/__tests__/send-whatsapp-template.test.ts
@@ -533,6 +533,179 @@ describe("processWhatsappTemplate", () => {
   })
 })
 
+describe("processWhatsappTemplate — template quick-reply flow routing", () => {
+  const quickReplyTemplateComponents = [
+    {
+      type: "BUTTONS",
+      buttons: [
+        { type: "URL", text: "Open", url: "https://example.com" },
+        { type: "QUICK_REPLY", text: "Stop" },
+      ],
+    },
+  ]
+
+  const statusButtons = [
+    { id: "btn-delivered", label: "Delivered" },
+    { id: "btn-failed", label: "Failed" },
+  ]
+  const quickReplyButton = { id: "btn-qr", label: "Stop" }
+
+  const flowWithQuickReply = {
+    id: "flow-1",
+    versionId: "fv-1",
+    buttons: [...statusButtons, quickReplyButton] as unknown as NonNullable<
+      ProcessWhatsappTemplateParams["flow"]
+    >["buttons"],
+  }
+
+  const encodedFlowButtons = [
+    {
+      id: "btn-delivered",
+      label: "Delivered",
+      buttonType: "postback",
+      postback: "flow-1:fv-1:btn-delivered",
+    },
+    {
+      id: "btn-failed",
+      label: "Failed",
+      buttonType: "postback",
+      postback: "flow-1:fv-1:btn-failed",
+    },
+    {
+      id: "btn-qr",
+      label: "Stop",
+      buttonType: "postback",
+      postback: "flow-1:fv-1:btn-qr",
+    },
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateMessageRepository.mockResolvedValue({
+      create: mockRepositoryCreate,
+      updateSourceId: mockRepositoryUpdateSourceId,
+    })
+    mockValidateTemplate.mockResolvedValue({
+      inbox: { integrationWhatsapp: { id: "iw-1" } },
+      template: {
+        id: "tmpl-wa-1",
+        name: "wa-template",
+        language: "en",
+        components: quickReplyTemplateComponents,
+      },
+    })
+    mockReplaceVariables.mockResolvedValue({})
+    mockContactVariables.mockResolvedValue([])
+    mockSendFlowStep.mockResolvedValue({ messageIds: ["provider-wa-1"] })
+    mockConvertButtons.mockReturnValue(encodedFlowButtons)
+    mockEmit.mockResolvedValue(undefined)
+  })
+
+  test("injects a quick_reply param whose payload is the seeded button's encoded postback", async () => {
+    await processWhatsappTemplate({
+      conversation: fakeConversation,
+      contactInbox: fakeContactInbox,
+      template: fakeTemplate,
+      flow: flowWithQuickReply,
+    })
+
+    const sentStep = mockSendFlowStep.mock.calls[0][0].step
+    expect(sentStep.template.params.button).toEqual([
+      { sub_type: "quick_reply", index: 1, payload: "flow-1:fv-1:btn-qr" },
+    ])
+  })
+
+  test("passes metadata into button conversion so postbacks carry broadcast/sequence context", async () => {
+    const metadata = { broadcastId: "broadcast-9" } as never
+
+    await processWhatsappTemplate({
+      conversation: fakeConversation,
+      contactInbox: fakeContactInbox,
+      template: fakeTemplate,
+      flow: flowWithQuickReply,
+      metadata,
+    })
+
+    expect(mockConvertButtons).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flowId: "flow-1",
+        flowVersionId: "fv-1",
+        contactInboxId: "ci-1",
+        metadata,
+      }),
+    )
+  })
+
+  test("stores the flow buttons on the message payload for status routing and inbox rendering", async () => {
+    await processWhatsappTemplate({
+      conversation: fakeConversation,
+      contactInbox: fakeContactInbox,
+      template: fakeTemplate,
+      flow: flowWithQuickReply,
+    })
+
+    expect(mockRepositoryCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contentAttributes: expect.objectContaining({
+          payload: { templateType: "button", buttons: encodedFlowButtons },
+        }),
+      }),
+    )
+  })
+
+  test("a legacy manually-typed payload at the same index is replaced by the generated postback", async () => {
+    // Old form let users type a payload; once the button is connected to a
+    // flow branch, the generated postback must win or the branch never routes
+    // (send-layer dedupe keeps the first content-bearing entry).
+    mockReplaceVariables.mockResolvedValue({
+      button: [{ sub_type: "quick_reply", index: 1, payload: "OLD_MANUAL" }],
+    })
+
+    await processWhatsappTemplate({
+      conversation: fakeConversation,
+      contactInbox: fakeContactInbox,
+      template: fakeTemplate,
+      flow: flowWithQuickReply,
+    })
+
+    const sentStep = mockSendFlowStep.mock.calls[0][0].step
+    expect(sentStep.template.params.button).toEqual([
+      { sub_type: "quick_reply", index: 1, payload: "flow-1:fv-1:btn-qr" },
+    ])
+  })
+
+  test("legacy steps with only status buttons inject nothing (Meta default applies)", async () => {
+    mockConvertButtons.mockReturnValue(encodedFlowButtons.slice(0, 2))
+
+    await processWhatsappTemplate({
+      conversation: fakeConversation,
+      contactInbox: fakeContactInbox,
+      template: fakeTemplate,
+      flow: {
+        ...flowWithQuickReply,
+        buttons: statusButtons as unknown as NonNullable<
+          ProcessWhatsappTemplateParams["flow"]
+        >["buttons"],
+      },
+    })
+
+    const sentStep = mockSendFlowStep.mock.calls[0][0].step
+    expect(sentStep.template.params.button).toBeUndefined()
+  })
+
+  test("broadcast sends (no flow) inject nothing and skip button conversion", async () => {
+    await processWhatsappTemplate({
+      conversation: fakeConversation,
+      contactInbox: fakeContactInbox,
+      template: fakeTemplate,
+    })
+
+    expect(mockConvertButtons).not.toHaveBeenCalled()
+    const sentStep = mockSendFlowStep.mock.calls[0][0].step
+    expect(sentStep.template.params.button).toBeUndefined()
+  })
+})
+
 describe("processWhatsappTemplate — BSUID auth-template guard (D5)", () => {
   const bsuidKeyedContactInbox = {
     ...fakeContactInbox,

--- a/apps/worker/src/chat/handlers/send-whatsapp-template.ts
+++ b/apps/worker/src/chat/handlers/send-whatsapp-template.ts
@@ -15,6 +15,7 @@ import type {
 import { emit } from "@chatbotx.io/event-bus"
 import type { MetadataPayload } from "@chatbotx.io/flow-config"
 import {
+  bindWaTemplateQuickReplyButtons,
   extractTemplateParams,
   messageEventTypeSchema,
   type SendWaTemplateMessageStepSchema,
@@ -141,6 +142,67 @@ export interface ProcessWhatsappTemplateResult {
   providerMessageId?: string
 }
 
+type WaTemplateParams = SendWaTemplateMessageStepSchema["template"]["params"]
+
+/**
+ * Template quick-reply buttons route exactly like regular flow buttons: each
+ * seeded step button already receives an encoded postback from
+ * `convertButtonsToTemplate`. That same string becomes the quick_reply
+ * component payload, so the value Meta echoes back in
+ * `messages.button.payload` is the postback the flow-action handler routes.
+ * Steps without a quick-reply tail (legacy flows, broadcasts) yield no
+ * bindings and the params pass through untouched — no component is sent and
+ * Meta's default (button text) applies.
+ */
+function withQuickReplyButtonParams(props: {
+  params: WaTemplateParams
+  components: TemplateComponent[]
+  stepButtons: SendWaTemplateMessageStepSchema["buttons"]
+  flowButtonTemplates: ReturnType<typeof convertButtonsToTemplate>
+}): WaTemplateParams {
+  const postbackByButtonId = new Map(
+    props.flowButtonTemplates.map((button) => [button.id, button.postback]),
+  )
+
+  const quickReplyParams = bindWaTemplateQuickReplyButtons(
+    props.components,
+    props.stepButtons,
+  ).flatMap(({ templateButtonIndex, stepButton }) => {
+    const payload = postbackByButtonId.get(stepButton.id)
+    return payload
+      ? [
+          {
+            sub_type: "quick_reply" as const,
+            index: templateButtonIndex,
+            payload,
+          },
+        ]
+      : []
+  })
+
+  if (quickReplyParams.length === 0) {
+    return props.params
+  }
+
+  // Generated postbacks must win over quick-reply payloads persisted by the
+  // old form at the same template index — otherwise the send-layer dedupe
+  // keeps the legacy payload and the connected flow branch never routes.
+  const boundIndexes = new Set(quickReplyParams.map((param) => param.index))
+  const withoutBoundLegacyQuickReplies = (props.params.button ?? []).filter(
+    (param) =>
+      !(
+        param?.sub_type === "quick_reply" &&
+        typeof param.index === "number" &&
+        boundIndexes.has(param.index)
+      ),
+  )
+
+  return {
+    ...props.params,
+    button: [...withoutBoundLegacyQuickReplies, ...quickReplyParams],
+  }
+}
+
 export async function processWhatsappTemplate(
   params: ProcessWhatsappTemplateParams,
 ): Promise<ProcessWhatsappTemplateResult> {
@@ -206,13 +268,32 @@ export async function processWhatsappTemplate(
       components: (validated.template.components as TemplateComponent[]) || [],
     })
 
+    const flowButtons = flow?.buttons ?? []
+    const flowButtonTemplates =
+      flow && flowButtons.length > 0
+        ? convertButtonsToTemplate({
+            flowId: flow.id,
+            flowVersionId: flow.versionId,
+            buttons: flowButtons,
+            metadata,
+            contactInboxId: contactInbox.id,
+          })
+        : []
+
+    const resolvedParams = withQuickReplyButtonParams({
+      params: replacedParams,
+      components: (validated.template.components as TemplateComponent[]) || [],
+      stepButtons: flowButtons,
+      flowButtonTemplates,
+    })
+
     const contentAttributes = {
       type: "whatsapp_template",
       template: {
         name: template.name,
         language: template.language,
         id: template.id,
-        params: replacedParams,
+        params: resolvedParams,
       },
       stepId: step?.id,
       nodeId: step?.nodeId,
@@ -224,15 +305,10 @@ export async function processWhatsappTemplate(
       metadata,
     }
 
-    if (flow?.buttons && flow.buttons.length > 0) {
+    if (flowButtonTemplates.length > 0) {
       contentAttributes.payload = {
         templateType: "button",
-        buttons: convertButtonsToTemplate({
-          flowId: flow.id,
-          flowVersionId: flow.versionId,
-          buttons: flow.buttons,
-          contactInboxId: contactInbox.id,
-        }),
+        buttons: flowButtonTemplates,
       }
     }
 
@@ -291,11 +367,12 @@ export async function processWhatsappTemplate(
         nodeId: step?.nodeId ?? createId(),
         stepType: stepTypes.enum.sendWaTemplateMessage,
         buttons: [],
-        // Send the variable-resolved params to the channel. The raw
-        // `template.params` still holds unresolved tokens like {{first_name}};
-        // the integration builds the Graph API payload verbatim and cannot
-        // resolve them, so the recipient would otherwise receive literal tokens.
-        template: { ...template, params: replacedParams },
+        // Send the variable-resolved params (plus injected quick-reply
+        // payloads) to the channel. The raw `template.params` still holds
+        // unresolved tokens like {{first_name}}; the integration builds the
+        // Graph API payload verbatim and cannot resolve them, so the recipient
+        // would otherwise receive literal tokens.
+        template: { ...template, params: resolvedParams },
       },
       metadata,
       messageId: newMessage.id,

--- a/integrations/whatsapp/__tests__/outgoing-template-params.test.ts
+++ b/integrations/whatsapp/__tests__/outgoing-template-params.test.ts
@@ -1,9 +1,17 @@
+import type { TemplateComponent } from "@chatbotx.io/flow-config"
 import {
+  bindWaTemplateQuickReplyButtons,
+  buttonStepDefaultFn,
+  decodeButtonPayload,
   decodeTemplateFlowToken,
+  encodeButtonPayload,
+  extractTemplateParams,
+  seedWaTemplateStepButtons,
   TemplateFlowOrigin,
 } from "@chatbotx.io/flow-config"
 import { ChannelError, ChannelErrorCategory } from "@chatbotx.io/sdk"
 import { beforeEach, describe, expect, test, vi } from "vitest"
+import { readTemplateButtonReply } from "../src/handlers/message/incoming-reply"
 
 const { mockApiFetch, mockGetWhatsappClient, mockLogger } = vi.hoisted(() => {
   const apiFetch = vi.fn()
@@ -74,26 +82,38 @@ const sendFlowTemplate = (
     },
   } as never)
 
+type TemplatePayloadComponent = {
+  type: string
+  sub_type?: string
+  index?: number
+  parameters: Array<{
+    type: string
+    text?: string
+    payload?: string
+    parameter_name?: string
+    action?: {
+      flow_token?: string
+      flow_action_data?: Record<string, unknown>
+    }
+  }>
+  cards?: Array<{
+    card_index: number
+    components: TemplatePayloadComponent[]
+  }>
+}
+
 const templatePayload = () =>
   JSON.parse((mockApiFetch.mock.calls[0][1] as RequestInit).body as string) as {
     template: {
-      components: Array<{
-        type: string
-        parameters: Array<{
-          type: string
-          text?: string
-          parameter_name?: string
-          action?: {
-            flow_token?: string
-            flow_action_data?: Record<string, unknown>
-          }
-        }>
-      }>
+      components: TemplatePayloadComponent[]
     }
   }
 
 const componentOfType = (type: string) =>
   templatePayload().template.components.find((c) => c.type === type)
+
+const componentsOfType = (type: string) =>
+  templatePayload().template.components.filter((c) => c.type === type)
 
 describe("whatsapp outgoing template parameters", () => {
   beforeEach(() => {
@@ -206,6 +226,296 @@ describe("whatsapp outgoing template parameters", () => {
       broadcastId: "11612473309626371",
       buttonIndex: 1,
     })
+  })
+})
+
+describe("button component hygiene", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiFetch.mockResolvedValue(
+      new Response(JSON.stringify({ messages: [{ id: "wamid.raw-1" }] }), {
+        status: 200,
+      }),
+    )
+  })
+
+  test("quick reply with a blank payload emits NO button component (Meta rejects payload: '')", async () => {
+    await sendTemplate({
+      body: [{ type: "text", text: "Hello" }],
+      button: [{ sub_type: "quick_reply", index: 1, payload: "" }],
+    })
+
+    expect(componentsOfType("button")).toEqual([])
+  })
+
+  test("quick reply with a whitespace-only payload is also omitted", async () => {
+    await sendTemplate({
+      button: [{ sub_type: "quick_reply", index: 0, payload: "   " }],
+    })
+
+    expect(componentsOfType("button")).toEqual([])
+  })
+
+  test("quick reply with a real payload is sent byte-for-byte with its template index", async () => {
+    await sendTemplate({
+      button: [{ sub_type: "quick_reply", index: 1, payload: " f1:v1:btn-9 " }],
+    })
+
+    expect(componentsOfType("button")).toEqual([
+      {
+        type: "button",
+        sub_type: "quick_reply",
+        index: 1,
+        parameters: [{ type: "payload", payload: " f1:v1:btn-9 " }],
+      },
+    ])
+  })
+
+  test("legacy duplicate quick reply entries collapse to the one carrying content", async () => {
+    // Shape persisted by the old form: a stale blank entry plus the entry the
+    // visible input actually wrote, both at the same template index.
+    await sendTemplate({
+      button: [
+        { sub_type: "quick_reply", index: 1, payload: "" },
+        { sub_type: "quick_reply", index: 1, payload: "KEEP" },
+      ],
+    })
+
+    expect(componentsOfType("button")).toEqual([
+      {
+        type: "button",
+        sub_type: "quick_reply",
+        index: 1,
+        parameters: [{ type: "payload", payload: "KEEP" }],
+      },
+    ])
+  })
+
+  test("legacy duplicate dynamic-URL entries collapse to the one carrying text", async () => {
+    await sendTemplate({
+      button: [
+        { sub_type: "url", index: 1, text: "" },
+        { sub_type: "url", index: 1, text: "summer-sale" },
+      ],
+    })
+
+    expect(componentsOfType("button")).toEqual([
+      {
+        type: "button",
+        sub_type: "url",
+        index: 1,
+        parameters: [{ type: "text", text: "summer-sale" }],
+      },
+    ])
+  })
+
+  test("null holes from sparse form arrays are skipped without crashing or shifting indexes", async () => {
+    await sendTemplate({
+      button: [null, { sub_type: "url", index: 1, text: "suffix" }],
+    })
+
+    expect(componentsOfType("button")).toEqual([
+      {
+        type: "button",
+        sub_type: "url",
+        index: 1,
+        parameters: [{ type: "text", text: "suffix" }],
+      },
+    ])
+  })
+
+  test("a lone dynamic-URL entry with empty text is still emitted (missing suffix must surface as an error)", async () => {
+    await sendTemplate({
+      button: [{ sub_type: "url", index: 0, text: "" }],
+    })
+
+    expect(componentsOfType("button")).toEqual([
+      {
+        type: "button",
+        sub_type: "url",
+        index: 0,
+        parameters: [{ type: "text", text: "" }],
+      },
+    ])
+  })
+
+  test("entries without an explicit index keep their positional fallback and never collapse", async () => {
+    await sendTemplate({
+      button: [
+        { sub_type: "url", text: "a" },
+        { sub_type: "url", text: "b" },
+      ],
+    })
+
+    expect(componentsOfType("button")).toEqual([
+      {
+        type: "button",
+        sub_type: "url",
+        index: 0,
+        parameters: [{ type: "text", text: "a" }],
+      },
+      {
+        type: "button",
+        sub_type: "url",
+        index: 1,
+        parameters: [{ type: "text", text: "b" }],
+      },
+    ])
+  })
+
+  test("carousel card quick replies with blank payloads are omitted from the card", async () => {
+    await sendTemplate({
+      carousel: [
+        {
+          card_index: 0,
+          body: [{ type: "text", text: "Card body" }],
+          button: [
+            { sub_type: "quick_reply", index: 0, payload: "" },
+            { sub_type: "url", index: 1, text: "card-suffix" },
+          ],
+        },
+      ],
+    })
+
+    const card = componentOfType("carousel")?.cards?.[0]
+    const cardButtons =
+      card?.components.filter((c) => c.type === "button") ?? []
+    expect(cardButtons).toEqual([
+      {
+        type: "button",
+        sub_type: "url",
+        index: 1,
+        parameters: [{ type: "text", text: "card-suffix" }],
+      },
+    ])
+  })
+})
+
+describe("customer scenario — approved template with static URL + quick reply (error #132018)", () => {
+  // Exact component shape of the customer's APPROVED template that failed in
+  // production: IMAGE header, 3 positional body variables, static URL button
+  // at index 0, quick-reply button at index 1.
+  const customerComponents = [
+    { type: "HEADER", format: "IMAGE" },
+    {
+      type: "BODY",
+      text: "Olá, {{1}}\n\n{{2}}\n\n{{3}}\n\nPara mais informações, clique no botão abaixo.",
+    },
+    {
+      type: "BUTTONS",
+      buttons: [
+        {
+          url: "https://sfvtwj.short.gy/a7awnm0p",
+          text: "Clique aqui",
+          type: "URL",
+        },
+        { text: "Parar mensagens", type: "QUICK_REPLY" },
+      ],
+    },
+  ] as unknown as TemplateComponent[]
+
+  // What the broadcast/flow form produces after template selection: seeded
+  // defaults from the real extractor, then the user's typed values.
+  const filledCustomerParams = () => {
+    const params = extractTemplateParams(customerComponents)
+    return {
+      ...params,
+      header: [{ type: "image", image: { link: "https://cdn.example/x.png" } }],
+      body: params.body?.map((param, position) => ({
+        ...param,
+        text: `${position + 1}`,
+      })),
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiFetch.mockResolvedValue(
+      new Response(JSON.stringify({ messages: [{ id: "wamid.raw-1" }] }), {
+        status: 200,
+      }),
+    )
+  })
+
+  test("broadcast send produces the exact Graph payload Meta accepts — no button components at all", async () => {
+    await sendTemplate(filledCustomerParams())
+
+    expect(templatePayload().template.components).toEqual([
+      {
+        type: "header",
+        parameters: [
+          { type: "image", image: { link: "https://cdn.example/x.png" } },
+        ],
+      },
+      {
+        type: "body",
+        parameters: [
+          { type: "text", text: "1" },
+          { type: "text", text: "2" },
+          { type: "text", text: "3" },
+        ],
+      },
+    ])
+  })
+
+  test("flow send routes the quick reply end-to-end: seeded button → Graph payload → inbound postback", async () => {
+    // Real seeding exactly as the flow editor does it.
+    const stepButtons = seedWaTemplateStepButtons(
+      [
+        buttonStepDefaultFn({ label: "Delivered" }),
+        buttonStepDefaultFn({ label: "Failed" }),
+      ],
+      customerComponents,
+    )
+    // Real binding + encoding exactly as the worker does it.
+    const [binding] = bindWaTemplateQuickReplyButtons(
+      customerComponents,
+      stepButtons,
+    )
+    const postback = encodeButtonPayload({
+      flowId: "11612473309626368",
+      flowVersionId: "11612473309626369",
+      buttonId: binding.stepButton.id,
+    })
+
+    await sendTemplate({
+      ...filledCustomerParams(),
+      button: [{ sub_type: "quick_reply", index: 1, payload: postback }],
+    })
+
+    expect(componentsOfType("button")).toEqual([
+      {
+        type: "button",
+        sub_type: "quick_reply",
+        index: 1,
+        parameters: [{ type: "payload", payload: postback }],
+      },
+    ])
+
+    // Meta echoes the payload back in messages.button.payload — verify the
+    // real inbound parser + payload codec route it to the seeded button.
+    const reply = readTemplateButtonReply({
+      payload: postback,
+      text: "Parar mensagens",
+    })
+    expect(reply.postbackAction).toBe(postback)
+    expect(decodeButtonPayload(reply.postbackAction ?? "")).toEqual({
+      flowId: "11612473309626368",
+      flowVersionId: "11612473309626369",
+      buttonId: binding.stepButton.id,
+    })
+  })
+
+  test("a tap on a quick reply sent WITHOUT payload (broadcast) falls back to the button text", () => {
+    const reply = readTemplateButtonReply({
+      payload: "Parar mensagens",
+      text: "Parar mensagens",
+    })
+
+    // Not a flow postback — the worker's sanitizeFlowAction drops it and the
+    // message is handled as plain text by keyword automation.
+    expect(decodeButtonPayload(reply.postbackAction ?? "")).toBeNull()
+    expect(reply.text).toBe("Parar mensagens")
   })
 })
 

--- a/integrations/whatsapp/src/handlers/message/outgoing-message/send-wa-template.ts
+++ b/integrations/whatsapp/src/handlers/message/outgoing-message/send-wa-template.ts
@@ -163,26 +163,120 @@ function buildTemplateFlowToken(
   return null
 }
 
+const DEFAULT_BUTTON_SUB_TYPE = "url"
+
+const isBlank = (value: string | undefined): boolean => !value?.trim()
+
+/**
+ * Whether the entry carries a real value for its sub_type. Used to pick the
+ * winner among duplicate entries; sub_types whose value is generated at send
+ * time (flow tokens) always count as content.
+ */
+const buttonParamContentChecks: Record<
+  string,
+  (param: WaTemplateButtonParam) => boolean
+> = {
+  url: (param) => !isBlank(param.text),
+  quick_reply: (param) => !isBlank(param.payload),
+  copy_code: (param) => !isBlank(param.coupon_code),
+  flow: () => true,
+  catalog: (param) => !isBlank(param.thumbnail_product_retailer_id),
+  mpm: (param) => (param.sections?.length ?? 0) > 0,
+}
+
+const buttonSubTypeOf = (param: WaTemplateButtonParam): string =>
+  param.sub_type || DEFAULT_BUTTON_SUB_TYPE
+
+const hasButtonParamContent = (param: WaTemplateButtonParam): boolean =>
+  buttonParamContentChecks[buttonSubTypeOf(param)]?.(param) ?? true
+
+type ResolvedButtonParam = {
+  param: WaTemplateButtonParam
+  /** Template button index, resolved from the entry's own array position when absent. */
+  index: number
+  hasExplicitIndex: boolean
+}
+
+const explicitIndexKey = (entry: ResolvedButtonParam): string =>
+  `${buttonSubTypeOf(entry.param)}:${entry.index}`
+
+/**
+ * Collapses duplicate `(sub_type, index)` entries left behind by forms that
+ * wrote at the wrong array slot, keeping the FIRST entry that carries content.
+ * Entries without an explicit index keep today's positional behavior and are
+ * never collapsed. The worker's `withQuickReplyButtonParams` relies on this
+ * first-with-content tie-break: it removes legacy quick-reply entries at
+ * indexes it re-binds, so change the winner rule here and there together.
+ */
+function dedupeExplicitIndexParams(
+  entries: ResolvedButtonParam[],
+): ResolvedButtonParam[] {
+  const winners = new Map<string, ResolvedButtonParam>()
+
+  for (const entry of entries) {
+    if (!entry.hasExplicitIndex) {
+      continue
+    }
+    const key = explicitIndexKey(entry)
+    const current = winners.get(key)
+    if (
+      !current ||
+      (!hasButtonParamContent(current.param) &&
+        hasButtonParamContent(entry.param))
+    ) {
+      winners.set(key, entry)
+    }
+  }
+
+  return entries.filter(
+    (entry) =>
+      !entry.hasExplicitIndex || winners.get(explicitIndexKey(entry)) === entry,
+  )
+}
+
+/**
+ * Normalizes persisted button params before they become Graph API components:
+ * drops null holes from sparse form arrays, drops quick replies without a
+ * payload (Meta rejects `payload: ""`; omitting the component makes the tap
+ * return the button text instead), and collapses legacy duplicates. Indexes are
+ * resolved from the ORIGINAL array positions so removals never shift the
+ * positional fallback of the remaining entries.
+ */
+function resolveButtonParams(
+  buttons: ReadonlyArray<WaTemplateButtonParam | null | undefined>,
+): ResolvedButtonParam[] {
+  const resolved = buttons.flatMap((param, position) =>
+    param
+      ? [
+          {
+            param,
+            index: param.index ?? position,
+            hasExplicitIndex: typeof param.index === "number",
+          },
+        ]
+      : [],
+  )
+
+  const withoutBlankQuickReplies = resolved.filter(
+    (entry) =>
+      buttonSubTypeOf(entry.param) !== "quick_reply" ||
+      !isBlank(entry.param.payload),
+  )
+
+  return dedupeExplicitIndexParams(withoutBlankQuickReplies)
+}
+
 function buildButtonComponents(
-  buttons: WaTemplateButtonParam[],
+  buttons: ReadonlyArray<WaTemplateButtonParam | null | undefined>,
   tokenContext: TemplateFlowTokenContext,
   cardIndex?: number,
 ): WhatsAppTemplateComponent[] {
-  const components: WhatsAppTemplateComponent[] = []
-
-  for (let i = 0; i < buttons.length; i++) {
-    const param = buttons[i]
-    const subType = param.sub_type || "url"
-
-    components.push({
-      type: "button",
-      sub_type: subType,
-      index: param.index ?? i,
-      parameters: [buildButtonParameter(param, tokenContext, cardIndex)],
-    })
-  }
-
-  return components
+  return resolveButtonParams(buttons).map(({ param, index }) => ({
+    type: "button",
+    sub_type: buttonSubTypeOf(param),
+    index,
+    parameters: [buildButtonParameter(param, tokenContext, cardIndex)],
+  }))
 }
 
 function buildCarouselComponent(

--- a/packages/flow-config/__tests__/wa-template-quick-reply-buttons.test.ts
+++ b/packages/flow-config/__tests__/wa-template-quick-reply-buttons.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, test } from "vitest"
+import {
+  bindWaTemplateQuickReplyButtons,
+  buttonStepDefaultFn,
+  extractParameterInfos,
+  extractTemplateParams,
+  extractTemplateQuickReplyButtons,
+  seedWaTemplateStepButtons,
+  sendWaTemplateMessageStepSchema,
+  stepTypes,
+  type TemplateComponent,
+  WA_TEMPLATE_STATUS_BUTTON_COUNT,
+} from "../src"
+
+const buttonsComponent = (
+  buttons: Record<string, unknown>[],
+): TemplateComponent =>
+  ({ type: "BUTTONS", buttons }) as unknown as TemplateComponent
+
+// The failing production shape: a static (non-parameterized) button BEFORE a
+// parameterized one, so dense param positions diverge from template indexes.
+const staticUrlThenQuickReply = [
+  buttonsComponent([
+    { type: "URL", text: "Clique aqui", url: "https://example.com/a" },
+    { type: "QUICK_REPLY", text: "Parar mensagens" },
+  ]),
+]
+
+describe("extractTemplateParams — quick replies are zero-config", () => {
+  test("creates NO param entry for quick reply buttons", () => {
+    const params = extractTemplateParams(staticUrlThenQuickReply)
+    expect(params.button).toBeUndefined()
+  })
+
+  test("still creates entries for dynamic URL buttons, with template index preserved", () => {
+    const params = extractTemplateParams([
+      buttonsComponent([
+        { type: "QUICK_REPLY", text: "Stop" },
+        { type: "URL", text: "Shop", url: "https://example.com/{{1}}" },
+      ]),
+    ])
+
+    expect(params.button).toEqual([{ sub_type: "url", index: 1, text: "" }])
+  })
+})
+
+describe("extractParameterInfos — dense paramIndex for button fields", () => {
+  test("emits no parameter info for quick reply buttons", () => {
+    const infos = extractParameterInfos(staticUrlThenQuickReply)
+    expect(infos).toEqual([])
+  })
+
+  test("paramIndex is the dense position while buttonIndex stays the template index", () => {
+    const infos = extractParameterInfos([
+      buttonsComponent([
+        { type: "PHONE_NUMBER", text: "Call", phone_number: "+15550001111" },
+        { type: "URL", text: "Shop", url: "https://example.com/{{1}}" },
+        { type: "COPY_CODE", text: "Copy" },
+      ]),
+    ])
+
+    expect(infos).toEqual([
+      expect.objectContaining({
+        buttonSubType: "url",
+        buttonIndex: 1,
+        paramIndex: 0,
+      }),
+      expect.objectContaining({
+        buttonSubType: "copy_code",
+        buttonIndex: 2,
+        paramIndex: 1,
+      }),
+    ])
+  })
+})
+
+describe("extractTemplateQuickReplyButtons", () => {
+  test("returns quick replies with their template button index", () => {
+    expect(extractTemplateQuickReplyButtons(staticUrlThenQuickReply)).toEqual([
+      { templateButtonIndex: 1, text: "Parar mensagens" },
+    ])
+  })
+
+  test("returns an empty list when the template has no quick replies", () => {
+    expect(
+      extractTemplateQuickReplyButtons([
+        buttonsComponent([
+          { type: "URL", text: "Open", url: "https://example.com" },
+        ]),
+      ]),
+    ).toEqual([])
+  })
+})
+
+describe("seedWaTemplateStepButtons", () => {
+  const statusButtons = [
+    buttonStepDefaultFn({ label: "Delivered" }),
+    buttonStepDefaultFn({ label: "Failed" }),
+  ]
+
+  test("keeps the status branches in front and appends one button per quick reply", () => {
+    const seeded = seedWaTemplateStepButtons(
+      statusButtons,
+      staticUrlThenQuickReply,
+    )
+
+    expect(seeded).toHaveLength(WA_TEMPLATE_STATUS_BUTTON_COUNT + 1)
+    expect(seeded[0]).toBe(statusButtons[0])
+    expect(seeded[1]).toBe(statusButtons[1])
+    expect(seeded[2].label).toBe("Parar mensagens")
+  })
+
+  test("truncates quick reply labels to the step button label limit", () => {
+    const seeded = seedWaTemplateStepButtons(statusButtons, [
+      buttonsComponent([{ type: "QUICK_REPLY", text: "A".repeat(25) }]),
+    ])
+
+    expect(seeded[2].label).toBe("A".repeat(20))
+  })
+
+  test("reselecting a template with the same quick replies keeps button ids (edges survive)", () => {
+    const firstSeed = seedWaTemplateStepButtons(
+      statusButtons,
+      staticUrlThenQuickReply,
+    )
+    const secondSeed = seedWaTemplateStepButtons(
+      firstSeed,
+      staticUrlThenQuickReply,
+    )
+
+    expect(secondSeed[2]).toBe(firstSeed[2])
+  })
+
+  test("a template text edit keeps the button's id and configured action — only the label follows", () => {
+    const firstSeed = seedWaTemplateStepButtons(
+      statusButtons,
+      staticUrlThenQuickReply,
+    )
+    const renamedTemplate = [
+      buttonsComponent([
+        { type: "URL", text: "Clique aqui", url: "https://example.com/a" },
+        { type: "QUICK_REPLY", text: "Stop now" },
+      ]),
+    ]
+
+    const secondSeed = seedWaTemplateStepButtons(firstSeed, renamedTemplate)
+
+    expect(secondSeed[2].id).toBe(firstSeed[2].id)
+    expect(secondSeed[2].label).toBe("Stop now")
+  })
+
+  test("switching to a template without quick replies drops the tail but keeps status branches", () => {
+    const seeded = seedWaTemplateStepButtons(
+      seedWaTemplateStepButtons(statusButtons, staticUrlThenQuickReply),
+      [buttonsComponent([{ type: "URL", text: "Open", url: "https://x.co" }])],
+    )
+
+    expect(seeded).toEqual(statusButtons)
+  })
+})
+
+describe("sendWaTemplateMessageStepSchema — legacy data and configured buttons", () => {
+  const baseStep = {
+    id: "step-1",
+    nodeId: "node-1",
+    stepType: stepTypes.enum.sendWaTemplateMessage,
+    template: {
+      id: "tmpl-1",
+      name: "tpl",
+      language: "en",
+      inboxId: null,
+      params: {},
+    },
+    buttons: [],
+  }
+
+  test("accepts and strips null holes persisted by the old sparse form arrays", () => {
+    const parsed = sendWaTemplateMessageStepSchema.parse({
+      ...baseStep,
+      template: {
+        ...baseStep.template,
+        params: {
+          button: [null, { sub_type: "quick_reply", index: 1, payload: "" }],
+        },
+      },
+    })
+
+    expect(parsed.template.params.button).toEqual([
+      { sub_type: "quick_reply", index: 1, payload: "" },
+    ])
+  })
+
+  test("strips null holes inside carousel card buttons too", () => {
+    const parsed = sendWaTemplateMessageStepSchema.parse({
+      ...baseStep,
+      template: {
+        ...baseStep.template,
+        params: {
+          carousel: [
+            {
+              card_index: 0,
+              button: [null, { sub_type: "url", index: 1, text: "suffix" }],
+            },
+          ],
+        },
+      },
+    })
+
+    expect(parsed.template.params.carousel?.[0]?.button).toEqual([
+      { sub_type: "url", index: 1, text: "suffix" },
+    ])
+  })
+
+  test("preserves a quick-reply button's configured action through parse (publish must not wipe it)", () => {
+    const configuredButton = {
+      id: "11612473309626372",
+      label: "Parar mensagens",
+      buttonType: "startAnotherNode" as const,
+      beforeStep: {
+        id: "11612473309626373",
+        stepType: "startAnotherNode" as const,
+        nodeId: "11612473309626374",
+      },
+      steps: [],
+    }
+
+    const parsed = sendWaTemplateMessageStepSchema.parse({
+      ...baseStep,
+      buttons: [
+        buttonStepDefaultFn({ label: "Delivered" }),
+        buttonStepDefaultFn({ label: "Failed" }),
+        configuredButton,
+      ],
+    })
+
+    expect(parsed.buttons[2]).toMatchObject({
+      label: "Parar mensagens",
+      buttonType: "startAnotherNode",
+      beforeStep: { nodeId: "11612473309626374" },
+    })
+  })
+
+  test("an empty buttons list still falls back to the Delivered/Failed status defaults", () => {
+    const parsed = sendWaTemplateMessageStepSchema.parse(baseStep)
+
+    expect(parsed.buttons.map((button) => button.label)).toEqual([
+      "Delivered",
+      "Failed",
+    ])
+  })
+})
+
+describe("bindWaTemplateQuickReplyButtons", () => {
+  test("pairs quick replies with the seeded tail by position", () => {
+    const tailButton = buttonStepDefaultFn({ label: "Parar mensagens" })
+    const bindings = bindWaTemplateQuickReplyButtons(staticUrlThenQuickReply, [
+      buttonStepDefaultFn({ label: "Delivered" }),
+      buttonStepDefaultFn({ label: "Failed" }),
+      tailButton,
+    ])
+
+    expect(bindings).toEqual([
+      { templateButtonIndex: 1, stepButton: tailButton },
+    ])
+  })
+
+  test("legacy steps with only status buttons yield no bindings", () => {
+    const bindings = bindWaTemplateQuickReplyButtons(staticUrlThenQuickReply, [
+      buttonStepDefaultFn({ label: "Delivered" }),
+      buttonStepDefaultFn({ label: "Failed" }),
+    ])
+
+    expect(bindings).toEqual([])
+  })
+})

--- a/packages/flow-config/src/steps/button.ts
+++ b/packages/flow-config/src/steps/button.ts
@@ -81,3 +81,32 @@ export const buttonStepDefaultFn = (
   steps: [],
   ...props,
 })
+
+/**
+ * Reconciles template-derived buttons with the buttons a user already
+ * configured on the step, pairing by position. The existing button always
+ * keeps its id and configured action (buttonType/beforeStep/steps) so edges
+ * and behavior survive template edits; only the label follows the template.
+ * Returns the existing object untouched when nothing changes, so callers can
+ * detect a no-op reseed by reference equality.
+ */
+export function mergeTemplateButtonsWithExisting(
+  templateButtons: ButtonStepProps[],
+  existingButtons: ButtonStepProps[] = [],
+): ButtonStepProps[] {
+  return templateButtons.map((templateButton, index) => {
+    const existingButton = existingButtons[index]
+
+    if (!existingButton) {
+      return templateButton
+    }
+    if (existingButton.label === templateButton.label) {
+      return existingButton
+    }
+
+    return {
+      ...existingButton,
+      label: templateButton.label,
+    }
+  })
+}

--- a/packages/flow-config/src/steps/send-messenger-message-template.ts
+++ b/packages/flow-config/src/steps/send-messenger-message-template.ts
@@ -2,7 +2,11 @@ import { createId } from "@chatbotx.io/utils"
 import { z } from "zod"
 import { baseStepSchema } from "./base"
 import type { ButtonStepProps } from "./button"
-import { buttonStepDefaultFn, buttonStepSchema } from "./button"
+import {
+  buttonStepDefaultFn,
+  buttonStepSchema,
+  mergeTemplateButtonsWithExisting,
+} from "./button"
 import { stepTypes } from "./step-action"
 import type { ParameterInfo } from "./wa-template-utils"
 
@@ -276,16 +280,5 @@ export function mergeMessengerFlowButtonsWithExisting(
   templateButtons: ButtonStepProps[],
   existingButtons: ButtonStepProps[] = [],
 ): ButtonStepProps[] {
-  return templateButtons.map((templateButton, index) => {
-    const existingButton = existingButtons[index]
-
-    if (!existingButton) {
-      return templateButton
-    }
-
-    return {
-      ...existingButton,
-      label: templateButton.label,
-    }
-  })
+  return mergeTemplateButtonsWithExisting(templateButtons, existingButtons)
 }

--- a/packages/flow-config/src/steps/send-wa-message-template.ts
+++ b/packages/flow-config/src/steps/send-wa-message-template.ts
@@ -44,6 +44,20 @@ export const waTemplateButtonParamSchema = z.object({
 })
 export type WaTemplateButtonParam = z.infer<typeof waTemplateButtonParamSchema>
 
+/**
+ * Button params persisted before the dense-slot form fix could contain `null`
+ * holes (the form wrote at the template button index, leaving earlier slots
+ * empty; JSON serialization turned the holes into nulls). Accept and strip
+ * them so those saved flows and broadcasts keep validating and sending.
+ */
+const waTemplateButtonParamListSchema = z
+  .array(waTemplateButtonParamSchema.nullable())
+  .transform((buttons) =>
+    buttons.filter(
+      (button): button is WaTemplateButtonParam => button !== null,
+    ),
+  )
+
 export const waTemplateCarouselCardSchema = z.object({
   card_index: z.number(),
   header: z
@@ -63,7 +77,7 @@ export const waTemplateCarouselCardSchema = z.object({
       }),
     )
     .optional(),
-  button: z.array(waTemplateButtonParamSchema).optional(),
+  button: waTemplateButtonParamListSchema.optional(),
 })
 export type WaTemplateCarouselCard = z.infer<
   typeof waTemplateCarouselCardSchema
@@ -103,7 +117,7 @@ export const waTemplateParamsSchema = z.object({
       }),
     )
     .optional(),
-  button: z.array(waTemplateButtonParamSchema).optional(),
+  button: waTemplateButtonParamListSchema.optional(),
   carousel: z.array(waTemplateCarouselCardSchema).optional(),
   limited_time_offer: z
     .object({
@@ -221,12 +235,6 @@ function extractButtonParams(
         sub_type: "copy_code",
         index: idx,
         coupon_code: "",
-      })
-    } else if (buttonType === "QUICK_REPLY") {
-      buttonParams.push({
-        sub_type: "quick_reply",
-        index: idx,
-        payload: "",
       })
     } else if (buttonType === "FLOW") {
       buttonParams.push({
@@ -373,23 +381,19 @@ export const sendWaTemplateMessageStepSchema = baseStepSchema.extend({
   buttons: z
     .array(buttonStepSchema)
     .default([])
+    // Buttons are kept as-is: the leading pair are the delivery status
+    // branches, and any tail buttons are template quick replies whose
+    // configured actions (Send Message, Perform Action, ...) must survive
+    // publish. Only a missing list falls back to the status defaults.
     .transform((buttons) => {
-      const templateButtons = buttons.map((btn) => ({
-        id: btn.id,
-        label: btn.label,
-        beforeStep: null,
-        steps: [],
-        buttonType: null,
-      }))
-
-      if (templateButtons.length === 0) {
+      if (buttons.length === 0) {
         return [
           buttonStepDefaultFn({ label: "Delivered" }),
           buttonStepDefaultFn({ label: "Failed" }),
         ]
       }
 
-      return templateButtons
+      return buttons
     }),
 })
 

--- a/packages/flow-config/src/steps/wa-template-utils.ts
+++ b/packages/flow-config/src/steps/wa-template-utils.ts
@@ -1,3 +1,9 @@
+import type { ButtonStepProps } from "./button"
+import {
+  BUTTON_LABEL_MAX,
+  buttonStepDefaultFn,
+  mergeTemplateButtonsWithExisting,
+} from "./button"
 import type {
   ButtonSubType,
   SendWaTemplateMessageStepSchema,
@@ -18,6 +24,14 @@ export type ParameterInfo = {
   flowSourceId?: string
   navigateScreenId?: string
   cardIndex?: number
+  /**
+   * Dense position of this button param among the parameterized buttons of its
+   * component. `extractButtonParams` stores param entries densely (only
+   * parameterized buttons get an entry), so form fields must write at this
+   * position — writing at `buttonIndex` creates duplicate entries whenever a
+   * non-parameterized button (static URL, phone number) precedes this one.
+   */
+  paramIndex?: number
 }
 
 function extractButtonParameterInfos(
@@ -28,6 +42,7 @@ function extractButtonParameterInfos(
 
   for (const [buttonIdx, button] of buttons.entries()) {
     const buttonType = button.type.toUpperCase()
+    const paramIndex = params.length
 
     if (buttonType === "URL" && button.url?.includes("{{1}}")) {
       params.push({
@@ -37,6 +52,7 @@ function extractButtonParameterInfos(
         buttonIndex: buttonIdx,
         buttonSubType: "url",
         cardIndex,
+        paramIndex,
       })
     } else if (buttonType === "COPY_CODE") {
       params.push({
@@ -47,16 +63,7 @@ function extractButtonParameterInfos(
         buttonSubType: "copy_code",
         format: "coupon_code",
         cardIndex,
-      })
-    } else if (buttonType === "QUICK_REPLY") {
-      params.push({
-        type: "button",
-        index: 0,
-        paramName: "payload",
-        buttonIndex: buttonIdx,
-        buttonSubType: "quick_reply",
-        format: "quick_reply",
-        cardIndex,
+        paramIndex,
       })
     } else if (buttonType === "FLOW") {
       params.push({
@@ -69,6 +76,7 @@ function extractButtonParameterInfos(
         flowSourceId: toOptionalString(button.flow_id),
         navigateScreenId: toOptionalString(button.navigate_screen),
         cardIndex,
+        paramIndex,
       })
     } else if (buttonType === "CATALOG") {
       params.push({
@@ -79,6 +87,7 @@ function extractButtonParameterInfos(
         buttonSubType: "catalog",
         format: "catalog",
         cardIndex,
+        paramIndex,
       })
     } else if (buttonType === "MPM") {
       params.push({
@@ -89,6 +98,7 @@ function extractButtonParameterInfos(
         buttonSubType: "mpm",
         format: "mpm",
         cardIndex,
+        paramIndex,
       })
     }
   }
@@ -199,6 +209,117 @@ function extractCarouselParameterInfos(
   }
 
   return params
+}
+
+const QUICK_REPLY_BUTTON_TYPE = "QUICK_REPLY"
+
+/**
+ * The first step buttons of a `sendWaTemplateMessage` step are the delivery
+ * status branches (`Delivered`/`Failed`) that the message-status handler routes
+ * by label. They must always stay in front; template quick-reply buttons are
+ * appended after them.
+ */
+export const WA_TEMPLATE_STATUS_BUTTON_COUNT = 2
+
+export type TemplateQuickReplyButton = {
+  /** Zero-based position of the button within the template's button list. */
+  templateButtonIndex: number
+  text: string
+}
+
+export function extractTemplateQuickReplyButtons(
+  components: TemplateComponent[],
+): TemplateQuickReplyButton[] {
+  const buttonsComponent = components?.find(
+    (component) => component.type === "BUTTONS" && component.buttons,
+  )
+
+  return (buttonsComponent?.buttons ?? []).flatMap((button, index) =>
+    button.type.toUpperCase() === QUICK_REPLY_BUTTON_TYPE
+      ? [{ templateButtonIndex: index, text: button.text }]
+      : [],
+  )
+}
+
+export type WaTemplateStepButtonsSplit<TButton> = {
+  statusButtons: TButton[]
+  quickReplyButtons: TButton[]
+}
+
+/**
+ * Single owner of the "first N buttons are status branches, the rest are
+ * template quick replies" rule, so editor, viewer, seeding, and binding can
+ * never disagree on where the split sits.
+ */
+export function splitWaTemplateStepButtons<TButton>(
+  buttons: readonly TButton[],
+): WaTemplateStepButtonsSplit<TButton> {
+  return {
+    statusButtons: buttons.slice(0, WA_TEMPLATE_STATUS_BUTTON_COUNT),
+    quickReplyButtons: buttons.slice(WA_TEMPLATE_STATUS_BUTTON_COUNT),
+  }
+}
+
+/**
+ * Rebuilds a `sendWaTemplateMessage` step's buttons for a newly selected
+ * template: the leading status branches are preserved (with their edges), and
+ * the tail follows the template's quick-reply buttons. Existing tail buttons
+ * keep their id and configured action across template edits — only the label
+ * follows the template — and unchanged buttons keep their object identity so
+ * callers can detect a no-op reseed by reference.
+ */
+export function seedWaTemplateStepButtons(
+  existingButtons: ButtonStepProps[],
+  components: TemplateComponent[],
+): ButtonStepProps[] {
+  const { statusButtons, quickReplyButtons: previousQuickReplies } =
+    splitWaTemplateStepButtons(existingButtons)
+
+  const templateButtons = extractTemplateQuickReplyButtons(components).map(
+    (quickReply) =>
+      buttonStepDefaultFn({
+        label: quickReply.text.slice(0, BUTTON_LABEL_MAX),
+      }),
+  )
+
+  return [
+    ...statusButtons,
+    ...mergeTemplateButtonsWithExisting(templateButtons, previousQuickReplies),
+  ]
+}
+
+export type WaTemplateStepButtonRef = Pick<ButtonStepProps, "id" | "label">
+
+export type WaTemplateQuickReplyBinding = {
+  templateButtonIndex: number
+  stepButton: WaTemplateStepButtonRef
+}
+
+/**
+ * Pairs the template's quick-reply buttons with the step buttons that
+ * `seedWaTemplateStepButtons` appended after the status branches, by position.
+ * Steps saved before quick-reply seeding existed have no tail and yield no
+ * bindings, so their sends stay component-free (Meta's default applies).
+ */
+export function bindWaTemplateQuickReplyButtons(
+  components: TemplateComponent[],
+  stepButtons: readonly WaTemplateStepButtonRef[],
+): WaTemplateQuickReplyBinding[] {
+  const { quickReplyButtons } = splitWaTemplateStepButtons(stepButtons)
+  // Broadcasts and legacy status-only steps have no tail — skip the template
+  // component scan entirely on this high-volume send path.
+  if (quickReplyButtons.length === 0) {
+    return []
+  }
+
+  return extractTemplateQuickReplyButtons(components).flatMap(
+    (quickReply, position) => {
+      const stepButton = quickReplyButtons[position]
+      return stepButton
+        ? [{ templateButtonIndex: quickReply.templateButtonIndex, stepButton }]
+        : []
+    },
+  )
 }
 
 export function extractParameterInfos(


### PR DESCRIPTION
## Summary

- Sending a WhatsApp template with quick reply buttons no longer fails with Meta error `(#132018) There's an issue with the parameters in your template` — fixed for broadcasts and flows, including ones saved before this change (no re-save needed).
- The "Quick Reply Payload" input is removed from broadcast and flow forms; quick reply buttons now work with zero configuration.
- In the flow builder, each template quick reply now appears as a connectable button on the step (after the Delivered/Failed branches): tapping it routes the contact to the connected branch, and the button can be configured with the standard button actions (Send Message, Perform Action, Start Another Node, ...) like Messenger template buttons.
- Delivery status branches (Delivered/Failed) keep their existing behavior, and configured button actions now survive publish.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`, `pnpm --filter worker check-types`, `@chatbotx.io/flow-config`, `@chatbotx.io/integration-whatsapp`
- [x] Unit tests: quick reply omission/dedupe/index handling in the Graph payload, legacy null-hole and duplicate-entry data, quick reply seeding/binding, payload injection and legacy-payload replacement, carousel cards (flow-config 264, whatsapp 193, worker 25)
- [ ] Manual: send a broadcast with a template that previously failed with #132018 → delivered
- [ ] Manual: connect a template quick reply to a node in a flow, send, tap the button on WhatsApp → the connected branch runs
- [ ] Manual: reopen a flow step saved before this change → no validation error, quick reply handle appears