### PR TITLE
feat(permissions): rename contacts permission to contacts / inbox and gate all sidebar menus

### DIFF
--- a/apps/builder/__tests__/contacts-route-guards.test.ts
+++ b/apps/builder/__tests__/contacts-route-guards.test.ts
@@ -19,6 +19,12 @@ vi.mock("next/navigation", () => ({
   notFound: mockNotFound,
 }))
 
+vi.mock("@/lib/workspace/require-not-scheduled-for-deletion", () => ({
+  enforceWorkspaceNotScheduledForDeletionFromRequest: vi.fn(
+    async () => undefined,
+  ),
+}))
+
 vi.mock("next-intl/server", () => ({
   getTranslations: vi.fn(async () => (key: string) => key),
 }))

--- a/apps/builder/__tests__/inbox-route-guards.test.ts
+++ b/apps/builder/__tests__/inbox-route-guards.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockGetCurrentUserAndTargetWorkspace, mockNotFound } = vi.hoisted(
+  () => ({
+    mockGetCurrentUserAndTargetWorkspace: vi.fn(),
+    mockNotFound: vi.fn(() => {
+      throw new Error("not found")
+    }),
+  }),
+)
+
+vi.mock("@/lib/auth/utils", () => ({
+  getCurrentUserAndTargetWorkspace: mockGetCurrentUserAndTargetWorkspace,
+}))
+
+vi.mock("next/navigation", () => ({
+  notFound: mockNotFound,
+}))
+
+vi.mock("@/lib/workspace/require-not-scheduled-for-deletion", () => ({
+  enforceWorkspaceNotScheduledForDeletionFromRequest: vi.fn(
+    async () => undefined,
+  ),
+}))
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({
+    get: () => undefined,
+  })),
+}))
+
+vi.mock("@/features/chat/chat-layout", () => ({
+  ChatLayout: () => null,
+}))
+
+vi.mock("@/features/chat/store/chat-store-provider", () => ({
+  ChatStoreProvider: ({ children }: { children: unknown }) => children,
+}))
+
+vi.mock("@/features/custom-fields/provider/custom-field-store-context", () => ({
+  CustomFieldStoreProvider: ({ children }: { children: unknown }) => children,
+}))
+
+vi.mock("@/features/flows/provider/flow-store-context", () => ({
+  FlowStoreProvider: ({ children }: { children: unknown }) => children,
+}))
+
+vi.mock("@/features/inboxes/provider/inbox-store-context", () => ({
+  InboxStoreProvider: ({ children }: { children: unknown }) => children,
+}))
+
+vi.mock("@/features/saved-replies/provider/saved-reply-store-context", () => ({
+  SavedReplyStoreProvider: ({ children }: { children: unknown }) => children,
+}))
+
+vi.mock("@/features/sequences/provider/sequence-store-context", () => ({
+  SequenceStoreProvider: ({ children }: { children: unknown }) => children,
+}))
+
+vi.mock("@/features/tags/provider/tag-store-context", () => ({
+  TagStoreProvider: ({ children }: { children: unknown }) => children,
+}))
+
+vi.mock("@/features/users/provider/user-store-context", () => ({
+  UserStoreProvider: ({ children }: { children: unknown }) => children,
+}))
+
+const { default: InboxPage } = await import(
+  "../src/app/space/[workspaceId]/inbox/page"
+)
+
+const basePermissions = {
+  superAdmin: false,
+  analytics: false,
+  flows: false,
+  contacts: false,
+  onlyAssignedContacts: false,
+  emailAndPhone: false,
+  broadcast: false,
+  ecommerce: false,
+}
+
+describe("inbox route guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("allows assigned-only members to reach the inbox page", async () => {
+    mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
+      user: { id: "user-1" },
+      targetWorkspaceMember: {
+        permissions: {
+          ...basePermissions,
+          onlyAssignedContacts: true,
+        },
+      },
+    })
+
+    await expect(
+      InboxPage({ params: Promise.resolve({ workspaceId: "ws-1" }) }),
+    ).resolves.toBeDefined()
+
+    expect(mockNotFound).not.toHaveBeenCalled()
+  })
+
+  test("rejects members without full or assigned-only contact access", async () => {
+    mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
+      user: { id: "user-1" },
+      targetWorkspaceMember: {
+        permissions: basePermissions,
+      },
+    })
+
+    await expect(
+      InboxPage({ params: Promise.resolve({ workspaceId: "ws-1" }) }),
+    ).rejects.toThrow("not found")
+
+    expect(mockNotFound).toHaveBeenCalled()
+  })
+})

--- a/apps/builder/__tests__/page-automated-responses-route-guards.test.ts
+++ b/apps/builder/__tests__/page-automated-responses-route-guards.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockGetCurrentUserAndTargetWorkspace, mockNotFound } = vi.hoisted(
+  () => ({
+    mockGetCurrentUserAndTargetWorkspace: vi.fn(),
+    mockNotFound: vi.fn(() => {
+      throw new Error("not found")
+    }),
+  }),
+)
+
+vi.mock("@/lib/auth/utils", () => ({
+  getCurrentUserAndTargetWorkspace: mockGetCurrentUserAndTargetWorkspace,
+}))
+
+vi.mock("next/navigation", () => ({
+  notFound: mockNotFound,
+}))
+
+vi.mock("@/lib/workspace/require-not-scheduled-for-deletion", () => ({
+  enforceWorkspaceNotScheduledForDeletionFromRequest: vi.fn(
+    async () => undefined,
+  ),
+}))
+
+vi.mock("@/features/automated-response/keywords-tab", () => ({
+  KeywordsTab: () => null,
+}))
+
+vi.mock("@/features/automated-response/keywords-description", () => ({
+  KeywordsDescription: () => null,
+}))
+
+vi.mock("@/features/flows/provider/flow-store-context", () => ({
+  FlowStoreProvider: ({ children }: { children: unknown }) => children,
+}))
+
+vi.mock("@/features/folders/provider/folder-store-context", () => ({
+  FolderStoreProvider: ({ children }: { children: unknown }) => children,
+}))
+
+const { default: PageAutomatedResponsesFolderableLayout } = await import(
+  "../src/app/space/[workspaceId]/(has-folder)/page-automated-responses/layout"
+)
+const { default: PageAutomatedResponsesLayout } = await import(
+  "../src/app/space/[workspaceId]/page-automated-responses/layout"
+)
+
+const basePermissions = {
+  superAdmin: false,
+  analytics: false,
+  flows: false,
+  contacts: false,
+  onlyAssignedContacts: false,
+  emailAndPhone: false,
+  broadcast: false,
+  ecommerce: false,
+}
+
+describe("page-automated-responses route guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("allows super admins to reach the outbound keywords layouts", async () => {
+    mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
+      targetWorkspaceMember: {
+        permissions: {
+          ...basePermissions,
+          superAdmin: true,
+        },
+      },
+    })
+
+    await expect(
+      PageAutomatedResponsesFolderableLayout({
+        children: null,
+        folders: null,
+        params: Promise.resolve({ workspaceId: "ws-1" }),
+      }),
+    ).resolves.toBeDefined()
+    await expect(
+      PageAutomatedResponsesLayout({
+        children: null,
+        params: Promise.resolve({ workspaceId: "ws-1" }),
+      }),
+    ).resolves.toBeDefined()
+
+    expect(mockNotFound).not.toHaveBeenCalled()
+  })
+
+  test("rejects fully-permissioned non-super-admins on the outbound keywords layouts", async () => {
+    mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
+      targetWorkspaceMember: {
+        permissions: {
+          ...basePermissions,
+          analytics: true,
+          flows: true,
+          contacts: true,
+          onlyAssignedContacts: true,
+          emailAndPhone: true,
+          broadcast: true,
+          ecommerce: true,
+        },
+      },
+    })
+
+    await expect(
+      PageAutomatedResponsesFolderableLayout({
+        children: null,
+        folders: null,
+        params: Promise.resolve({ workspaceId: "ws-1" }),
+      }),
+    ).rejects.toThrow("not found")
+    await expect(
+      PageAutomatedResponsesLayout({
+        children: null,
+        params: Promise.resolve({ workspaceId: "ws-1" }),
+      }),
+    ).rejects.toThrow("not found")
+
+    expect(mockNotFound).toHaveBeenCalled()
+  })
+})

--- a/apps/builder/__tests__/require-workspace-permission.test.ts
+++ b/apps/builder/__tests__/require-workspace-permission.test.ts
@@ -110,4 +110,46 @@ describe("resolveGuardedWorkspaceId", () => {
       ),
     ).rejects.toThrow("not found")
   })
+
+  test("returns the workspace id for super admins on superAdmin-gated routes", async () => {
+    mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
+      targetWorkspaceMember: {
+        permissions: {
+          ...basePermissions,
+          superAdmin: true,
+        },
+      },
+    })
+
+    await expect(
+      resolveGuardedWorkspaceId(
+        Promise.resolve({ workspaceId: "ws-1" }),
+        "superAdmin",
+      ),
+    ).resolves.toBe("ws-1")
+  })
+
+  test("rejects fully-permissioned non-super-admins on superAdmin-gated routes", async () => {
+    mockGetCurrentUserAndTargetWorkspace.mockResolvedValue({
+      targetWorkspaceMember: {
+        permissions: {
+          ...basePermissions,
+          analytics: true,
+          flows: true,
+          contacts: true,
+          onlyAssignedContacts: true,
+          emailAndPhone: true,
+          broadcast: true,
+          ecommerce: true,
+        },
+      },
+    })
+
+    await expect(
+      resolveGuardedWorkspaceId(
+        Promise.resolve({ workspaceId: "ws-1" }),
+        "superAdmin",
+      ),
+    ).rejects.toThrow("not found")
+  })
 })

--- a/apps/builder/__tests__/workspace-permission-routes.test.ts
+++ b/apps/builder/__tests__/workspace-permission-routes.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, test } from "vitest"
 import {
+  hasContactsAccess,
   hasWorkspacePermission,
   PERMISSION_NAV,
   resolveWorkspaceLandingSegment,
@@ -38,6 +39,24 @@ describe("workspace permission routes", () => {
   })
 })
 
+describe("hasContactsAccess", () => {
+  test("grants access with the full contacts flag", () => {
+    expect(hasContactsAccess({ contacts: true })).toBe(true)
+  })
+
+  test("grants access with only the assigned-contacts flag", () => {
+    expect(hasContactsAccess({ onlyAssignedContacts: true })).toBe(true)
+  })
+
+  test("grants access to super admins", () => {
+    expect(hasContactsAccess({ superAdmin: true })).toBe(true)
+  })
+
+  test("denies access without any contacts flag", () => {
+    expect(hasContactsAccess({})).toBe(false)
+  })
+})
+
 describe("resolveWorkspaceLandingSegment", () => {
   test("lands super admins on the dashboard", () => {
     expect(resolveWorkspaceLandingSegment({ superAdmin: true })).toBe(
@@ -61,7 +80,7 @@ describe("resolveWorkspaceLandingSegment", () => {
     ).toBe("flows")
   })
 
-  test("lands on the first granted section in nav priority order", () => {
+  test("lands contacts members on the inbox in nav priority order", () => {
     expect(
       resolveWorkspaceLandingSegment({
         superAdmin: false,
@@ -69,10 +88,27 @@ describe("resolveWorkspaceLandingSegment", () => {
         flows: false,
         contacts: true,
       }),
-    ).toBe("contacts")
+    ).toBe("inbox")
   })
 
-  test("falls back to the ungated inbox when no section is granted", () => {
-    expect(resolveWorkspaceLandingSegment({})).toBe("inbox")
+  test("lands assigned-only members on the inbox", () => {
+    expect(resolveWorkspaceLandingSegment({ onlyAssignedContacts: true })).toBe(
+      "inbox",
+    )
+  })
+
+  test("prefers the inbox over flows for contacts members", () => {
+    expect(
+      resolveWorkspaceLandingSegment({ flows: true, contacts: true }),
+    ).toBe("inbox")
+  })
+
+  test("lands ecommerce-only members on products", () => {
+    expect(resolveWorkspaceLandingSegment({ ecommerce: true })).toBe("products")
+  })
+
+  test("returns null when no section is granted", () => {
+    expect(resolveWorkspaceLandingSegment({})).toBeNull()
+    expect(resolveWorkspaceLandingSegment({ emailAndPhone: true })).toBeNull()
   })
 })

--- a/apps/builder/messages/ar.json
+++ b/apps/builder/messages/ar.json
@@ -1649,7 +1649,7 @@
       "superAdmin": "مسؤول أعلى",
       "analytics": "التحليلات",
       "flows": "المسارات",
-      "contacts": "جهات الاتصال",
+      "contacts": "جهات الاتصال / صندوق الوارد",
       "onlyAssignedContacts": "جهات الاتصال المسندة فقط",
       "emailAndPhone": "البريد الإلكتروني والهاتف",
       "broadcast": "البث",

--- a/apps/builder/messages/da.json
+++ b/apps/builder/messages/da.json
@@ -1575,7 +1575,7 @@
       "superAdmin": "Super Admin",
       "analytics": "Analytics",
       "flows": "Flows",
-      "contacts": "Kontakter",
+      "contacts": "Kontakter / Inbox",
       "onlyAssignedContacts": "Kun Tildelt Kontakter",
       "emailAndPhone": "E-mail og Telefon",
       "broadcast": "Broadcast",

--- a/apps/builder/messages/de.json
+++ b/apps/builder/messages/de.json
@@ -1575,7 +1575,7 @@
       "superAdmin": "Super-Admin",
       "analytics": "Analysen",
       "flows": "Flows",
-      "contacts": "Kontakte",
+      "contacts": "Kontakte / Posteingang",
       "onlyAssignedContacts": "Nur zugewiesene Kontakte",
       "emailAndPhone": "E-Mail und Telefon",
       "broadcast": "Broadcast",

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -1658,7 +1658,7 @@
       "superAdmin": "Super Admin",
       "analytics": "Analytics",
       "flows": "Flows",
-      "contacts": "Contacts",
+      "contacts": "Contacts / Inbox",
       "onlyAssignedContacts": "Only Assigned Contacts",
       "emailAndPhone": "Email and Phone",
       "broadcast": "Broadcast",

--- a/apps/builder/messages/es.json
+++ b/apps/builder/messages/es.json
@@ -1649,7 +1649,7 @@
       "superAdmin": "Superadministrador",
       "analytics": "Analíticas",
       "flows": "Flujos",
-      "contacts": "Contactos",
+      "contacts": "Contactos / Bandeja de entrada",
       "onlyAssignedContacts": "Solo Assigned Contactos",
       "emailAndPhone": "Email y Phone",
       "broadcast": "Difusión",

--- a/apps/builder/messages/fi.json
+++ b/apps/builder/messages/fi.json
@@ -1575,7 +1575,7 @@
       "superAdmin": "Pääylläpitäjä",
       "analytics": "Analytiikka",
       "flows": "Flow't",
-      "contacts": "Yhteystiedot",
+      "contacts": "Yhteystiedot / Saapuneet",
       "onlyAssignedContacts": "Vain määritetyt yhteystiedot",
       "emailAndPhone": "Sähköposti ja puhelin",
       "broadcast": "Joukkolähetys",

--- a/apps/builder/messages/fr.json
+++ b/apps/builder/messages/fr.json
@@ -1575,7 +1575,7 @@
       "superAdmin": "Super administrateur",
       "analytics": "Analyses",
       "flows": "Flux",
-      "contacts": "Contacts",
+      "contacts": "Contacts / Boîte de réception",
       "onlyAssignedContacts": "Uniquement les contacts attribués",
       "emailAndPhone": "E-mail et téléphone",
       "broadcast": "Diffusion",

--- a/apps/builder/messages/he.json
+++ b/apps/builder/messages/he.json
@@ -4061,7 +4061,7 @@
       "superAdmin": "מנהל-על",
       "analytics": "נתונים אנליטיים",
       "flows": "תהליכים",
-      "contacts": "אנשי קשר",
+      "contacts": "אנשי קשר / תיבת דואר נכנס",
       "onlyAssignedContacts": "אנשי קשר שהוקצו בלבד",
       "emailAndPhone": "דוא\"ל וטלפון",
       "broadcast": "שידור",

--- a/apps/builder/messages/id.json
+++ b/apps/builder/messages/id.json
@@ -1575,7 +1575,7 @@
       "superAdmin": "Super Admin",
       "analytics": "Analitik",
       "flows": "Flow",
-      "contacts": "Kontak",
+      "contacts": "Kontak / Inbox",
       "onlyAssignedContacts": "Hanya Kontak yang Ditugaskan",
       "emailAndPhone": "Email dan Telepon",
       "broadcast": "Broadcast",

--- a/apps/builder/messages/it.json
+++ b/apps/builder/messages/it.json
@@ -957,7 +957,7 @@
       "superAdmin": "Super amministratore",
       "analytics": "Analisi",
       "flows": "Flussi",
-      "contacts": "Contatti",
+      "contacts": "Contatti / Posta in arrivo",
       "onlyAssignedContacts": "Solo contatti assegnati",
       "emailAndPhone": "E-mail e telefono",
       "broadcast": "Broadcast",

--- a/apps/builder/messages/ja.json
+++ b/apps/builder/messages/ja.json
@@ -1575,7 +1575,7 @@
       "superAdmin": "スーパー管理者",
       "analytics": "分析",
       "flows": "フロー",
-      "contacts": "連絡先",
+      "contacts": "連絡先 / 受信トレイ",
       "onlyAssignedContacts": "割り当てられた連絡先のみ",
       "emailAndPhone": "メールと電話番号",
       "broadcast": "一斉配信",

--- a/apps/builder/messages/nl.json
+++ b/apps/builder/messages/nl.json
@@ -1389,7 +1389,7 @@
       "superAdmin": "Superbeheerder",
       "analytics": "Analyses",
       "flows": "Flows",
-      "contacts": "Contacten",
+      "contacts": "Contacten / Inbox",
       "onlyAssignedContacts": "Alleen toegewezen contacten",
       "emailAndPhone": "E-mail en telefoon",
       "broadcast": "Broadcast",

--- a/apps/builder/messages/pt-BR.json
+++ b/apps/builder/messages/pt-BR.json
@@ -1575,7 +1575,7 @@
       "superAdmin": "Superadministrador",
       "analytics": "Análises",
       "flows": "Fluxos",
-      "contacts": "Contatos",
+      "contacts": "Contatos / Caixa de entrada",
       "onlyAssignedContacts": "Somente contatos atribuídos",
       "emailAndPhone": "E-mail e telefone",
       "broadcast": "Transmissão",

--- a/apps/builder/messages/pt-PT.json
+++ b/apps/builder/messages/pt-PT.json
@@ -1575,7 +1575,7 @@
       "superAdmin": "Superadministrador",
       "analytics": "Análises",
       "flows": "Fluxos",
-      "contacts": "Contactos",
+      "contacts": "Contactos / Caixa de entrada",
       "onlyAssignedContacts": "Apenas contactos atribuídos",
       "emailAndPhone": "E-mail e telefone",
       "broadcast": "Difusão",

--- a/apps/builder/messages/ro.json
+++ b/apps/builder/messages/ro.json
@@ -2330,7 +2330,7 @@
       "superAdmin": "Super administrator",
       "analytics": "Analiză",
       "flows": "Fluxuri",
-      "contacts": "Contacte",
+      "contacts": "Contacte / Căsuță de mesaje",
       "onlyAssignedContacts": "Numai contactele atribuite",
       "emailAndPhone": "E-mail și telefon",
       "broadcast": "Difuzare",

--- a/apps/builder/messages/sv.json
+++ b/apps/builder/messages/sv.json
@@ -2177,7 +2177,7 @@
     "permissions": {
       "analytics": "Analys",
       "broadcast": "Utskick",
-      "contacts": "Kontakter",
+      "contacts": "Kontakter / Inkorg",
       "ecommerce": "E-handel",
       "emailAndPhone": "E-post och telefon",
       "flows": "Flöden",

--- a/apps/builder/messages/tr.json
+++ b/apps/builder/messages/tr.json
@@ -1649,7 +1649,7 @@
       "superAdmin": "Süper Yönetici",
       "analytics": "Analizler",
       "flows": "Akışlar",
-      "contacts": "Kişiler",
+      "contacts": "Kişiler / Gelen Kutusu",
       "onlyAssignedContacts": "Yalnızca Atanmış Kişiler",
       "emailAndPhone": "E-posta ve Telefon",
       "broadcast": "Toplu Gönderim",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -1613,7 +1613,7 @@
       "superAdmin": "Siêu quản trị viên",
       "analytics": "Phân tích",
       "flows": "Luồng",
-      "contacts": "Liên hệ",
+      "contacts": "Liên hệ / Hộp thư",
       "onlyAssignedContacts": "Chỉ liên hệ được gán",
       "emailAndPhone": "Email và Số điện thoại",
       "broadcast": "Phát sóng",

--- a/apps/builder/messages/zh-CN.json
+++ b/apps/builder/messages/zh-CN.json
@@ -2180,7 +2180,7 @@
     "permissions": {
       "analytics": "分析",
       "broadcast": "广播",
-      "contacts": "联系人",
+      "contacts": "联系人 / 收件匣",
       "ecommerce": "电子商务",
       "emailAndPhone": "电子邮件和电话",
       "flows": "流程",

--- a/apps/builder/messages/zh-TW.json
+++ b/apps/builder/messages/zh-TW.json
@@ -957,7 +957,7 @@
       "superAdmin": "超級管理員",
       "analytics": "分析",
       "flows": "流程",
-      "contacts": "聯絡人",
+      "contacts": "聯絡人 / 收件匣",
       "onlyAssignedContacts": "僅分配聯絡人",
       "emailAndPhone": "電子郵件和電話",
       "broadcast": "廣播",

--- a/apps/builder/src/app/space/[workspaceId]/(ai)/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(ai)/layout.tsx
@@ -1,10 +1,9 @@
-import { getIdFromParams } from "@chatbotx.io/utils"
-import { notFound } from "next/navigation"
 import type { ReactNode } from "react"
 import { AIToolsStoreProvider } from "@/features/ai-tools/provider/ai-tools-store-context"
 import { CustomFieldStoreProvider } from "@/features/custom-fields/provider/custom-field-store-context"
 import { NoAIIntegrationFound } from "@/features/integrations/components/no-ai-integration-found"
 import { hasAIIntegration } from "@/features/integrations/queries/get-ai-integrations"
+import { resolveGuardedWorkspaceId } from "@/lib/auth/require-workspace-permission"
 
 export default async function AILayout({
   params,
@@ -13,10 +12,7 @@ export default async function AILayout({
   params: Promise<{ workspaceId: string }>
   children: ReactNode
 }) {
-  const workspaceId = getIdFromParams(await params, "workspaceId")
-  if (!workspaceId) {
-    return notFound()
-  }
+  const workspaceId = await resolveGuardedWorkspaceId(params, "flows")
 
   const hasAIIntegrationResult = await hasAIIntegration(workspaceId)
   if (!hasAIIntegrationResult) {

--- a/apps/builder/src/app/space/[workspaceId]/(has-folder)/automated-responses/@folders/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(has-folder)/automated-responses/@folders/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation"
 import type { SearchParams } from "nuqs/server"
 import SharedFolderSlot from "@/features/folders/shared-folder-slot"
 import { withWorkspaceIdSchema } from "@/features/workspaces/schema/resource"
+import { requireWorkspacePermission } from "@/lib/auth/require-workspace-permission"
 
 export default async function FolderPage(props: {
   params: Promise<{ workspaceId: string }>
@@ -11,6 +12,7 @@ export default async function FolderPage(props: {
   if (!data) {
     return notFound()
   }
+  await requireWorkspacePermission(data.workspaceId, "superAdmin")
 
   return (
     <SharedFolderSlot

--- a/apps/builder/src/app/space/[workspaceId]/(has-folder)/automated-responses/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(has-folder)/automated-responses/layout.tsx
@@ -1,10 +1,9 @@
-import { getIdFromParams } from "@chatbotx.io/utils"
-import { notFound } from "next/navigation"
 import type { ReactNode } from "react"
 import { KeywordsDescription } from "@/features/automated-response/keywords-description"
 import { KeywordsTab } from "@/features/automated-response/keywords-tab"
 import { FlowStoreProvider } from "@/features/flows/provider/flow-store-context"
 import { FolderStoreProvider } from "@/features/folders/provider/folder-store-context"
+import { resolveGuardedWorkspaceId } from "@/lib/auth/require-workspace-permission"
 
 export default async function FolderableLayout({
   children,
@@ -15,10 +14,7 @@ export default async function FolderableLayout({
   folders: ReactNode
   params: Promise<{ workspaceId: string }>
 }) {
-  const workspaceId = getIdFromParams(await params, "workspaceId")
-  if (!workspaceId) {
-    return notFound()
-  }
+  const workspaceId = await resolveGuardedWorkspaceId(params, "superAdmin")
 
   return (
     <FolderStoreProvider

--- a/apps/builder/src/app/space/[workspaceId]/(has-folder)/page-automated-responses/@folders/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(has-folder)/page-automated-responses/@folders/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation"
 import type { SearchParams } from "nuqs/server"
 import SharedFolderSlot from "@/features/folders/shared-folder-slot"
 import { withWorkspaceIdSchema } from "@/features/workspaces/schema/resource"
+import { requireWorkspacePermission } from "@/lib/auth/require-workspace-permission"
 
 export default async function FolderPage(props: {
   params: Promise<{ workspaceId: string }>
@@ -11,6 +12,7 @@ export default async function FolderPage(props: {
   if (!data) {
     return notFound()
   }
+  await requireWorkspacePermission(data.workspaceId, "superAdmin")
 
   return (
     <SharedFolderSlot

--- a/apps/builder/src/app/space/[workspaceId]/(has-folder)/page-automated-responses/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(has-folder)/page-automated-responses/layout.tsx
@@ -1,10 +1,9 @@
-import { getIdFromParams } from "@chatbotx.io/utils"
-import { notFound } from "next/navigation"
 import type { ReactNode } from "react"
 import { KeywordsDescription } from "@/features/automated-response/keywords-description"
 import { KeywordsTab } from "@/features/automated-response/keywords-tab"
 import { FlowStoreProvider } from "@/features/flows/provider/flow-store-context"
 import { FolderStoreProvider } from "@/features/folders/provider/folder-store-context"
+import { resolveGuardedWorkspaceId } from "@/lib/auth/require-workspace-permission"
 
 export default async function FolderableLayout({
   children,
@@ -15,10 +14,7 @@ export default async function FolderableLayout({
   folders: ReactNode
   params: Promise<{ workspaceId: string }>
 }) {
-  const workspaceId = getIdFromParams(await params, "workspaceId")
-  if (!workspaceId) {
-    return notFound()
-  }
+  const workspaceId = await resolveGuardedWorkspaceId(params, "superAdmin")
 
   return (
     <FolderStoreProvider

--- a/apps/builder/src/app/space/[workspaceId]/(has-folder)/triggers/@folders/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(has-folder)/triggers/@folders/page.tsx
@@ -2,6 +2,7 @@ import { getIdFromParams } from "@chatbotx.io/utils"
 import { notFound } from "next/navigation"
 import type { SearchParams } from "nuqs/server"
 import SharedFolderSlot from "@/features/folders/shared-folder-slot"
+import { requireWorkspacePermission } from "@/lib/auth/require-workspace-permission"
 
 export default async function FolderPage(props: {
   params: Promise<{ workspaceId: string }>
@@ -11,6 +12,7 @@ export default async function FolderPage(props: {
   if (!workspaceId) {
     return notFound()
   }
+  await requireWorkspacePermission(workspaceId, "superAdmin")
 
   return (
     <SharedFolderSlot

--- a/apps/builder/src/app/space/[workspaceId]/(has-folder)/triggers/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(has-folder)/triggers/layout.tsx
@@ -1,8 +1,7 @@
 import { folderTypes } from "@chatbotx.io/database/partials"
-import { getIdFromParams } from "@chatbotx.io/utils"
-import { notFound } from "next/navigation"
 import type { ReactNode } from "react"
 import { FolderStoreProvider } from "@/features/folders/provider/folder-store-context"
+import { resolveGuardedWorkspaceId } from "@/lib/auth/require-workspace-permission"
 
 export default async function TriggersLayout({
   children,
@@ -13,10 +12,7 @@ export default async function TriggersLayout({
   folders: ReactNode
   params: Promise<{ workspaceId: string }>
 }) {
-  const workspaceId = getIdFromParams(await params, "workspaceId")
-  if (!workspaceId) {
-    return notFound()
-  }
+  const workspaceId = await resolveGuardedWorkspaceId(params, "superAdmin")
 
   return (
     <FolderStoreProvider

--- a/apps/builder/src/app/space/[workspaceId]/(has-folder)/webhooks/@folders/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(has-folder)/webhooks/@folders/page.tsx
@@ -2,6 +2,7 @@ import { getIdFromParams } from "@chatbotx.io/utils"
 import { notFound } from "next/navigation"
 import type { SearchParams } from "nuqs/server"
 import SharedFolderSlot from "@/features/folders/shared-folder-slot"
+import { requireWorkspacePermission } from "@/lib/auth/require-workspace-permission"
 
 export default async function FolderPage(props: {
   params: Promise<{ workspaceId: string }>
@@ -11,6 +12,7 @@ export default async function FolderPage(props: {
   if (!workspaceId) {
     return notFound()
   }
+  await requireWorkspacePermission(workspaceId, "superAdmin")
 
   return (
     <SharedFolderSlot

--- a/apps/builder/src/app/space/[workspaceId]/(has-folder)/webhooks/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(has-folder)/webhooks/layout.tsx
@@ -1,8 +1,7 @@
 import { folderTypes } from "@chatbotx.io/database/partials"
-import { getIdFromParams } from "@chatbotx.io/utils"
-import { notFound } from "next/navigation"
 import type { ReactNode } from "react"
 import { FolderStoreProvider } from "@/features/folders/provider/folder-store-context"
+import { resolveGuardedWorkspaceId } from "@/lib/auth/require-workspace-permission"
 
 export default async function WebhooksLayout({
   children,
@@ -13,10 +12,7 @@ export default async function WebhooksLayout({
   folders: ReactNode
   params: Promise<{ workspaceId: string }>
 }) {
-  const workspaceId = getIdFromParams(await params, "workspaceId")
-  if (!workspaceId) {
-    return notFound()
-  }
+  const workspaceId = await resolveGuardedWorkspaceId(params, "superAdmin")
 
   return (
     <FolderStoreProvider

--- a/apps/builder/src/app/space/[workspaceId]/automated-responses/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/automated-responses/layout.tsx
@@ -1,6 +1,5 @@
-import { getIdFromParams } from "@chatbotx.io/utils"
-import { notFound } from "next/navigation"
 import { FlowStoreProvider } from "@/features/flows/provider/flow-store-context"
+import { resolveGuardedWorkspaceId } from "@/lib/auth/require-workspace-permission"
 
 export default async function AutomatedResponsesLayout({
   children,
@@ -9,10 +8,7 @@ export default async function AutomatedResponsesLayout({
   params: Promise<{ workspaceId: string }>
   children: React.ReactNode
 }) {
-  const workspaceId = getIdFromParams(await params, "workspaceId")
-  if (!workspaceId) {
-    return notFound()
-  }
+  const workspaceId = await resolveGuardedWorkspaceId(params, "superAdmin")
 
   return (
     <FlowStoreProvider workspaceId={workspaceId}>{children}</FlowStoreProvider>

--- a/apps/builder/src/app/space/[workspaceId]/inbox/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/inbox/page.tsx
@@ -11,6 +11,7 @@ import { SavedReplyStoreProvider } from "@/features/saved-replies/provider/saved
 import { SequenceStoreProvider } from "@/features/sequences/provider/sequence-store-context"
 import { TagStoreProvider } from "@/features/tags/provider/tag-store-context"
 import { UserStoreProvider } from "@/features/users/provider/user-store-context"
+import { requireContactsAccess } from "@/lib/auth/require-workspace-permission"
 import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
 
 type InboxPageProps = {
@@ -22,6 +23,8 @@ export default async function InboxPage({ params }: InboxPageProps) {
   if (!workspaceId) {
     return notFound()
   }
+
+  await requireContactsAccess(workspaceId)
 
   const layout = (await cookies()).get("csm:layout:inbox")
   const savedLayout = layout ? JSON.parse(layout.value) : [25, 50, 25]

--- a/apps/builder/src/app/space/[workspaceId]/page-automated-responses/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/page-automated-responses/layout.tsx
@@ -1,6 +1,5 @@
-import { getIdFromParams } from "@chatbotx.io/utils"
-import { notFound } from "next/navigation"
 import { FlowStoreProvider } from "@/features/flows/provider/flow-store-context"
+import { resolveGuardedWorkspaceId } from "@/lib/auth/require-workspace-permission"
 
 export default async function PageAutomatedResponsesLayout({
   children,
@@ -9,10 +8,7 @@ export default async function PageAutomatedResponsesLayout({
   params: Promise<{ workspaceId: string }>
   children: React.ReactNode
 }) {
-  const workspaceId = getIdFromParams(await params, "workspaceId")
-  if (!workspaceId) {
-    return notFound()
-  }
+  const workspaceId = await resolveGuardedWorkspaceId(params, "superAdmin")
 
   return (
     <FlowStoreProvider workspaceId={workspaceId}>{children}</FlowStoreProvider>

--- a/apps/builder/src/app/space/[workspaceId]/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/page.tsx
@@ -35,6 +35,11 @@ export default async function WorkspacePage(props: WorkspacePageProps) {
   const segment = resolveWorkspaceLandingSegment(
     userAndWorkspace.targetWorkspaceMember.permissions,
   )
+  // No accessible section (e.g. only `emailAndPhone`): fail closed instead of
+  // redirecting into a section that would 404 anyway.
+  if (!segment) {
+    return notFound()
+  }
 
   return redirect(`/space/${workspaceId}/${segment}`)
 }

--- a/apps/builder/src/app/space/[workspaceId]/tools/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/tools/page.tsx
@@ -1,5 +1,12 @@
 import { ToolsList } from "@/features/tools/tools-list"
+import { resolveGuardedWorkspaceId } from "@/lib/auth/require-workspace-permission"
 
-export default async function ToolsPage() {
+export default async function ToolsPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string }>
+}) {
+  await resolveGuardedWorkspaceId(params, "flows")
+
   return <ToolsList />
 }

--- a/apps/builder/src/app/space/[workspaceId]/triggers/[id]/edit/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/triggers/[id]/edit/page.tsx
@@ -6,6 +6,7 @@ import { TagStoreProvider } from "@/features/tags/provider/tag-store-context"
 import { findTrigger } from "@/features/triggers/queries"
 import UpdateTriggerForm from "@/features/triggers/update-trigger-form"
 import { withWorkspaceIdAndIdSchema } from "@/features/workspaces/schema/resource"
+import { requireWorkspacePermission } from "@/lib/auth/require-workspace-permission"
 
 export default async function UpdateTriggerPage({
   params,
@@ -18,6 +19,7 @@ export default async function UpdateTriggerPage({
   }
 
   const { workspaceId, id } = data
+  await requireWorkspacePermission(workspaceId, "superAdmin")
   const trigger = await findTrigger({ workspaceId, id })
   if (!trigger) {
     return notFound()

--- a/apps/builder/src/app/space/[workspaceId]/webhooks/[id]/edit/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/webhooks/[id]/edit/page.tsx
@@ -6,6 +6,7 @@ import { TagStoreProvider } from "@/features/tags/provider/tag-store-context"
 import { findWebhook } from "@/features/webhooks/queries"
 import UpdateWebhookForm from "@/features/webhooks/update-webhook-form"
 import { withWorkspaceIdAndIdSchema } from "@/features/workspaces/schema/resource"
+import { requireWorkspacePermission } from "@/lib/auth/require-workspace-permission"
 
 export default async function UpdateWebhookPage({
   params,
@@ -18,6 +19,7 @@ export default async function UpdateWebhookPage({
   }
 
   const { workspaceId, id } = data
+  await requireWorkspacePermission(workspaceId, "superAdmin")
   const webhook = await findWebhook({ workspaceId, id })
   if (!webhook) {
     return notFound()

--- a/apps/builder/src/components/app-sidebar.tsx
+++ b/apps/builder/src/components/app-sidebar.tsx
@@ -32,10 +32,10 @@ import { NavMain } from "@/components/nav-main"
 import { NavUsage, type QuotaSummary } from "@/components/nav-usage"
 import { NavUser } from "@/components/nav-user"
 import { WorkspaceSwitcher } from "@/components/workspace-switcher"
-import { canAccessContactsSection } from "@/features/contacts/permissions"
 import type { WorkspaceResource } from "@/features/workspaces/schema/resource"
 import { authClient } from "@/lib/auth/auth-client"
 import {
+  hasContactsAccess,
   hasWorkspacePermission,
   PERMISSION_NAV,
   type WorkspacePermissionKey,
@@ -45,7 +45,7 @@ type SidebarNavItem = {
   title: string
   url: string
   icon: LucideIcon
-  permission?: WorkspacePermissionKey
+  permission: WorkspacePermissionKey
 }
 
 const SETTINGS_GENERAL_URL_SEGMENT = "/settings/general"
@@ -90,6 +90,7 @@ export function AppSidebar({
         title: t("fields.inbox.label"),
         url: `/space/${workspaceId}/inbox`,
         icon: MessageCircleMoreIcon,
+        permission: PERMISSION_NAV.contacts,
       },
       {
         title: t("fields.flows.label"),
@@ -107,11 +108,13 @@ export function AppSidebar({
         title: t("aiAgent.title"),
         url: `/space/${workspaceId}/ai-agents`,
         icon: BrainIcon,
+        permission: PERMISSION_NAV.flows,
       },
       {
         title: t("keywords.title"),
         url: `/space/${workspaceId}/automated-responses`,
         icon: AtomIcon,
+        permission: "superAdmin",
       },
       {
         title: t("broadcasts.title"),
@@ -129,16 +132,19 @@ export function AppSidebar({
         title: t("triggers.title"),
         url: `/space/${workspaceId}/triggers`,
         icon: LightbulbIcon,
+        permission: "superAdmin",
       },
       {
         title: t("webhooks.title"),
         url: `/space/${workspaceId}/webhooks`,
         icon: WebhookIcon,
+        permission: "superAdmin",
       },
       {
         title: t("tools.title"),
         url: `/space/${workspaceId}/tools`,
         icon: WrenchIcon,
+        permission: PERMISSION_NAV.flows,
       },
       {
         title: t("settings.title"),
@@ -150,12 +156,12 @@ export function AppSidebar({
   }
 
   const navMain = data.navMain
-    .filter(
-      (item) =>
-        !item.permission ||
-        (item.permission === PERMISSION_NAV.contacts
-          ? canAccessContactsSection(permissions)
-          : hasWorkspacePermission(permissions, item.permission)),
+    .filter((item) =>
+      // Items gated on the `contacts` flag (Contacts, Inbox) use the shared
+      // contacts-access rule, which also admits assigned-only members.
+      item.permission === PERMISSION_NAV.contacts
+        ? hasContactsAccess(permissions)
+        : hasWorkspacePermission(permissions, item.permission),
     )
     .map((item) => ({
       ...item,

--- a/apps/builder/src/features/contacts/permissions.ts
+++ b/apps/builder/src/features/contacts/permissions.ts
@@ -1,6 +1,9 @@
 import { ChatbotXException } from "@chatbotx.io/business/errors"
 import type { WorkspaceMemberPermissions } from "@chatbotx.io/database/partials"
-import { hasWorkspacePermission } from "@/lib/auth/permission-routes"
+import {
+  hasContactsAccess,
+  hasWorkspacePermission,
+} from "@/lib/auth/permission-routes"
 import { getCurrentUserAndTargetWorkspace } from "@/lib/auth/utils"
 
 type Permissions = WorkspaceMemberPermissions | Record<string, unknown>
@@ -17,10 +20,7 @@ export function canViewContactEmailAndPhone(permissions: Permissions): boolean {
 }
 
 export function canAccessContactsSection(permissions: Permissions): boolean {
-  return (
-    hasWorkspacePermission(permissions, "contacts") ||
-    hasWorkspacePermission(permissions, "onlyAssignedContacts")
-  )
+  return hasContactsAccess(permissions)
 }
 
 export function getAssignedContactsUserId(input: {

--- a/apps/builder/src/lib/auth/permission-routes.ts
+++ b/apps/builder/src/lib/auth/permission-routes.ts
@@ -11,44 +11,65 @@ export const PERMISSION_NAV = {
 
 export type WorkspacePermissionKey = keyof WorkspaceMemberPermissions
 
+type PermissionsInput = WorkspaceMemberPermissions | Record<string, unknown>
+
 // The `permissions` jsonb column defaults to `{}`, so at runtime any flag can be
 // absent even though the type claims every key is present. The `Record` union is
 // intentional: it accepts a possibly-partial object, and the strict `=== true`
 // checks fail closed on missing/undefined keys.
 export function hasWorkspacePermission(
-  permissions: WorkspaceMemberPermissions | Record<string, unknown>,
+  permissions: PermissionsInput,
   key: WorkspacePermissionKey,
 ): boolean {
   return permissions.superAdmin === true || permissions[key] === true
 }
 
-// Ordered candidates for the workspace landing route. Each entry maps a path
-// segment (relative to `/space/:workspaceId`) to an optional permission gate.
-// A `null` gate means the page is always reachable, so the last always-open
-// entry guarantees resolution never falls through to a 404. Order reflects the
-// sidebar nav priority: prefer analytics/flows-style landing spots, then fall
-// back to the ungated inbox.
-const WORKSPACE_LANDING_ROUTES = [
-  ...Object.entries(PERMISSION_NAV).map(([segment, permission]) => ({
-    segment,
-    permission,
-  })),
-  { segment: "inbox", permission: null },
-] as const satisfies ReadonlyArray<{
-  segment: string
-  permission: WorkspacePermissionKey | null
-}>
+// Shared "Contacts / Inbox" access rule used by both the /contacts and /inbox
+// sections: full contacts access OR assigned-only access; superAdmin bypasses
+// via hasWorkspacePermission.
+export function hasContactsAccess(permissions: PermissionsInput): boolean {
+  return (
+    hasWorkspacePermission(permissions, "contacts") ||
+    hasWorkspacePermission(permissions, "onlyAssignedContacts")
+  )
+}
+
+// Landing candidates in sidebar nav priority order: every PERMISSION_NAV
+// segment plus `inbox`, which shares the contacts-access rule. Deriving the
+// gates from PERMISSION_NAV keeps a new section added there from silently
+// missing landing resolution.
+const WORKSPACE_LANDING_SEGMENTS = [
+  "dashboard",
+  "inbox",
+  "flows",
+  "contacts",
+  "broadcasts",
+  "sequences",
+  "products",
+] as const satisfies ReadonlyArray<keyof typeof PERMISSION_NAV | "inbox">
+
+function canAccessLandingSegment(
+  segment: (typeof WORKSPACE_LANDING_SEGMENTS)[number],
+  permissions: PermissionsInput,
+): boolean {
+  // `inbox` and `contacts` use the shared contacts-access rule, so members
+  // with only `onlyAssignedContacts` still land there.
+  if (segment === "inbox" || segment === "contacts") {
+    return hasContactsAccess(permissions)
+  }
+  return hasWorkspacePermission(permissions, PERMISSION_NAV[segment])
+}
 
 // Resolve the first section the member can access. Used by the workspace root
 // page so users without `analytics` don't get redirected into a 404 dashboard.
+// Returns null when the member can access no section; the caller turns that
+// into notFound() so we fail closed instead of redirecting into a 404 loop.
 export function resolveWorkspaceLandingSegment(
-  permissions: WorkspaceMemberPermissions | Record<string, unknown>,
-): string {
-  const target = WORKSPACE_LANDING_ROUTES.find(
-    (route) =>
-      route.permission === null ||
-      hasWorkspacePermission(permissions, route.permission),
+  permissions: PermissionsInput,
+): string | null {
+  return (
+    WORKSPACE_LANDING_SEGMENTS.find((segment) =>
+      canAccessLandingSegment(segment, permissions),
+    ) ?? null
   )
-  // `inbox` is always ungated, so `find` always resolves; fall back defensively.
-  return target?.segment ?? "inbox"
 }

--- a/apps/builder/src/lib/auth/require-workspace-permission.ts
+++ b/apps/builder/src/lib/auth/require-workspace-permission.ts
@@ -50,6 +50,16 @@ export async function requireContactsAccess(
   if (!canAccess) {
     notFound()
   }
+
+  if (userAndWorkspace) {
+    await enforceWorkspaceNotScheduledForDeletionFromRequest(
+      userAndWorkspace.targetWorkspace,
+      hasWorkspacePermission(
+        userAndWorkspace.targetWorkspaceMember.permissions,
+        "superAdmin",
+      ),
+    )
+  }
 }
 
 export async function resolveGuardedWorkspaceId(


### PR DESCRIPTION
## Summary
- The `contacts` member permission now controls both the **Contacts** and **Inbox** sections; its label is renamed to "Contacts / Inbox" in all 20 locales (jsonb key unchanged, no migration). A member with only this permission sees exactly those two menus.
- Every sidebar item is now permission-gated for non-super-admins: Inbox → contacts access (includes `onlyAssignedContacts`), AI Agents/Tools → `flows`, Keywords/Triggers/Webhooks → workspace `superAdmin`.
- Matching server-side guards ensure hidden menus cannot be reached by typing URLs; the workspace landing route is derived from `PERMISSION_NAV`, prefers `/inbox` for contacts members, and fails closed (404) for members with no accessible section.

## Changes
- `apps/builder/src/components/app-sidebar.tsx` — `permission` required on every nav item; filter uses the shared `hasContactsAccess` rule
- `apps/builder/src/lib/auth/permission-routes.ts` — new `hasContactsAccess`; landing segments derived from `PERMISSION_NAV` with a contacts/inbox override; resolver returns `null` when nothing is accessible
- `apps/builder/src/lib/auth/require-workspace-permission.ts` — `requireContactsAccess` now also enforces the scheduled-for-deletion redirect, matching `requireWorkspacePermission`
- Route guards: `inbox/page.tsx` (contacts access), `(ai)/layout.tsx` + `tools/page.tsx` (`flows`), both `automated-responses` and `page-automated-responses` twins, `triggers`, `webhooks` layouts/edit pages and their `@folders` slots (`superAdmin`)
- `apps/builder/messages/*.json` × 20 — `fields.permissions.contacts` label
- Tests: new `inbox-route-guards` and `page-automated-responses-route-guards` suites; landing/guard suites updated

Known follow-ups (deliberately out of scope): mutation server actions for triggers/webhooks/keywords still rely on membership only; Tools destination routes (qr-codes, magic-links, fb/ig comments, …) remain URL-reachable.

## Test plan
- [x] pnpm lint
- [x] pnpm --filter builder check-types
- [x] pnpm --filter builder test (257 files / 1607 tests)
- [ ] manual verification: member with only "Contacts / Inbox" sees just Contacts + Inbox and lands on /inbox; direct URLs to gated sections return 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)