### PR TITLE
fix(zalo): stop duplicating inbox-sent messages and handle postback/receipt webhooks

### DIFF
--- a/apps/worker/__tests__/received-message.test.ts
+++ b/apps/worker/__tests__/received-message.test.ts
@@ -38,6 +38,7 @@ const {
   mockChatQueueAdd,
   mockSyncScopedIdentity,
   mockIsUniqueViolationError,
+  mockDetectFlowVersion,
 } = vi.hoisted(() => {
   const mockDbSet = vi.fn()
   const updateChain = { set: mockDbSet, where: vi.fn() }
@@ -111,6 +112,7 @@ const {
       }),
     ),
     mockIsUniqueViolationError: vi.fn().mockReturnValue(false),
+    mockDetectFlowVersion: vi.fn(),
   }
 })
 
@@ -287,6 +289,10 @@ vi.mock("@chatbotx.io/worker-config", () => ({
 
 vi.mock("../src/lib/logger", () => ({
   logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock("../src/lib/db", () => ({
+  detectFlowVersion: mockDetectFlowVersion,
 }))
 
 vi.mock("../src/services/integrations", () => ({
@@ -799,6 +805,110 @@ describe("receiveMessage — message repository branch", () => {
       kind: "postback",
       data: expect.objectContaining({ action: postbackAction }),
     })
+  })
+
+  test("replaces a raw postback payload echo with the flow button label", async () => {
+    const postbackAction = encodeButtonPayload({ flowId: "42", buttonId: "77" })
+    mockDetectFlowVersion.mockResolvedValue({
+      flowVersion: {
+        id: "fv-1",
+        nodes: [
+          {
+            id: "node-1",
+            data: {
+              details: {
+                steps: [
+                  {
+                    buttons: [
+                      {
+                        id: "77",
+                        label: "Xem sản phẩm",
+                        buttonType: "nextStep",
+                        beforeStep: null,
+                        steps: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+      useLatestFlowVersion: true,
+    })
+    mockRunChannelHandler.mockResolvedValue({
+      message: {
+        ...baseIncomingMessage,
+        text: `postback_${postbackAction}`,
+        attachments: [],
+      },
+      contact: { sourceId: "psid-123", firstName: "Test" },
+      postbackAction,
+      quickReplyAction: null,
+      ref: null,
+    })
+
+    await receiveMessage({ ...baseProps, integrationType: "zalo" })
+
+    expect(mockDetectFlowVersion).toHaveBeenCalledWith({
+      flowId: "42",
+      flowVersionId: undefined,
+      workspaceId: "ws-1",
+    })
+    expect(mockCreateOrUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Xem sản phẩm" }),
+    )
+    expect(mockUpdateTracking).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ lastBtnTitle: "Xem sản phẩm" }),
+      }),
+    )
+    expect(mockAutomatedResponseEnqueueFlowAction).toHaveBeenCalledWith({
+      kind: "postback",
+      data: expect.objectContaining({ action: postbackAction }),
+    })
+  })
+
+  test("keeps the raw postback text when the flow can no longer be resolved", async () => {
+    const postbackAction = encodeButtonPayload({ flowId: "42", buttonId: "77" })
+    mockDetectFlowVersion.mockRejectedValue(new Error("FlowVersion not found"))
+    mockRunChannelHandler.mockResolvedValue({
+      message: {
+        ...baseIncomingMessage,
+        text: `postback_${postbackAction}`,
+        attachments: [],
+      },
+      contact: { sourceId: "psid-123", firstName: "Test" },
+      postbackAction,
+      quickReplyAction: null,
+      ref: null,
+    })
+
+    await receiveMessage({ ...baseProps, integrationType: "zalo" })
+
+    expect(mockCreateOrUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ text: `postback_${postbackAction}` }),
+    )
+  })
+
+  test("does not rewrite text when the channel already supplies a button title", async () => {
+    const postbackAction = encodeButtonPayload({ flowId: "42", buttonId: "77" })
+    mockRunChannelHandler.mockResolvedValue({
+      message: { ...baseIncomingMessage, attachments: [] },
+      contact: { sourceId: "psid-123", firstName: "Test" },
+      postbackAction,
+      quickReplyAction: null,
+      buttonTitle: "Nút Messenger",
+      ref: null,
+    })
+
+    await receiveMessage(baseProps)
+
+    expect(mockDetectFlowVersion).not.toHaveBeenCalled()
+    expect(mockCreateOrUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "hello" }),
+    )
   })
 
   test("sends Vietnamese feedback instead of going silent when an appointment cancel token is invalid", async () => {

--- a/apps/worker/src/integration/handlers/flow-action.ts
+++ b/apps/worker/src/integration/handlers/flow-action.ts
@@ -1,4 +1,12 @@
-import { decodeButtonPayload } from "@chatbotx.io/flow-config"
+import {
+  decodeButtonPayload,
+  type FlowNode,
+  resolveFlowActionTarget,
+  ZALO_POSTBACK_TEXT_PREFIX,
+} from "@chatbotx.io/flow-config"
+import type { IncomingMessage } from "@chatbotx.io/sdk"
+import { normalizeError } from "universal-error-normalizer"
+import { detectFlowVersion } from "../../lib/db"
 import { logger } from "../../lib/logger"
 
 export type FlowActionKind = "postback" | "quickReply"
@@ -35,4 +43,59 @@ export const sanitizeFlowAction = (
   )
 
   return null
+}
+
+/**
+ * Zalo and Telegram deliver a button tap as a plain text message whose body is
+ * the encoded postback payload, with no button title alongside it — unlike
+ * Messenger/WhatsApp, which send the title. The echo formats differ: Zalo
+ * prefixes the payload (`postback_123::456`), Telegram sends it bare
+ * (`123::456`). Resolve the tapped button's label from the flow so the inbox
+ * shows what the contact actually pressed instead of the raw payload.
+ *
+ * Returns null (leaving the raw text untouched) whenever the channel already
+ * provided a title, the text is not the bare payload echo, or the flow/button
+ * can no longer be resolved — a stale tap must never fail the message save.
+ */
+export const resolvePostbackButtonLabel = async (props: {
+  postbackAction: string | null
+  buttonTitle: string | null | undefined
+  message: IncomingMessage | null
+  workspaceId: string
+}): Promise<string | null> => {
+  const { postbackAction, buttonTitle, message, workspaceId } = props
+  if (!postbackAction || buttonTitle || !message?.text) {
+    return null
+  }
+
+  const isRawPayloadEcho =
+    message.text === postbackAction ||
+    message.text === `${ZALO_POSTBACK_TEXT_PREFIX}${postbackAction}`
+  if (!isRawPayloadEcho) {
+    return null
+  }
+
+  const parsedAction = decodeButtonPayload(postbackAction)
+  if (!parsedAction?.buttonId) {
+    return null
+  }
+
+  try {
+    const { flowVersion } = await detectFlowVersion({
+      flowId: parsedAction.flowId,
+      flowVersionId: parsedAction.flowVersionId,
+      workspaceId,
+    })
+    const target = resolveFlowActionTarget(
+      flowVersion.nodes as unknown as FlowNode[],
+      parsedAction.buttonId,
+    )
+    return target?.details.label ?? null
+  } catch (error) {
+    logger.warn(
+      { error: normalizeError(error), postbackAction, workspaceId },
+      "Could not resolve button label for postback message",
+    )
+    return null
+  }
 }

--- a/apps/worker/src/integration/handlers/received-message.ts
+++ b/apps/worker/src/integration/handlers/received-message.ts
@@ -85,7 +85,7 @@ import {
   integrationService,
   isInstagramViaFacebook,
 } from "../../services/integrations"
-import { sanitizeFlowAction } from "./flow-action"
+import { resolvePostbackButtonLabel, sanitizeFlowAction } from "./flow-action"
 
 type ContactInboxTracking = ContactInboxTrackingData
 
@@ -249,25 +249,40 @@ export const receiveMessage = async (
     integrationIdentifier,
   })
 
-  const detected = await detectContactAndConversation({
-    incomingContact,
-    inbox,
-    integrationRow,
-    source:
-      metaReferralToContactSource(referralSource) ??
-      contactSources.enum.inboundMessage,
-  })
+  // Label resolution only reads the raw text (direction correction never
+  // changes it) and the workspace, so it can overlap the contact lookup.
+  const [detected, postbackButtonLabel] = await Promise.all([
+    detectContactAndConversation({
+      incomingContact,
+      inbox,
+      integrationRow,
+      source:
+        metaReferralToContactSource(referralSource) ??
+        contactSources.enum.inboundMessage,
+    }),
+    resolvePostbackButtonLabel({
+      postbackAction,
+      buttonTitle: parsedMessage.buttonTitle,
+      message: rawIncomingMessage,
+      workspaceId: inbox.workspaceId,
+    }),
+  ])
   if (!detected) {
     throw new SdkException("Unable to resolve contact and conversation")
   }
   const { contactInbox, conversation, contact, isNewContact } = detected
-  const incomingMessage = correctStoryReplyDirectionForNewContact(
+  const directedIncomingMessage = correctStoryReplyDirectionForNewContact(
     rawIncomingMessage,
     isNewContact,
   )
+  const incomingMessage =
+    postbackButtonLabel && directedIncomingMessage
+      ? { ...directedIncomingMessage, text: postbackButtonLabel }
+      : directedIncomingMessage
   const systemFieldUpdates = getReceivedMessageSystemFieldUpdates({
-    ...parsedMessage,
+    buttonTitle: parsedMessage.buttonTitle || postbackButtonLabel,
     message: incomingMessage,
+    referral: parsedMessage.referral,
   })
 
   // Overwrite Contact.phoneNumber/email from message text — every inbound

--- a/integrations/zalo/__tests__/outgoing-message-ids.test.ts
+++ b/integrations/zalo/__tests__/outgoing-message-ids.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockSendMessageToZaloOA } = vi.hoisted(() => ({
+  mockSendMessageToZaloOA: vi.fn(),
+}))
+
+vi.mock("../src/api/message", () => ({
+  sendMessageToZaloOA: mockSendMessageToZaloOA,
+  uploadAttachment: vi.fn(),
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+const { sendMessage, sendFlowStep } = await import(
+  "../src/handlers/message/outgoing-message"
+)
+
+const ctx = {
+  auth: { tokens: { accessToken: "tok" } },
+} as never
+
+const contact = {
+  id: "contact-1",
+  sourceId: "zalo-uid-1",
+} as never
+
+describe("zalo outgoing handlers return provider message ids", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSendMessageToZaloOA.mockResolvedValue({
+      error: 0,
+      message: "Success",
+      data: { message_id: "m_provider-1" },
+    })
+  })
+
+  test("sendMessage returns the Send API message_id so the worker can persist sourceId", async () => {
+    const result = await sendMessage({
+      ctx,
+      data: {
+        contact,
+        message: {
+          id: "msg-1",
+          contentType: "text",
+          messageType: "outgoing",
+          text: "hello",
+        },
+      },
+    } as never)
+
+    expect(mockSendMessageToZaloOA).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ messageIds: ["m_provider-1"] })
+  })
+
+  test("sendFlowStep (sendText) returns the Send API message_id", async () => {
+    const result = await sendFlowStep({
+      ctx,
+      data: {
+        contact,
+        flowId: "flow-1",
+        step: {
+          id: "step-1",
+          stepType: "sendText",
+          text: "automated reply",
+          buttons: [],
+        },
+      },
+    } as never)
+
+    expect(mockSendMessageToZaloOA).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ messageIds: ["m_provider-1"] })
+  })
+
+  test("sendMessage tolerates a response without data.message_id", async () => {
+    mockSendMessageToZaloOA.mockResolvedValue({
+      error: 0,
+      message: "Success",
+    })
+
+    const result = await sendMessage({
+      ctx,
+      data: {
+        contact,
+        message: {
+          id: "msg-1",
+          contentType: "text",
+          messageType: "outgoing",
+          text: "hello",
+        },
+      },
+    } as never)
+
+    expect(result).toEqual({ messageIds: [] })
+  })
+})

--- a/integrations/zalo/__tests__/webhook-routing.test.ts
+++ b/integrations/zalo/__tests__/webhook-routing.test.ts
@@ -1,0 +1,127 @@
+import type { ContextQueue, HandleRequestProps } from "@chatbotx.io/sdk"
+import { describe, expect, test, vi } from "vitest"
+import { webhookHandler } from "../src/handlers/webhook"
+import type { ZaloConfig } from "../src/schema/definition"
+
+const APP_ID = "app-1"
+
+const config = { clientId: APP_ID } as unknown as ZaloConfig
+
+const buildProps = (
+  body: Record<string, unknown>,
+  queueAdd: ContextQueue["add"],
+): HandleRequestProps<ZaloConfig> =>
+  ({
+    config,
+    req: new Request("https://example.com/webhook", {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+    }),
+    queue: { add: queueAdd },
+  }) as unknown as HandleRequestProps<ZaloConfig>
+
+describe("zalo webhookHandler event routing", () => {
+  test("acks user_received_message delivery receipts without enqueueing", async () => {
+    const queueAdd = vi.fn()
+
+    const result = await webhookHandler(
+      buildProps(
+        {
+          app_id: APP_ID,
+          event_name: "user_received_message",
+          sender: { id: "oa-1" },
+          recipient: { id: "user-1" },
+          message: { msg_id: "m-1" },
+        },
+        queueAdd,
+      ),
+    )
+
+    expect(result).toBe("ok")
+    expect(queueAdd).not.toHaveBeenCalled()
+  })
+
+  test("routes user_send_text to the incomingMessage queue", async () => {
+    const queueAdd = vi.fn()
+
+    await webhookHandler(
+      buildProps(
+        {
+          app_id: APP_ID,
+          event_name: "user_send_text",
+          sender: { id: "user-1" },
+          recipient: { id: "oa-1" },
+          message: { msg_id: "m-2", text: "hello" },
+        },
+        queueAdd,
+      ),
+    )
+
+    expect(queueAdd).toHaveBeenCalledWith(
+      "incomingMessage",
+      expect.objectContaining({
+        type: "incomingMessage",
+        data: expect.objectContaining({
+          integrationType: "zalo",
+          integrationIdentifier: "oa-1",
+        }),
+      }),
+    )
+  })
+
+  test("routes oa_send_text echoes to the incomingMessage queue", async () => {
+    const queueAdd = vi.fn()
+
+    await webhookHandler(
+      buildProps(
+        {
+          app_id: APP_ID,
+          event_name: "oa_send_text",
+          sender: { id: "oa-1" },
+          recipient: { id: "user-1" },
+          message: { msg_id: "m-3", text: "reply" },
+        },
+        queueAdd,
+      ),
+    )
+
+    expect(queueAdd).toHaveBeenCalledWith(
+      "incomingMessage",
+      expect.objectContaining({
+        type: "incomingMessage",
+        data: expect.objectContaining({
+          integrationIdentifier: "oa-1",
+        }),
+      }),
+    )
+  })
+
+  test("routes user_seen_message to the contactMarkAsRead queue", async () => {
+    const queueAdd = vi.fn()
+
+    await webhookHandler(
+      buildProps(
+        {
+          app_id: APP_ID,
+          event_name: "user_seen_message",
+          sender: { id: "user-1" },
+          recipient: { id: "oa-1" },
+          message: { msg_ids: ["m-4"] },
+        },
+        queueAdd,
+      ),
+    )
+
+    expect(queueAdd).toHaveBeenCalledWith(
+      "contactMarkAsRead",
+      expect.objectContaining({
+        type: "contactMarkAsRead",
+        data: expect.objectContaining({
+          integrationIdentifier: "oa-1",
+          sourceConversationId: "user-1",
+        }),
+      }),
+    )
+  })
+})

--- a/integrations/zalo/src/handlers/message/incoming-message/index.ts
+++ b/integrations/zalo/src/handlers/message/incoming-message/index.ts
@@ -1,3 +1,4 @@
+import { ZALO_POSTBACK_TEXT_PREFIX } from "@chatbotx.io/flow-config"
 import {
   type Context,
   contentTypes,
@@ -134,8 +135,8 @@ const getMessageEntity = async (
 
   // Detect postback action
   let postbackAction: string | null = null
-  if (message.text?.startsWith("postback_")) {
-    postbackAction = message.text.replace("postback_", "")
+  if (message.text?.startsWith(ZALO_POSTBACK_TEXT_PREFIX)) {
+    postbackAction = message.text.slice(ZALO_POSTBACK_TEXT_PREFIX.length)
   }
 
   return { message, postbackAction }

--- a/integrations/zalo/src/handlers/message/outgoing-message/index.ts
+++ b/integrations/zalo/src/handlers/message/outgoing-message/index.ts
@@ -29,13 +29,17 @@ export const sendMessage: MessageHandlers<ZaloAuthValue>["sendMessage"] =
       ctx,
       data: { contact, message },
     } = props
+    const messageIds: string[] = []
     try {
       for await (const zaloMessage of convertMessageToZaloMessage(
         ctx.auth,
         message,
       )) {
         const payload = buildMessagePayload(contact, zaloMessage)
-        await sendMessageToZaloOA(ctx.auth, payload)
+        const response = await sendMessageToZaloOA(ctx.auth, payload)
+        if (response.data?.message_id) {
+          messageIds.push(response.data.message_id)
+        }
         logger.info(`Message sent for Zalo OA UID: ${contact.sourceId}`)
       }
     } catch (error) {
@@ -43,8 +47,10 @@ export const sendMessage: MessageHandlers<ZaloAuthValue>["sendMessage"] =
       throw mapToChannelError(error)
     }
 
+    // Returning the provider ids lets the worker backfill the row's sourceId,
+    // so the oa_send_* webhook echo dedups instead of inserting a duplicate.
     return {
-      messageIds: [],
+      messageIds,
     }
   }
 
@@ -150,12 +156,16 @@ export const sendFlowStep: MessageHandlers<ZaloAuthValue>["sendFlowStep"] =
       ctx,
       data: { contact },
     } = props
+    const messageIds: string[] = []
     try {
       for await (const zaloMessage of convertFlowStepToZaloMessage(props)) {
-        await sendMessageToZaloOA(
+        const response = await sendMessageToZaloOA(
           ctx.auth,
           buildMessagePayload(contact, zaloMessage),
         )
+        if (response.data?.message_id) {
+          messageIds.push(response.data.message_id)
+        }
         logger.info(`Message sent for ID: ${contact.sourceId}`)
       }
     } catch (error) {
@@ -164,6 +174,6 @@ export const sendFlowStep: MessageHandlers<ZaloAuthValue>["sendFlowStep"] =
     }
 
     return {
-      messageIds: [],
+      messageIds,
     }
   }

--- a/integrations/zalo/src/handlers/message/outgoing-message/send-button.ts
+++ b/integrations/zalo/src/handlers/message/outgoing-message/send-button.ts
@@ -5,6 +5,7 @@ import {
   encodeButtonPayload,
   extractMetadata,
   type MetadataPayload,
+  ZALO_POSTBACK_TEXT_PREFIX,
 } from "@chatbotx.io/flow-config"
 import type { MessageButtonTemplate } from "@chatbotx.io/sdk"
 import { chunk } from "remeda"
@@ -42,7 +43,7 @@ export function getButtonTemplate(props: {
       return {
         type: "oa.query.hide",
         title: button.label,
-        payload: `postback_${buttonPayload}`,
+        payload: `${ZALO_POSTBACK_TEXT_PREFIX}${buttonPayload}`,
       }
   }
 }
@@ -82,6 +83,6 @@ export function getCanonicalButtonTemplate(
   return {
     type: "oa.query.hide",
     title: button.label,
-    payload: `postback_${button.postback}`,
+    payload: `${ZALO_POSTBACK_TEXT_PREFIX}${button.postback}`,
   }
 }

--- a/integrations/zalo/src/handlers/webhook.ts
+++ b/integrations/zalo/src/handlers/webhook.ts
@@ -87,6 +87,14 @@ const handleWebhookEvent = async (
       throw new SdkException("Missing sender/recipient in message event")
     }
 
+    // Delivery receipts carry only the delivered msg_id — no text or
+    // attachments — so routing them to incomingMessage makes the handler
+    // throw "No content found" and the job retry forever. There is no
+    // delivered-status pipeline yet; ack and drop.
+    if (webhookData.event_name === "user_received_message") {
+      return
+    }
+
     if (webhookData.event_name === "user_seen_message") {
       await queue.add("contactMarkAsRead", {
         type: "contactMarkAsRead",

--- a/integrations/zalo/src/schema/webhook.ts
+++ b/integrations/zalo/src/schema/webhook.ts
@@ -123,6 +123,7 @@ export const zaloWebhookEventSchema = z.object({
       "user_send_location",
       "user_send_file",
       "user_send_audio",
+      "user_received_message",
       "user_seen_message",
       "oa_send_msg",
       "oa_send_text",
@@ -173,10 +174,17 @@ export const zaloSendMessageRequest = z.object({
 })
 export type ZaloSendMessageRequest = z.infer<typeof zaloSendMessageRequest>
 
+// The /v3.0/oa/message/cs response is enveloped like uploadAttachmentResponse;
+// message_id here equals the msg_id later echoed on oa_send_* webhook events.
 export const zaloSendMessageResponseSchema = z.object({
-  recipient_id: z.string(),
-  message_id: z.string().optional(),
-  attachment_id: z.string().optional(),
+  data: z
+    .object({
+      message_id: z.string().optional(),
+      user_id: z.string().optional(),
+    })
+    .optional(),
+  error: z.number(),
+  message: z.string(),
 })
 export type ZaloSendMessageResponse = z.infer<
   typeof zaloSendMessageResponseSchema

--- a/packages/flow-config/src/util.ts
+++ b/packages/flow-config/src/util.ts
@@ -70,6 +70,13 @@ export const buttonPayloadSchema = z
   }))
 export type ButtonPayload = z.infer<typeof buttonPayloadSchema>
 
+/**
+ * Zalo-only wire prefix: `oa.query.hide` button payloads echo back from the
+ * webhook as a text message reading `postback_<payload>`. Zalo's send/receive
+ * handlers and the worker's label resolution must all agree on this marker.
+ */
+export const ZALO_POSTBACK_TEXT_PREFIX = "postback_"
+
 export const encodeButtonPayload = (props: ButtonPayload): string => {
   const parts = [
     props.flowId,


### PR DESCRIPTION
## Summary
- Messages sent from the ChatbotX inbox to a Zalo OA contact appeared twice in the conversation: the Send API response was mistyped as flat, so the provider `message_id` was discarded, the worker's `sourceId` backfill no-oped, and the `oa_send_*` webhook echo missed the `findBySourceId` dedup and inserted a second row. Fix the response schema to the real `{ data, error, message }` envelope and return the provider ids from `sendMessage`/`sendFlowStep` so the existing dedup path works. Delivery is unaffected — only ChatbotX's own inbox showed duplicates.
- `user_received_message` delivery receipts carry no content; routing them to `incomingMessage` made the handler throw "No content found" and the job retry forever. Ack and drop them at the webhook router.
- Zalo button taps echoed back as raw `postback_<flowId>::<buttonId>` text in the inbox; resolve the tapped button's label from the flow version before saving, falling back to the raw text when the flow can no longer be resolved.

## Changes
- `integrations/zalo/src/schema/webhook.ts` — envelope-shaped `zaloSendMessageResponseSchema`, add `user_received_message` to the event enum
- `integrations/zalo/src/handlers/message/outgoing-message/index.ts` — collect and return real `messageIds` from `sendMessage`/`sendFlowStep`
- `integrations/zalo/src/handlers/webhook.ts` — ack `user_received_message` without enqueueing
- `apps/worker/src/integration/handlers/flow-action.ts`, `received-message.ts` — `resolvePostbackButtonLabel` and wiring
- `packages/flow-config/src/util.ts`, `integrations/zalo/.../send-button.ts`, `incoming-message/index.ts` — shared `ZALO_POSTBACK_TEXT_PREFIX` constant
- Tests: `integrations/zalo/__tests__/outgoing-message-ids.test.ts`, `webhook-routing.test.ts`, extended `apps/worker/__tests__/received-message.test.ts`

## Test plan
- [x] `pnpm --filter @chatbotx.io/integration-zalo test` (31 passed)
- [x] `pnpm --filter worker test` (1571 passed)
- [x] `pnpm --filter @chatbotx.io/flow-config test` (289 passed)
- [x] `check-types` clean for `integration-zalo`, `worker`, `flow-config`
- [ ] Manual: send one text from the inbox to a Zalo OA contact — exactly one row with a non-null `sourceId`; confirm Send API `message_id` equals the echo's `msg_id` on live traffic
- [ ] Manual: tap a flow button on Zalo — inbox shows the button label, not `postback_...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)