### PR TITLE
feat(flows): allow custom field variables in media step urls

### DIFF
--- a/apps/builder/src/components/direct-upload.tsx
+++ b/apps/builder/src/components/direct-upload.tsx
@@ -5,8 +5,14 @@ import { FormFieldWrapper } from "@chatbotx.io/ui/components/form/field-wrapper"
 import { InputField } from "@chatbotx.io/ui/components/form/input-field"
 import { Button } from "@chatbotx.io/ui/components/ui/button"
 import { Input } from "@chatbotx.io/ui/components/ui/input"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@chatbotx.io/ui/components/ui/popover"
 import { DirectUploadButton } from "@chatbotx.io/ui/components/uploader/direct-upload-button"
 import {
+  CodeXml,
   FileIcon,
   ImageIcon,
   ImagePlayIcon,
@@ -16,21 +22,86 @@ import {
 } from "lucide-react"
 import Image from "next/image"
 import { useTranslations } from "next-intl"
-import { useMemo, useRef } from "react"
+import { useMemo, useRef, useState } from "react"
 import { useFormContext, useWatch } from "react-hook-form"
 import { toast } from "sonner"
+import { usePromptVariableOptions } from "@/components/tiptap/use-prompt-variable-options"
 import { useWorkspaceId } from "@/hooks/routing"
+
+function UrlVariablePicker({
+  onSelect,
+}: {
+  onSelect: (variableName: string) => void
+}) {
+  const t = useTranslations()
+  const [isOpen, setIsOpen] = useState(false)
+  const promptVariableOptions = usePromptVariableOptions({})
+
+  if (promptVariableOptions.length === 0) {
+    return null
+  }
+
+  return (
+    <Popover onOpenChange={setIsOpen} open={isOpen}>
+      <PopoverTrigger
+        render={
+          <Button
+            aria-label={t("actions.addVariable")}
+            size="icon"
+            title={t("actions.addVariable")}
+            type="button"
+            variant="outline"
+          >
+            <CodeXml className="size-4" />
+          </Button>
+        }
+      />
+      <PopoverContent className="w-auto p-0">
+        <div className="max-h-60 w-50 overflow-y-auto">
+          {promptVariableOptions.map((field, index) => {
+            const showGroup =
+              Boolean(field.group) &&
+              promptVariableOptions[index - 1]?.group !== field.group
+
+            return (
+              <div key={field.value}>
+                {showGroup ? (
+                  <div className="px-2 pt-2 pb-1 font-medium text-muted-foreground text-xs">
+                    {field.group}
+                  </div>
+                ) : null}
+                <Button
+                  className="w-full cursor-pointer justify-start rounded-none p-2"
+                  onClick={() => {
+                    onSelect(field.value)
+                    setIsOpen(false)
+                  }}
+                  variant="ghost"
+                >
+                  {field.label}
+                </Button>
+              </div>
+            )
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
 
 export function DirectUploadOrInsertLink({
   parentName,
   fileType,
   uploadPath,
   onSuccess,
+  showVariablePicker = false,
 }: {
   parentName: string
   fileType: FileType
   uploadPath: string
   onSuccess?: (url: string) => void
+  // Requires a mounted CustomFieldStoreProvider (e.g. inside the flow editor).
+  showVariablePicker?: boolean
 }) {
   const t = useTranslations()
   const workspaceId = useWorkspaceId()
@@ -81,6 +152,14 @@ export function DirectUploadOrInsertLink({
         }
     }
   }, [fileType])
+
+  const insertUrlVariable = (variableName: string) => {
+    const currentUrl = getValues(`${parentName}.url`) || ""
+    setValue(`${parentName}.url`, `${currentUrl}{{${variableName}}}`, {
+      shouldValidate: true,
+      shouldDirty: true,
+    })
+  }
 
   const clearInputFile = () => {
     setValue(`${parentName}.url`, "", {
@@ -215,6 +294,9 @@ export function DirectUploadOrInsertLink({
             name={`${parentName}.url`}
             placeholder={t("fields.url.placeholder")}
           />
+          {showVariablePicker && (
+            <UrlVariablePicker onSelect={insertUrlVariable} />
+          )}
           {onSuccess && (
             <Button
               disabled={!publicUrl}

--- a/apps/builder/src/features/flows/react-flow/steps/send-audio/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-audio/editor.tsx
@@ -20,6 +20,7 @@ const SendAudioStepEditor = ({ parentName }: SendAudioStepEditorProps) => {
         <DirectUploadOrInsertLink
           fileType="audio"
           parentName={parentName}
+          showVariablePicker
           uploadPath={`public/space/${params.workspaceId}/flows/${params.id}/steps/${stepId}`}
         />
       </div>

--- a/apps/builder/src/features/flows/react-flow/steps/send-card/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-card/editor.tsx
@@ -23,6 +23,7 @@ const SendCardStepEditor = ({ parentName }: SendCardStepEditorProps) => {
         <DirectUploadOrInsertLink
           fileType="image"
           parentName={`${parentName}.image`}
+          showVariablePicker
           uploadPath={`public/space/${params.workspaceId}/flows/${params.id}/steps/${stepId}`}
         />
         <Input

--- a/apps/builder/src/features/flows/react-flow/steps/send-file/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-file/editor.tsx
@@ -20,6 +20,7 @@ const SendFileStepEditor = ({ parentName }: SendFileStepEditorProps) => {
         <DirectUploadOrInsertLink
           fileType="file"
           parentName={parentName}
+          showVariablePicker
           uploadPath={`public/space/${params.workspaceId}/flows/${params.id}/steps/${stepId}`}
         />
       </div>

--- a/apps/builder/src/features/flows/react-flow/steps/send-image/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-image/editor.tsx
@@ -20,6 +20,7 @@ const SendImageStepEditor = ({ parentName }: SendImageStepEditorProps) => {
         <DirectUploadOrInsertLink
           fileType="image"
           parentName={parentName}
+          showVariablePicker
           uploadPath={`public/space/${params.workspaceId}/flows/${params.id}/steps/${stepId}`}
         />
       </div>

--- a/apps/builder/src/features/flows/react-flow/steps/send-video/editor.tsx
+++ b/apps/builder/src/features/flows/react-flow/steps/send-video/editor.tsx
@@ -20,6 +20,7 @@ const SendVideoStepEditor = ({ parentName }: SendVideoStepEditorProps) => {
         <DirectUploadOrInsertLink
           fileType="video"
           parentName={parentName}
+          showVariablePicker
           uploadPath={`public/space/${params.workspaceId}/flows/${params.id}/steps/${stepId}`}
         />
       </div>

--- a/packages/flow-config/src/steps/send-audio.ts
+++ b/packages/flow-config/src/steps/send-audio.ts
@@ -1,4 +1,4 @@
-import { createId } from "@chatbotx.io/utils"
+import { createId, zodUrlWithVariables } from "@chatbotx.io/utils"
 import { z } from "zod"
 import { uploadModes } from "../types"
 import { baseStepSchema } from "./base"
@@ -8,7 +8,7 @@ import { stepTypes } from "./step-action"
 export const sendAudioStepSchema = baseStepSchema.extend({
   stepType: z.literal(stepTypes.enum.sendAudio),
   mode: uploadModes,
-  url: z.url(),
+  url: zodUrlWithVariables(),
   buttons: z.array(buttonStepSchema),
 })
 

--- a/packages/flow-config/src/steps/send-card.ts
+++ b/packages/flow-config/src/steps/send-card.ts
@@ -1,4 +1,4 @@
-import { createId } from "@chatbotx.io/utils"
+import { createId, zodUrlWithVariables } from "@chatbotx.io/utils"
 import { z } from "zod"
 import { baseStepSchema } from "./base"
 import { buttonStepSchema } from "./button"
@@ -11,7 +11,7 @@ export const sendCardStepSchema = baseStepSchema.extend({
   subtitle: z.string().trim().max(80).optional(),
   image: sendImageStepSchema
     .extend({
-      url: z.url().or(z.literal("")),
+      url: zodUrlWithVariables().or(z.literal("")),
     })
     .optional(),
   buttons: z.array(buttonStepSchema).max(3),

--- a/packages/flow-config/src/steps/send-file.ts
+++ b/packages/flow-config/src/steps/send-file.ts
@@ -1,4 +1,4 @@
-import { createId } from "@chatbotx.io/utils"
+import { createId, zodUrlWithVariables } from "@chatbotx.io/utils"
 import { z } from "zod"
 import { uploadModes } from "../types"
 import { baseStepSchema } from "./base"
@@ -8,7 +8,7 @@ import { stepTypes } from "./step-action"
 export const sendFileStepSchema = baseStepSchema.extend({
   stepType: z.literal(stepTypes.enum.sendFile),
   mode: uploadModes,
-  url: z.url(),
+  url: zodUrlWithVariables(),
   buttons: z.array(buttonStepSchema),
 })
 

--- a/packages/flow-config/src/steps/send-gif.ts
+++ b/packages/flow-config/src/steps/send-gif.ts
@@ -1,11 +1,11 @@
-import { createId } from "@chatbotx.io/utils"
+import { createId, zodUrlWithVariables } from "@chatbotx.io/utils"
 import { z } from "zod"
 import { baseStepSchema } from "./base"
 import { stepTypes } from "./step-action"
 
 export const sendGifStepSchema = baseStepSchema.extend({
   stepType: z.literal(stepTypes.enum.sendGif),
-  url: z.url(),
+  url: zodUrlWithVariables(),
 })
 
 export type SendGifStepSchema = z.infer<typeof sendGifStepSchema>

--- a/packages/flow-config/src/steps/send-image.ts
+++ b/packages/flow-config/src/steps/send-image.ts
@@ -1,4 +1,4 @@
-import { createId } from "@chatbotx.io/utils"
+import { createId, zodUrlWithVariables } from "@chatbotx.io/utils"
 import { z } from "zod"
 import { uploadModes } from "../types"
 import { baseStepSchema } from "./base"
@@ -8,7 +8,9 @@ import { stepTypes } from "./step-action"
 export const sendImageStepSchema = baseStepSchema.extend({
   stepType: z.literal(stepTypes.enum.sendImage),
   mode: uploadModes,
-  url: z.url(),
+  // Accepts a plain URL or a `{{customField}}` placeholder resolved at send
+  // time by the worker's contact-variable interpolation.
+  url: zodUrlWithVariables(),
   buttons: z.array(buttonStepSchema),
 })
 

--- a/packages/flow-config/src/steps/send-video.ts
+++ b/packages/flow-config/src/steps/send-video.ts
@@ -1,4 +1,4 @@
-import { createId } from "@chatbotx.io/utils"
+import { createId, zodUrlWithVariables } from "@chatbotx.io/utils"
 import { z } from "zod"
 import { uploadModes } from "../types"
 import { baseStepSchema } from "./base"
@@ -8,7 +8,7 @@ import { stepTypes } from "./step-action"
 export const sendVideoStepSchema = baseStepSchema.extend({
   stepType: z.literal(stepTypes.enum.sendVideo),
   mode: uploadModes,
-  url: z.url(),
+  url: zodUrlWithVariables(),
   buttons: z.array(buttonStepSchema),
 })
 


### PR DESCRIPTION
## Summary
- Media send steps (image, card/carousel, video, audio, file, gif) rejected `{{customField}}` values in the URL field because the schema used a strict `z.url()`, even though the worker already interpolates contact variables on the whole step before sending (`resolveContactVariablesDeep` in `send-flow-step.ts`).
- Relax the url schema to the existing `zodUrlWithVariables()` helper (same pattern as the open-website step), so a value that is a valid URL or contains a `{{...}}` placeholder passes; empty/plain-text values are still rejected.
- Add a custom-field picker dropdown next to the URL input (same option source as the message editor's variable popover) so users can insert `{{field}}` without typing it.

## Changes
- `packages/flow-config/src/steps/send-{image,card,video,audio,file,gif}.ts` — `z.url()` → `zodUrlWithVariables()` (card keeps `.or(z.literal(""))`).
- `apps/builder/src/components/direct-upload.tsx` — new `UrlVariablePicker` popover, opt-in via `showVariablePicker` prop (requires `CustomFieldStoreProvider`, mounted in the flow editor).
- `apps/builder/src/features/flows/react-flow/steps/send-{image,card,video,audio,file}/editor.tsx` — enable the picker.

No i18n changes (reuses `actions.addVariable`). Canvas viewers are safe with placeholder values: `useDynamicImagePreview` only renders previews for `https` URLs.

## Test plan
- [x] biome check on changed files
- [x] pnpm --filter @chatbotx.io/flow-config check-types
- [x] pnpm --filter builder check-types
- [x] schema smoke test: `{{image}}` accepted, plain text and empty string still rejected
- [ ] manual verification: insert `{{image}}` via picker in an Image step, publish, run flow with a contact whose `image` custom field holds an image link

🤖 Generated with [Claude Code](https://claude.com/claude-code)