### PR TITLE
fix(builder): use absolute link for google sheets manage button

### DIFF
--- a/apps/builder/src/features/integration-google-sheets/google-sheets-manage.tsx
+++ b/apps/builder/src/features/integration-google-sheets/google-sheets-manage.tsx
@@ -58,7 +58,10 @@ export function GoogleSheetsManage({
       {integrationGoogleSheets ? (
         <div className="flex flex-col gap-2">
           <Button size="sm" variant="secondary">
-            <Link className="w-full" href="../google-sheets">
+            <Link
+              className="w-full"
+              href={`/space/${workspaceId}/google-sheets`}
+            >
               {t("actions.manage")}
             </Link>
           </Button>


### PR DESCRIPTION
## Summary
- The **Manage** button on the Google Sheets integration settings page led to a 404 (`/space/:id/settings/google-sheets`). It used the only relative `href` in the app (`../google-sheets`), which broke when #945 converted the integration settings parallel-route slots into real nested routes and changed the page URL.
- Replace it with an absolute link to the spreadsheets page so it no longer depends on where the parent route lives.

## Changes
- `apps/builder/src/features/integration-google-sheets/google-sheets-manage.tsx` — `href="../google-sheets"` → `` href={`/space/${workspaceId}/google-sheets`} `` (uses the existing `workspaceId` prop)

## Test plan
- [x] `biome check` clean on the touched file
- [x] `pnpm --filter builder check-types` clean
- [ ] Manual: on `/space/:id/settings/integrations/google-sheets` with a connected account, click **Manage** — lands on `/space/:id/google-sheets` (spreadsheets list), not a 404