### PR TITLE
fix(comment-automation): send private reply flows on instagram channels

### DIFF
--- a/apps/worker/__tests__/comment-automation.test.ts
+++ b/apps/worker/__tests__/comment-automation.test.ts
@@ -632,7 +632,7 @@ describe("processCommentAutomation flow private reply", () => {
     )
   })
 
-  test("instagram: enqueues sendFlow without a commentAnchor (no private_replies API)", async () => {
+  test("instagram: enqueues a sendFlow job carrying a private commentAnchor", async () => {
     mockFindActiveAutomations.mockResolvedValue([
       buildAutomation({ privateReply: { type: "flow", value: "flow-1" } }),
     ])
@@ -645,7 +645,34 @@ describe("processCommentAutomation flow private reply", () => {
     expect(mockIntegrationQueueAdd).toHaveBeenCalledWith(
       "sendFlow",
       expect.objectContaining({
-        data: expect.not.objectContaining({ commentAnchor: expect.anything() }),
+        type: "sendFlow",
+        data: expect.objectContaining({
+          flowId: "flow-1",
+          commentAnchor: { commentId: COMMENT_ID, replyChannel: "private" },
+        }),
+      }),
+      expect.anything(),
+    )
+  })
+
+  test("instagramFacebook: enqueues a sendFlow job carrying a private commentAnchor", async () => {
+    mockFindActiveAutomations.mockResolvedValue([
+      buildAutomation({ privateReply: { type: "flow", value: "flow-1" } }),
+    ])
+
+    await processCommentAutomation({
+      ...buildJobData(),
+      integrationType: "instagramFacebook",
+    } as any)
+
+    expect(mockIntegrationQueueAdd).toHaveBeenCalledWith(
+      "sendFlow",
+      expect.objectContaining({
+        type: "sendFlow",
+        data: expect.objectContaining({
+          flowId: "flow-1",
+          commentAnchor: { commentId: COMMENT_ID, replyChannel: "private" },
+        }),
       }),
       expect.anything(),
     )

--- a/apps/worker/__tests__/send-flow-step.test.ts
+++ b/apps/worker/__tests__/send-flow-step.test.ts
@@ -1101,12 +1101,32 @@ describe("sendFlowStep", () => {
     expect(mockSendMessageToChannel).not.toHaveBeenCalled()
   })
 
-  test("suppresses a private commentAnchor when the resolved contactInbox is not messenger", async () => {
+  test("forwards a private commentAnchor when the resolved contactInbox is instagram", async () => {
     const instagramContactInbox = {
       ...fakeContactInbox,
       channel: "instagram",
     } as unknown as typeof fakeContactInbox
     mockFindContactInbox.mockResolvedValue(instagramContactInbox)
+
+    await sendFlowStep({
+      ...baseParams,
+      commentAnchor: { commentId: "comment-1", replyChannel: "private" },
+    })
+
+    expect(mockSendFlowStepToChannel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commentAnchor: { commentId: "comment-1", replyChannel: "private" },
+      }),
+    )
+    expect(mockSendMessageToChannel).not.toHaveBeenCalled()
+  })
+
+  test("suppresses a private commentAnchor when the resolved contactInbox is neither messenger nor instagram", async () => {
+    const webchatContactInbox = {
+      ...fakeContactInbox,
+      channel: "webchat",
+    } as unknown as typeof fakeContactInbox
+    mockFindContactInbox.mockResolvedValue(webchatContactInbox)
 
     await sendFlowStep({
       ...baseParams,

--- a/apps/worker/src/chat/handlers/send-flow-step.ts
+++ b/apps/worker/src/chat/handlers/send-flow-step.ts
@@ -696,13 +696,16 @@ export async function sendFlowStep({
           messageId: message?.id,
           messageCreatedAt: message?.createdAt,
           sendFrom,
-          // Comment-anchored private replies are Messenger-only (no Instagram
-          // private_replies equivalent) — defensive re-check in case a resolved
-          // contactInboxId ever points at a different channel than the job
-          // intended. A "public" anchor never reaches this branch (routed to
-          // sendMessageToChannel above instead).
+          // Comment-anchored private replies are supported on Messenger and
+          // Instagram (both variants collapse to the "instagram" channel),
+          // which share Meta's comment_id-anchored Send API — defensive
+          // re-check in case a resolved contactInboxId ever points at a
+          // different channel than the job intended. A "public" anchor never
+          // reaches this branch (routed to sendMessageToChannel above
+          // instead).
           commentAnchor:
-            targetContactInbox.channel === channelTypes.enum.messenger &&
+            (targetContactInbox.channel === channelTypes.enum.messenger ||
+              targetContactInbox.channel === channelTypes.enum.instagram) &&
             commentAnchor?.replyChannel === "private"
               ? commentAnchor
               : undefined,

--- a/apps/worker/src/integration/handlers/comment-automation/private-reply.ts
+++ b/apps/worker/src/integration/handlers/comment-automation/private-reply.ts
@@ -103,14 +103,15 @@ export async function executePrivateReply(
           contactInboxId: ctx.contactInboxId,
           flowId: privateReply.value,
           origin: webhookChannelOrigin(),
-          ...(ctx.channelType === "messenger"
-            ? {
-                commentAnchor: {
-                  commentId: ctx.commentId,
-                  replyChannel: "private" as const,
-                },
-              }
-            : {}),
+          // The anchor lets the channel deliver the flow's first message via
+          // Meta's comment_id-anchored Send API (7-day comment window) instead
+          // of a normal DM gated by the 24-hour messaging window. Supported on
+          // all comment-automation channels (messenger, instagram,
+          // instagramFacebook).
+          commentAnchor: {
+            commentId: ctx.commentId,
+            replyChannel: "private" as const,
+          },
         },
       },
       { delay: ctx.delay },

--- a/integrations/instagram-facebook/__tests__/send-flow-step-comment-anchor.test.ts
+++ b/integrations/instagram-facebook/__tests__/send-flow-step-comment-anchor.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockSendInstagramMessage, mockSendPrivateReplyMessage } = vi.hoisted(
+  () => ({
+    mockSendInstagramMessage: vi.fn(),
+    mockSendPrivateReplyMessage: vi.fn(),
+  }),
+)
+
+vi.mock("../src/apis/page", () => ({
+  sendInstagramMessage: mockSendInstagramMessage,
+}))
+
+vi.mock("../src/apis/comment", () => ({
+  sendPrivateReplyMessage: mockSendPrivateReplyMessage,
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+const { sendFlowStep } = await import(
+  "../src/handlers/message/outgoing-message"
+)
+
+const ctx = {
+  auth: {
+    tokens: { accessToken: "tok" },
+    metadata: { igId: "ig-1", version: "v23.0" },
+  },
+} as never
+
+const contact = { id: "contact-1", sourceId: "igsid-1" } as never
+
+const textStep = {
+  id: "step-1",
+  nodeId: "node-1",
+  stepType: "sendText",
+  text: "private reply via flow",
+  buttons: [],
+}
+
+describe("instagram-facebook sendFlowStep — comment-anchored private reply", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSendInstagramMessage.mockResolvedValue({
+      recipient_id: "igsid-1",
+      message_id: "m_normal-1",
+    })
+    mockSendPrivateReplyMessage.mockResolvedValue({
+      recipient_id: "igsid-1",
+      message_id: "m_anchored-1",
+    })
+  })
+
+  test("uses the comment_id-anchored Send API when commentAnchor is present", async () => {
+    const result = await sendFlowStep({
+      ctx,
+      data: {
+        contact,
+        commentAnchor: { commentId: "comment-1", replyChannel: "private" },
+        step: textStep,
+      },
+    } as never)
+
+    expect(mockSendPrivateReplyMessage).toHaveBeenCalledTimes(1)
+    expect(mockSendPrivateReplyMessage).toHaveBeenCalledWith(
+      ctx.auth,
+      "comment-1",
+      expect.objectContaining({ text: "private reply via flow" }),
+    )
+    expect(mockSendInstagramMessage).not.toHaveBeenCalled()
+    expect(result).toEqual({ messageIds: ["m_anchored-1"] })
+  })
+
+  test("uses the normal Send API when commentAnchor.replyChannel is public (defense-in-depth: public replies are never routed here)", async () => {
+    const result = await sendFlowStep({
+      ctx,
+      data: {
+        contact,
+        commentAnchor: { commentId: "comment-1", replyChannel: "public" },
+        step: textStep,
+      },
+    } as never)
+
+    expect(mockSendInstagramMessage).toHaveBeenCalledTimes(1)
+    expect(mockSendPrivateReplyMessage).not.toHaveBeenCalled()
+    expect(result).toEqual({ messageIds: ["m_normal-1"] })
+  })
+
+  test("uses the normal Send API when commentAnchor is absent (regression guard)", async () => {
+    const result = await sendFlowStep({
+      ctx,
+      data: {
+        contact,
+        step: textStep,
+      },
+    } as never)
+
+    expect(mockSendInstagramMessage).toHaveBeenCalledTimes(1)
+    expect(mockSendPrivateReplyMessage).not.toHaveBeenCalled()
+    expect(result).toEqual({ messageIds: ["m_normal-1"] })
+  })
+
+  test("only the first Instagram message of a multi-message step uses the comment anchor", async () => {
+    const cards = Array.from({ length: 11 }, (_, i) => ({
+      title: `Card ${i}`,
+      buttons: [],
+    }))
+
+    const result = await sendFlowStep({
+      ctx,
+      data: {
+        contact,
+        commentAnchor: { commentId: "comment-1", replyChannel: "private" },
+        step: {
+          id: "step-1",
+          nodeId: "node-1",
+          stepType: "sendCarousel",
+          cards,
+        },
+      },
+    } as never)
+
+    // 11 cards chunked by 10 → 2 Instagram messages for this single step
+    expect(mockSendPrivateReplyMessage).toHaveBeenCalledTimes(1)
+    expect(mockSendPrivateReplyMessage).toHaveBeenCalledWith(
+      ctx.auth,
+      "comment-1",
+      expect.anything(),
+    )
+    expect(mockSendInstagramMessage).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ messageIds: ["m_anchored-1", "m_normal-1"] })
+  })
+})

--- a/integrations/instagram-facebook/__tests__/send-private-reply.test.ts
+++ b/integrations/instagram-facebook/__tests__/send-private-reply.test.ts
@@ -24,7 +24,10 @@ describe("sendPrivateReply", () => {
           )
           await expect(request.json()).resolves.toEqual({
             recipient: { comment_id: COMMENT_ID },
-            message: { text: "Hello from Instagram via Facebook" },
+            message: {
+              text: "Hello from Instagram via Facebook",
+              metadata: "SENT_FROM_CHATBOTX",
+            },
           })
           return HttpResponse.json({ recipient_id: "recipient-1" })
         },

--- a/integrations/instagram-facebook/src/apis/comment.ts
+++ b/integrations/instagram-facebook/src/apis/comment.ts
@@ -1,7 +1,13 @@
 import { DEFAULT_API_VERSION } from "../constants"
 import { rescue } from "../exception"
 import { instagramGraphClient } from "../lib/http-client"
-import type { InstagramAuthValue } from "../schemas"
+import {
+  INSTAGRAM_MESSAGE_METADATA,
+  type InstagramAuthValue,
+  type InstagramMessageAttachmentPayload,
+  type InstagramSendMessage,
+  type InstagramSendMessageResponse,
+} from "../schemas"
 
 export const sendComment = (
   auth: InstagramAuthValue,
@@ -58,37 +64,49 @@ export const hideComment = (
 }
 
 /**
- * Sends a private DM reply to the author of a comment, addressing the
- * Instagram business account directly via igId rather than the Page node
- * (Meta's Messenger Platform private-reply endpoint also accepts
+ * Sends a private DM reply to the author of a comment with an arbitrary
+ * message payload (text, attachment, quick replies, …) — used by flow-based
+ * private replies to deliver the *first* outgoing message of the run,
+ * addressing the Instagram business account directly via igId rather than the
+ * Page node (Meta's Messenger Platform private-reply endpoint also accepts
  * `/<IG_ID>/messages` — see
  * https://developers.facebook.com/docs/messenger-platform/instagram/features/private-replies).
+ * The comment_id-anchored Send API bypasses the normal messaging-window
+ * requirement.
+ *
+ * Stamps `message.metadata` like every other Instagram send path so the
+ * message_echo webhook (`handlers/webhook.ts`) recognizes and skips our own
+ * echo instead of re-ingesting it as an incoming message.
  */
-export const sendPrivateReply = (
+export const sendPrivateReplyMessage = (
   auth: InstagramAuthValue,
   commentId: string,
-  message: string,
-): Promise<{ message_id?: string; recipient_id: string }> => {
+  message: InstagramSendMessage | InstagramMessageAttachmentPayload,
+): Promise<InstagramSendMessageResponse> => {
   const version = auth.metadata.version ?? DEFAULT_API_VERSION
   const endpoint = `${version}/${auth.metadata.igId}/messages`
 
   return rescue(endpoint, () =>
-    instagramGraphClient.post<{
-      message_id?: string
-      recipient_id: string
-    }>(endpoint, {
+    instagramGraphClient.post<InstagramSendMessageResponse>(endpoint, {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${auth.tokens.accessToken}`,
       },
       json: {
         recipient: { comment_id: commentId },
-        message: { text: message },
+        message: { ...message, metadata: INSTAGRAM_MESSAGE_METADATA },
       },
       retry: 0,
     }),
   )
 }
+
+export const sendPrivateReply = (
+  auth: InstagramAuthValue,
+  commentId: string,
+  message: string,
+): Promise<InstagramSendMessageResponse> =>
+  sendPrivateReplyMessage(auth, commentId, { text: message })
 
 export const likeComment = (
   auth: InstagramAuthValue,

--- a/integrations/instagram-facebook/src/handlers/message/outgoing-message/index.ts
+++ b/integrations/instagram-facebook/src/handlers/message/outgoing-message/index.ts
@@ -15,6 +15,7 @@ import {
   type OutgoingMessage,
   type SendFlowStepProps,
 } from "@chatbotx.io/sdk"
+import { sendPrivateReplyMessage } from "../../../apis/comment"
 import { sendInstagramMessage } from "../../../apis/page"
 import { mapToChannelError } from "../../../lib/error-mapper"
 import { logger } from "../../../lib/logger"
@@ -193,17 +194,37 @@ export const sendFlowStep = async (
 ) => {
   const {
     ctx,
-    data: { contact },
+    data: { contact, commentAnchor },
   } = props
   const messageIds: string[] = []
   try {
+    // Consumed by the first Instagram message yielded below, if a private
+    // comment anchor is present — a single flow step can yield more than one
+    // message (e.g. text + attachments), so only the very first send uses the
+    // comment_id-anchored API (exempt from the messaging window); the rest
+    // use the normal path. A "public" anchor is never honored here — it's
+    // delivered via the comment channel's sendComment, not this message
+    // channel's sendFlowStep (see send-flow-step.ts). This check is
+    // defense-in-depth against a public anchor ever reaching this handler by
+    // mistake.
+    let anchorCommentId =
+      commentAnchor?.replyChannel === "private"
+        ? commentAnchor.commentId
+        : undefined
     for await (const instagramMessage of convertFlowStepToInstagramMessage(
       props,
     )) {
-      const response = await sendInstagramMessage(
-        ctx.auth,
-        buildMessagePayload(contact, instagramMessage),
-      )
+      const response = anchorCommentId
+        ? await sendPrivateReplyMessage(
+            ctx.auth,
+            anchorCommentId,
+            instagramMessage,
+          )
+        : await sendInstagramMessage(
+            ctx.auth,
+            buildMessagePayload(contact, instagramMessage),
+          )
+      anchorCommentId = undefined
       if (response.message_id) {
         messageIds.push(response.message_id)
       }

--- a/integrations/instagram/__tests__/comment-automation-api.test.ts
+++ b/integrations/instagram/__tests__/comment-automation-api.test.ts
@@ -108,7 +108,10 @@ describe("Instagram Login comment automation APIs", () => {
           )
           await expect(request.json()).resolves.toEqual({
             recipient: { comment_id: COMMENT_ID },
-            message: { text: "Hello from Instagram Login" },
+            message: {
+              text: "Hello from Instagram Login",
+              metadata: "SENT_FROM_CHATBOTX",
+            },
           })
           return HttpResponse.json({ recipient_id: "recipient-1" })
         },

--- a/integrations/instagram/__tests__/send-flow-step-comment-anchor.test.ts
+++ b/integrations/instagram/__tests__/send-flow-step-comment-anchor.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockSendInstagramMessage, mockSendPrivateReplyMessage } = vi.hoisted(
+  () => ({
+    mockSendInstagramMessage: vi.fn(),
+    mockSendPrivateReplyMessage: vi.fn(),
+  }),
+)
+
+vi.mock("../src/apis/page", () => ({
+  sendInstagramMessage: mockSendInstagramMessage,
+}))
+
+vi.mock("../src/apis/comment", () => ({
+  sendPrivateReplyMessage: mockSendPrivateReplyMessage,
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+const { sendFlowStep } = await import(
+  "../src/handlers/message/outgoing-message"
+)
+
+const ctx = {
+  auth: {
+    tokens: { accessToken: "tok" },
+    metadata: { version: "v23.0" },
+  },
+} as never
+
+const freshContact = {
+  id: "contact-1",
+  sourceId: "igsid-1",
+  lastIncomingMessageAt: new Date(Date.now() - 60 * 60 * 1000),
+} as never
+
+// Outside the 24-hour response window: a normal automated send must be
+// rejected by resolveInstagramMessagingPolicy, an anchored one must not.
+const staleContact = {
+  id: "contact-1",
+  sourceId: "igsid-1",
+  lastIncomingMessageAt: new Date(Date.now() - 25 * 60 * 60 * 1000),
+} as never
+
+const textStep = {
+  id: "step-1",
+  nodeId: "node-1",
+  stepType: "sendText",
+  text: "private reply via flow",
+  buttons: [],
+}
+
+describe("instagram sendFlowStep — comment-anchored private reply", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSendInstagramMessage.mockResolvedValue({
+      recipient_id: "igsid-1",
+      message_id: "m_normal-1",
+    })
+    mockSendPrivateReplyMessage.mockResolvedValue({
+      recipient_id: "igsid-1",
+      message_id: "m_anchored-1",
+    })
+  })
+
+  test("uses the comment_id-anchored Send API when commentAnchor is present", async () => {
+    const result = await sendFlowStep({
+      ctx,
+      data: {
+        contact: freshContact,
+        commentAnchor: { commentId: "comment-1", replyChannel: "private" },
+        step: textStep,
+      },
+    } as never)
+
+    expect(mockSendPrivateReplyMessage).toHaveBeenCalledTimes(1)
+    expect(mockSendPrivateReplyMessage).toHaveBeenCalledWith(
+      ctx.auth,
+      "comment-1",
+      expect.objectContaining({ text: "private reply via flow" }),
+    )
+    expect(mockSendInstagramMessage).not.toHaveBeenCalled()
+    expect(result).toEqual({ messageIds: ["m_anchored-1"] })
+  })
+
+  test("an anchored send succeeds outside the 24-hour window (the regression this fix is for)", async () => {
+    const result = await sendFlowStep({
+      ctx,
+      data: {
+        contact: staleContact,
+        commentAnchor: { commentId: "comment-1", replyChannel: "private" },
+        step: textStep,
+      },
+    } as never)
+
+    expect(mockSendPrivateReplyMessage).toHaveBeenCalledTimes(1)
+    expect(mockSendInstagramMessage).not.toHaveBeenCalled()
+    expect(result).toEqual({ messageIds: ["m_anchored-1"] })
+  })
+
+  test("a non-anchored send outside the 24-hour window still throws (lazy policy keeps enforcing)", async () => {
+    await expect(
+      sendFlowStep({
+        ctx,
+        data: {
+          contact: staleContact,
+          step: textStep,
+        },
+      } as never),
+    ).rejects.toThrow(
+      "Cannot send an Instagram automated message outside the 24-hour response window",
+    )
+
+    expect(mockSendInstagramMessage).not.toHaveBeenCalled()
+    expect(mockSendPrivateReplyMessage).not.toHaveBeenCalled()
+  })
+
+  test("uses the normal Send API when commentAnchor.replyChannel is public (defense-in-depth: public replies are never routed here)", async () => {
+    const result = await sendFlowStep({
+      ctx,
+      data: {
+        contact: freshContact,
+        commentAnchor: { commentId: "comment-1", replyChannel: "public" },
+        step: textStep,
+      },
+    } as never)
+
+    expect(mockSendInstagramMessage).toHaveBeenCalledTimes(1)
+    expect(mockSendPrivateReplyMessage).not.toHaveBeenCalled()
+    expect(result).toEqual({ messageIds: ["m_normal-1"] })
+  })
+
+  test("only the first Instagram message of a multi-message step uses the comment anchor", async () => {
+    const cards = Array.from({ length: 11 }, (_, i) => ({
+      title: `Card ${i}`,
+      buttons: [],
+    }))
+
+    const result = await sendFlowStep({
+      ctx,
+      data: {
+        contact: freshContact,
+        commentAnchor: { commentId: "comment-1", replyChannel: "private" },
+        step: {
+          id: "step-1",
+          nodeId: "node-1",
+          stepType: "sendCarousel",
+          cards,
+        },
+      },
+    } as never)
+
+    // 11 cards chunked by 10 → 2 Instagram messages for this single step
+    expect(mockSendPrivateReplyMessage).toHaveBeenCalledTimes(1)
+    expect(mockSendPrivateReplyMessage).toHaveBeenCalledWith(
+      ctx.auth,
+      "comment-1",
+      expect.anything(),
+    )
+    expect(mockSendInstagramMessage).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ messageIds: ["m_anchored-1", "m_normal-1"] })
+  })
+})

--- a/integrations/instagram/src/apis/comment.ts
+++ b/integrations/instagram/src/apis/comment.ts
@@ -1,7 +1,13 @@
 import { DEFAULT_API_VERSION } from "../constants"
 import { rescue } from "../exception"
 import { instagramBusinessClient } from "../lib/http-client"
-import type { InstagramAuthValue } from "../schemas"
+import {
+  INSTAGRAM_MESSAGE_METADATA,
+  type InstagramAuthValue,
+  type InstagramMessageAttachmentPayload,
+  type InstagramSendMessage,
+  type InstagramSendMessageResponse,
+} from "../schemas"
 
 export const sendComment = (
   auth: InstagramAuthValue,
@@ -58,32 +64,44 @@ export const hideComment = (
 }
 
 /**
- * Sends a private DM reply to the author of a comment. On graph.instagram.com
- * (Instagram Login), messages are sent through the `me/messages` endpoint —
- * matching sendInstagramMessage — using the comment id as the recipient reference.
+ * Sends a private DM reply to the author of a comment with an arbitrary
+ * message payload (text, attachment, quick replies, …) — used by flow-based
+ * private replies to deliver the *first* outgoing message of the run. On
+ * graph.instagram.com (Instagram Login), messages are sent through the
+ * `me/messages` endpoint — matching sendInstagramMessage — using the comment
+ * id as the recipient reference (Meta's comment_id-anchored Send API, which
+ * bypasses the normal messaging-window requirement).
+ *
+ * Stamps `message.metadata` like every other Instagram send path so the
+ * message_echo webhook (`handlers/webhook.ts`) recognizes and skips our own
+ * echo instead of re-ingesting it as an incoming message.
  */
-export const sendPrivateReply = (
+export const sendPrivateReplyMessage = (
   auth: InstagramAuthValue,
   commentId: string,
-  message: string,
-): Promise<{ message_id?: string; recipient_id: string }> => {
+  message: InstagramSendMessage | InstagramMessageAttachmentPayload,
+): Promise<InstagramSendMessageResponse> => {
   const version = auth.metadata.version ?? DEFAULT_API_VERSION
   const endpoint = `${version}/me/messages`
 
   return rescue(endpoint, () =>
-    instagramBusinessClient.post<{
-      message_id?: string
-      recipient_id: string
-    }>(endpoint, {
+    instagramBusinessClient.post<InstagramSendMessageResponse>(endpoint, {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${auth.tokens.accessToken}`,
       },
       json: {
         recipient: { comment_id: commentId },
-        message: { text: message },
+        message: { ...message, metadata: INSTAGRAM_MESSAGE_METADATA },
       },
       retry: 0,
     }),
   )
 }
+
+export const sendPrivateReply = (
+  auth: InstagramAuthValue,
+  commentId: string,
+  message: string,
+): Promise<InstagramSendMessageResponse> =>
+  sendPrivateReplyMessage(auth, commentId, { text: message })

--- a/integrations/instagram/src/handlers/message/outgoing-message/index.ts
+++ b/integrations/instagram/src/handlers/message/outgoing-message/index.ts
@@ -20,6 +20,7 @@ import {
   type OutgoingMessage,
   type SendFlowStepProps,
 } from "@chatbotx.io/sdk"
+import { sendPrivateReplyMessage } from "../../../apis/comment"
 import { sendInstagramMessage } from "../../../apis/page"
 import { mapToChannelError } from "../../../lib/error-mapper"
 import { logger } from "../../../lib/logger"
@@ -265,18 +266,43 @@ export const sendFlowStep = async (
 ) => {
   const {
     ctx,
-    data: { contact, sendFrom },
+    data: { contact, sendFrom, commentAnchor },
   } = props
   const messageIds: string[] = []
   try {
-    const policy = resolveInstagramMessagingPolicy({ contact, sendFrom })
+    // Resolved lazily (and at most once): an up-front resolve would throw
+    // `instagram_response_window_expired` and kill a comment-anchored first
+    // send, which is exempt from the 24-hour window (Meta's comment_id
+    // recipient uses the 7-day comment window instead).
+    let policy: InstagramMessagingPolicy | undefined
+    const getPolicy = () =>
+      (policy ??= resolveInstagramMessagingPolicy({ contact, sendFrom }))
+    // Consumed by the first Instagram message yielded below, if a private
+    // comment anchor is present — a single flow step can yield more than one
+    // message (e.g. text + attachments), so only the very first send uses the
+    // comment_id-anchored API; the rest use the normal window-gated path.
+    // A "public" anchor is never honored here — it's delivered via the
+    // comment channel's sendComment, not this message channel's sendFlowStep
+    // (see send-flow-step.ts). This check is defense-in-depth against a
+    // public anchor ever reaching this handler by mistake.
+    let anchorCommentId =
+      commentAnchor?.replyChannel === "private"
+        ? commentAnchor.commentId
+        : undefined
     for await (const instagramMessage of convertFlowStepToInstagramMessage(
       props,
     )) {
-      const response = await sendInstagramMessage(
-        ctx.auth,
-        buildMessagePayload(contact, instagramMessage, policy),
-      )
+      const response = anchorCommentId
+        ? await sendPrivateReplyMessage(
+            ctx.auth,
+            anchorCommentId,
+            instagramMessage,
+          )
+        : await sendInstagramMessage(
+            ctx.auth,
+            buildMessagePayload(contact, instagramMessage, getPolicy()),
+          )
+      anchorCommentId = undefined
       if (response.message_id) {
         messageIds.push(response.message_id)
       }

--- a/packages/sdk/src/lib/integration.ts
+++ b/packages/sdk/src/lib/integration.ts
@@ -70,7 +70,10 @@ export type ChannelSendFlowStepProps<IAuth extends AuthValue> = {
     metadata?: MetadataPayload
     richResponse?: RichResponseContentAttributes
     sendFrom?: "inbox"
-    /** See {@link CommentAnchor}. Channels other than Messenger ignore it. */
+    /**
+     * See {@link CommentAnchor}. Honored by Messenger and Instagram; other
+     * channels ignore it.
+     */
     commentAnchor?: CommentAnchor
   }
 }

--- a/packages/sdk/src/lib/shared/index.ts
+++ b/packages/sdk/src/lib/shared/index.ts
@@ -70,11 +70,11 @@ export type ReceivedMessageResult = {
  * - `"public"`: post it as a public comment reply (`comment.sendComment`),
  *   same as the `text`/`AIAgent` public reply types. Works on any channel
  *   that implements `sendComment` (Messenger, Instagram).
- * - `"private"`: send it via Facebook's comment_id-anchored Send API
+ * - `"private"`: send it via Meta's comment_id-anchored Send API
  *   (bypasses the normal messaging-window rule) instead of the standard
- *   PSID-based send, which Facebook rejects for users who only commented and
- *   never messaged the Page. Messenger-only (no Instagram private_replies
- *   equivalent).
+ *   PSID-based send, which Meta rejects for users who only commented and
+ *   never messaged the Page. Supported on Messenger and Instagram (both
+ *   Instagram Login and Instagram-via-Facebook variants).
  */
 export type CommentAnchor = {
   commentId: string


### PR DESCRIPTION
## Summary
- Flow-type private replies on `instagram` / `instagramFacebook` comment automations were enqueued without a `commentAnchor`, so the flow went out as a normal DM gated by the 24-hour messaging window and failed for commenters outside it (text replies already used the comment_id-anchored API and worked).
- Mirrors the existing Messenger fix: the first flow message is delivered through Meta's `recipient: { comment_id }` Send API (7-day comment window, exempt from the 24h rule); subsequent messages use the normal path.
- Bonus fix: IG private replies (flow and text) now stamp `metadata: SENT_FROM_CHATBOTX`, so coexist message_echo webhooks dedup them instead of re-ingesting our own reply as an incoming message.

## Changes
- `apps/worker/src/integration/handlers/comment-automation/private-reply.ts` — always attach the private `commentAnchor` to `sendFlow` jobs (was messenger-only).
- `apps/worker/src/chat/handlers/send-flow-step.ts` — defensive channel gate now also allows `instagram`; stale "no Instagram private_replies equivalent" comment corrected.
- `integrations/instagram` + `integrations/instagram-facebook` — new `sendPrivateReplyMessage` API (full message payload, metadata stamp, `retry: 0`); `sendPrivateReply` delegates to it; `sendFlowStep` consumes the anchor for the first yielded message.
- `integrations/instagram` — `resolveInstagramMessagingPolicy` is now resolved lazily (memoized) in `sendFlowStep` so the up-front `instagram_response_window_expired` throw no longer kills the exempt anchored send; non-anchored sends keep the exact same enforcement.
- `packages/sdk` — `CommentAnchor` JSDoc updated to reflect Messenger + Instagram support.
- Tests: new `send-flow-step-comment-anchor.test.ts` for both IG integrations (incl. the >24h regression case both ways); worker tests flipped from asserting the old messenger-only behavior; API tests updated for the metadata stamp.

## Test plan
- [x] `vitest` — instagram 58/58, instagram-facebook 32/32, messenger 209/209, worker 1596/1596
- [x] `turbo check-types` — 56/56 packages (pre-commit hook)
- [x] `ultracite`/biome clean (pre-commit hook)
- [ ] Manual: on an IG channel, trigger a comment automation with a flow private reply for a contact whose last incoming message is >24h old; first flow message arrives as DM, no `instagram_response_window_expired` in worker logs, no duplicate incoming message (echo dedup)