### PR TITLE
fix(zalo): surface real OAuth errors and harden daily token refresh

### DIFF
--- a/apps/builder/src/features/workspaces/actions/refresh-all-channel-tokens.action.ts
+++ b/apps/builder/src/features/workspaces/actions/refresh-all-channel-tokens.action.ts
@@ -36,7 +36,11 @@ import { authActionClient } from "@/lib/safe-action"
 import { resolveWorkspaceBlockState } from "@/lib/workspace-quota"
 
 const BATCH_SIZE = 50
-const REFRESH_LOCK_TIMEOUT_SECONDS = 10
+// Must outlive the channel APIs' HTTP timeouts (Zalo's OAuth client allows
+// 30s): the Zalo refresh token is single-use, so if the lock expired mid-call
+// the daily cron could consume the same refresh token concurrently and
+// clobber the rotated tokens.
+const REFRESH_LOCK_TIMEOUT_SECONDS = 60
 
 type RefreshResult = "failed" | "refreshed" | "skipped"
 type RefreshSummary = { refreshed: number; failed: number }
@@ -64,7 +68,14 @@ async function runInBatches<T>(
   const results: RefreshResult[] = []
   for (let i = 0; i < items.length; i += BATCH_SIZE) {
     const batch = items.slice(i, i + BATCH_SIZE)
-    results.push(...(await Promise.all(batch.map(worker))))
+    results.push(
+      ...(await Promise.all(
+        // A failed lock acquisition (the daily cron already refreshing this
+        // row, redis hiccup) throws outside the worker's own try/catch; it
+        // must not reject the whole batch and abort the remaining rows.
+        batch.map((item) => worker(item).catch((): RefreshResult => "failed")),
+      )),
+    )
   }
   return results
 }

--- a/apps/worker/src/schedule/handlers/refresh-channel-tokens.ts
+++ b/apps/worker/src/schedule/handlers/refresh-channel-tokens.ts
@@ -29,10 +29,13 @@ const refreshTokenAdapter: Record<
   telegram: undefined,
 }
 
-export async function refreshChannelTokens(): Promise<void> {
+export async function refreshChannelTokens(
+  channels?: ChannelType[],
+): Promise<void> {
   const entries = Object.entries(refreshTokenAdapter).filter(
     (entry): entry is [ChannelType, () => Promise<void>] =>
-      entry[1] !== undefined,
+      entry[1] !== undefined &&
+      (!channels || channels.includes(entry[0] as ChannelType)),
   )
 
   const results = await Promise.allSettled(

--- a/apps/worker/src/schedule/handlers/refresh-zalo-tokens.ts
+++ b/apps/worker/src/schedule/handlers/refresh-zalo-tokens.ts
@@ -8,52 +8,67 @@ import { distributedLock } from "@chatbotx.io/redis"
 import { logger } from "../../lib/logger"
 
 const BATCH_SIZE = 50
-const REFRESH_LOCK_TIMEOUT_SECONDS = 10
+// Must outlive the OAuth client's 30s HTTP timeout: the Zalo refresh token is
+// single-use, so if the lock expired mid-call another process could consume
+// the same refresh token concurrently and clobber the rotated tokens.
+const REFRESH_LOCK_TIMEOUT_SECONDS = 60
 
 async function refreshOne(integration: {
   id: string
   workspaceId: string
 }): Promise<void> {
-  await distributedLock.runExclusive({
-    key: `auth:refresh:zalo:${integration.id}`,
-    timeoutInSeconds: REFRESH_LOCK_TIMEOUT_SECONDS,
-    fn: async () => {
-      try {
-        const current = await zaloIntegrationService.findById({
-          id: integration.id,
-          workspaceId: integration.workspaceId,
-        })
-        const auth = current.auth as ZaloAuthValue
-        if (!auth.tokens.refreshToken) {
-          logger.warn(
-            `[refreshZaloTokens] id=${integration.id} skipped: no refreshToken`,
-          )
-          return
-        }
+  await distributedLock
+    .runExclusive({
+      key: `auth:refresh:zalo:${integration.id}`,
+      timeoutInSeconds: REFRESH_LOCK_TIMEOUT_SECONDS,
+      fn: () => refreshWithLockHeld(integration),
+    })
+    .catch((error) => {
+      // A failed lock acquisition (another process already refreshing, redis
+      // hiccup) must not reject the whole batch and abort the remaining
+      // integrations for the day.
+      logger.error(
+        error,
+        `[refreshZaloTokens] id=${integration.id} lock failed`,
+      )
+    })
+}
 
-        const newTokens = await refreshAccessToken(
-          auth,
-          auth.tokens.refreshToken,
-        )
+async function refreshWithLockHeld(integration: {
+  id: string
+  workspaceId: string
+}): Promise<void> {
+  try {
+    const current = await zaloIntegrationService.findById({
+      id: integration.id,
+      workspaceId: integration.workspaceId,
+    })
+    const auth = current.auth as ZaloAuthValue
+    if (!auth.tokens.refreshToken) {
+      logger.warn(
+        `[refreshZaloTokens] id=${integration.id} skipped: no refreshToken`,
+      )
+      return
+    }
 
-        await zaloIntegrationService.updateAuth(integration.id, {
-          ...auth,
-          tokens: {
-            ...auth.tokens,
-            accessToken: newTokens.access_token,
-            refreshToken: newTokens.refresh_token,
-            expiresAt: calculateExpiresAt(newTokens.expires_in),
-          },
-        })
-      } catch (error) {
-        logger.error(error, `[refreshZaloTokens] id=${integration.id} failed`)
-        await zaloIntegrationService.markTokenRefreshError(
-          integration.id,
-          error instanceof Error ? error.message : String(error),
-        )
-      }
-    },
-  })
+    const newTokens = await refreshAccessToken(auth, auth.tokens.refreshToken)
+
+    await zaloIntegrationService.updateAuth(integration.id, {
+      ...auth,
+      tokens: {
+        ...auth.tokens,
+        accessToken: newTokens.access_token,
+        refreshToken: newTokens.refresh_token,
+        expiresAt: calculateExpiresAt(newTokens.expires_in),
+      },
+    })
+  } catch (error) {
+    logger.error(error, `[refreshZaloTokens] id=${integration.id} failed`)
+    await zaloIntegrationService.markTokenRefreshError(
+      integration.id,
+      error instanceof Error ? error.message : String(error),
+    )
+  }
 }
 
 export async function refreshZaloTokens(): Promise<void> {

--- a/apps/worker/src/schedule/handlers/register-schedules.ts
+++ b/apps/worker/src/schedule/handlers/register-schedules.ts
@@ -1,3 +1,4 @@
+import { channelTypes } from "@chatbotx.io/database/partials"
 import {
   PURGE_WORKSPACES_INTERVAL_MINUTES,
   ScheduleJobData,
@@ -290,6 +291,26 @@ export const registerSchedules = async () => {
       data: {
         type: ScheduleJobData.refreshChannelTokens,
         data: {},
+      },
+    },
+  )
+
+  // Zalo and TikTok tokens only live ~24-25h, so the single 02:00 run leaves
+  // almost no margin: one missed run and they expire mid-day. This extra
+  // midday run keeps them at most ~12h from a refresh; the long-lived
+  // Meta/WhatsApp tokens stay on the daily run above.
+  await scheduleQueue.upsertJobScheduler(
+    "refreshShortLivedChannelTokens",
+    {
+      pattern: "0 14 * * *",
+    },
+    {
+      name: ScheduleJobData.refreshChannelTokens,
+      data: {
+        type: ScheduleJobData.refreshChannelTokens,
+        data: {
+          channels: [channelTypes.enum.zalo, channelTypes.enum.tiktok],
+        },
       },
     },
   )

--- a/apps/worker/src/schedule/worker.ts
+++ b/apps/worker/src/schedule/worker.ts
@@ -141,7 +141,7 @@ async function startScheduleWorker() {
           return
 
         case ScheduleJobData.refreshChannelTokens:
-          await refreshChannelTokens()
+          await refreshChannelTokens(job.data.data.channels)
           return
 
         case ScheduleJobData.unsubscribeExpiredTrials:

--- a/integrations/zalo/__tests__/refresh-access-token.test.ts
+++ b/integrations/zalo/__tests__/refresh-access-token.test.ts
@@ -1,0 +1,78 @@
+import type { Oauth2Config } from "@chatbotx.io/sdk"
+import { HttpResponse, http, server } from "@chatbotx.io/vitest-config/msw"
+import { describe, expect, test } from "vitest"
+import { refreshAccessToken } from "../src/api/auth"
+
+const TOKEN_URL = "https://oauth.zaloapp.com/v4/oa/access_token"
+
+const setting = {
+  clientId: "app-1",
+  clientSecret: "secret-1",
+  redirectUrl: "https://app.example.com/integrations/zalo/callback",
+} as Oauth2Config
+
+const mockTokenEndpoint = (body: Record<string, unknown>, status = 200) => {
+  server.use(
+    http.post(TOKEN_URL, async ({ request }) => {
+      expect(request.headers.get("secret_key")).toBe("secret-1")
+      const params = new URLSearchParams(await request.text())
+      expect(params.get("grant_type")).toBe("refresh_token")
+      expect(params.get("refresh_token")).toBe("refresh-1")
+      expect(params.get("app_id")).toBe("app-1")
+      return HttpResponse.json(body, { status })
+    }),
+  )
+}
+
+describe("refreshAccessToken", () => {
+  test("returns the rotated tokens on success", async () => {
+    mockTokenEndpoint({
+      access_token: "new-access",
+      refresh_token: "new-refresh",
+      expires_in: "90000",
+    })
+
+    await expect(refreshAccessToken(setting, "refresh-1")).resolves.toEqual({
+      access_token: "new-access",
+      refresh_token: "new-refresh",
+      expires_in: "90000",
+    })
+  })
+
+  test("rejects with the OAuth error description when Zalo returns an error_name body with HTTP 200", async () => {
+    mockTokenEndpoint({
+      error_name: "invalid_grant",
+      error_reason: "refresh token invalid",
+      error_description: "Refresh token is invalid or expired",
+    })
+
+    await expect(refreshAccessToken(setting, "refresh-1")).rejects.toThrow(
+      "Refresh token is invalid or expired",
+    )
+  })
+
+  test("rejects with a meaningful message when the error body has a numeric error but no message", async () => {
+    mockTokenEndpoint({
+      error: -14_020,
+      error_name: "invalid_grant",
+    })
+
+    await expect(refreshAccessToken(setting, "refresh-1")).rejects.toThrow(
+      "invalid_grant",
+    )
+  })
+
+  test("rejects instead of returning token-less success bodies", async () => {
+    mockTokenEndpoint({ unexpected: "shape" })
+
+    await expect(refreshAccessToken(setting, "refresh-1")).rejects.toThrow(
+      "Refresh access token failed",
+    )
+  })
+
+  test("rejects on non-200 responses", async () => {
+    mockTokenEndpoint({ error_name: "invalid_request" }, 400)
+
+    await expect(refreshAccessToken(setting, "refresh-1")).rejects.toThrow()
+  })
+})

--- a/integrations/zalo/src/api/auth.ts
+++ b/integrations/zalo/src/api/auth.ts
@@ -51,7 +51,7 @@ export const refreshAccessToken = (
   handleZaloError("Refresh access token", async () => {
     const client = ZaloHttpClient.createOAuthClient()
 
-    return await client.post<ZaloAccessTokenResponse>(
+    const tokens = await client.post<ZaloAccessTokenResponse>(
       ZALO_API_ENDPOINTS.AUTH.ACCESS_TOKEN,
       {
         headers: {
@@ -66,6 +66,17 @@ export const refreshAccessToken = (
         }),
       },
     )
+
+    // The OAuth endpoint can report failures with HTTP 200 and an unexpected
+    // body shape; a token-less "success" written to the database would
+    // overwrite a working auth with undefined tokens and brick the channel.
+    if (!(tokens.access_token && tokens.refresh_token)) {
+      throw new ZaloException(
+        `Refresh access token failed: ${JSON.stringify(tokens)}`,
+      )
+    }
+
+    return tokens
   })
 
 export type ZaloOAProfileResponse = {

--- a/integrations/zalo/src/lib/http-client.ts
+++ b/integrations/zalo/src/lib/http-client.ts
@@ -4,8 +4,14 @@ import { parseOriginError, ZaloException } from "./exception"
 import { logger } from "./logger"
 
 type ZaloApiErrorResponse = {
-  error: number
-  message: string
+  error?: number
+  message?: string
+  // The OAuth endpoints (/v4/oa/access_token) report failures with these
+  // fields instead of the numeric error/message pair — and may do so with
+  // HTTP 200, so status-based handling never sees them.
+  error_name?: string
+  error_reason?: string
+  error_description?: string
 }
 
 type ZaloClientConfig = {
@@ -83,14 +89,26 @@ export class ZaloHttpClient {
       const response = await responsePromise
       const data = (await response.json()) as T & ZaloApiErrorResponse
 
-      if (typeof data === "object" && data !== null && "error" in data) {
+      if (typeof data === "object" && data !== null) {
         const apiError = data as ZaloApiErrorResponse
-        if (apiError.error !== 0) {
-          const wrapped = { response: { error: apiError } }
+        const hasNumericError =
+          "error" in apiError && Number(apiError.error) !== 0
+        const hasOauthError = typeof apiError.error_name === "string"
+
+        if (hasNumericError || hasOauthError) {
+          const message =
+            apiError.message ??
+            apiError.error_description ??
+            apiError.error_reason ??
+            apiError.error_name
+          const wrapped = {
+            response: { error: { error: apiError.error, message } },
+          }
           const sdkException = parseOriginError(wrapped)
 
           throw new ZaloException(
-            sdkException.message ?? `Zalo OA API error: ${apiError.message}`,
+            sdkException.message ??
+              `Zalo OA API error: ${JSON.stringify(data)}`,
             sdkException.httpStatusCode,
             sdkException.code,
             sdkException.subCode,

--- a/packages/worker-config/src/queues/schedule/index.ts
+++ b/packages/worker-config/src/queues/schedule/index.ts
@@ -1,3 +1,4 @@
+import type { ChannelType } from "@chatbotx.io/database/partials"
 import { Queue } from "bullmq"
 import { z } from "zod"
 import {
@@ -168,7 +169,9 @@ export type ScheduleJobPurgeAutomationThrottle = {
 
 export type ScheduleJobRefreshChannelTokens = {
   type: typeof ScheduleJobData.refreshChannelTokens
-  data: Record<string, never>
+  // No `channels` = refresh every channel. The short-lived scheduler passes
+  // ["zalo", "tiktok"] for the extra midday run (see register-schedules.ts).
+  data: { channels?: ChannelType[] }
 }
 
 export type ScheduleJobUnsubscribeExpiredTrials = {


### PR DESCRIPTION
## Summary
- Customers reported `tokenRefreshError` showing literally `Zalo OA API error: undefined` and Zalo OA channels dying while in active use. Root cause: Zalo's OAuth token endpoint reports failures with `error_name` / `error_reason` / `error_description` — sometimes with **HTTP 200** — instead of the numeric `error`/`message` pair the HTTP client parses, so the real error text was dropped, and error bodies without a numeric `error` field passed through as *success*, letting the daily refresh overwrite a working auth with `accessToken: undefined`.
- Two more hardening gaps around the single-use Zalo refresh token: the 10s refresh lock could expire under the OAuth client's 30s HTTP timeout (daily cron and the manual refresh-all action could then consume the same refresh token concurrently), and a failed lock acquisition rejected the whole batch — aborting the rest of the day's run.
- Zalo/TikTok tokens only live ~24–25h against a 24h cron (~1h margin): one missed run expired them mid-day. They now refresh twice daily.

## Changes
- `integrations/zalo/src/lib/http-client.ts` — recognize OAuth-style error bodies (`error_name` present, or numeric `error` ≠ 0) and build the exception message from `message ?? error_description ?? error_reason ?? error_name`, falling back to the raw body instead of `undefined`.
- `integrations/zalo/src/api/auth.ts` — `refreshAccessToken` now rejects token-less "success" bodies before they can reach the database (same guard the connect callback already had). Protects all three callers: daily cron, manual refresh-all, `integration.refreshAuth`.
- `apps/worker/src/schedule/handlers/refresh-zalo-tokens.ts` — lock TTL 10s → 60s (must outlive the 30s HTTP timeout); a failed lock acquisition now logs and skips that one integration instead of aborting the whole run.
- `apps/builder/src/features/workspaces/actions/refresh-all-channel-tokens.action.ts` — same TTL bump (shared constant) and `runInBatches` contains per-row failures for every channel.
- `apps/worker/src/schedule/*` + `packages/worker-config` — `refreshChannelTokens` accepts an optional `channels` filter; a second scheduler (`refreshShortLivedChannelTokens`, `0 14 * * *`) re-runs zalo + tiktok at midday while Meta/WhatsApp stay on the daily `0 2 * * *` run.
- `integrations/zalo/__tests__/refresh-access-token.test.ts` — 5 msw tests: success rotation, HTTP-200 `error_name` body, numeric-error-without-message body, token-less body, non-200 response.

## Test plan
- [x] `pnpm --filter @chatbotx.io/integration-zalo vitest run` — 36/36 passing (5 new)
- [x] `pnpm --filter worker vitest run` — 1594/1594 passing
- [x] `tsc --noEmit` on `integrations/zalo`, `apps/worker`, `apps/builder`, `packages/worker-config` — clean
- [x] biome — clean
- [ ] Manual: point a stale refresh token at the daily job and verify `tokenRefreshError` now shows Zalo's actual `error_description` instead of `undefined`; confirm the `refreshShortLivedChannelTokens` scheduler appears in Redis after worker boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BntxUBTSs34gN45veGCjhr