### PR TITLE
docs(comment-automation): correct instagram support status

### DIFF
--- a/.agents/skills/fb-comment-automation/SKILL.md
+++ b/.agents/skills/fb-comment-automation/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: fb-comment-automation
 description: >-
-  Work on Facebook/Messenger comment automation — the feature that auto-replies to,
-  likes, or hides comments on Facebook Page posts. Use when changing the comment
-  webhook path, the automation matching/filter logic, reply dispatch (text/flow/AI
-  agent), hide rules, post targeting, or the fb-comments builder feature. Read this
-  BEFORE editing anything under comment-automation to avoid the silent-failure traps.
+  Work on Facebook/Messenger and Instagram comment automation — the feature that
+  auto-replies to, likes, or hides comments on Facebook Page and Instagram posts. Use
+  when changing the comment webhook path, the automation matching/filter logic, reply
+  dispatch (text/flow/AI agent), hide rules, post targeting, or the fb-comments /
+  ig-comments builder features. Read this BEFORE editing anything under
+  comment-automation to avoid the silent-failure traps.
 ---
 
-# Facebook Comment Automation
+# Facebook & Instagram Comment Automation
 
 Full reference: [`docs/fb-comment-automation.md`](../../../docs/fb-comment-automation.md).
 Read it before non-trivial changes. This skill is the quick map + the traps.
@@ -19,20 +20,22 @@ Read it before non-trivial changes. This skill is the quick map + the traps.
 |---|---|
 | Automation loop, filters, dispatch | `apps/worker/src/integration/handlers/comment-automation/index.ts` |
 | AI-agent reply (generate + deliver) | `apps/worker/src/integration/handlers/comment-automation/ai-reply.ts` |
+| Per-channel private DM dispatch | `apps/worker/src/integration/handlers/comment-automation/private-reply.ts` (`PRIVATE_REPLY_TEXT_SENDERS`) |
+| Supported channels union | `apps/worker/src/integration/handlers/comment-automation/channel-type.ts` (`CommentAutomationChannelType`) |
 | Attachment info (image/video for hide) | `apps/worker/src/integration/handlers/comment-automation/comment-attachment.ts` |
 | Receive comment + enqueue automation | `apps/worker/src/integration/handlers/received-message.ts` (`receiveComment`) |
-| Webhook parse + enqueue | `integrations/messenger/src/handlers/webhook.ts` |
-| Webhook value schema | `integrations/messenger/src/schema.ts` (`messengerFeedCommentValueSchema`) |
+| Webhook parse + enqueue | `integrations/messenger/src/handlers/webhook.ts`, `integrations/instagram/src/handlers/webhook.ts`, `integrations/instagram-facebook/src/handlers/webhook.ts` |
+| Webhook value schema | `integrations/messenger/src/schema.ts` (`messengerFeedCommentValueSchema`), `integrations/instagram{,-facebook}/src/schemas.ts` (`instagramCommentEventValueSchema`) |
 | DB queries (match/dedup/schedule) | `packages/business/src/fb-comment-automation/service.ts` |
 | Schema + option/reply Zod partials | `packages/database/src/schema/fb-comment-automation.ts`, `.../partials/fb-comment-automation.ts` |
 | Dedup ledger | `packages/database/src/schema/fb-comment-automation-reply.ts` |
 | Job types | `packages/worker-config/src/queues/integration/index.ts` |
-| Builder feature (form, actions) | `apps/builder/src/features/fb-comments/` |
+| Builder feature (form, actions) | `apps/builder/src/features/fb-comments/` (Facebook), `apps/builder/src/features/ig-comments/` (Instagram) |
 | Tests | `apps/worker/__tests__/comment-automation.test.ts` |
 
 ## Data-flow in one line
 
-`feed webhook (verb "add") → incomingComment → receiveComment → processCommentAutomation → (AIAgent) commentAIReply`.
+`feed webhook (verb "add") / instagram comments webhook → incomingComment → receiveComment → processCommentAutomation → (AIAgent) commentAIReply`.
 
 ## The traps (read before editing)
 
@@ -64,9 +67,15 @@ Read it before non-trivial changes. This skill is the quick map + the traps.
    `(automationId, contactId)` + `postId != ?` queries — no new index needed; use a
    `LIMIT 1` existence check, not `$count`.
 
-6. **Instagram is not implemented.** Builder never sets `type`, so it defaults to
-   `messenger`. Don't add IG-only behavior expecting it to run. IG private-DM text is out
-   of scope.
+6. **Three channels, one loop.** `type` is `messenger` | `instagram` (Instagram Login) |
+   `instagramFacebook` (Instagram via Facebook Login) — see
+   `CommentAutomationChannelType` — and `findActiveAutomations` filters on it, so every
+   capability must be routed per channel. Private DM text works on all three via
+   `PRIVATE_REPLY_TEXT_SENDERS` (comment_id-anchored Send API); comment liking exists
+   only on `messenger` + `instagramFacebook` (Instagram Login's `likeComment` is a logged
+   no-op); the attachment lookup behind `hideComments.hasImage`/`hasVideo` is
+   messenger-only. Hide an unsupported toggle in the builder form instead of shipping a
+   dead switch.
 
 7. **`options.trackUserTags` is a no-op** (defined, not implemented). Every other option
    (including `replyToUsersWhoCommentedOnOtherPosts`) IS enforced — see the option table in
@@ -87,9 +96,11 @@ Read it before non-trivial changes. This skill is the quick map + the traps.
 ## Adding a new reply type (recipe)
 
 1. Extend `fbCommentReplySchema.type` (partials).
-2. Handle it in BOTH `executePublicReply` and `executePrivateReply` (`index.ts`). Public =
-   message `type:"comment"` + `replyToCommentId` via `sendChannelMessage`; private =
-   `sendPrivateReply` (messenger only).
+2. Handle it in BOTH `executePublicReply` (`public-reply.ts`) and `executePrivateReply`
+   (`private-reply.ts`). Public = message `type:"comment"` + `replyToCommentId` via
+   `sendChannelMessage`; private = the channel's entry in `PRIVATE_REPLY_TEXT_SENDERS`, so
+   a new type has to work for all three channels (messenger, instagram,
+   instagramFacebook).
 3. Update `willSendReply` so dedup/`repliesCount` only count when a reply is actually
    dispatchable (e.g. require `value`).
 4. If it needs async work (like AIAgent), add a dedicated job in worker-config, a handler,

--- a/docs/fb-comment-automation.md
+++ b/docs/fb-comment-automation.md
@@ -1,13 +1,15 @@
-# Facebook Comment Automation
+# Facebook & Instagram Comment Automation
 
-This document describes the Facebook/Messenger **comment automation** feature: how a
-comment on a Page post flows from the webhook to an automated reply, how each config
-option is matched and enforced, and the non-obvious pitfalls that have caused silent
-failures. It is the reference for anyone touching the comment-automation code.
+This document describes the **comment automation** feature: how a comment on a Facebook
+Page post or an Instagram post flows from the webhook to an automated reply, how each
+config option is matched and enforced, and the non-obvious pitfalls that have caused
+silent failures. It is the reference for anyone touching the comment-automation code.
 
-> Scope: **Facebook Pages via the Messenger integration.** Instagram comment automation
-> is not implemented — the builder always stores `type = "messenger"` (see
-> [Known gaps](#known-gaps--pitfalls)).
+> Scope: the three `CommentAutomationChannelType` values (`channel-type.ts`) —
+> `messenger` (Facebook Pages), `instagram` (Instagram Login) and `instagramFacebook`
+> (Instagram via Facebook Login). All three share one table, one worker loop and one set
+> of filters; the per-channel capability differences are listed under
+> [Known gaps](#known-gaps--pitfalls).
 
 ## Tables
 
@@ -22,8 +24,9 @@ Zod partials (option/reply/post/schedule shapes):
 ## End-to-end flow
 
 ```
-Facebook Page (comment added)
-  → webhook: integrations/messenger/src/handlers/webhook.ts   (field === "feed", verb === "add")
+Facebook Page / Instagram post (comment added)
+  → webhook: messenger (field === "feed", verb === "add")
+             instagram, instagram-facebook (field === "comments")
   → BullMQ "incomingComment" job
   → apps/worker/.../received-message.ts  receiveComment()      (save message, gate on active-hours)
   → BullMQ "processCommentAutomation" job (jobId = comment-auto-${commentId})
@@ -37,13 +40,14 @@ Key files:
 
 | Concern | File |
 |---|---|
-| Webhook parse + enqueue | [`integrations/messenger/src/handlers/webhook.ts`](../integrations/messenger/src/handlers/webhook.ts) |
-| Webhook value schema | [`integrations/messenger/src/schema.ts`](../integrations/messenger/src/schema.ts) (`messengerFeedCommentValueSchema`) |
+| Webhook parse + enqueue | [`integrations/messenger/src/handlers/webhook.ts`](../integrations/messenger/src/handlers/webhook.ts), [`integrations/instagram/src/handlers/webhook.ts`](../integrations/instagram/src/handlers/webhook.ts), [`integrations/instagram-facebook/src/handlers/webhook.ts`](../integrations/instagram-facebook/src/handlers/webhook.ts) |
+| Webhook value schema | [`integrations/messenger/src/schema.ts`](../integrations/messenger/src/schema.ts) (`messengerFeedCommentValueSchema`), `integrations/instagram{,-facebook}/src/schemas.ts` (`instagramCommentEventValueSchema`) |
 | Receive + enqueue automation | [`apps/worker/src/integration/handlers/received-message.ts`](../apps/worker/src/integration/handlers/received-message.ts) (`receiveComment`) |
 | Automation loop + filters + dispatch | [`apps/worker/src/integration/handlers/comment-automation/index.ts`](../apps/worker/src/integration/handlers/comment-automation/index.ts) |
+| Per-channel private DM dispatch | [`apps/worker/src/integration/handlers/comment-automation/private-reply.ts`](../apps/worker/src/integration/handlers/comment-automation/private-reply.ts) (`PRIVATE_REPLY_TEXT_SENDERS`) |
 | AI reply generation + delivery | [`apps/worker/src/integration/handlers/comment-automation/ai-reply.ts`](../apps/worker/src/integration/handlers/comment-automation/ai-reply.ts) |
 | DB queries (match/dedup/schedule) | [`packages/business/src/fb-comment-automation/service.ts`](../packages/business/src/fb-comment-automation/service.ts) |
-| Builder form + actions | [`apps/builder/src/features/fb-comments/`](../apps/builder/src/features/fb-comments/) |
+| Builder form + actions | [`apps/builder/src/features/fb-comments/`](../apps/builder/src/features/fb-comments/) (Facebook), [`apps/builder/src/features/ig-comments/`](../apps/builder/src/features/ig-comments/) (Instagram) |
 | Job types | [`packages/worker-config/src/queues/integration/index.ts`](../packages/worker-config/src/queues/integration/index.ts) |
 
 ## Facebook ID formats (critical)
@@ -64,6 +68,9 @@ silent failures:
   `{pageId}_{postId}`; **reels** store a bare video id; **manual entry** is whatever the
   user pastes. `matchPost` normalizes both sides on the trailing story id
   (`normalizePostId`) so all three match the webhook `post_id`.
+- **Instagram ids are not composite.** Its `comments` webhook carries a bare comment `id`
+  and a bare `media.id` (used as `postId`), and the `ig-comments` picker stores those same
+  bare media ids — `normalizePostId` is a no-op there.
 
 ## Config options — matching & enforcement
 
@@ -75,7 +82,7 @@ Each filter that fails calls `logAutomationSkipped(..., reason)` (logged at `inf
 | Option / field | Meaning | Enforcement |
 |---|---|---|
 | `isActive` | Automation on/off | `findActiveAutomations` filters `isActive: true`. |
-| `type` | `messenger` \| `instagram` | `findActiveAutomations` filters `type === channelType`. Builder always writes `messenger`. |
+| `type` | `messenger` \| `instagram` \| `instagramFacebook` | `findActiveAutomations` filters `type === channelType`, which is the incoming `integrationType`. The builder writes it: `fb-comments` → `messenger`, `ig-comments` → the selected Instagram variant. |
 | `startTime`/`endTime` | Daily active window (workspace tz) | `isWithinSchedule` — lexicographic `"HH:mm"` compare, handles overnight windows; null → always within. |
 | `post` (`all` / `postIds`) | Which posts | `matchPost` — `all` always true; `postIds` matches via normalized trailing id. |
 | `options.ignoreCommentReplies` (default **true**) | Skip replies-to-comments | Skips only when `isCommentReply(parentId, postId)` is true. |
@@ -102,8 +109,8 @@ Each filter that fails calls `logAutomationSkipped(..., reason)` (logged at `inf
 | Type | `value` | Public reply behavior | Private reply behavior |
 |---|---|---|---|
 | `none` | — | no-op | no-op |
-| `text` | the text | Posts a public comment reply: message `type: "comment"` + `contentAttributes.replyToCommentId`, enqueued as `sendChannelMessage`. | `sendPrivateReply` (Messenger Send API DM). |
-| `flow` | flow id | Enqueues `sendFlow` with `flowId`. | Same. |
+| `text` | the text | Posts a public comment reply: message `type: "comment"` + `contentAttributes.replyToCommentId`, enqueued as `sendChannelMessage`. | `PRIVATE_REPLY_TEXT_SENDERS[channelType]` (`private-reply.ts`) → the channel's comment_id-anchored Send API DM. |
+| `flow` | flow id | Enqueues `sendFlow` with `flowId` and a `public` `commentAnchor`, so the flow's first step is posted as a comment reply. | Same job with a `private` anchor: the flow's **first** message is sent through the comment_id-anchored Send API (comment window, not the 24-hour messaging window); later messages take the normal window-gated path. |
 | `AIAgent` | **AI agent id** | Enqueues a delayed `commentAIReply` job → `processCommentAIReply` generates text with the **selected** agent (`generateAIReplyText`, tools/rich off) and posts it as a **public comment reply**. | Same job, `replyChannel: "private"` → generated text sent as a **DM**. |
 
 The `AIAgent` path deliberately does **not** reuse the DM auto-responder pipeline
@@ -118,9 +125,15 @@ send), and the comment handler owns the channel routing.
   comment when `ignoreCommentReplies` is on.)
 - **Post-id formats differ by picker tab.** Always compare via `normalizePostId`. Reels
   may still need verification that the stored `video_id` equals the webhook `story_id`.
-- **Instagram is not wired.** `type` is never set by the builder → always `messenger`.
-  Do not assume IG automations run. IG private-DM text replies are also out of scope
-  (no `private_replies` API).
+- **Capabilities differ per channel.** Private DM replies work on all three channels
+  (`PRIVATE_REPLY_TEXT_SENDERS`), but comment liking exists only on `messenger` and
+  `instagramFacebook` — Instagram Login has no like API, so its `likeComment` handler
+  is a logged no-op — and the attachment lookup behind `hideComments.hasImage` /
+  `hasVideo` is implemented only for `messenger` (`comment-attachment.ts`
+  short-circuits every other channel to "no attachment"). The `ig-comments` form gates
+  each toggle separately: the like switch renders only for `instagramFacebook`, while
+  `hasImage`/`hasVideo` are hidden for both Instagram variants. Keep that pattern —
+  hide an unsupported toggle rather than rendering a dead one.
 - **`options.trackUserTags` is defined but not implemented** — the toggle has no effect.
 - **`getPriorContactInboxCount` counts `ContactInbox` rows**, so a contact who DM'd via
   another inbox is treated as "not new."
@@ -134,7 +147,9 @@ send), and the comment handler owns the channel routing.
 [`apps/worker/__tests__/comment-automation.test.ts`](../apps/worker/__tests__/comment-automation.test.ts)
 covers: `isCommentReply`, reply filtering, `matchPost` normalization, the
 `replyToUsersWhoCommentedOnOtherPosts` gate, AIAgent enqueue (public/private), the
-`processCommentAIReply` delivery paths, and hide-keyword case-insensitivity. Run:
+`processCommentAIReply` delivery paths, per-channel private-reply routing (messenger /
+instagram / instagramFacebook) and flow-reply comment anchors, and hide-keyword
+case-insensitivity. Run:
 
 ```bash
 pnpm --filter worker vitest run __tests__/comment-automation.test.ts


### PR DESCRIPTION
`docs/fb-comment-automation.md` and the `fb-comment-automation` skill were last updated on 2026-07-13 (#729). Since then:

- **#874** shipped the `ig-comments` builder feature and the `instagram` / `instagramFacebook` channel types
- **#831** and **#1018** moved flow-based private replies onto Meta's comment_id-anchored Send API

None of those PRs touched the docs, so both files still assert the opposite of what the code does:

| file | claim | reality |
| --- | --- | --- |
| `docs/fb-comment-automation.md` (scope banner) | "Instagram comment automation is not implemented — the builder always stores `type = "messenger"`" | `CommentAutomationChannelType` has three values; `ig-comments` writes `instagram` / `instagramFacebook` |
| `docs/fb-comment-automation.md` (known gaps) | "Instagram is not wired … IG private-DM text replies are also out of scope (no `private_replies` API)" | `PRIVATE_REPLY_TEXT_SENDERS` covers all three channels via the comment_id-anchored Send API |
| `SKILL.md` (trap 6) | "Instagram is not implemented … Don't add IG-only behavior expecting it to run" | same as above |
| `SKILL.md` (reply-type recipe) | "private = `sendPrivateReply` (messenger only)" | per-channel entry in `PRIVATE_REPLY_TEXT_SENDERS` |

The skill file matters most here: it is the runbook agents are routed to, and trap 6 actively told them not to work on Instagram. Its frontmatter `description` was also still FB-only, so it would not have been selected for Instagram work at all.

## What changed

Descriptions only — no structural rewrite, no new sections.

- Scope banner now names the three `CommentAutomationChannelType` values and points at Known gaps for the per-channel differences
- The `type` option row, the `text` / `flow` reply-type rows, the flow diagram and both key-file tables now cover the Instagram paths
- "Instagram is not wired" is replaced by the **real** remaining limits: comment liking exists only on `messenger` and `instagramFacebook` (Instagram Login's `likeComment` handler is a logged no-op), and the `hideComments.hasImage` / `hasVideo` attachment lookup is messenger-only (`comment-attachment.ts` short-circuits every other channel)
- Added a note that Instagram ids are not composite, so `normalizePostId` is a no-op there
- `SKILL.md`: frontmatter description, trap 6, the "where things live" table and the reply-type recipe updated; the stale `(index.ts)` pointer corrected to `public-reply.ts` / `private-reply.ts` after the module split

Statements that could not be confirmed from the code were left untouched — the Reels `video_id` / `story_id` question, `options.trackUserTags` (re-verified as still a no-op), and Instagram's `parent_id` semantics on top-level comments, which no code asserts either way.

`pnpm lint` is clean (only the two pre-existing generated-file errors), and all relative links and in-page anchors still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jr3BRqH3woCzbcePEBPira
