### PR TITLE
fix(auth): white-label sign-in — root-tenant SSO fallback and per-credential OAuth origins

### DIFF
--- a/apps/builder/__tests__/ads-account-switcher.test.tsx
+++ b/apps/builder/__tests__/ads-account-switcher.test.tsx
@@ -107,6 +107,7 @@ describe("AdsAccountSwitcher", () => {
       root.render(
         <AdsAccountSwitcher
           integrations={integrations}
+          oauthCallbackUrl="https://broker.test/integrations/whatsapp/callback"
           whatsappCredentialPublic={null}
           workspaceId="ws-1"
         />,

--- a/apps/builder/__tests__/ads-analytics-view-revenue-delivery.test.tsx
+++ b/apps/builder/__tests__/ads-analytics-view-revenue-delivery.test.tsx
@@ -182,6 +182,7 @@ describe("AdsAnalyticsView revenue and delivery", () => {
     await act(async () => {
       root.render(
         <AdsAnalyticsView
+          oauthCallbackUrl="https://broker.test/integrations/whatsapp/callback"
           promises={Promise.resolve([
             analyticsData,
             deliverySummary,
@@ -234,6 +235,7 @@ describe("AdsAnalyticsView revenue and delivery", () => {
     await act(async () => {
       root.render(
         <AdsAnalyticsView
+          oauthCallbackUrl="https://broker.test/integrations/whatsapp/callback"
           promises={Promise.resolve([
             analyticsData,
             deliverySummary,

--- a/apps/builder/__tests__/channel-reconnect-actions.test.ts
+++ b/apps/builder/__tests__/channel-reconnect-actions.test.ts
@@ -62,6 +62,12 @@ vi.mock("@chatbotx.io/business", () => ({
   platformCredentialService: {
     resolveForOwner: mockResolveForOwner,
   },
+  customDomainService: {
+    findActiveByTenantId: mockFindActiveByTenantId,
+  },
+  tenantService: {
+    findByOwner: mockFindByOwner,
+  },
 }))
 
 vi.mock("@/lib/platform-credential-owner", () => ({
@@ -98,9 +104,18 @@ vi.mock("@/lib/domain", () => ({
   getOriginUrlFromHeader: vi.fn(async () => "https://app.example.com"),
 }))
 
+const BROKER_ORIGIN = "https://broker.example.com"
+
 vi.mock("@/lib/oauth-broker", () => ({
-  buildBrokerCallbackUrl: (path: string) => `https://broker.example.com${path}`,
+  getBrokerOrigin: () => BROKER_ORIGIN,
 }))
+
+const { mockFindActiveByTenantId, mockFindByOwner } = vi.hoisted(() => ({
+  mockFindActiveByTenantId: vi.fn(),
+  mockFindByOwner: vi.fn(),
+}))
+
+vi.mock("@/env", () => ({ isCloud: () => true }))
 
 await import("../src/features/integration-messenger/actions/reconnect.action")
 await import("../src/features/integration-instagram/actions/reconnect.action")
@@ -134,12 +149,15 @@ describe("reconnectMessengerAction", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockResolveForOwner.mockResolvedValue({
+      userId: null,
       config: {
         clientId: "client-1",
         clientSecret: "secret-1",
         version: "v23.0",
       },
     })
+    mockFindByOwner.mockResolvedValue(undefined)
+    mockFindActiveByTenantId.mockResolvedValue(undefined)
   })
 
   test("redirects to the Facebook dialog with reconnect state", async () => {
@@ -185,18 +203,46 @@ describe("reconnectMessengerAction", () => {
     )
     expect(mockRedirect).not.toHaveBeenCalled()
   })
-})
 
-describe("reconnectInstagramAction", () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
+  test("uses the reseller's active custom domain for a tenant-owned credential", async () => {
+    mockFindMessengerIntegration.mockResolvedValue({
+      id: "im-1",
+      pageId: "page-1",
+    })
     mockResolveForOwner.mockResolvedValue({
+      userId: "owner-1",
       config: {
         clientId: "client-1",
         clientSecret: "secret-1",
         version: "v23.0",
       },
     })
+    mockFindByOwner.mockResolvedValue({ id: "t1", status: "active" })
+    mockFindActiveByTenantId.mockResolvedValue({ domain: "chat.acme.com" })
+
+    await executeMessengerReconnect()
+
+    expect(mockGenerateMessengerAuthUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        redirectUrl: "https://chat.acme.com/integrations/messenger/callback",
+      }),
+    )
+  })
+})
+
+describe("reconnectInstagramAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockResolveForOwner.mockResolvedValue({
+      userId: null,
+      config: {
+        clientId: "client-1",
+        clientSecret: "secret-1",
+        version: "v23.0",
+      },
+    })
+    mockFindByOwner.mockResolvedValue(undefined)
+    mockFindActiveByTenantId.mockResolvedValue(undefined)
   })
 
   test("opens the direct Instagram dialog for type instagram", async () => {

--- a/apps/builder/__tests__/channel-reconnect-actions.test.ts
+++ b/apps/builder/__tests__/channel-reconnect-actions.test.ts
@@ -313,6 +313,7 @@ describe("reconnectZaloAction", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockResolveForOwner.mockResolvedValue({
+      userId: null,
       config: {
         clientId: "client-1",
         clientSecret: "secret-1",
@@ -320,6 +321,8 @@ describe("reconnectZaloAction", () => {
         version: "v4",
       },
     })
+    mockFindByOwner.mockResolvedValue(undefined)
+    mockFindActiveByTenantId.mockResolvedValue(undefined)
   })
 
   test("redirects to the Zalo dialog with reconnect state", async () => {
@@ -364,5 +367,28 @@ describe("reconnectZaloAction", () => {
       "Zalo App settings not found",
     )
     expect(mockRedirect).not.toHaveBeenCalled()
+  })
+
+  test("uses the reseller's active custom domain for a tenant-owned credential", async () => {
+    mockFindZaloIntegration.mockResolvedValue({ id: "iz-1", oaId: "oa-1" })
+    mockResolveForOwner.mockResolvedValue({
+      userId: "owner-1",
+      config: {
+        clientId: "client-1",
+        clientSecret: "secret-1",
+        verifyToken: "verify-1",
+        version: "v4",
+      },
+    })
+    mockFindByOwner.mockResolvedValue({ id: "t1", status: "active" })
+    mockFindActiveByTenantId.mockResolvedValue({ domain: "chat.acme.com" })
+
+    await executeZaloReconnect()
+
+    expect(mockGenerateZaloAuthUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        redirectUrl: "https://chat.acme.com/integrations/zalo/callback",
+      }),
+    )
   })
 })

--- a/apps/builder/__tests__/channel-reconnect-handlers.test.ts
+++ b/apps/builder/__tests__/channel-reconnect-handlers.test.ts
@@ -663,6 +663,7 @@ describe("reconnectZaloHandler", () => {
       req: new Request(
         "https://broker.example.com/integrations/zalo/callback?code=code-1",
       ),
+      callbackUrl: "https://broker.example.com/integrations/zalo/callback",
     })
 
   test("stores the fresh tokens when the authorized OA matches", async () => {

--- a/apps/builder/__tests__/channels-create-messenger-reuse.test.ts
+++ b/apps/builder/__tests__/channels-create-messenger-reuse.test.ts
@@ -185,7 +185,7 @@ describe("GET /channels/create/messenger — Facebook SSO token reuse", () => {
     expect(mockEncryptAuth).not.toHaveBeenCalled()
     expect(mockCookieSet).not.toHaveBeenCalled()
     expect(mockGenerateMessengerRedirectUri).toHaveBeenCalledWith(
-      messengerCredential.publicConfig,
+      messengerCredential,
       "ws-1",
     )
   })

--- a/apps/builder/__tests__/conversion-events-account-reset.test.tsx
+++ b/apps/builder/__tests__/conversion-events-account-reset.test.tsx
@@ -130,6 +130,7 @@ describe("ConversionEventsView account selection", () => {
     await act(async () => {
       root.render(
         <ConversionEventsView
+          oauthCallbackUrl="https://broker.test/integrations/whatsapp/callback"
           promises={Promise.resolve([data])}
           selectedAccount={data.whatsappIntegrations[0]}
           switcherIntegrations={switcherIntegrations}
@@ -154,6 +155,7 @@ describe("ConversionEventsView account selection", () => {
     await act(async () => {
       root.render(
         <ConversionEventsView
+          oauthCallbackUrl="https://broker.test/integrations/whatsapp/callback"
           promises={Promise.resolve([data])}
           selectedAccount={data.whatsappIntegrations[1]}
           switcherIntegrations={switcherIntegrations}

--- a/apps/builder/__tests__/conversion-events-rule-types.test.tsx
+++ b/apps/builder/__tests__/conversion-events-rule-types.test.tsx
@@ -205,6 +205,7 @@ describe("ConversionEventsView rule types", () => {
     await act(async () => {
       root.render(
         <ConversionEventsView
+          oauthCallbackUrl="https://broker.test/integrations/whatsapp/callback"
           promises={Promise.resolve([data])}
           selectedAccount={data.whatsappIntegrations[0]}
           switcherIntegrations={switcherIntegrations}
@@ -236,6 +237,7 @@ describe("ConversionEventsView rule types", () => {
     await act(async () => {
       root.render(
         <ConversionEventsView
+          oauthCallbackUrl="https://broker.test/integrations/whatsapp/callback"
           promises={Promise.resolve([data])}
           selectedAccount={data.whatsappIntegrations[0]}
           switcherIntegrations={switcherIntegrations}
@@ -268,6 +270,7 @@ describe("ConversionEventsView rule types", () => {
     await act(async () => {
       root.render(
         <ConversionEventsView
+          oauthCallbackUrl="https://broker.test/integrations/whatsapp/callback"
           promises={Promise.resolve([data])}
           selectedAccount={data.whatsappIntegrations[0]}
           switcherIntegrations={switcherIntegrations}
@@ -311,6 +314,7 @@ describe("ConversionEventsView rule types", () => {
     await act(async () => {
       root.render(
         <ConversionEventsView
+          oauthCallbackUrl="https://broker.test/integrations/whatsapp/callback"
           promises={Promise.resolve([data])}
           selectedAccount={data.whatsappIntegrations[0]}
           switcherIntegrations={switcherIntegrations}
@@ -353,6 +357,7 @@ describe("ConversionEventsView rule types", () => {
     await act(async () => {
       root.render(
         <ConversionEventsView
+          oauthCallbackUrl="https://broker.test/integrations/whatsapp/callback"
           promises={Promise.resolve([data])}
           selectedAccount={data.whatsappIntegrations[0]}
           switcherIntegrations={switcherIntegrations}

--- a/apps/builder/__tests__/oauth-reconnect-callback.test.ts
+++ b/apps/builder/__tests__/oauth-reconnect-callback.test.ts
@@ -515,6 +515,7 @@ describe("handleCallback OAuth reconnect", () => {
       workspaceId: "1",
       integrationId: "5",
       req: request,
+      callbackUrl: "https://broker.example.com/integrations/zalo/callback",
     })
     expect(mockConnectZaloHandler).not.toHaveBeenCalled()
 

--- a/apps/builder/__tests__/oauth-referer.test.ts
+++ b/apps/builder/__tests__/oauth-referer.test.ts
@@ -185,16 +185,21 @@ describe("with a dedicated broker host", () => {
     )
   })
 
-  test("does not relay from the builder host — only the broker host relays", async () => {
+  test("relays from the builder host too — relay is not broker-only (tenant-owned credential landed on the platform host)", async () => {
     mockFindActiveByDomain.mockResolvedValue(activeDomain)
     const { resolveRelayTarget } = await loadWithBroker()
 
+    // A reseller with their own app registers their custom domain as the
+    // redirect_uri, so a flow that started on the platform host can still
+    // land the callback on the tenant's own domain.
     const callbackUrl = new URL(
       `${PLATFORM_URL}/integrations/tiktok/callback?code=abc`,
     )
     const referer = "https://chat.acme.com/space/42/dashboard"
 
-    expect(await resolveRelayTarget(callbackUrl, referer)).toBeNull()
+    expect(await resolveRelayTarget(callbackUrl, referer)).toBe(
+      "https://chat.acme.com/integrations/tiktok/callback?code=abc",
+    )
   })
 
   test("does not relay back to the broker itself", async () => {

--- a/apps/builder/__tests__/provider-origin.test.ts
+++ b/apps/builder/__tests__/provider-origin.test.ts
@@ -1,0 +1,166 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const BROKER_ORIGIN = "https://broker.test"
+
+const { mockFindActiveByTenantId, mockFindByOwner } = vi.hoisted(() => ({
+  mockFindActiveByTenantId: vi.fn(),
+  mockFindByOwner: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  customDomainService: {
+    findActiveByTenantId: mockFindActiveByTenantId,
+  },
+  tenantService: {
+    findByOwner: mockFindByOwner,
+  },
+}))
+
+const mockIsCloud = vi.fn(() => true)
+vi.mock("@/env", () => ({
+  isCloud: mockIsCloud,
+}))
+
+vi.mock("@/lib/oauth-broker", () => ({
+  getBrokerOrigin: () => BROKER_ORIGIN,
+}))
+
+async function loadModule() {
+  vi.resetModules()
+  return await import("@/lib/provider-origin")
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockIsCloud.mockReturnValue(true)
+})
+
+describe("resolveTenantCustomDomainOrigin", () => {
+  test("returns null on non-cloud editions without looking up the tenant", async () => {
+    mockIsCloud.mockReturnValue(false)
+    const { resolveTenantCustomDomainOrigin } = await loadModule()
+
+    expect(await resolveTenantCustomDomainOrigin("owner-1")).toBeNull()
+    expect(mockFindByOwner).not.toHaveBeenCalled()
+  })
+
+  test("returns null when the owner has no tenant", async () => {
+    mockFindByOwner.mockResolvedValue(undefined)
+    const { resolveTenantCustomDomainOrigin } = await loadModule()
+
+    expect(await resolveTenantCustomDomainOrigin("owner-1")).toBeNull()
+    expect(mockFindActiveByTenantId).not.toHaveBeenCalled()
+  })
+
+  test("returns null when the tenant is suspended", async () => {
+    mockFindByOwner.mockResolvedValue({ id: "t1", status: "suspended" })
+    const { resolveTenantCustomDomainOrigin } = await loadModule()
+
+    expect(await resolveTenantCustomDomainOrigin("owner-1")).toBeNull()
+    expect(mockFindActiveByTenantId).not.toHaveBeenCalled()
+  })
+
+  test("returns null when the tenant has no active custom domain", async () => {
+    mockFindByOwner.mockResolvedValue({ id: "t1", status: "active" })
+    mockFindActiveByTenantId.mockResolvedValue(undefined)
+    const { resolveTenantCustomDomainOrigin } = await loadModule()
+
+    expect(await resolveTenantCustomDomainOrigin("owner-1")).toBeNull()
+    expect(mockFindActiveByTenantId).toHaveBeenCalledWith("t1")
+  })
+
+  test("returns the https origin of the active custom domain", async () => {
+    mockFindByOwner.mockResolvedValue({ id: "t1", status: "active" })
+    mockFindActiveByTenantId.mockResolvedValue({ domain: "chat.acme.com" })
+    const { resolveTenantCustomDomainOrigin } = await loadModule()
+
+    expect(await resolveTenantCustomDomainOrigin("owner-1")).toBe(
+      "https://chat.acme.com",
+    )
+  })
+})
+
+describe("resolveTenantProviderOrigin", () => {
+  test("falls back to the broker origin when there is no active custom domain", async () => {
+    mockFindByOwner.mockResolvedValue(undefined)
+    const { resolveTenantProviderOrigin } = await loadModule()
+
+    expect(await resolveTenantProviderOrigin("owner-1")).toBe(BROKER_ORIGIN)
+  })
+
+  test("returns the tenant's custom domain origin when active", async () => {
+    mockFindByOwner.mockResolvedValue({ id: "t1", status: "active" })
+    mockFindActiveByTenantId.mockResolvedValue({ domain: "chat.acme.com" })
+    const { resolveTenantProviderOrigin } = await loadModule()
+
+    expect(await resolveTenantProviderOrigin("owner-1")).toBe(
+      "https://chat.acme.com",
+    )
+  })
+})
+
+describe("resolveProviderOriginForCredential", () => {
+  test("returns the broker origin for a platform credential (userId null)", async () => {
+    const { resolveProviderOriginForCredential } = await loadModule()
+
+    expect(await resolveProviderOriginForCredential({ userId: null })).toBe(
+      BROKER_ORIGIN,
+    )
+    expect(mockFindByOwner).not.toHaveBeenCalled()
+  })
+
+  test("returns the broker origin when no credential is passed", async () => {
+    const { resolveProviderOriginForCredential } = await loadModule()
+
+    expect(await resolveProviderOriginForCredential(undefined)).toBe(
+      BROKER_ORIGIN,
+    )
+  })
+
+  test("resolves the tenant origin for a tenant-owned credential (userId set)", async () => {
+    mockFindByOwner.mockResolvedValue({ id: "t1", status: "active" })
+    mockFindActiveByTenantId.mockResolvedValue({ domain: "chat.acme.com" })
+    const { resolveProviderOriginForCredential } = await loadModule()
+
+    expect(
+      await resolveProviderOriginForCredential({ userId: "owner-1" }),
+    ).toBe("https://chat.acme.com")
+    expect(mockFindByOwner).toHaveBeenCalledWith("owner-1")
+  })
+})
+
+describe("buildProviderCallbackUrl", () => {
+  test("joins the path onto the broker origin for a platform credential", async () => {
+    const { buildProviderCallbackUrl } = await loadModule()
+
+    expect(
+      await buildProviderCallbackUrl(
+        { userId: null },
+        "/integrations/messenger/callback",
+      ),
+    ).toBe(`${BROKER_ORIGIN}/integrations/messenger/callback`)
+  })
+
+  test("joins the path onto the tenant's custom domain for a tenant-owned credential", async () => {
+    mockFindByOwner.mockResolvedValue({ id: "t1", status: "active" })
+    mockFindActiveByTenantId.mockResolvedValue({ domain: "chat.acme.com" })
+    const { buildProviderCallbackUrl } = await loadModule()
+
+    expect(
+      await buildProviderCallbackUrl(
+        { userId: "owner-1" },
+        "/integrations/messenger/callback",
+      ),
+    ).toBe("https://chat.acme.com/integrations/messenger/callback")
+  })
+})
+
+describe("PLACEHOLDER_DOMAIN_ORIGIN", () => {
+  test("is a literal, non-resolvable placeholder for display only", async () => {
+    const { PLACEHOLDER_DOMAIN_ORIGIN } = await loadModule()
+
+    expect(PLACEHOLDER_DOMAIN_ORIGIN).toBe("https://<your-domain.com>")
+  })
+})

--- a/apps/builder/__tests__/social-auth-instances.test.ts
+++ b/apps/builder/__tests__/social-auth-instances.test.ts
@@ -7,27 +7,37 @@ const SOCIAL_PROVIDERS = ["google", "facebook"] as const
 
 const FACEBOOK_SSO_SCOPES = ["email", "public_profile", "pages_messaging"]
 
+const BROKER_ORIGIN = "https://broker.test"
+
 const {
   mockCreateAuth,
+  mockFindActiveByTenantId,
   mockFindDecryptedPlatform,
   mockResolveForOwner,
   mockResolveTenantByDomain,
   mockResolveTenantOwnerId,
   mockUpgradeFacebookAccount,
 } = vi.hoisted(() => ({
-  // createAuth is mocked to a cheap stub tagged by the (provider, clientId) it
-  // was built with, so we can assert which app an instance signs in with and
-  // that instances are reused per credential rather than rebuilt.
+  // createAuth is mocked to a cheap stub tagged by the (provider, clientId,
+  // redirectOrigin) it was built with, so we can assert which app + origin an
+  // instance signs in with and that instances are reused per credential
+  // rather than rebuilt.
   mockCreateAuth: vi.fn(
     (config: {
       socialCredentials?: Record<string, { clientId: string } | null>
+      socialRedirectOrigin?: string
     }) => {
       const [provider, credential] = Object.entries(
         config.socialCredentials ?? {},
       )[0] ?? [null, null]
-      return { provider, clientId: credential?.clientId ?? null }
+      return {
+        provider,
+        clientId: credential?.clientId ?? null,
+        redirectOrigin: config.socialRedirectOrigin,
+      }
     },
   ),
+  mockFindActiveByTenantId: vi.fn(),
   mockFindDecryptedPlatform: vi.fn(),
   mockResolveForOwner: vi.fn(),
   mockResolveTenantByDomain: vi.fn(),
@@ -52,6 +62,9 @@ vi.mock("@/lib/auth/on-user-created", () => ({
 }))
 
 vi.mock("@chatbotx.io/business", () => ({
+  customDomainService: {
+    findActiveByTenantId: mockFindActiveByTenantId,
+  },
   platformCredentialService: {
     findDecryptedPlatform: mockFindDecryptedPlatform,
     resolveForOwner: mockResolveForOwner,
@@ -67,13 +80,22 @@ vi.mock("@/lib/auth/upgrade-facebook-account", () => ({
   upgradeFacebookAccount: mockUpgradeFacebookAccount,
 }))
 
+vi.mock("@/lib/oauth-broker", () => ({
+  getBrokerOrigin: () => BROKER_ORIGIN,
+}))
+
 const mockIsCommunity = vi.fn(() => false)
 vi.mock("@/env", () => ({
   isCommunity: mockIsCommunity,
   isCloud: vi.fn(() => false),
 }))
 
-const credential = (clientId: string, clientSecret = "secret") => ({
+const credential = (
+  clientId: string,
+  clientSecret = "secret",
+  userId: string | null = null,
+) => ({
+  userId,
   config: { clientId, clientSecret, verifyToken: "token", version: "v1" },
 })
 
@@ -86,6 +108,7 @@ async function loadModule() {
 beforeEach(() => {
   vi.clearAllMocks()
   mockIsCommunity.mockReturnValue(false)
+  mockFindActiveByTenantId.mockResolvedValue(undefined)
 })
 
 describe("isSocialLoginEnabledForTenant — google", () => {
@@ -304,5 +327,101 @@ describe("getSocialAuthForTenant", () => {
       clientSecret: "secret",
       version: "v23.0",
     })
+  })
+})
+
+describe("getSocialAuthForTenant — tenant-owned credential redirect origin", () => {
+  test("root tenant always resolves the broker origin, even with userId set on the platform row", async () => {
+    mockFindDecryptedPlatform.mockResolvedValue(
+      credential("platform-client", "secret", null),
+    )
+    const { getSocialAuthForTenant } = await loadModule()
+
+    await getSocialAuthForTenant(ROOT_TENANT_ID, "google")
+
+    expect(mockCreateAuth).toHaveBeenCalledWith(
+      expect.objectContaining({ socialRedirectOrigin: BROKER_ORIGIN }),
+    )
+    expect(mockFindActiveByTenantId).not.toHaveBeenCalled()
+  })
+
+  test("a non-root tenant with an inherited (platform) credential still resolves the broker origin", async () => {
+    mockResolveTenantOwnerId.mockResolvedValue(undefined)
+    mockResolveForOwner.mockResolvedValue(undefined)
+    mockFindDecryptedPlatform.mockResolvedValue(
+      credential("platform-client", "secret", null),
+    )
+    const { getSocialAuthForTenant } = await loadModule()
+
+    await getSocialAuthForTenant("42", "google")
+
+    expect(mockCreateAuth).toHaveBeenCalledWith(
+      expect.objectContaining({ socialRedirectOrigin: BROKER_ORIGIN }),
+    )
+  })
+
+  test("a tenant-owned credential with an active custom domain resolves that domain's origin", async () => {
+    mockResolveTenantOwnerId.mockResolvedValue("owner-1")
+    mockResolveForOwner.mockResolvedValue(
+      credential("reseller-client", "secret", "owner-1"),
+    )
+    mockFindActiveByTenantId.mockResolvedValue({ domain: "chat.acme.com" })
+    const { getSocialAuthForTenant } = await loadModule()
+
+    await getSocialAuthForTenant("42", "google")
+
+    expect(mockFindActiveByTenantId).toHaveBeenCalledWith("42")
+    expect(mockCreateAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        socialRedirectOrigin: "https://chat.acme.com",
+      }),
+    )
+  })
+
+  test("a tenant-owned credential with no active custom domain falls back to the broker origin", async () => {
+    mockResolveTenantOwnerId.mockResolvedValue("owner-1")
+    mockResolveForOwner.mockResolvedValue(
+      credential("reseller-client", "secret", "owner-1"),
+    )
+    mockFindActiveByTenantId.mockResolvedValue(undefined)
+    const { getSocialAuthForTenant } = await loadModule()
+
+    await getSocialAuthForTenant("42", "google")
+
+    expect(mockCreateAuth).toHaveBeenCalledWith(
+      expect.objectContaining({ socialRedirectOrigin: BROKER_ORIGIN }),
+    )
+  })
+
+  test("distinct redirect origins for the same credential resolve to distinct cached instances", async () => {
+    mockResolveTenantOwnerId.mockResolvedValue("owner-1")
+    mockResolveForOwner.mockResolvedValue(
+      credential("reseller-client", "secret", "owner-1"),
+    )
+    const { getSocialAuthForTenant } = await loadModule()
+
+    mockFindActiveByTenantId.mockResolvedValueOnce(undefined)
+    const beforeDomain = await getSocialAuthForTenant("42", "google")
+
+    mockFindActiveByTenantId.mockResolvedValueOnce({ domain: "chat.acme.com" })
+    const afterDomain = await getSocialAuthForTenant("42", "google")
+
+    expect(beforeDomain).not.toBe(afterDomain)
+    expect(mockCreateAuth).toHaveBeenCalledTimes(2)
+  })
+
+  test("the same tenant-owned credential and domain reuse the cached instance", async () => {
+    mockResolveTenantOwnerId.mockResolvedValue("owner-1")
+    mockResolveForOwner.mockResolvedValue(
+      credential("reseller-client", "secret", "owner-1"),
+    )
+    mockFindActiveByTenantId.mockResolvedValue({ domain: "chat.acme.com" })
+    const { getSocialAuthForTenant } = await loadModule()
+
+    const first = await getSocialAuthForTenant("42", "google")
+    const second = await getSocialAuthForTenant("42", "google")
+
+    expect(first).toBe(second)
+    expect(mockCreateAuth).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/builder/__tests__/social-login-community.test.ts
+++ b/apps/builder/__tests__/social-login-community.test.ts
@@ -61,6 +61,7 @@ vi.mock("@/lib/auth/upgrade-facebook-account", () => ({
 vi.mock("@/env", () => ({
   isCommunity: vi.fn(() => true),
   isCloud: vi.fn(() => false),
+  env: { NEXT_PUBLIC_BUILDER_URL: "https://app.example.com" },
 }))
 
 const credential = (clientId: string) => ({

--- a/apps/builder/__tests__/tiktok-settings-actions.test.ts
+++ b/apps/builder/__tests__/tiktok-settings-actions.test.ts
@@ -1,11 +1,22 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
-const { removeSpy, resolveSpy, subscribeSpy, upsertSpy } = vi.hoisted(() => ({
+const BROKER_ORIGIN = "https://broker.test"
+
+const {
+  removeSpy,
+  resolveSpy,
+  subscribeSpy,
+  upsertSpy,
+  mockFindActiveByTenantId,
+  mockFindByOwner,
+} = vi.hoisted(() => ({
   removeSpy: vi.fn(),
   resolveSpy: vi.fn(),
   subscribeSpy: vi.fn(),
   upsertSpy: vi.fn(),
+  mockFindActiveByTenantId: vi.fn(),
+  mockFindByOwner: vi.fn(),
 }))
 vi.mock("@/lib/safe-action", () => {
   const chain: Record<string, any> = {}
@@ -16,13 +27,15 @@ vi.mock("@/lib/safe-action", () => {
 })
 vi.mock("@chatbotx.io/business", () => ({
   platformCredentialService: { remove: removeSpy, upsert: upsertSpy },
+  customDomainService: { findActiveByTenantId: mockFindActiveByTenantId },
+  tenantService: { findByOwner: mockFindByOwner },
 }))
 vi.mock("@chatbotx.io/integration-tiktok", () => ({
   subscribeWebhook: subscribeSpy,
 }))
 vi.mock("@/env", () => ({ isCloud: () => true }))
 vi.mock("@/lib/oauth-broker", () => ({
-  buildBrokerCallbackUrl: (path: string) => path,
+  getBrokerOrigin: () => BROKER_ORIGIN,
 }))
 vi.mock("../src/features/platform-credentials/scope", () => ({
   credentialScopeSchema: {},
@@ -42,6 +55,8 @@ describe("TikTok credential actions", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     resolveSpy.mockReturnValue("user-1")
+    mockFindByOwner.mockResolvedValue(undefined)
+    mockFindActiveByTenantId.mockResolvedValue(undefined)
   })
   test("upserts all fields and subscribes webhook", async () => {
     await call(updateTiktokSettingAction)({
@@ -56,6 +71,52 @@ describe("TikTok credential actions", () => {
     })
     expect(subscribeSpy).toHaveBeenCalled()
   })
+
+  test("subscribes the webhook on the broker origin for user scope with no active custom domain", async () => {
+    await call(updateTiktokSettingAction)({
+      ctx: { user: { id: "user-1" } },
+      bindArgsParsedInputs: ["user"],
+      parsedInput: { clientId: "id", clientSecret: "secret" },
+    })
+
+    expect(subscribeSpy).toHaveBeenCalledWith(
+      { clientId: "id", clientSecret: "secret" },
+      `${BROKER_ORIGIN}/integrations/tiktok/webhook`,
+    )
+  })
+
+  test("subscribes the webhook on the tenant's active custom domain for user scope", async () => {
+    mockFindByOwner.mockResolvedValue({ id: "t1", status: "active" })
+    mockFindActiveByTenantId.mockResolvedValue({ domain: "chat.acme.com" })
+
+    await call(updateTiktokSettingAction)({
+      ctx: { user: { id: "user-1" } },
+      bindArgsParsedInputs: ["user"],
+      parsedInput: { clientId: "id", clientSecret: "secret" },
+    })
+
+    expect(subscribeSpy).toHaveBeenCalledWith(
+      { clientId: "id", clientSecret: "secret" },
+      "https://chat.acme.com/integrations/tiktok/webhook",
+    )
+  })
+
+  test("subscribes the webhook on the broker origin for platform scope, ignoring any tenant domain", async () => {
+    resolveSpy.mockReturnValue(undefined)
+
+    await call(updateTiktokSettingAction)({
+      ctx: { user: { id: "admin-1" } },
+      bindArgsParsedInputs: ["platform"],
+      parsedInput: { clientId: "id", clientSecret: "secret" },
+    })
+
+    expect(subscribeSpy).toHaveBeenCalledWith(
+      { clientId: "id", clientSecret: "secret" },
+      `${BROKER_ORIGIN}/integrations/tiktok/webhook`,
+    )
+    expect(mockFindByOwner).not.toHaveBeenCalled()
+  })
+
   test.each(["clientId", "clientSecret"])("rejects empty %s", (field) => {
     expect(
       tiktokCredentialUpdateSchema.safeParse({

--- a/apps/builder/__tests__/whatsapp-automatic-events-card.test.tsx
+++ b/apps/builder/__tests__/whatsapp-automatic-events-card.test.tsx
@@ -70,6 +70,7 @@ describe("WhatsappAutomaticEventsCard", () => {
       root.render(
         <WhatsappAutomaticEventsCard
           integrationWhatsapp={integration}
+          oauthCallbackUrl="https://broker.test/integrations/whatsapp/callback"
           whatsappCredentialPublic={credential}
           workspaceId="ws-1"
         />,

--- a/apps/builder/__tests__/whatsapp-connect-card.test.tsx
+++ b/apps/builder/__tests__/whatsapp-connect-card.test.tsx
@@ -6,6 +6,7 @@ import WhatsappCreate from "@/features/integration-whatsapp/components/whatsapp-
 import { WA_OAUTH_RESULT } from "@/features/integration-whatsapp/libs/embedded-signup"
 
 const BROKER_ORIGIN = "https://broker.test"
+const OAUTH_CALLBACK_URL = `${BROKER_ORIGIN}/integrations/whatsapp/callback`
 const OAUTH_CODE = "AQD-relayed-code"
 
 /** Echoes the key back so assertions never depend on the English copy. */
@@ -20,10 +21,6 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("sonner", () => ({
   toast: { error: vi.fn(), success: vi.fn() },
-}))
-
-vi.mock("@/lib/oauth-broker", () => ({
-  getBrokerOrigin: () => BROKER_ORIGIN,
 }))
 
 vi.mock("@/features/integration-whatsapp/actions/connect.action", () => ({
@@ -74,7 +71,13 @@ describe("WhatsappCreate connect card", () => {
     root = createRoot(container)
 
     act(() => {
-      root.render(<WhatsappCreate settings={SETTINGS} workspaceId="ws-1" />)
+      root.render(
+        <WhatsappCreate
+          oauthCallbackUrl={OAUTH_CALLBACK_URL}
+          settings={SETTINGS}
+          workspaceId="ws-1"
+        />,
+      )
     })
   })
 

--- a/apps/builder/__tests__/whatsapp-embedded-signup-auto-connect.test.tsx
+++ b/apps/builder/__tests__/whatsapp-embedded-signup-auto-connect.test.tsx
@@ -18,22 +18,25 @@ const BROKER_ORIGIN = "https://broker.test"
 const FOREIGN_ORIGIN = "https://evil.test"
 const OAUTH_CODE = "AQD-relayed-code"
 
-vi.mock("@/lib/oauth-broker", () => ({
-  getBrokerOrigin: () => BROKER_ORIGIN,
-}))
-
 type ProbeProps = {
   hasFailed: boolean
   onSubmit: () => void
   onRelayError: () => void
+  callbackOrigin?: string
 }
 
 /** Mirrors the hook's output into the DOM so assertions read one source. */
-function Probe({ hasFailed, onSubmit, onRelayError }: ProbeProps) {
+function Probe({
+  hasFailed,
+  onSubmit,
+  onRelayError,
+  callbackOrigin = BROKER_ORIGIN,
+}: ProbeProps) {
   const { isConnecting } = useEmbeddedSignupAutoConnect({
     hasFailed,
     onSubmit,
     onRelayError,
+    callbackOrigin,
   })
 
   return <output data-testid="is-connecting">{String(isConnecting)}</output>
@@ -82,11 +85,12 @@ describe("useEmbeddedSignupAutoConnect", () => {
     container.remove()
   })
 
-  const render = (hasFailed = false) => {
+  const render = (hasFailed = false, callbackOrigin = BROKER_ORIGIN) => {
     act(() => {
       root.render(
         <Harness>
           <Probe
+            callbackOrigin={callbackOrigin}
             hasFailed={hasFailed}
             onRelayError={onRelayError}
             onSubmit={onSubmit}
@@ -112,7 +116,7 @@ describe("useEmbeddedSignupAutoConnect", () => {
     container.querySelector<HTMLElement>("[data-testid='is-connecting']")
       ?.textContent
 
-  test("submits as soon as the broker relays a code", () => {
+  test("submits as soon as the callback origin relays a code", () => {
     render()
     expect(isConnecting()).toBe("false")
     expect(onSubmit).not.toHaveBeenCalled()
@@ -125,6 +129,21 @@ describe("useEmbeddedSignupAutoConnect", () => {
     // Still connecting afterwards: the button must stay frozen while the action
     // is in flight rather than flashing back to the launch state.
     expect(isConnecting()).toBe("true")
+  })
+
+  test("trusts a tenant's own custom-domain callback origin, not just the broker", () => {
+    const tenantOrigin = "https://reseller.example.com"
+    render(false, tenantOrigin)
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    // A message from the broker origin is no longer relevant once the
+    // credential is tenant-owned — only the registered custom-domain
+    // callback is trusted.
+    relay(successPayload(), BROKER_ORIGIN)
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    relay(successPayload(), tenantOrigin)
+    expect(onSubmit).toHaveBeenCalledTimes(1)
   })
 
   test("submits once for one code, not on every re-render", () => {

--- a/apps/builder/__tests__/whatsapp-embedded-signup.test.ts
+++ b/apps/builder/__tests__/whatsapp-embedded-signup.test.ts
@@ -23,14 +23,16 @@ afterEach(() => {
 })
 
 describe("buildFacebookOAuthDialogUrl", () => {
-  test("opens the Facebook dialog with the broker callback as redirect_uri", async () => {
+  test("opens the Facebook dialog with the caller-supplied redirect_uri", async () => {
     const { buildFacebookOAuthDialogUrl, decodeOAuthState } = await loadWith({
       NEXT_PUBLIC_BROKER_URL: BROKER_URL,
     })
 
+    const redirectUri = `${BROKER_URL}/integrations/whatsapp/callback`
     const result = new URL(
       buildFacebookOAuthDialogUrl({
         resellerOrigin: RESELLER_ORIGIN,
+        redirectUri,
         clientId: "client-1",
         configId: "config-1",
         version: "v21.0",
@@ -45,10 +47,9 @@ describe("buildFacebookOAuthDialogUrl", () => {
     expect(result.searchParams.get("client_id")).toBe("client-1")
     expect(result.searchParams.get("config_id")).toBe("config-1")
     expect(result.searchParams.get("response_type")).toBe("code")
-    // redirect_uri must be the Meta-registered broker callback, not the reseller.
-    expect(result.searchParams.get("redirect_uri")).toBe(
-      `${BROKER_URL}/integrations/whatsapp/callback`,
-    )
+    // redirect_uri is passed straight through — this module no longer decides
+    // which host it points at (see lib/provider-origin.ts).
+    expect(result.searchParams.get("redirect_uri")).toBe(redirectUri)
 
     const state = decodeOAuthState(result.searchParams.get("state") ?? "")
     expect(state).toEqual({ referer: RESELLER_ORIGIN, locale: "vi" })
@@ -59,14 +60,16 @@ describe("buildFacebookOAuthDialogUrl", () => {
     expect(extras.featureType).toBe("only_waba_sharing")
   })
 
-  test("falls back to the builder origin when no broker is configured", async () => {
+  test("passes through a tenant-owned credential's own custom-domain redirect_uri unchanged", async () => {
     const { buildFacebookOAuthDialogUrl } = await loadWith({
-      NEXT_PUBLIC_BROKER_URL: undefined,
+      NEXT_PUBLIC_BROKER_URL: BROKER_URL,
     })
 
+    const redirectUri = `${RESELLER_ORIGIN}/integrations/whatsapp/callback`
     const result = new URL(
       buildFacebookOAuthDialogUrl({
         resellerOrigin: RESELLER_ORIGIN,
+        redirectUri,
         clientId: "client-1",
         configId: "config-1",
         version: "v21.0",
@@ -75,9 +78,28 @@ describe("buildFacebookOAuthDialogUrl", () => {
       }),
     )
 
-    expect(result.searchParams.get("redirect_uri")).toBe(
-      `${BUILDER_URL}/integrations/whatsapp/callback`,
+    expect(result.searchParams.get("redirect_uri")).toBe(redirectUri)
+  })
+
+  test("still works without a configured broker when the caller supplies the builder origin", async () => {
+    const { buildFacebookOAuthDialogUrl } = await loadWith({
+      NEXT_PUBLIC_BROKER_URL: undefined,
+    })
+
+    const redirectUri = `${BUILDER_URL}/integrations/whatsapp/callback`
+    const result = new URL(
+      buildFacebookOAuthDialogUrl({
+        resellerOrigin: RESELLER_ORIGIN,
+        redirectUri,
+        clientId: "client-1",
+        configId: "config-1",
+        version: "v21.0",
+        connectExisting: true,
+        transferPhoneNumber: false,
+      }),
     )
+
+    expect(result.searchParams.get("redirect_uri")).toBe(redirectUri)
   })
 })
 

--- a/apps/builder/__tests__/whatsapp-oauth-relay.test.ts
+++ b/apps/builder/__tests__/whatsapp-oauth-relay.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, test } from "vitest"
 import { WA_OAUTH_RESULT } from "@/features/integration-whatsapp/libs/embedded-signup"
 import { parseOAuthRelayResult } from "@/features/integration-whatsapp/libs/oauth-relay"
 
-const brokerOrigin = "https://broker.example.com"
+const expectedOrigin = "https://broker.example.com"
 
 describe("parseOAuthRelayResult", () => {
   test("ignores messages from the wrong origin", () => {
     expect(
       parseOAuthRelayResult({
         origin: "https://attacker.example.com",
-        brokerOrigin,
+        expectedOrigin,
         data: {
           type: WA_OAUTH_RESULT,
           status: "success",
@@ -19,11 +19,11 @@ describe("parseOAuthRelayResult", () => {
     ).toEqual({ type: "ignored" })
   })
 
-  test("ignores non-relay data from the broker origin", () => {
+  test("ignores non-relay data from the expected origin", () => {
     expect(
       parseOAuthRelayResult({
-        origin: brokerOrigin,
-        brokerOrigin,
+        origin: expectedOrigin,
+        expectedOrigin,
         data: { type: "OTHER_MESSAGE", status: "success", code: "oauth-code" },
       }),
     ).toEqual({ type: "ignored" })
@@ -32,8 +32,8 @@ describe("parseOAuthRelayResult", () => {
   test("returns success when the relay payload contains a code", () => {
     expect(
       parseOAuthRelayResult({
-        origin: brokerOrigin,
-        brokerOrigin,
+        origin: expectedOrigin,
+        expectedOrigin,
         data: {
           type: WA_OAUTH_RESULT,
           status: "success",
@@ -46,8 +46,8 @@ describe("parseOAuthRelayResult", () => {
   test("returns error when the relay success payload omits the code", () => {
     expect(
       parseOAuthRelayResult({
-        origin: brokerOrigin,
-        brokerOrigin,
+        origin: expectedOrigin,
+        expectedOrigin,
         data: { type: WA_OAUTH_RESULT, status: "success" },
       }),
     ).toEqual({ type: "error" })
@@ -56,10 +56,37 @@ describe("parseOAuthRelayResult", () => {
   test("returns error when the relay reports an error status", () => {
     expect(
       parseOAuthRelayResult({
-        origin: brokerOrigin,
-        brokerOrigin,
+        origin: expectedOrigin,
+        expectedOrigin,
         data: { type: WA_OAUTH_RESULT, status: "error" },
       }),
     ).toEqual({ type: "error" })
+  })
+
+  test("trusts a tenant's own custom domain as the expected origin, not just the broker", () => {
+    const tenantOrigin = "https://reseller.example.com"
+    expect(
+      parseOAuthRelayResult({
+        origin: tenantOrigin,
+        expectedOrigin: tenantOrigin,
+        data: {
+          type: WA_OAUTH_RESULT,
+          status: "success",
+          code: "oauth-code",
+        },
+      }),
+    ).toEqual({ type: "success", code: "oauth-code" })
+
+    expect(
+      parseOAuthRelayResult({
+        origin: expectedOrigin,
+        expectedOrigin: tenantOrigin,
+        data: {
+          type: WA_OAUTH_RESULT,
+          status: "success",
+          code: "oauth-code",
+        },
+      }),
+    ).toEqual({ type: "ignored" })
   })
 })

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -1924,7 +1924,7 @@
     },
     "authCallbackUrl": {
       "label": "Auth Callback URL",
-      "hint": "Register this exact URL as the OAuth redirect URI in your provider app. It must use this host, not your custom domain — the provider cannot reach a custom domain."
+      "hint": "Register this exact URL as the OAuth redirect URI in your provider app. With your own app and an active custom domain, it's on your custom domain; otherwise it's on the platform host."
     },
     "signInCallbackUrl": {
       "label": "Sign-in Callback URL",
@@ -1932,7 +1932,7 @@
     },
     "webhookUrl": {
       "label": "Webhook URL",
-      "hint": "Register this exact Webhook URL in your provider app. It must use this host, not your custom domain — the provider cannot reach a custom domain."
+      "hint": "Register this exact Webhook URL in your provider app. With your own app and an active custom domain, it's on your custom domain; otherwise it's on the platform host."
     },
     "tiktok": {
       "label": "TikTok",

--- a/apps/builder/src/app/(no-sidebar)/channels/create/messenger/route.ts
+++ b/apps/builder/src/app/(no-sidebar)/channels/create/messenger/route.ts
@@ -87,9 +87,6 @@ export async function GET(req: NextRequest) {
     redirect("/channels/messenger/select")
   }
 
-  const redirectUri = await generateMessengerRedirectUri(
-    messenger.publicConfig,
-    workspaceId,
-  )
+  const redirectUri = await generateMessengerRedirectUri(messenger, workspaceId)
   redirect(redirectUri)
 }

--- a/apps/builder/src/app/(no-sidebar)/channels/create/page.tsx
+++ b/apps/builder/src/app/(no-sidebar)/channels/create/page.tsx
@@ -11,10 +11,12 @@ import { TelegramConnect } from "@/features/integration-telegram/components/tele
 import { generateTiktokRedirectUri } from "@/features/integration-tiktok/libs/tiktok"
 import { SimpleCreateWebchat } from "@/features/integration-webchat/simple-create-webchat"
 import WhatsappCreate from "@/features/integration-whatsapp/components/whatsapp-create"
+import { WHATSAPP_OAUTH_CALLBACK_PATH } from "@/features/integration-whatsapp/libs/embedded-signup"
 import { generateZaloRedirectUri } from "@/features/integration-zalo/libs/zalo"
 import { requireWorkspacePermission } from "@/lib/auth/require-workspace-permission"
 import { getCurrentUserId } from "@/lib/auth/utils"
 import { resolvePlatformOwnerId } from "@/lib/platform-credential-owner"
+import { buildProviderCallbackUrl } from "@/lib/provider-origin"
 
 export const dynamic = "force-dynamic"
 
@@ -97,8 +99,13 @@ export default async function CreateChannelPage(props: CreateChannelPageProps) {
     ])
 
   if (selectedChannel === "whatsapp" && whatsapp && isVisible("whatsapp")) {
+    const oauthCallbackUrl = await buildProviderCallbackUrl(
+      whatsapp,
+      WHATSAPP_OAUTH_CALLBACK_PATH,
+    )
     return (
       <WhatsappCreate
+        oauthCallbackUrl={oauthCallbackUrl}
         settings={whatsapp.publicConfig}
         workspaceId={workspaceId}
       />
@@ -125,7 +132,7 @@ export default async function CreateChannelPage(props: CreateChannelPageProps) {
     isVisible("instagram")
   ) {
     const redirectUri = await generateInstagramRedirectUri(
-      instagram.publicConfig,
+      instagram,
       workspaceId,
     )
     redirect(redirectUri)
@@ -140,25 +147,19 @@ export default async function CreateChannelPage(props: CreateChannelPageProps) {
     isVisible("instagram")
   ) {
     const redirectUri = await generateInstagramFacebookRedirectUri(
-      instagramFacebook.publicConfig,
+      instagramFacebook,
       workspaceId,
     )
     redirect(redirectUri)
   }
 
   if (selectedChannel === "zalo" && zalo && isVisible("zalo")) {
-    const redirectUri = await generateZaloRedirectUri(
-      zalo.publicConfig,
-      workspaceId,
-    )
+    const redirectUri = await generateZaloRedirectUri(zalo, workspaceId)
     redirect(redirectUri)
   }
 
   if (selectedChannel === "tiktok" && tiktok && isVisible("tiktok")) {
-    const redirectUri = await generateTiktokRedirectUri(
-      tiktok.publicConfig,
-      workspaceId,
-    )
+    const redirectUri = await generateTiktokRedirectUri(tiktok, workspaceId)
     redirect(redirectUri)
   }
 

--- a/apps/builder/src/app/api/auth/[...all]/route.ts
+++ b/apps/builder/src/app/api/auth/[...all]/route.ts
@@ -17,8 +17,8 @@ import { resolveRelayTarget } from "@/lib/oauth-referer"
  * within that reseller's tenant (or the platform when no custom domain matches).
  *
  * The reseller that owns a custom domain can also sign in on that domain: when a
- * scoped lookup misses, the adapter falls back to the tenant owner (`User.id =
- * tenantId`). So a reseller signs into the builder on both the platform URL and
+ * scoped lookup misses, the adapter falls back to the tenant owner (`Tenant.ownerId`,
+ * root-tenant row only). So a reseller signs into the builder on both the platform URL and
  * their own domain; their sub-accounts only on the reseller's domain. This
  * fallback applies to every auth method, including OAuth social sign-in — see
  * the findOne reseller-owner fallback in `@chatbotx.io/auth` `server.ts`.

--- a/apps/builder/src/app/api/auth/[...all]/route.ts
+++ b/apps/builder/src/app/api/auth/[...all]/route.ts
@@ -23,21 +23,26 @@ import { resolveRelayTarget } from "@/lib/oauth-referer"
  * fallback applies to every auth method, including OAuth social sign-in — see
  * the findOne reseller-owner fallback in `@chatbotx.io/auth` `server.ts`.
  *
- * OAuth still needs special tenant recovery: the provider redirects to a fixed,
- * pre-registered redirect URI (the broker host — `NEXT_PUBLIC_BROKER_URL`,
- * defaulting to the builder URL), so on the `/callback/*` leg `x-domain` is the
- * broker host. There we recover the tenant from the persisted OAuth `state`
- * instead — its `callbackURL` carries the originating reseller origin. Without
- * this, a social signup on a reseller domain would be created in the root
- * tenant. See `resolveTenantFromOAuthState`.
+ * OAuth still needs special tenant recovery: the provider redirects to a
+ * redirect URI pinned per-credential (the reseller's own active custom domain
+ * for a tenant-owned credential, else the broker host —
+ * `NEXT_PUBLIC_BROKER_URL`, defaulting to the builder URL; see
+ * `auth-instances.ts`), so on the `/callback/*` leg `x-domain` may not match
+ * where the flow started. There we recover the tenant from the persisted
+ * OAuth `state` instead — its `callbackURL` carries the originating reseller
+ * origin. Without this, a social signup on a reseller domain would be created
+ * in the root tenant. See `resolveTenantFromOAuthState`.
  *
  * Two further white-label concerns are handled here:
  *
- * 1. Relay — the fixed broker callback must run on the *originating* branded
- *    host, otherwise the session cookie is minted on the broker host and never
- *    reaches the reseller domain the user is on. So on the `/callback/*` leg we
- *    bounce the callback (same code + state) back to that host before handling.
- *    Mirrors the Facebook/TikTok relay in `integrations/[...integration]`.
+ * 1. Relay — the registered callback host can differ from the *originating*
+ *    branded host (inherited/platform credentials always land on the broker;
+ *    a tenant-owned credential lands on the reseller's own domain even when
+ *    the flow started on the platform host). Landing anywhere but the
+ *    originating host mints the session cookie somewhere the user isn't, so
+ *    on the `/callback/*` leg we bounce the callback (same code + state) back
+ *    to that host before handling. Mirrors the Facebook/TikTok relay in
+ *    `integrations/[...integration]`.
  *
  * 2. Per-tenant social apps — better-auth freezes social-provider config at init,
  *    so we dispatch the social/callback legs to a per-credential auth instance

--- a/apps/builder/src/app/api/auth/[...all]/route.ts
+++ b/apps/builder/src/app/api/auth/[...all]/route.ts
@@ -19,16 +19,17 @@ import { resolveRelayTarget } from "@/lib/oauth-referer"
  * The reseller that owns a custom domain can also sign in on that domain: when a
  * scoped lookup misses, the adapter falls back to the tenant owner (`User.id =
  * tenantId`). So a reseller signs into the builder on both the platform URL and
- * their own domain; their sub-accounts only on the reseller's domain. See the
- * findOne reseller-owner fallback in `@chatbotx.io/auth` `server.ts`.
+ * their own domain; their sub-accounts only on the reseller's domain. This
+ * fallback applies to every auth method, including OAuth social sign-in — see
+ * the findOne reseller-owner fallback in `@chatbotx.io/auth` `server.ts`.
  *
- * OAuth is the exception: the provider redirects to a fixed, pre-registered
- * redirect URI (the broker host — `NEXT_PUBLIC_BROKER_URL`, defaulting to
- * the builder URL), so on the `/callback/*` leg `x-domain` is the broker host.
- * There we recover the tenant from the persisted OAuth `state` instead — its
- * `callbackURL` carries the originating reseller origin. Without this, a social
- * signup on a reseller domain would be created in the root tenant.
- * See `resolveTenantFromOAuthState`.
+ * OAuth still needs special tenant recovery: the provider redirects to a fixed,
+ * pre-registered redirect URI (the broker host — `NEXT_PUBLIC_BROKER_URL`,
+ * defaulting to the builder URL), so on the `/callback/*` leg `x-domain` is the
+ * broker host. There we recover the tenant from the persisted OAuth `state`
+ * instead — its `callbackURL` carries the originating reseller origin. Without
+ * this, a social signup on a reseller domain would be created in the root
+ * tenant. See `resolveTenantFromOAuthState`.
  *
  * Two further white-label concerns are handled here:
  *
@@ -88,50 +89,38 @@ const handle = async (request: Request): Promise<Response> => {
     ? await resolveTenantFromOAuthState(state)
     : await resolveTenantByDomain(request.headers.get("x-domain"))
 
-  // Social sign-in/callback must stay strictly tenant-scoped: the reseller-owner
-  // fallback in the adapter is suppressed so a social login on a reseller domain
-  // resolves to a tenant-scoped user (created when absent) instead of matching the
-  // owner's root-tenant platform account. See `isStrictTenantScope` in the adapter.
-  const isSocialPath =
-    getCallbackProvider(url.pathname) !== null ||
-    isSocialSignInPath(url.pathname)
-
-  return withTenant(
-    tenantId,
-    async () => {
-      // White-label relay: when the social flow started on a branded custom domain
-      // (or the builder URL) but the provider redirected to the fixed broker
-      // callback, bounce back to that origin — where the authorize-time cookies live
-      // and where the session cookie must be set — preserving the original code +
-      // state. The re-entry runs on the originating host, so this guard does not
-      // match again.
-      if (isCallback) {
-        const callbackURL = await resolveOAuthStateCallbackURL(state)
-        const relayTarget = callbackURL
-          ? await resolveRelayTarget(url, callbackURL)
-          : null
-        if (relayTarget) {
-          return Response.redirect(relayTarget, 302)
-        }
+  return withTenant(tenantId, async () => {
+    // White-label relay: when the social flow started on a branded custom domain
+    // (or the builder URL) but the provider redirected to the fixed broker
+    // callback, bounce back to that origin — where the authorize-time cookies live
+    // and where the session cookie must be set — preserving the original code +
+    // state. The re-entry runs on the originating host, so this guard does not
+    // match again.
+    if (isCallback) {
+      const callbackURL = await resolveOAuthStateCallbackURL(state)
+      const relayTarget = callbackURL
+        ? await resolveRelayTarget(url, callbackURL)
+        : null
+      if (relayTarget) {
+        return Response.redirect(relayTarget, 302)
       }
+    }
 
-      const provider =
-        getCallbackProvider(url.pathname) ??
-        (isSocialSignInPath(url.pathname)
-          ? await getSignInProvider(request)
-          : null)
+    const provider =
+      getCallbackProvider(url.pathname) ??
+      (isSocialSignInPath(url.pathname)
+        ? await getSignInProvider(request)
+        : null)
 
-      const instance = provider
-        ? await getSocialAuthForTenant(tenantId, provider)
-        : auth
+    const instance = provider
+      ? await getSocialAuthForTenant(tenantId, provider)
+      : auth
 
-      // Re-home a baseURL-resolved verification redirect onto the branded host
-      // the user is on (magic-link/verify, verify-email, reset-password).
-      const response = await instance.handler(request)
-      return rewriteAuthRedirectToPublicHost(request, response)
-    },
-    { strictScope: isSocialPath },
-  )
+    // Re-home a baseURL-resolved verification redirect onto the branded host
+    // the user is on (magic-link/verify, verify-email, reset-password).
+    const response = await instance.handler(request)
+    return rewriteAuthRedirectToPublicHost(request, response)
+  })
 }
 
 export const GET = handle

--- a/apps/builder/src/app/integrations/[...integration]/callback.ts
+++ b/apps/builder/src/app/integrations/[...integration]/callback.ts
@@ -526,22 +526,23 @@ export const handleCallback = async (
         return notFound()
       }
 
-      if (stateParams.reconnectIntegrationId) {
-        const result = await reconnectZaloHandler({
-          zaloSettings: zaloCredential.config,
-          workspaceId: workspace.id,
-          integrationId: stateParams.reconnectIntegrationId,
-          req,
-        })
-        return redirect(buildReconnectRedirectUrl(safeReferer, result))
-      }
-
       // Must match the redirect_uri used at authorize time — the tenant's
       // custom domain for a tenant-owned credential, else the broker.
       const zaloRedirectUrl = await buildProviderCallbackUrl(
         zaloCredential,
         "/integrations/zalo/callback",
       )
+
+      if (stateParams.reconnectIntegrationId) {
+        const result = await reconnectZaloHandler({
+          zaloSettings: zaloCredential.config,
+          workspaceId: workspace.id,
+          integrationId: stateParams.reconnectIntegrationId,
+          req,
+          callbackUrl: zaloRedirectUrl,
+        })
+        return redirect(buildReconnectRedirectUrl(safeReferer, result))
+      }
 
       await connectZaloHandler({
         zaloSettings: zaloCredential.config,

--- a/apps/builder/src/app/integrations/[...integration]/callback.ts
+++ b/apps/builder/src/app/integrations/[...integration]/callback.ts
@@ -65,9 +65,9 @@ import {
   FB_PENDING_AUTH_MAX_AGE,
 } from "@/lib/facebook-pending-auth"
 import { logger } from "@/lib/log"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { resolveRelayTarget, sanitizeReferer } from "@/lib/oauth-referer"
 import { resolveOwnerForWorkspace } from "@/lib/platform-credential-owner"
+import { buildProviderCallbackUrl } from "@/lib/provider-origin"
 
 const stateValidationSchema = z.object({
   workspaceId: zodBigintAsString().optional(),
@@ -199,11 +199,13 @@ export const handleCallback = async (
     return notFound()
   }
 
-  // White-label relay: Facebook/TikTok OAuth always lands on the fixed broker
-  // callback (the only registered redirect_uri). When the flow started on a
-  // branded custom domain, bounce the callback back to that domain — where the
-  // user's session cookie lives — preserving the original code + state. The
-  // re-entry runs on the white-label host, so this guard does not match again.
+  // White-label relay: the redirect_uri is pinned per-credential (broker for
+  // inherited/platform, the reseller's own custom domain for a tenant-owned
+  // one — see `lib/provider-origin.ts`), so the callback host can differ from
+  // where the flow started. When it does, bounce the callback back to the
+  // originating domain — where the user's session cookie lives — preserving
+  // the original code + state. The re-entry runs on the originating host, so
+  // this guard does not match again.
   const relayTarget = await resolveRelayTarget(url, stateParams.referer)
   if (relayTarget) {
     return redirect(relayTarget)
@@ -275,9 +277,10 @@ export const handleCallback = async (
         return notFound()
       }
 
-      // Must match the redirect_uri used at authorize time (the fixed broker
-      // callback), even though this handler may run on a white-label host.
-      const callbackUrl = buildBrokerCallbackUrl(
+      // Must match the redirect_uri used at authorize time — the tenant's
+      // custom domain for a tenant-owned credential, else the broker.
+      const callbackUrl = await buildProviderCallbackUrl(
+        messengerCredential,
         "/integrations/messenger/callback",
       )
 
@@ -383,9 +386,10 @@ export const handleCallback = async (
         return notFound()
       }
 
-      // Must match the redirect_uri used at authorize time (the fixed broker
-      // callback), even though this handler may run on a white-label host.
-      const callbackUrl = buildBrokerCallbackUrl(
+      // Must match the redirect_uri used at authorize time — the tenant's
+      // custom domain for a tenant-owned credential, else the broker.
+      const callbackUrl = await buildProviderCallbackUrl(
+        instagramCredential,
         "/integrations/instagram/callback",
       )
 
@@ -435,7 +439,10 @@ export const handleCallback = async (
         return notFound()
       }
 
-      const callbackUrl = buildBrokerCallbackUrl(
+      // Must match the redirect_uri used at authorize time — the tenant's
+      // custom domain for a tenant-owned credential, else the broker.
+      const callbackUrl = await buildProviderCallbackUrl(
+        instagramFacebookCredential,
         "/integrations/instagram-facebook/callback",
       )
 
@@ -493,9 +500,10 @@ export const handleCallback = async (
         return notFound()
       }
 
-      // Must match the redirect_uri used at authorize time (the fixed broker
-      // callback), even though this handler may run on a white-label host.
-      const tiktokCallbackUrl = buildBrokerCallbackUrl(
+      // Must match the redirect_uri used at authorize time — the tenant's
+      // custom domain for a tenant-owned credential, else the broker.
+      const tiktokCallbackUrl = await buildProviderCallbackUrl(
+        tiktokCredential,
         "/integrations/tiktok/callback",
       )
 
@@ -528,10 +536,18 @@ export const handleCallback = async (
         return redirect(buildReconnectRedirectUrl(safeReferer, result))
       }
 
+      // Must match the redirect_uri used at authorize time — the tenant's
+      // custom domain for a tenant-owned credential, else the broker.
+      const zaloRedirectUrl = await buildProviderCallbackUrl(
+        zaloCredential,
+        "/integrations/zalo/callback",
+      )
+
       await connectZaloHandler({
         zaloSettings: zaloCredential.config,
         workspaceId: workspace.id,
         req,
+        redirectUrl: zaloRedirectUrl,
       })
 
       return redirect(safeReferer)
@@ -549,9 +565,10 @@ export const handleCallback = async (
         return notFound()
       }
 
-      // Must match the redirect_uri used at authorize time (the fixed broker
-      // callback), even though this handler may run on a white-label host.
-      const callbackUrl = buildBrokerCallbackUrl(
+      // Must match the redirect_uri used at authorize time — the tenant's
+      // custom domain for a tenant-owned credential, else the broker.
+      const callbackUrl = await buildProviderCallbackUrl(
+        facebookAdsCredential,
         "/integrations/facebook-ads/callback",
       )
 
@@ -574,7 +591,10 @@ export const handleCallback = async (
         return notFound()
       }
 
-      const callbackUrl = buildBrokerCallbackUrl(
+      // Must match the redirect_uri used at authorize time — the tenant's
+      // custom domain for a tenant-owned credential, else the broker.
+      const callbackUrl = await buildProviderCallbackUrl(
+        googleCredential,
         "/integrations/google-calendar/callback",
       )
       try {
@@ -617,10 +637,11 @@ export const handleCallback = async (
         return notFound()
       }
 
-      // Must match the redirect_uri used at authorize time (the fixed broker
-      // callback), even though this handler may run on a white-label host after
-      // the relay above. See `connect.action.ts`.
-      const callbackUrl = buildBrokerCallbackUrl(
+      // Must match the redirect_uri used at authorize time — the tenant's
+      // custom domain for a tenant-owned credential, else the broker. See
+      // `connect.action.ts`.
+      const callbackUrl = await buildProviderCallbackUrl(
+        googleCredential,
         "/integrations/google-sheets/callback",
       )
 

--- a/apps/builder/src/app/space/[workspaceId]/(integrations)/whatsapps/[id]/capi/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(integrations)/whatsapps/[id]/capi/page.tsx
@@ -7,8 +7,10 @@ import {
 import { notFound } from "next/navigation"
 import { WhatsappCapiTab } from "@/features/integration-whatsapp/components/whatsapp-capi-tab"
 import { hasWhatsappCapiScope } from "@/features/integration-whatsapp/libs/capi-scope"
+import { WHATSAPP_OAUTH_CALLBACK_PATH } from "@/features/integration-whatsapp/libs/embedded-signup"
 import { withWorkspaceIdAndIdSchema } from "@/features/workspaces/schema/resource"
 import { resolveOwnerForWorkspace } from "@/lib/platform-credential-owner"
+import { resolveProviderOriginForCredential } from "@/lib/provider-origin"
 
 export default async function WhatsappCapiPage(props: {
   params: Promise<{ workspaceId: string; id: string }>
@@ -56,6 +58,8 @@ export default async function WhatsappCapiPage(props: {
       : integrationWhatsapp
 
   const resolved = refreshed ?? integrationWhatsapp
+  const oauthCallbackOrigin =
+    await resolveProviderOriginForCredential(whatsappCredential)
 
   return (
     <WhatsappCapiTab
@@ -70,6 +74,10 @@ export default async function WhatsappCapiPage(props: {
         hasCapiScope: resolved.hasCapiScope,
         datasetId: resolved.datasetId,
       }}
+      oauthCallbackUrl={new URL(
+        WHATSAPP_OAUTH_CALLBACK_PATH,
+        oauthCallbackOrigin,
+      ).toString()}
       whatsappCredentialPublic={whatsappCredential?.publicConfig ?? null}
     />
   )

--- a/apps/builder/src/app/space/[workspaceId]/dashboard/ads/conversion-events/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/dashboard/ads/conversion-events/page.tsx
@@ -31,6 +31,7 @@ export default async function ConversionEventsPage(props: {
   return (
     <Suspense>
       <ConversionEventsView
+        oauthCallbackUrl={switcherData.oauthCallbackUrl}
         promises={promises}
         selectedAccount={selectedAccount}
         switcherIntegrations={switcherData.integrations}

--- a/apps/builder/src/app/space/[workspaceId]/dashboard/ads/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/dashboard/ads/page.tsx
@@ -48,6 +48,7 @@ export default async function AdsAnalyticsPage(props: {
       <div className="flex min-w-0 flex-1 flex-col gap-5">
         <Suspense>
           <AdsAnalyticsView
+            oauthCallbackUrl={switcherData.oauthCallbackUrl}
             promises={promises}
             range={search}
             selectedIntegrationWhatsappId={selectedAccount?.id ?? null}

--- a/apps/builder/src/features/ads/components/ads-account-control.tsx
+++ b/apps/builder/src/features/ads/components/ads-account-control.tsx
@@ -10,12 +10,14 @@ type AdsAccountControlProps = {
   integrations: AdsSwitcherData["integrations"]
   whatsappCredentialPublic: AdsSwitcherData["whatsappCredentialPublic"]
   workspaceId: string
+  oauthCallbackUrl: AdsSwitcherData["oauthCallbackUrl"]
 }
 
 export function AdsAccountControl({
   integrations,
   whatsappCredentialPublic,
   workspaceId,
+  oauthCallbackUrl,
 }: AdsAccountControlProps) {
   const t = useTranslations()
 
@@ -33,6 +35,7 @@ export function AdsAccountControl({
   return (
     <AdsAccountSwitcher
       integrations={integrations}
+      oauthCallbackUrl={oauthCallbackUrl}
       whatsappCredentialPublic={whatsappCredentialPublic}
       workspaceId={workspaceId}
     />

--- a/apps/builder/src/features/ads/components/ads-account-switcher.tsx
+++ b/apps/builder/src/features/ads/components/ads-account-switcher.tsx
@@ -30,10 +30,12 @@ export function AdsAccountSwitcher({
   integrations,
   whatsappCredentialPublic,
   workspaceId,
+  oauthCallbackUrl,
 }: {
   integrations: AdsAccountSwitcherIntegration[]
   whatsappCredentialPublic: WhatsappCredentialPublic | null
   workspaceId: string
+  oauthCallbackUrl: string
 }) {
   const pathname = usePathname()
   const router = useRouter()
@@ -109,6 +111,7 @@ export function AdsAccountSwitcher({
       {selectedStatus === "missingPermission" && (
         <WhatsappReconnectButton
           integrationWhatsappId={selectedIntegration.id}
+          oauthCallbackUrl={oauthCallbackUrl}
           settings={whatsappCredentialPublic}
           workspaceId={workspaceId}
         />

--- a/apps/builder/src/features/ads/components/ads-analytics-view.tsx
+++ b/apps/builder/src/features/ads/components/ads-analytics-view.tsx
@@ -85,6 +85,7 @@ type AdsAnalyticsViewProps = {
   >
   switcherIntegrations: AdsSwitcherData["integrations"]
   whatsappCredentialPublic: AdsSwitcherData["whatsappCredentialPublic"]
+  oauthCallbackUrl: AdsSwitcherData["oauthCallbackUrl"]
 }
 
 const formatFunnelPercent = (value: number, total: number) => {
@@ -512,6 +513,7 @@ export function AdsAnalyticsView({
   selectedIntegrationWhatsappId,
   switcherIntegrations,
   whatsappCredentialPublic,
+  oauthCallbackUrl,
   workspaceId,
 }: AdsAnalyticsViewProps) {
   const t = useTranslations()
@@ -539,6 +541,7 @@ export function AdsAnalyticsView({
         <div className="flex flex-col items-end gap-8">
           <AdsAccountControl
             integrations={switcherIntegrations}
+            oauthCallbackUrl={oauthCallbackUrl}
             whatsappCredentialPublic={whatsappCredentialPublic}
             workspaceId={workspaceId}
           />

--- a/apps/builder/src/features/ads/components/conversion-events-view.tsx
+++ b/apps/builder/src/features/ads/components/conversion-events-view.tsx
@@ -45,6 +45,7 @@ type ConversionEventsViewProps = {
   selectedAccount: ConversionEventsData["whatsappIntegrations"][number] | null
   switcherIntegrations: AdsSwitcherData["integrations"]
   whatsappCredentialPublic: AdsSwitcherData["whatsappCredentialPublic"]
+  oauthCallbackUrl: AdsSwitcherData["oauthCallbackUrl"]
 }
 
 type WhatsappRuleBuilderProps = {
@@ -318,6 +319,7 @@ export function ConversionEventsView({
   selectedAccount,
   switcherIntegrations,
   whatsappCredentialPublic,
+  oauthCallbackUrl,
 }: ConversionEventsViewProps) {
   const t = useTranslations()
   const [data] = use(promises)
@@ -335,6 +337,7 @@ export function ConversionEventsView({
           </Button>
           <AdsAccountControl
             integrations={switcherIntegrations}
+            oauthCallbackUrl={oauthCallbackUrl}
             whatsappCredentialPublic={whatsappCredentialPublic}
             workspaceId={workspaceId}
           />

--- a/apps/builder/src/features/ads/queries/switcher.ts
+++ b/apps/builder/src/features/ads/queries/switcher.ts
@@ -4,6 +4,8 @@ import {
   workspaceService,
 } from "@chatbotx.io/business"
 import type { WhatsappCredentialPublic } from "@chatbotx.io/database/partials"
+import { WHATSAPP_OAUTH_CALLBACK_PATH } from "@/features/integration-whatsapp/libs/embedded-signup"
+import { resolveProviderOriginForCredential } from "@/lib/provider-origin"
 
 export type AdsSwitcherIntegration = {
   id: string
@@ -16,6 +18,7 @@ export type AdsSwitcherIntegration = {
 export type AdsSwitcherData = {
   integrations: AdsSwitcherIntegration[]
   whatsappCredentialPublic: WhatsappCredentialPublic | null
+  oauthCallbackUrl: string
 }
 
 export async function getAdsSwitcherData(
@@ -30,6 +33,8 @@ export async function getAdsSwitcherData(
     integrationWhatsappService.listByWorkspaceId(workspaceId),
   ])
 
+  const originUrl = await resolveProviderOriginForCredential(whatsappCredential)
+
   return {
     integrations: integrations.map((integration) => ({
       id: integration.id,
@@ -39,5 +44,9 @@ export async function getAdsSwitcherData(
       hasCapiScope: integration.hasCapiScope,
     })),
     whatsappCredentialPublic: whatsappCredential?.publicConfig ?? null,
+    oauthCallbackUrl: new URL(
+      WHATSAPP_OAUTH_CALLBACK_PATH,
+      originUrl,
+    ).toString(),
   }
 }

--- a/apps/builder/src/features/external-calendars/actions/connect.action.ts
+++ b/apps/builder/src/features/external-calendars/actions/connect.action.ts
@@ -8,8 +8,8 @@ import { redirect } from "next/navigation"
 import { workspaceIdrequestParams } from "@/features/common/schemas"
 import { integrations } from "@/integration"
 import { getOriginUrlFromHeader } from "@/lib/domain"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { resolvePlatformOwnerId } from "@/lib/platform-credential-owner"
+import { buildProviderCallbackUrl } from "@/lib/provider-origin"
 import { workspaceActionClient } from "@/lib/safe-action"
 import { connectExternalCalendarRequest } from "../schemas/action"
 
@@ -43,7 +43,8 @@ export const connectGoogleCalendarAction = workspaceActionClient
       const authUrl = await integrations.googleCalendar.handleRequest?.({
         config: {
           ...googleCredential.config,
-          redirectUrl: buildBrokerCallbackUrl(
+          redirectUrl: await buildProviderCallbackUrl(
+            googleCredential,
             "/integrations/google-calendar/callback",
           ),
           stateParams: {

--- a/apps/builder/src/features/facebook-lead-ad-automation/actions/connect-lead-ads.action.ts
+++ b/apps/builder/src/features/facebook-lead-ad-automation/actions/connect-lead-ads.action.ts
@@ -8,8 +8,8 @@ import { redirect } from "next/navigation"
 import { getTranslations } from "next-intl/server"
 import { workspaceIdrequestParams } from "@/features/common/schemas"
 import { getOriginUrlFromHeader } from "@/lib/domain"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { resolveOwnerForWorkspace } from "@/lib/platform-credential-owner"
+import { buildProviderCallbackUrl } from "@/lib/provider-origin"
 import { workspaceActionClient } from "@/lib/safe-action"
 
 export const connectLeadAdsAction = workspaceActionClient
@@ -36,7 +36,8 @@ export const connectLeadAdsAction = workspaceActionClient
       // Facebook app, so this OAuth lands there too. `flow` flags the lead-ads
       // dispatch in the callback handler; `referer` returns the user to the
       // Lead Ads list on completion or cancel.
-      const redirectUrl = buildBrokerCallbackUrl(
+      const redirectUrl = await buildProviderCallbackUrl(
+        messengerCredential,
         "/integrations/messenger/callback",
       )
       const baseUrl = await getOriginUrlFromHeader()

--- a/apps/builder/src/features/integration-facebook-ads/actions/connect-redirect.ts
+++ b/apps/builder/src/features/integration-facebook-ads/actions/connect-redirect.ts
@@ -5,8 +5,8 @@ import { generateAdsAuthUrl } from "@chatbotx.io/integration-facebook-ads"
 import { redirect } from "next/navigation"
 import { getTranslations } from "next-intl/server"
 import { getOriginUrlFromHeader } from "@/lib/domain"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { resolveOwnerForWorkspace } from "@/lib/platform-credential-owner"
+import { buildProviderCallbackUrl } from "@/lib/provider-origin"
 
 export async function buildFacebookAdsAuthRedirect({
   workspace,
@@ -31,7 +31,10 @@ export async function buildFacebookAdsAuthRedirect({
   // Ads token-storage dispatch in the callback handler; `referer` is the
   // page the user returns to on completion or cancel. Mirrors
   // `generateMessengerRedirectUri` in integration-messenger/libs/oauth.ts.
-  const redirectUrl = buildBrokerCallbackUrl("/integrations/messenger/callback")
+  const redirectUrl = await buildProviderCallbackUrl(
+    messengerCredential,
+    "/integrations/messenger/callback",
+  )
   const baseUrl = await getOriginUrlFromHeader()
   const referer = new URL(refererPath, baseUrl).toString()
 

--- a/apps/builder/src/features/integration-google-sheets/actions/connect.action.ts
+++ b/apps/builder/src/features/integration-google-sheets/actions/connect.action.ts
@@ -8,8 +8,8 @@ import { redirect } from "next/navigation"
 import { workspaceIdrequestParams } from "@/features/common/schemas"
 import { integrations } from "@/integration"
 import { getOriginUrlFromHeader } from "@/lib/domain"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { resolveOwnerForWorkspace } from "@/lib/platform-credential-owner"
+import { buildProviderCallbackUrl } from "@/lib/provider-origin"
 import { workspaceActionClient } from "@/lib/safe-action"
 import {
   type ConnectGoogleSheetsSchema,
@@ -39,15 +39,16 @@ export const connectGoogleSheets = workspaceActionClient
       }
 
       const originUrl = await getOriginUrlFromHeader()
-      // The OAuth redirect_uri must be registered in the Google app (platform or
-      // reseller-owned). A white-label custom domain is not registered there, so
-      // we always send Google to the fixed broker callback and carry the
-      // originating branded origin in `referer`; the callback relays back to it.
-      // Mirrors the messenger/instagram authorize flow. See `oauth-referer.ts`.
+      // The OAuth redirect_uri must be registered in the Google app. For a
+      // tenant-owned credential (their own app), that's the reseller's custom
+      // domain; otherwise it's the broker, and the originating branded origin
+      // is carried in `referer` (the callback relays back to it). Mirrors the
+      // messenger/instagram authorize flow. See `oauth-referer.ts`.
       const redirectUrl = (await integrations.googleSheets.handleRequest?.({
         config: {
           ...googleCredential.config,
-          redirectUrl: buildBrokerCallbackUrl(
+          redirectUrl: await buildProviderCallbackUrl(
+            googleCredential,
             "/integrations/google-sheets/callback",
           ),
           stateParams: {

--- a/apps/builder/src/features/integration-instagram/actions/reconnect.action.ts
+++ b/apps/builder/src/features/integration-instagram/actions/reconnect.action.ts
@@ -11,8 +11,8 @@ import { generateAuthUrl as generateInstagramFacebookAuthUrl } from "@chatbotx.i
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { redirect } from "next/navigation"
 import { getOriginUrlFromHeader } from "@/lib/domain"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { resolveOwnerForWorkspace } from "@/lib/platform-credential-owner"
+import { buildProviderCallbackUrl } from "@/lib/provider-origin"
 import { workspaceActionClient } from "@/lib/safe-action"
 
 /**
@@ -52,7 +52,8 @@ export const reconnectInstagramAction = workspaceActionClient
         throw new ChatbotXException("Instagram App settings not found")
       }
 
-      const redirectUrl = buildBrokerCallbackUrl(
+      const redirectUrl = await buildProviderCallbackUrl(
+        instagramCredential,
         connectedWithFacebookLogin
           ? "/integrations/instagram-facebook/callback"
           : "/integrations/instagram/callback",

--- a/apps/builder/src/features/integration-instagram/libs/oauth-facebook.ts
+++ b/apps/builder/src/features/integration-instagram/libs/oauth-facebook.ts
@@ -1,13 +1,21 @@
 import type { InstagramCredentialPublic } from "@chatbotx.io/database/partials"
 import { generateAuthUrl } from "@chatbotx.io/integration-instagram-facebook"
 import { getOriginFromHeader } from "@/lib/domain"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
+import { buildProviderCallbackUrl } from "@/lib/provider-origin"
 
 export async function generateInstagramFacebookRedirectUri(
-  publicConfig: InstagramCredentialPublic,
+  credential: {
+    userId: string | null
+    publicConfig: InstagramCredentialPublic
+  },
   workspaceId?: string | null,
 ) {
-  const redirectUrl = buildBrokerCallbackUrl(
+  // The OAuth redirect_uri must be registered in the Facebook app. For a
+  // tenant-owned credential (their own app), that's the reseller's custom
+  // domain; otherwise it's the broker, and the originating branded domain is
+  // recovered from `referer` (the callback relays back to it).
+  const redirectUrl = await buildProviderCallbackUrl(
+    credential,
     "/integrations/instagram-facebook/callback",
   )
   const baseUrl = await getOriginFromHeader()
@@ -16,8 +24,8 @@ export async function generateInstagramFacebookRedirectUri(
     : baseUrl
 
   return generateAuthUrl({
-    clientId: publicConfig.clientId,
-    version: publicConfig.version,
+    clientId: credential.publicConfig.clientId,
+    version: credential.publicConfig.version,
     redirectUrl,
     stateParams: {
       workspaceId,

--- a/apps/builder/src/features/integration-instagram/libs/oauth.ts
+++ b/apps/builder/src/features/integration-instagram/libs/oauth.ts
@@ -1,25 +1,31 @@
 import type { InstagramCredentialPublic } from "@chatbotx.io/database/partials"
 import { generateAuthUrl } from "@chatbotx.io/integration-instagram"
 import { getOriginFromHeader } from "@/lib/domain"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
+import { buildProviderCallbackUrl } from "@/lib/provider-origin"
 
 export async function generateInstagramRedirectUri(
-  publicConfig: InstagramCredentialPublic,
+  credential: {
+    userId: string | null
+    publicConfig: InstagramCredentialPublic
+  },
   workspaceId?: string | null,
 ) {
-  // The OAuth redirect_uri must be registered in the Facebook app (platform or
-  // reseller-owned). A white-label custom domain is not registered there, so we
-  // always send Facebook to the fixed broker callback and recover the originating
-  // branded domain from `referer` (the callback relays back to it).
-  const redirectUrl = buildBrokerCallbackUrl("/integrations/instagram/callback")
+  // The OAuth redirect_uri must be registered in the Facebook app. For a
+  // tenant-owned credential (their own app), that's the reseller's custom
+  // domain; otherwise it's the broker, and the originating branded domain is
+  // recovered from `referer` (the callback relays back to it).
+  const redirectUrl = await buildProviderCallbackUrl(
+    credential,
+    "/integrations/instagram/callback",
+  )
   const baseUrl = await getOriginFromHeader()
   const referer = workspaceId
     ? new URL(`/space/${workspaceId}`, baseUrl).toString()
     : baseUrl
 
   return generateAuthUrl({
-    clientId: publicConfig.clientId,
-    version: publicConfig.version,
+    clientId: credential.publicConfig.clientId,
+    version: credential.publicConfig.version,
     redirectUrl,
     stateParams: {
       workspaceId,

--- a/apps/builder/src/features/integration-messenger/actions/reconnect.action.ts
+++ b/apps/builder/src/features/integration-messenger/actions/reconnect.action.ts
@@ -10,8 +10,8 @@ import { generateAuthUrl } from "@chatbotx.io/integration-messenger"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { redirect } from "next/navigation"
 import { getOriginUrlFromHeader } from "@/lib/domain"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { resolveOwnerForWorkspace } from "@/lib/platform-credential-owner"
+import { buildProviderCallbackUrl } from "@/lib/provider-origin"
 import { workspaceActionClient } from "@/lib/safe-action"
 
 /**
@@ -48,7 +48,8 @@ export const reconnectMessengerAction = workspaceActionClient
         throw new ChatbotXException("Messenger App settings not found")
       }
 
-      const redirectUrl = buildBrokerCallbackUrl(
+      const redirectUrl = await buildProviderCallbackUrl(
+        messengerCredential,
         "/integrations/messenger/callback",
       )
       const baseUrl = await getOriginUrlFromHeader()

--- a/apps/builder/src/features/integration-messenger/libs/oauth.ts
+++ b/apps/builder/src/features/integration-messenger/libs/oauth.ts
@@ -1,7 +1,7 @@
 import type { MessengerCredentialPublic } from "@chatbotx.io/database/partials"
 import { generateAuthUrl } from "@chatbotx.io/integration-messenger"
 import { getOriginFromHeader } from "@/lib/domain"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
+import { buildProviderCallbackUrl } from "@/lib/provider-origin"
 
 /**
  * Where a Messenger OAuth flow returns the user once tokens are stored — the
@@ -19,19 +19,25 @@ export async function buildMessengerReferer(
 }
 
 export async function generateMessengerRedirectUri(
-  publicConfig: MessengerCredentialPublic,
+  credential: {
+    userId: string | null
+    publicConfig: MessengerCredentialPublic
+  },
   workspaceId?: string | null,
 ) {
-  // The OAuth redirect_uri must be registered in the Facebook app (platform or
-  // reseller-owned). A white-label custom domain is not registered there, so we
-  // always send Facebook to the fixed broker callback and recover the originating
-  // branded domain from `referer` (the callback relays back to it).
-  const redirectUrl = buildBrokerCallbackUrl("/integrations/messenger/callback")
+  // The OAuth redirect_uri must be registered in the Facebook app. For a
+  // tenant-owned credential (their own app), that's the reseller's custom
+  // domain; otherwise it's the broker, and the originating branded domain is
+  // recovered from `referer` (the callback relays back to it).
+  const redirectUrl = await buildProviderCallbackUrl(
+    credential,
+    "/integrations/messenger/callback",
+  )
   const referer = await buildMessengerReferer(workspaceId)
 
   return generateAuthUrl({
-    clientId: publicConfig.clientId,
-    version: publicConfig.version,
+    clientId: credential.publicConfig.clientId,
+    version: credential.publicConfig.version,
     redirectUrl,
     stateParams: {
       workspaceId,

--- a/apps/builder/src/features/integration-tiktok/libs/tiktok.ts
+++ b/apps/builder/src/features/integration-tiktok/libs/tiktok.ts
@@ -1,24 +1,30 @@
 import type { TiktokCredentialPublic } from "@chatbotx.io/database/partials"
 import { generateAuthUrl } from "@chatbotx.io/integration-tiktok"
 import { getOriginFromHeader } from "@/lib/domain"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
+import { buildProviderCallbackUrl } from "@/lib/provider-origin"
 
 export async function generateTiktokRedirectUri(
-  publicConfig: TiktokCredentialPublic,
+  credential: {
+    userId: string | null
+    publicConfig: TiktokCredentialPublic
+  },
   workspaceId?: string | null,
 ) {
-  // The OAuth redirect_uri must be registered in the TikTok app (platform or
-  // reseller-owned). A white-label custom domain is not registered there, so we
-  // always send TikTok to the fixed broker callback and recover the originating
-  // branded domain from `referer` (the callback relays back to it).
-  const redirectUrl = buildBrokerCallbackUrl("/integrations/tiktok/callback")
+  // The OAuth redirect_uri must be registered in the TikTok app. For a
+  // tenant-owned credential (their own app), that's the reseller's custom
+  // domain; otherwise it's the broker, and the originating branded domain is
+  // recovered from `referer` (the callback relays back to it).
+  const redirectUrl = await buildProviderCallbackUrl(
+    credential,
+    "/integrations/tiktok/callback",
+  )
   const baseUrl = await getOriginFromHeader()
   const referer = workspaceId
     ? new URL(`/space/${workspaceId}`, baseUrl).toString()
     : baseUrl
 
   return generateAuthUrl({
-    clientId: publicConfig.clientId,
+    clientId: credential.publicConfig.clientId,
     redirectUrl,
     stateParams: {
       workspaceId,

--- a/apps/builder/src/features/integration-whatsapp/actions/connect.action.ts
+++ b/apps/builder/src/features/integration-whatsapp/actions/connect.action.ts
@@ -48,8 +48,8 @@ import { createId } from "@chatbotx.io/utils"
 import { getTranslations } from "next-intl/server"
 import { updateWorkspaceLogo } from "@/features/workspaces/actions/upload-logo"
 import { logger } from "@/lib/log"
-import { buildBrokerCallbackUrl, getBrokerOrigin } from "@/lib/oauth-broker"
 import { resolvePlatformOwnerId } from "@/lib/platform-credential-owner"
+import { resolveProviderOriginForCredential } from "@/lib/provider-origin"
 import { authActionClient } from "@/lib/safe-action"
 import { hasWhatsappCapiScope } from "../libs/capi-scope"
 import {
@@ -69,6 +69,7 @@ import { buildAuthValue, buildWebhookConfig } from "./webhook-url"
 async function resolveAccessToken(
   input: ConnectWhatsappSchema,
   whatsappSettings: WhatsappCredential,
+  originUrl: string,
   messages: ConnectErrorMessages,
 ): Promise<string> {
   if (input.accessToken) {
@@ -79,7 +80,7 @@ async function resolveAccessToken(
     const exchangeResult = await exchangeAccessToken(
       whatsappSettings,
       input.code,
-      buildBrokerCallbackUrl(WHATSAPP_OAUTH_CALLBACK_PATH),
+      new URL(WHATSAPP_OAUTH_CALLBACK_PATH, originUrl).toString(),
     )
     return exchangeResult.access_token
   }
@@ -370,11 +371,13 @@ type PreparedConnectInput =
 async function prepareConnectInput(params: {
   input: ConnectWhatsappSchema
   whatsappSettings: WhatsappCredential
+  originUrl: string
   ownerId: string
   userId: string
   messages: ConnectErrorMessages
 }): Promise<PreparedConnectInput> {
-  const { input, whatsappSettings, ownerId, userId, messages } = params
+  const { input, whatsappSettings, originUrl, ownerId, userId, messages } =
+    params
 
   if (input.signupSessionId) {
     const signupSessionClaim: SignupSessionClaim = {
@@ -414,6 +417,7 @@ async function prepareConnectInput(params: {
   const accessToken = await resolveAccessToken(
     input,
     whatsappSettings,
+    originUrl,
     messages,
   )
 
@@ -785,9 +789,18 @@ export const connectWhatsappAction = authActionClient
 
         const isManual = parsedInput.manualConnect
 
+        // Provider-facing URLs (the webhook override_callback_uri sent to Meta on
+        // manual connect, and the stored OAuth redirectUrl) must live on a host
+        // registered with Meta: the reseller's own custom domain for a
+        // tenant-owned credential (their own app), otherwise the broker. Mirrors
+        // the pattern used by messenger/instagram (lib/provider-origin.ts).
+        const originUrl =
+          await resolveProviderOriginForCredential(whatsappCredential)
+
         const preparedInput = await prepareConnectInput({
           input: parsedInput,
           whatsappSettings,
+          originUrl,
           ownerId,
           userId: ctx.user.id,
           messages,
@@ -799,12 +812,6 @@ export const connectWhatsappAction = authActionClient
         const { accessToken, wabaId, businessId, phoneNumber } = preparedInput
         await ensurePhoneNumberNotConnected(phoneNumber.id, messages)
 
-        // Provider-facing URLs (the webhook override_callback_uri sent to Meta on
-        // manual connect, and the stored OAuth redirectUrl) must live on the fixed
-        // broker / canonical host registered with Meta — never the white-label
-        // custom domain the request arrived on, which Meta cannot reach or trust.
-        // Mirrors the broker pattern used by messenger/instagram (lib/oauth-broker.ts).
-        const originUrl = getBrokerOrigin()
         const integrationId = createId()
 
         const { webhookUrl, verifyToken } = buildWebhookConfig({

--- a/apps/builder/src/features/integration-whatsapp/actions/reconnect.action.ts
+++ b/apps/builder/src/features/integration-whatsapp/actions/reconnect.action.ts
@@ -21,7 +21,7 @@ import { z } from "zod"
 import { hasWhatsappCapiScope } from "@/features/integration-whatsapp/libs/capi-scope"
 import { assertWorkspaceSuperAdmin } from "@/lib/auth/assert-workspace-super-admin"
 import { logger } from "@/lib/log"
-import { buildBrokerCallbackUrl, getBrokerOrigin } from "@/lib/oauth-broker"
+import { resolveProviderOriginForCredential } from "@/lib/provider-origin"
 import { workspaceActionClient } from "@/lib/safe-action"
 import { WHATSAPP_OAUTH_CALLBACK_PATH } from "../libs/embedded-signup"
 import { buildAuthValue, buildWebhookConfig } from "./webhook-url"
@@ -52,10 +52,15 @@ async function findReconnectTarget(input: {
   return existing
 }
 
+type WhatsappCredentialWithOwner = {
+  userId: string | null
+  config: WhatsappCredential
+}
+
 async function resolveWhatsappSettings(input: {
   ownerId: string
   t: ReconnectTranslations
-}): Promise<WhatsappCredential> {
+}): Promise<WhatsappCredentialWithOwner> {
   const credential = await platformCredentialService.resolveForOwner({
     ownerId: input.ownerId,
     type: "whatsapp",
@@ -66,7 +71,7 @@ async function resolveWhatsappSettings(input: {
     )
   }
 
-  return credential.config
+  return { userId: credential.userId, config: credential.config }
 }
 
 async function exchangeAndValidateWhatsappAccount(input: {
@@ -74,12 +79,13 @@ async function exchangeAndValidateWhatsappAccount(input: {
   existing: ExistingWhatsappIntegration
   t: ReconnectTranslations
   whatsappSettings: WhatsappCredential
+  originUrl: string
 }) {
   const accessToken = (
     await exchangeAccessToken(
       input.whatsappSettings,
       input.code,
-      buildBrokerCallbackUrl(WHATSAPP_OAUTH_CALLBACK_PATH),
+      new URL(WHATSAPP_OAUTH_CALLBACK_PATH, input.originUrl).toString(),
     )
   ).access_token
   const appAccessToken = `${input.whatsappSettings.clientId}|${input.whatsappSettings.clientSecret}`
@@ -128,11 +134,12 @@ async function buildReconnectAuth(input: {
   waba: Awaited<ReturnType<typeof findWaba>>
   wabaId: string
   whatsappSettings: WhatsappCredential
+  originUrl: string
   phoneNumber: Awaited<
     ReturnType<typeof whatsappListPhoneNumbers>
   >["data"][number]
 }) {
-  const originUrl = getBrokerOrigin()
+  const { originUrl } = input
   const webhookConfig = buildWebhookConfig({
     isManual: false,
     integrationId: input.integrationWhatsappId,
@@ -206,10 +213,12 @@ async function reconnectWhatsapp(input: {
     workspaceId: input.workspaceId,
     t,
   })
-  const whatsappSettings = await resolveWhatsappSettings({
+  const whatsappCredential = await resolveWhatsappSettings({
     ownerId: input.ctx.workspace.ownerId,
     t,
   })
+  const whatsappSettings = whatsappCredential.config
+  const originUrl = await resolveProviderOriginForCredential(whatsappCredential)
 
   const { accessToken, appAccessToken, wabaId, waba, phoneNumber } =
     await exchangeAndValidateWhatsappAccount({
@@ -217,6 +226,7 @@ async function reconnectWhatsapp(input: {
       existing,
       t,
       whatsappSettings,
+      originUrl,
     })
   const { auth, hasCapiScope } = await buildReconnectAuth({
     accessToken,
@@ -226,6 +236,7 @@ async function reconnectWhatsapp(input: {
     waba,
     wabaId,
     whatsappSettings,
+    originUrl,
     phoneNumber,
   })
 

--- a/apps/builder/src/features/integration-whatsapp/actions/webhook-url.ts
+++ b/apps/builder/src/features/integration-whatsapp/actions/webhook-url.ts
@@ -7,10 +7,11 @@ import { AuthType } from "@chatbotx.io/sdk"
 /**
  * Build the WhatsApp webhook callback config.
  *
- * `originUrl` must be a fixed, Meta-registered host (the OAuth broker / canonical
- * builder origin) — never a white-label custom domain. On manual connect this URL
- * is sent to Meta as `override_callback_uri`, and Meta cannot reach or trust an
- * unregistered branded domain. See `connect.action.ts` and `lib/oauth-broker.ts`.
+ * `originUrl` must be a host Meta can reach and trust: the reseller's own
+ * custom domain for a tenant-owned credential (their own app), otherwise the
+ * broker / canonical builder origin. On manual connect this URL is sent to
+ * Meta as `override_callback_uri`. See `connect.action.ts` and
+ * `lib/provider-origin.ts`.
  */
 export function buildWebhookConfig(params: {
   isManual: boolean
@@ -37,9 +38,9 @@ export function buildWebhookConfig(params: {
 }
 
 /**
- * Build the persisted WhatsApp auth value. `originUrl` follows the same
- * broker-host rule as `buildWebhookConfig`: the stored `redirectUrl` must live on
- * the fixed registered host, not a white-label custom domain.
+ * Build the persisted WhatsApp auth value. `originUrl` follows the same rule
+ * as `buildWebhookConfig`: the stored `redirectUrl` lives on the tenant's
+ * custom domain for a tenant-owned credential, otherwise the broker.
  */
 export async function buildAuthValue(params: {
   whatsappSettings: WhatsappCredential

--- a/apps/builder/src/features/integration-whatsapp/components/whatsapp-automatic-events-card.tsx
+++ b/apps/builder/src/features/integration-whatsapp/components/whatsapp-automatic-events-card.tsx
@@ -29,10 +29,12 @@ export function WhatsappAutomaticEventsCard({
   integrationWhatsapp,
   whatsappCredentialPublic,
   workspaceId,
+  oauthCallbackUrl,
 }: {
   integrationWhatsapp: AutomaticEventsIntegration
   whatsappCredentialPublic: WhatsappCredentialPublic | null
   workspaceId: string
+  oauthCallbackUrl: string
 }) {
   const t = useTranslations()
   const status = getPermissionStatus(
@@ -74,6 +76,7 @@ export function WhatsappAutomaticEventsCard({
           {status === "missingPermission" && (
             <WhatsappReconnectButton
               integrationWhatsappId={integrationWhatsapp.id}
+              oauthCallbackUrl={oauthCallbackUrl}
               settings={whatsappCredentialPublic}
               workspaceId={workspaceId}
             />

--- a/apps/builder/src/features/integration-whatsapp/components/whatsapp-capi-tab.tsx
+++ b/apps/builder/src/features/integration-whatsapp/components/whatsapp-capi-tab.tsx
@@ -44,6 +44,7 @@ type WhatsappCapiTabProps = {
   capiDisconnected: boolean
   credentialAvailable: boolean
   whatsappCredentialPublic: WhatsappCredentialPublic | null
+  oauthCallbackUrl: string
 }
 
 const statusDescriptionKey = {
@@ -93,6 +94,7 @@ export function WhatsappCapiTab({
   capiDisconnected,
   credentialAvailable,
   whatsappCredentialPublic,
+  oauthCallbackUrl,
 }: WhatsappCapiTabProps) {
   const t = useTranslations()
   const workspaceId = useWorkspaceId()
@@ -142,6 +144,7 @@ export function WhatsappCapiTab({
       </Card>
       <WhatsappAutomaticEventsCard
         integrationWhatsapp={integrationWhatsapp}
+        oauthCallbackUrl={oauthCallbackUrl}
         whatsappCredentialPublic={whatsappCredentialPublic}
         workspaceId={workspaceId}
       />

--- a/apps/builder/src/features/integration-whatsapp/components/whatsapp-create.tsx
+++ b/apps/builder/src/features/integration-whatsapp/components/whatsapp-create.tsx
@@ -92,11 +92,19 @@ function usePhoneNumbers() {
 type WhatsappCreateProps = {
   workspaceId?: string | null
   settings: WhatsappCredentialPublic
+  /**
+   * Absolute callback URL registered with Meta for this credential — the
+   * broker callback for inherited/platform credentials, or the reseller's
+   * own custom domain callback for a tenant-owned one. Computed server-side
+   * (see `lib/provider-origin.ts`).
+   */
+  oauthCallbackUrl: string
 }
 
 export default function WhatsappCreate({
   workspaceId,
   settings,
+  oauthCallbackUrl,
 }: WhatsappCreateProps) {
   const t = useTranslations()
   const { visibility, updateVisibility } = useFormVisibility()
@@ -263,6 +271,7 @@ export default function WhatsappCreate({
     return (
       <SdkConnectSection
         hasFailed={action.hasErrored}
+        oauthCallbackUrl={oauthCallbackUrl}
         onAutoSubmit={handleSubmitWithAction}
         settings={settings}
         visibility={visibility}
@@ -330,6 +339,8 @@ type SdkConnectSectionProps = {
   onAutoSubmit: () => void
   /** A failed connect hands the flow back to the user for a fresh signup. */
   hasFailed: boolean
+  /** Absolute callback URL registered with Meta for this credential. */
+  oauthCallbackUrl: string
 }
 
 const LAUNCH_BUTTON_CLASS =
@@ -344,6 +355,7 @@ function SdkConnectSection({
   settings,
   onAutoSubmit,
   hasFailed,
+  oauthCallbackUrl,
 }: SdkConnectSectionProps) {
   const t = useTranslations()
   const { control } = useFormContext<ConnectWhatsappSchema>()
@@ -361,11 +373,13 @@ function SdkConnectSection({
     onSubmit: onAutoSubmit,
     onRelayError: () =>
       toast.error(t("messages.connectFailed", { feature: "Whatsapp" })),
+    callbackOrigin: new URL(oauthCallbackUrl).origin,
   })
 
   const openFacebookDialog = useCallback(() => {
     const url = buildFacebookOAuthDialogUrl({
       resellerOrigin: window.location.origin,
+      redirectUri: oauthCallbackUrl,
       clientId: settings.clientId,
       configId: settings.configId,
       version: settings.version,
@@ -374,12 +388,18 @@ function SdkConnectSection({
       locale: document.documentElement.lang || undefined,
     })
     // Open a real tab (not a popup window) — popups get blocked, and a tab keeps
-    // `window.opener` set so the broker callback can relay the code back here.
+    // `window.opener` set so the callback route can relay the code back here.
     const authTab = window.open(url, "_blank")
     if (!authTab) {
       toast.error(t("whatsapp.embeddedSignupPopupBlocked"))
     }
-  }, [settings, watchConnectExisting, watchTransferPhoneNumber, t])
+  }, [
+    settings,
+    oauthCallbackUrl,
+    watchConnectExisting,
+    watchTransferPhoneNumber,
+    t,
+  ])
 
   // Once Meta hands back a code the card keeps every option on screen, showing the
   // choices the user made, but freezes all of them: the server re-derives the

--- a/apps/builder/src/features/integration-whatsapp/components/whatsapp-reconnect-button.tsx
+++ b/apps/builder/src/features/integration-whatsapp/components/whatsapp-reconnect-button.tsx
@@ -8,7 +8,6 @@ import { useTranslations } from "next-intl"
 import { useAction } from "next-safe-action/hooks"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
-import { getBrokerOrigin } from "@/lib/oauth-broker"
 import { reconnectWhatsappAction } from "../actions/reconnect.action"
 import { buildFacebookOAuthDialogUrl } from "../libs/embedded-signup"
 import { parseOAuthRelayResult } from "../libs/oauth-relay"
@@ -18,11 +17,19 @@ export function WhatsappReconnectButton({
   settings,
   workspaceId,
   disabled = false,
+  oauthCallbackUrl,
 }: {
   integrationWhatsappId: string
   settings: WhatsappCredentialPublic | null
   workspaceId: string
   disabled?: boolean
+  /**
+   * Absolute callback URL registered with Meta for this credential — the
+   * broker callback for inherited/platform credentials, or the reseller's
+   * own custom domain callback for a tenant-owned one. Computed server-side
+   * (see `lib/provider-origin.ts`).
+   */
+  oauthCallbackUrl: string
 }) {
   const router = useRouter()
   const t = useTranslations()
@@ -50,11 +57,11 @@ export function WhatsappReconnectButton({
   )
 
   useEffect(() => {
-    const brokerOrigin = getBrokerOrigin()
+    const expectedOrigin = new URL(oauthCallbackUrl).origin
     const handleMessage = (event: MessageEvent) => {
       const result = parseOAuthRelayResult({
         origin: event.origin,
-        brokerOrigin,
+        expectedOrigin,
         data: event.data,
       })
       if (result.type === "ignored") {
@@ -75,7 +82,7 @@ export function WhatsappReconnectButton({
 
     window.addEventListener("message", handleMessage)
     return () => window.removeEventListener("message", handleMessage)
-  }, [execute, setIsWaitingForCode, t])
+  }, [execute, oauthCallbackUrl, setIsWaitingForCode, t])
 
   const openReconnectDialog = () => {
     if (!settings?.clientId) {
@@ -86,6 +93,7 @@ export function WhatsappReconnectButton({
     const authTab = window.open(
       buildFacebookOAuthDialogUrl({
         resellerOrigin: window.location.origin,
+        redirectUri: oauthCallbackUrl,
         clientId: settings.clientId,
         configId: settings.configId,
         version: settings.version,

--- a/apps/builder/src/features/integration-whatsapp/hooks/use-embedded-signup-auto-connect.ts
+++ b/apps/builder/src/features/integration-whatsapp/hooks/use-embedded-signup-auto-connect.ts
@@ -3,7 +3,6 @@
 import { useCallbackRef } from "@chatbotx.io/ui/hooks/use-callback-ref"
 import { useEffect } from "react"
 import { useFormContext, useWatch } from "react-hook-form"
-import { getBrokerOrigin } from "@/lib/oauth-broker"
 import {
   WA_OAUTH_RESULT,
   type WhatsappOAuthRelayResult,
@@ -18,6 +17,12 @@ type UseEmbeddedSignupAutoConnectParams = {
   onSubmit: () => void
   /** The relay reported a failed signup; the caller owns the localized message. */
   onRelayError: () => void
+  /**
+   * The origin the OAuth callback route was registered on for this
+   * credential (broker or the reseller's own custom domain) — the only
+   * trusted `postMessage` sender. See `lib/provider-origin.ts`.
+   */
+  callbackOrigin: string
 }
 
 type EmbeddedSignupAutoConnect = {
@@ -45,6 +50,7 @@ export function useEmbeddedSignupAutoConnect({
   hasFailed,
   onSubmit,
   onRelayError,
+  callbackOrigin,
 }: UseEmbeddedSignupAutoConnectParams): EmbeddedSignupAutoConnect {
   const { control, setValue } = useFormContext<ConnectWhatsappSchema>()
   const code = useWatch({ control, name: FORM_FIELDS.CODE })
@@ -52,12 +58,11 @@ export function useEmbeddedSignupAutoConnect({
   const handleSubmit = useCallbackRef(onSubmit)
 
   useEffect(() => {
-    const brokerOrigin = getBrokerOrigin()
-
-    // Any window on the page can post here, so the broker origin is the only
-    // trusted sender — everything else is dropped without a word.
+    // Any window on the page can post here, so the registered callback
+    // origin is the only trusted sender — everything else is dropped
+    // without a word.
     const handleMessage = (event: MessageEvent) => {
-      if (event.origin !== brokerOrigin) {
+      if (event.origin !== callbackOrigin) {
         return
       }
 
@@ -76,7 +81,7 @@ export function useEmbeddedSignupAutoConnect({
 
     window.addEventListener("message", handleMessage)
     return () => window.removeEventListener("message", handleMessage)
-  }, [handleRelayError, setValue])
+  }, [callbackOrigin, handleRelayError, setValue])
 
   useEffect(() => {
     if (!hasFailed) {

--- a/apps/builder/src/features/integration-whatsapp/libs/embedded-signup.ts
+++ b/apps/builder/src/features/integration-whatsapp/libs/embedded-signup.ts
@@ -1,15 +1,16 @@
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
-
 /**
  * WhatsApp embedded-signup helpers.
  *
  * Instead of running the Facebook JS SDK (whose OAuth origin is bound to
  * `window.location`, so it breaks on a white-label reseller custom domain), we
- * open the Facebook OAuth dialog directly with `redirect_uri` set to the fixed,
- * Meta-registered broker callback. Facebook returns the `code` to that broker
- * route, which relays it back to the originating reseller tab via
- * `window.opener.postMessage`. The reseller — where the session cookie lives —
- * exchanges the code and derives the WABA/phone/business ids server-side.
+ * open the Facebook OAuth dialog directly with `redirect_uri` set to the
+ * Meta-registered host for the credential in use — the broker for
+ * inherited/platform credentials, or the reseller's own custom domain for a
+ * tenant-owned one (see `lib/provider-origin.ts`). Facebook returns the
+ * `code` to that route, which relays it back to the originating reseller tab
+ * via `window.opener.postMessage`. The reseller — where the session cookie
+ * lives — exchanges the code and derives the WABA/phone/business ids
+ * server-side.
  */
 
 export const EMBEDDED_SIGNUP_FEATURE_TYPES = {
@@ -23,15 +24,15 @@ const EMBEDDED_SIGNUP_FEATURES = {
 
 const FACEBOOK_DIALOG_BASE = "https://www.facebook.com"
 
-/** Broker route Facebook redirects the `code` to (the only registered URI). */
+/** Route Facebook redirects the `code` to — path only; see `redirectUri` above for the host. */
 export const WHATSAPP_OAUTH_CALLBACK_PATH = "/integrations/whatsapp/callback"
 
 /**
- * `window.postMessage` contract between the broker callback route and the
- * reseller tab. The reseller validates `event.origin === getBrokerOrigin()`
- * before trusting it, and the broker validates the reseller origin (from `state`)
- * before posting — so a signup `code` is never relayed to an origin we do not
- * control.
+ * `window.postMessage` contract between the OAuth callback route and the
+ * reseller tab. The reseller validates `event.origin` against the registered
+ * callback origin before trusting it, and the callback route validates the
+ * reseller origin (from `state`) before posting — so a signup `code` is
+ * never relayed to an origin we do not control.
  */
 export const WA_OAUTH_RESULT = "WA_OAUTH_RESULT" as const
 
@@ -126,8 +127,16 @@ function buildEmbeddedSignupExtras(featureType?: string) {
 }
 
 export type FacebookOAuthDialogParams = {
-  /** The reseller origin the broker relays the result back to. */
+  /** The reseller origin the callback relays the result back to. */
   resellerOrigin: string
+  /**
+   * Absolute callback URL registered with Meta for this credential — the
+   * broker callback for inherited/platform credentials, or the reseller's
+   * own custom domain callback for a tenant-owned one. Computed server-side
+   * (see `lib/provider-origin.ts`) and passed in, since this module is
+   * client-side and cannot resolve it itself.
+   */
+  redirectUri: string
   clientId: string
   configId: string
   version: string
@@ -137,9 +146,10 @@ export type FacebookOAuthDialogParams = {
 }
 
 /**
- * Build the absolute Facebook OAuth dialog URL to open in a popup. `redirect_uri`
- * is the broker callback (the only origin registered with Meta); `state` carries
- * the reseller origin so the broker can relay the `code` back to the right tab.
+ * Build the absolute Facebook OAuth dialog URL to open in a popup.
+ * `redirect_uri` is the caller-supplied, Meta-registered callback for this
+ * credential; `state` carries the reseller origin so that callback route can
+ * relay the `code` back to the right tab.
  */
 export function buildFacebookOAuthDialogUrl(
   params: FacebookOAuthDialogParams,
@@ -147,10 +157,7 @@ export function buildFacebookOAuthDialogUrl(
   const url = new URL(`${FACEBOOK_DIALOG_BASE}/${params.version}/dialog/oauth`)
   url.searchParams.set("client_id", params.clientId)
   url.searchParams.set("config_id", params.configId)
-  url.searchParams.set(
-    "redirect_uri",
-    buildBrokerCallbackUrl(WHATSAPP_OAUTH_CALLBACK_PATH),
-  )
+  url.searchParams.set("redirect_uri", params.redirectUri)
   url.searchParams.set("response_type", "code")
   url.searchParams.set(
     "state",

--- a/apps/builder/src/features/integration-whatsapp/libs/oauth-relay.ts
+++ b/apps/builder/src/features/integration-whatsapp/libs/oauth-relay.ts
@@ -12,13 +12,14 @@ const whatsappOAuthRelayResultSchema = z.object({
 
 export function parseOAuthRelayResult(params: {
   origin: string
-  brokerOrigin: string
+  /** The origin the OAuth callback was registered on for this credential. */
+  expectedOrigin: string
   data: unknown
 }):
   | { type: "ignored" }
   | { type: "success"; code: string }
   | { type: "error" } {
-  if (params.origin !== params.brokerOrigin) {
+  if (params.origin !== params.expectedOrigin) {
     return { type: "ignored" }
   }
 

--- a/apps/builder/src/features/integration-zalo/actions/connect-zalo.action.ts
+++ b/apps/builder/src/features/integration-zalo/actions/connect-zalo.action.ts
@@ -14,24 +14,25 @@ import type { ZaloAuthValue } from "@chatbotx.io/integration-zalo"
 import { invalidateCacheByTags } from "@chatbotx.io/redis"
 import { redirect } from "next/navigation"
 import { integrations } from "@/integration"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 
 export async function connectZaloHandler({
   zaloSettings,
   workspaceId,
   req,
+  redirectUrl,
 }: {
   zaloSettings: ZaloCredential
   workspaceId: string
   req: Request
+  redirectUrl: string
 }) {
   const authValue = (await integrations.zalo.handleRequest({
     config: {
       ...zaloSettings,
-      // Must match the redirect_uri used at authorize time (the fixed broker
-      // callback), even though this handler runs on the originating host after
-      // the relay. See `libs/zalo.ts` and `oauth-referer.ts`.
-      redirectUrl: buildBrokerCallbackUrl("/integrations/zalo/callback"),
+      // Must match the redirect_uri used at authorize time — the tenant's
+      // custom domain for a tenant-owned credential, else the broker. See
+      // `libs/zalo.ts` and `oauth-referer.ts`.
+      redirectUrl,
       stateParams: { workspaceId },
     },
     req,

--- a/apps/builder/src/features/integration-zalo/actions/reconnect-callback.ts
+++ b/apps/builder/src/features/integration-zalo/actions/reconnect-callback.ts
@@ -4,7 +4,6 @@ import type { ZaloAuthValue } from "@chatbotx.io/integration-zalo"
 import { integrations } from "@/integration"
 import type { ReconnectResult } from "@/lib/channel-reconnect"
 import { logger } from "@/lib/log"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 
 /**
  * Complete an OAuth reconnect for an existing Zalo OA integration: the user
@@ -17,6 +16,7 @@ export async function reconnectZaloHandler(props: {
   workspaceId: string
   integrationId: string
   req: Request
+  callbackUrl: string
 }): Promise<ReconnectResult> {
   const integrationZalo = await zaloIntegrationService
     .findById({ id: props.integrationId, workspaceId: props.workspaceId })
@@ -29,10 +29,11 @@ export async function reconnectZaloHandler(props: {
     const authValue = (await integrations.zalo.handleRequest({
       config: {
         ...props.zaloSettings,
-        // Must match the redirect_uri used at authorize time (the fixed broker
-        // callback), even though this handler runs on the originating host
-        // after the relay. See `libs/zalo.ts` and `oauth-referer.ts`.
-        redirectUrl: buildBrokerCallbackUrl("/integrations/zalo/callback"),
+        // Must match the redirect_uri used at authorize time — the tenant's
+        // custom domain for a tenant-owned credential, else the broker — even
+        // though this handler runs on the originating host after the relay.
+        // See `libs/zalo.ts` and `oauth-referer.ts`.
+        redirectUrl: props.callbackUrl,
         stateParams: { workspaceId: props.workspaceId },
       },
       req: props.req,

--- a/apps/builder/src/features/integration-zalo/actions/reconnect.action.ts
+++ b/apps/builder/src/features/integration-zalo/actions/reconnect.action.ts
@@ -10,8 +10,8 @@ import { generateAuthUrl } from "@chatbotx.io/integration-zalo"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { redirect } from "next/navigation"
 import { getOriginUrlFromHeader } from "@/lib/domain"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { resolveOwnerForWorkspace } from "@/lib/platform-credential-owner"
+import { buildProviderCallbackUrl } from "@/lib/provider-origin"
 import { workspaceActionClient } from "@/lib/safe-action"
 
 /**
@@ -44,7 +44,12 @@ export const reconnectZaloAction = workspaceActionClient
         throw new ChatbotXException("Zalo App settings not found")
       }
 
-      const redirectUrl = buildBrokerCallbackUrl("/integrations/zalo/callback")
+      // Must match the redirect_uri used at authorize time — the tenant's
+      // custom domain for a tenant-owned credential, else the broker.
+      const redirectUrl = await buildProviderCallbackUrl(
+        zaloCredential,
+        "/integrations/zalo/callback",
+      )
       const baseUrl = await getOriginUrlFromHeader()
       const referer = new URL(
         `/space/${workspaceId}/settings/channels?channel=zalo`,

--- a/apps/builder/src/features/integration-zalo/libs/zalo.ts
+++ b/apps/builder/src/features/integration-zalo/libs/zalo.ts
@@ -1,25 +1,32 @@
 import type { ZaloCredentialPublic } from "@chatbotx.io/database/partials"
 import { generateAuthUrl } from "@chatbotx.io/integration-zalo"
 import { getOriginFromHeader } from "@/lib/domain"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
+import { buildProviderCallbackUrl } from "@/lib/provider-origin"
 
 export async function generateZaloRedirectUri(
-  publicConfig: ZaloCredentialPublic,
+  credential: {
+    userId: string | null
+    publicConfig: ZaloCredentialPublic
+  },
   workspaceId?: string | null,
 ) {
   const baseUrl = await getOriginFromHeader()
 
-  // The OAuth redirect_uri must be registered in the Zalo app. A white-label
-  // custom domain (the live request host) is not registered there, so send Zalo
-  // to the fixed broker callback and recover the originating branded domain from
-  // `referer` (the callback relays back to it), matching the other integrations.
-  const redirectUrl = buildBrokerCallbackUrl("/integrations/zalo/callback")
+  // The OAuth redirect_uri must be registered in the Zalo app. For a
+  // tenant-owned credential (their own app), that's the reseller's custom
+  // domain; otherwise it's the broker, and the originating branded domain is
+  // recovered from `referer` (the callback relays back to it), matching the
+  // other integrations.
+  const redirectUrl = await buildProviderCallbackUrl(
+    credential,
+    "/integrations/zalo/callback",
+  )
   const referer = workspaceId
     ? new URL(`/space/${workspaceId}`, baseUrl).toString()
     : baseUrl
 
   return generateAuthUrl({
-    clientId: publicConfig.clientId,
+    clientId: credential.publicConfig.clientId,
     clientSecret: "",
     redirectUrl,
     stateParams: {

--- a/apps/builder/src/features/platform-credentials/google/google-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/google/google-settings.tsx
@@ -31,7 +31,6 @@ import { useAction } from "next-safe-action/hooks"
 import { useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { CredentialFallbackNote } from "../credential-fallback-note"
 import { DeleteCredentialDialog } from "../delete-credential-dialog"
 import { useCredentialScope } from "../provider/credential-scope-context"
@@ -41,21 +40,23 @@ import { updateGoogleSettingsAction } from "./update-google-settings.action"
 export function GoogleSettings({
   publicConfig,
   isInherited = false,
+  callbackOrigin,
 }: {
   publicConfig: GoogleCredentialPublic | null
   isInherited?: boolean
+  /** Origin to register with Google. See `MessengerSettings`' equivalent prop. */
+  callbackOrigin: string
 }) {
   const t = useTranslations()
   const { handleCopy } = useClipboard()
 
-  // Both Google Sheets (integration) and Google sign-in (SSO) always redirect to
-  // the fixed broker callback, regardless of the reseller's branded domain.
-  // Resellers using their own Google app must whitelist these exact URIs in their
-  // own Google console. See `oauth-broker.ts` / `oauth-referer.ts`.
-  const authCallbackUrl = buildBrokerCallbackUrl(
-    "/integrations/google/callback",
-  )
-  const signInCallbackUrl = buildBrokerCallbackUrl("/api/auth/callback/google")
+  // Google Sheets and Google Calendar are separate registered redirect_uris
+  // (each integration owns its own callback route), and Google sign-in (SSO)
+  // is a third. Resellers using their own Google app must whitelist all three
+  // exact URIs in their own Google console.
+  const sheetsCallbackUrl = `${callbackOrigin}/integrations/google-sheets/callback`
+  const calendarCallbackUrl = `${callbackOrigin}/integrations/google-calendar/callback`
+  const signInCallbackUrl = `${callbackOrigin}/api/auth/callback/google`
 
   return (
     <Card>
@@ -88,12 +89,32 @@ export function GoogleSettings({
             </div>
 
             <div className="flex flex-col gap-2">
-              <div className="font-bold">Auth Callback URL:</div>
+              <div className="font-bold">
+                {t("fields.authCallbackUrl.label")} (Google Sheets):
+              </div>
               <div className="flex items-center gap-2">
-                <span className="truncate">{authCallbackUrl}</span>
+                <span className="truncate">{sheetsCallbackUrl}</span>
                 <Button
                   className="flex-none"
-                  onClick={() => handleCopy(authCallbackUrl)}
+                  onClick={() => handleCopy(sheetsCallbackUrl)}
+                  size="icon"
+                  type="button"
+                  variant="outline"
+                >
+                  <CopyIcon className="size-4" />
+                </Button>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <div className="font-bold">
+                {t("fields.authCallbackUrl.label")} (Google Calendar):
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="truncate">{calendarCallbackUrl}</span>
+                <Button
+                  className="flex-none"
+                  onClick={() => handleCopy(calendarCallbackUrl)}
                   size="icon"
                   type="button"
                   variant="outline"

--- a/apps/builder/src/features/platform-credentials/instagram-facebook/instagram-facebook-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/instagram-facebook/instagram-facebook-settings.tsx
@@ -31,7 +31,6 @@ import { useAction } from "next-safe-action/hooks"
 import { useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { CredentialFallbackNote } from "../credential-fallback-note"
 import { DeleteCredentialDialog } from "../delete-credential-dialog"
 import { useCredentialScope } from "../provider/credential-scope-context"
@@ -42,18 +41,17 @@ import { updateInstagramFacebookSettingAction } from "./update-instagram-faceboo
 export function InstagramFacebookSettings({
   publicConfig,
   isInherited = false,
+  callbackOrigin,
 }: {
   publicConfig: InstagramFacebookCredentialPublic | null
   isInherited?: boolean
+  /** Origin to register with Meta. See `MessengerSettings`' equivalent prop. */
+  callbackOrigin: string
 }) {
   const t = useTranslations()
   const { handleCopy } = useClipboard()
-  const webhookUrl = buildBrokerCallbackUrl(
-    "/integrations/instagramFacebook/webhook",
-  )
-  const authCallbackUrl = buildBrokerCallbackUrl(
-    "/integrations/instagram-facebook/callback",
-  )
+  const webhookUrl = `${callbackOrigin}/integrations/instagramFacebook/webhook`
+  const authCallbackUrl = `${callbackOrigin}/integrations/instagram-facebook/callback`
 
   return (
     <Card>

--- a/apps/builder/src/features/platform-credentials/instagram/instagram-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/instagram/instagram-settings.tsx
@@ -31,7 +31,6 @@ import { useAction } from "next-safe-action/hooks"
 import { useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { CredentialFallbackNote } from "../credential-fallback-note"
 import { DeleteCredentialDialog } from "../delete-credential-dialog"
 import { useCredentialScope } from "../provider/credential-scope-context"
@@ -41,18 +40,16 @@ import { updateInstagramSettingAction } from "./update-instagram-settings.action
 export function InstagramSettings({
   publicConfig,
   isInherited = false,
+  callbackOrigin,
 }: {
   publicConfig: InstagramCredentialPublic | null
   isInherited?: boolean
+  /** Origin to register with Meta. See `MessengerSettings`' equivalent prop. */
+  callbackOrigin: string
 }) {
   const { handleCopy } = useClipboard()
-  // Webhook + OAuth callback URLs must live on the fixed, provider-registered
-  // broker host — never the reseller's white-label custom domain, which Meta
-  // cannot reach. Resellers using their own Facebook app whitelist these URIs.
-  const webhookUrl = buildBrokerCallbackUrl("/integrations/instagram/webhook")
-  const authCallbackUrl = buildBrokerCallbackUrl(
-    "/integrations/instagram/callback",
-  )
+  const webhookUrl = `${callbackOrigin}/integrations/instagram/webhook`
+  const authCallbackUrl = `${callbackOrigin}/integrations/instagram/callback`
 
   return (
     <Card>

--- a/apps/builder/src/features/platform-credentials/manage-platform-credentials.tsx
+++ b/apps/builder/src/features/platform-credentials/manage-platform-credentials.tsx
@@ -4,6 +4,11 @@ import type {
   CredentialType,
 } from "@chatbotx.io/database/partials"
 import { isCloud } from "@/env"
+import { getBrokerOrigin } from "@/lib/oauth-broker"
+import {
+  PLACEHOLDER_DOMAIN_ORIGIN,
+  resolveTenantCustomDomainOrigin,
+} from "@/lib/provider-origin"
 import { GiphySettings } from "./giphy/giphy-settings"
 import { GoogleSettings } from "./google/google-settings"
 import { InstagramSettings } from "./instagram/instagram-settings"
@@ -111,34 +116,55 @@ export async function ManagePlatformCredentials({
     tiktokResult.status === "fulfilled" ? tiktokResult.value : emptyCard
   const make = makeResult.status === "fulfilled" ? makeResult.value : emptyCard
 
+  // For a tenant-owned credential (their own app), provider-facing URLs must
+  // use the reseller's active custom domain — falling back to a literal
+  // placeholder when they haven't activated one yet, never the broker (that
+  // would silently mislead them into registering a host they don't control).
+  // Inherited credentials always show the broker, since the platform app is
+  // what's actually registered. See `lib/provider-origin.ts`.
+  const tenantOrigin = scopedUserId
+    ? ((await resolveTenantCustomDomainOrigin(scopedUserId)) ??
+      PLACEHOLDER_DOMAIN_ORIGIN)
+    : getBrokerOrigin()
+  const brokerOrigin = getBrokerOrigin()
+  const callbackOriginFor = (isInherited: boolean) =>
+    isInherited ? brokerOrigin : tenantOrigin
+
   return (
     <CredentialScopeProvider scope={scope}>
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <MessengerSettings
+          callbackOrigin={callbackOriginFor(messenger.isInherited)}
           isInherited={messenger.isInherited}
           publicConfig={messenger.publicConfig}
         />
         <InstagramSettings
+          callbackOrigin={callbackOriginFor(instagram.isInherited)}
           isInherited={instagram.isInherited}
           publicConfig={instagram.publicConfig}
         />
         <InstagramFacebookSettings
+          callbackOrigin={callbackOriginFor(instagramFacebook.isInherited)}
           isInherited={instagramFacebook.isInherited}
           publicConfig={instagramFacebook.publicConfig}
         />
         <GoogleSettings
+          callbackOrigin={callbackOriginFor(google.isInherited)}
           isInherited={google.isInherited}
           publicConfig={google.publicConfig}
         />
         <WhatsappSettings
+          callbackOrigin={callbackOriginFor(whatsapp.isInherited)}
           isInherited={whatsapp.isInherited}
           publicConfig={whatsapp.publicConfig}
         />
         <ZaloSettings
+          callbackOrigin={callbackOriginFor(zalo.isInherited)}
           isInherited={zalo.isInherited}
           publicConfig={zalo.publicConfig}
         />
         <TiktokSettings
+          callbackOrigin={callbackOriginFor(tiktok.isInherited)}
           isInherited={tiktok.isInherited}
           publicConfig={tiktok.publicConfig}
         />

--- a/apps/builder/src/features/platform-credentials/messenger/messenger-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/messenger/messenger-settings.tsx
@@ -31,7 +31,6 @@ import { useAction } from "next-safe-action/hooks"
 import { useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { CredentialFallbackNote } from "../credential-fallback-note"
 import { DeleteCredentialDialog } from "../delete-credential-dialog"
 import { useCredentialScope } from "../provider/credential-scope-context"
@@ -41,19 +40,22 @@ import { updateMessengerSettingAction } from "./update-messenger-settings.action
 export function MessengerSettings({
   publicConfig,
   isInherited = false,
+  callbackOrigin,
 }: {
   publicConfig: MessengerCredentialPublic | null
   isInherited?: boolean
+  /**
+   * Origin to register with Meta: the broker for inherited credentials, the
+   * reseller's own active custom domain (or the `<your-domain.com>`
+   * placeholder when none is active yet) for a tenant-owned credential. See
+   * `lib/provider-origin.ts`.
+   */
+  callbackOrigin: string
 }) {
   const t = useTranslations()
   const { handleCopy } = useClipboard()
-  // Webhook + OAuth callback URLs must live on the fixed, provider-registered
-  // broker host — never the reseller's white-label custom domain, which Meta
-  // cannot reach. Resellers using their own Facebook app whitelist these URIs.
-  const webhookUrl = buildBrokerCallbackUrl("/integrations/messenger/webhook")
-  const authCallbackUrl = buildBrokerCallbackUrl(
-    "/integrations/messenger/callback",
-  )
+  const webhookUrl = `${callbackOrigin}/integrations/messenger/webhook`
+  const authCallbackUrl = `${callbackOrigin}/integrations/messenger/callback`
 
   return (
     <Card>

--- a/apps/builder/src/features/platform-credentials/tiktok/tiktok-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/tiktok/tiktok-settings.tsx
@@ -31,7 +31,6 @@ import { useAction } from "next-safe-action/hooks"
 import { useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { CredentialFallbackNote } from "../credential-fallback-note"
 import { DeleteCredentialDialog } from "../delete-credential-dialog"
 import { useCredentialScope } from "../provider/credential-scope-context"
@@ -41,19 +40,17 @@ import { updateTiktokSettingAction } from "./update-tiktok-settings.action"
 export function TiktokSettings({
   publicConfig,
   isInherited = false,
+  callbackOrigin,
 }: {
   publicConfig: TiktokCredentialPublic | null
   isInherited?: boolean
+  /** Origin to register with TikTok. See `MessengerSettings`' equivalent prop. */
+  callbackOrigin: string
 }) {
   const t = useTranslations()
   const { handleCopy } = useClipboard()
-  // Both the webhook and OAuth callback must live on the fixed, provider-registered
-  // broker host (not the reseller's branded domain) — the provider cannot reach an
-  // unregistered custom domain. Resellers using their own TikTok app register these.
-  const webhookUrl = buildBrokerCallbackUrl("/integrations/tiktok/webhook")
-  const authCallbackUrl = buildBrokerCallbackUrl(
-    "/integrations/tiktok/callback",
-  )
+  const webhookUrl = `${callbackOrigin}/integrations/tiktok/webhook`
+  const authCallbackUrl = `${callbackOrigin}/integrations/tiktok/callback`
 
   return (
     <Card>

--- a/apps/builder/src/features/platform-credentials/tiktok/update-tiktok-settings.action.ts
+++ b/apps/builder/src/features/platform-credentials/tiktok/update-tiktok-settings.action.ts
@@ -6,7 +6,8 @@ import {
   tiktokCredentialUpdateSchema,
 } from "@chatbotx.io/database/partials"
 import { subscribeWebhook } from "@chatbotx.io/integration-tiktok"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
+import { getBrokerOrigin } from "@/lib/oauth-broker"
+import { resolveTenantProviderOrigin } from "@/lib/provider-origin"
 import { authActionClient } from "@/lib/safe-action"
 import { credentialScopeSchema, resolveCredentialScopedUserId } from "../scope"
 
@@ -20,9 +21,16 @@ export const updateTiktokSettingAction = authActionClient
       clientSecret: parsedInput.clientSecret,
     }
 
+    // The webhook must be registered on the same host TikTok's push actually
+    // reaches: the reseller's own custom domain for a tenant-owned (user
+    // scope) credential, otherwise the broker.
+    const webhookOrigin = scopedUserId
+      ? await resolveTenantProviderOrigin(scopedUserId)
+      : getBrokerOrigin()
+
     await subscribeWebhook(
       { clientId: config.clientId, clientSecret: config.clientSecret },
-      buildBrokerCallbackUrl("/integrations/tiktok/webhook"),
+      new URL("/integrations/tiktok/webhook", webhookOrigin).toString(),
     )
 
     await platformCredentialService.upsert({

--- a/apps/builder/src/features/platform-credentials/whatsapp/whatsapp-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/whatsapp/whatsapp-settings.tsx
@@ -31,7 +31,6 @@ import { useAction } from "next-safe-action/hooks"
 import { useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { CredentialFallbackNote } from "../credential-fallback-note"
 import { DeleteCredentialDialog } from "../delete-credential-dialog"
 import { useCredentialScope } from "../provider/credential-scope-context"
@@ -41,19 +40,17 @@ import { updateWhatsappSettingsAction } from "./update-whatsapp-settings.action"
 export function WhatsappSettings({
   publicConfig,
   isInherited = false,
+  callbackOrigin,
 }: {
   publicConfig: WhatsappCredentialPublic | null
   isInherited?: boolean
+  /** Origin to register with Meta. See `MessengerSettings`' equivalent prop. */
+  callbackOrigin: string
 }) {
   const t = useTranslations()
   const { handleCopy } = useClipboard()
-  // Webhook + OAuth callback URLs must live on the fixed, provider-registered
-  // broker host — never the reseller's white-label custom domain, which Meta
-  // cannot reach. This matches what `connect.action.ts` registers server-side.
-  const webhookUrl = buildBrokerCallbackUrl("/integrations/whatsapp/webhook")
-  const authCallbackUrl = buildBrokerCallbackUrl(
-    "/integrations/whatsapp/callback",
-  )
+  const webhookUrl = `${callbackOrigin}/integrations/whatsapp/webhook`
+  const authCallbackUrl = `${callbackOrigin}/integrations/whatsapp/callback`
 
   return (
     <Card>

--- a/apps/builder/src/features/platform-credentials/zalo/zalo-settings.tsx
+++ b/apps/builder/src/features/platform-credentials/zalo/zalo-settings.tsx
@@ -31,7 +31,6 @@ import { useAction } from "next-safe-action/hooks"
 import { useState } from "react"
 import { toast } from "sonner"
 import { useClipboard } from "@/hooks/use-clipboard"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { CredentialFallbackNote } from "../credential-fallback-note"
 import { DeleteCredentialDialog } from "../delete-credential-dialog"
 import { useCredentialScope } from "../provider/credential-scope-context"
@@ -41,17 +40,17 @@ import { updateZaloSettingsAction } from "./update-zalo-settings.action"
 export function ZaloSettings({
   publicConfig,
   isInherited = false,
+  callbackOrigin,
 }: {
   publicConfig: ZaloCredentialPublic | null
   isInherited?: boolean
+  /** Origin to register with Zalo. See `MessengerSettings`' equivalent prop. */
+  callbackOrigin: string
 }) {
   const t = useTranslations()
   const { handleCopy } = useClipboard()
-  // Webhook + OAuth callback URLs must live on the fixed, provider-registered
-  // broker host — never the reseller's white-label custom domain, which Zalo
-  // cannot reach. Resellers using their own Zalo app whitelist these URIs.
-  const webhookUrl = buildBrokerCallbackUrl("/integrations/zalo/webhook")
-  const authCallbackUrl = buildBrokerCallbackUrl("/integrations/zalo/callback")
+  const webhookUrl = `${callbackOrigin}/integrations/zalo/webhook`
+  const authCallbackUrl = `${callbackOrigin}/integrations/zalo/callback`
 
   return (
     <Card>

--- a/apps/builder/src/features/products/actions/meta-catalog.action.ts
+++ b/apps/builder/src/features/products/actions/meta-catalog.action.ts
@@ -21,8 +21,8 @@ import { getTranslations } from "next-intl/server"
 import { z } from "zod"
 import { workspaceIdrequestParams } from "@/features/common/schemas"
 import { getOriginUrlFromHeader } from "@/lib/domain"
-import { buildBrokerCallbackUrl } from "@/lib/oauth-broker"
 import { resolveOwnerForWorkspace } from "@/lib/platform-credential-owner"
+import { buildProviderCallbackUrl } from "@/lib/provider-origin"
 import {
   workspaceActionClient,
   workspaceActionClientAllowExpired,
@@ -40,7 +40,8 @@ export const connectMetaCatalogAction = workspaceActionClient
       const t = await getTranslations("metaCatalog.errors")
       throw new ChatbotXException(t("invalidAppSettings"))
     }
-    const redirectUrl = buildBrokerCallbackUrl(
+    const redirectUrl = await buildProviderCallbackUrl(
+      credential,
       "/integrations/messenger/callback",
     )
     const baseUrl = await getOriginUrlFromHeader()

--- a/apps/builder/src/lib/auth/auth-instances.ts
+++ b/apps/builder/src/lib/auth/auth-instances.ts
@@ -9,10 +9,14 @@ import {
   resolveTenantByDomain,
   resolveTenantOwnerId,
 } from "@chatbotx.io/auth/tenant"
-import { platformCredentialService } from "@chatbotx.io/business"
+import {
+  customDomainService,
+  platformCredentialService,
+} from "@chatbotx.io/business"
 import type { CredentialType } from "@chatbotx.io/database/partials"
 import { ROOT_TENANT_ID } from "@chatbotx.io/database/schema"
 import { isCommunity } from "@/env"
+import { getBrokerOrigin } from "@/lib/oauth-broker"
 import { onUserCreated } from "./on-user-created"
 import {
   FACEBOOK_SSO_SCOPES,
@@ -71,14 +75,22 @@ const instancesByProvider: Record<SocialProvider, Map<string, Auth>> = {
 /** A resolved credential, carrying the Meta API `version` for Facebook. */
 type FacebookAwareCredential = SocialAuthCredential & { version?: string }
 
-/** A stable, non-reversible cache key for a credential (client id + secret + version). */
-function credentialKey(credential: FacebookAwareCredential | null): string {
+/**
+ * A stable, non-reversible cache key for a credential (client id + secret +
+ * version + redirect origin) — a domain activation for a tenant-owned
+ * credential must resolve to a fresh instance, since `redirectURI` is frozen
+ * into the instance at creation (see module doc comment).
+ */
+function credentialKey(
+  credential: FacebookAwareCredential | null,
+  redirectOrigin: string,
+): string {
   if (!credential) {
     return NO_CREDENTIAL_KEY
   }
   return createHash("sha256")
     .update(
-      `${credential.clientId} ${credential.clientSecret} ${credential.version ?? ""}`,
+      `${credential.clientId} ${credential.clientSecret} ${credential.version ?? ""} ${redirectOrigin}`,
     )
     .digest("hex")
 }
@@ -86,9 +98,10 @@ function credentialKey(credential: FacebookAwareCredential | null): string {
 function getAuthForCredential(
   provider: SocialProvider,
   credential: FacebookAwareCredential | null,
+  redirectOrigin: string,
 ): Auth {
   const cache = instancesByProvider[provider]
-  const key = credentialKey(credential)
+  const key = credentialKey(credential, redirectOrigin)
   const cached = cache.get(key)
   if (cached) {
     return cached
@@ -96,6 +109,7 @@ function getAuthForCredential(
 
   const instance = createAuth({
     socialCredentials: { [provider]: credential },
+    socialRedirectOrigin: redirectOrigin,
     onUserCreated,
     // Facebook SSO requests the same Messenger-grade scopes as the channel
     // connect flow (so the token can later be reused to list Pages) and
@@ -118,22 +132,47 @@ function getAuthForCredential(
 /** Fallback only reached if a resolved messenger credential is somehow missing `version` (schema requires it). */
 const DEFAULT_MESSENGER_API_VERSION = "v23.0"
 
+type TenantCredentialResolution = {
+  credential: FacebookAwareCredential | null
+  /** The origin the social `redirectURI` must be pinned to for this credential. */
+  redirectOrigin: string
+}
+
+/**
+ * The origin a tenant's social `redirectURI` must be pinned to: the
+ * reseller's active custom domain for a tenant-owned credential (their own
+ * app, on a non-root tenant), else the broker.
+ */
+async function resolveTenantSocialRedirectOrigin(
+  credentialOwnerId: string | null | undefined,
+  tenantId: string,
+): Promise<string> {
+  if (!(credentialOwnerId && tenantId !== ROOT_TENANT_ID)) {
+    return getBrokerOrigin()
+  }
+  const domain = await customDomainService.findActiveByTenantId(tenantId)
+  return domain ? `https://${domain.domain}` : getBrokerOrigin()
+}
+
 /**
  * The credential a tenant signs in with for `provider`: the reseller's own app
  * when they configured one (and their tenant is active), otherwise the platform
- * default. Returns `null` when neither resolves or the secret is incomplete.
+ * default. `credential` is `null` when neither resolves or the secret is
+ * incomplete. `redirectOrigin` is the reseller's active custom domain for a
+ * tenant-owned credential (their own app, on a non-root tenant), else the
+ * broker.
  */
 async function resolveCredentialForTenant(
   tenantId: string,
   provider: SocialProvider,
-): Promise<FacebookAwareCredential | null> {
+): Promise<TenantCredentialResolution> {
   // Community edition ships without social sign-in (email/password + magic
   // link only). Resolving no credential builds the better-auth instance with
   // zero social providers, so /api/auth/sign-in/social, OAuth callbacks, and
   // link-social all reject — and the sign-in pages hide the buttons since
   // isSocialLoginEnabledForTenant derives from this same resolver.
   if (isCommunity()) {
-    return null
+    return { credential: null, redirectOrigin: getBrokerOrigin() }
   }
 
   const type = PROVIDER_CREDENTIAL_TYPE[provider]
@@ -142,19 +181,27 @@ async function resolveCredentialForTenant(
       ? await platformCredentialService.findDecryptedPlatform({ type })
       : await resolveResellerCredential(tenantId, type)
 
+  const redirectOrigin = await resolveTenantSocialRedirectOrigin(
+    decrypted?.userId,
+    tenantId,
+  )
+
   const clientId = decrypted?.config.clientId
   const clientSecret = decrypted?.config.clientSecret
   if (!(clientId && clientSecret)) {
-    return null
+    return { credential: null, redirectOrigin }
   }
 
   return {
-    clientId,
-    clientSecret,
-    version:
-      provider === "facebook"
-        ? (decrypted?.config as { version: string }).version
-        : undefined,
+    credential: {
+      clientId,
+      clientSecret,
+      version:
+        provider === "facebook"
+          ? (decrypted?.config as { version: string }).version
+          : undefined,
+    },
+    redirectOrigin,
   }
 }
 
@@ -174,10 +221,11 @@ export async function getSocialAuthForTenant(
   tenantId: string,
   provider: SocialProvider,
 ): Promise<Auth> {
-  return getAuthForCredential(
+  const { credential, redirectOrigin } = await resolveCredentialForTenant(
+    tenantId,
     provider,
-    await resolveCredentialForTenant(tenantId, provider),
   )
+  return getAuthForCredential(provider, credential, redirectOrigin)
 }
 
 /** Whether `provider` login resolves for the given tenant (drives button visibility). */
@@ -185,7 +233,8 @@ export async function isSocialLoginEnabledForTenant(
   tenantId: string,
   provider: SocialProvider,
 ): Promise<boolean> {
-  return (await resolveCredentialForTenant(tenantId, provider)) !== null
+  const { credential } = await resolveCredentialForTenant(tenantId, provider)
+  return credential !== null
 }
 
 /** The social providers enabled for the tenant that owns the given domain. */

--- a/apps/builder/src/lib/oauth-broker.ts
+++ b/apps/builder/src/lib/oauth-broker.ts
@@ -2,14 +2,15 @@ import { env } from "@/env"
 
 /**
  * The OAuth broker — a dedicated, brand-neutral host (GHL/LeadConnector-style)
- * registered as the single `redirect_uri` with every OAuth provider (Google,
- * Facebook, TikTok, Google Sheets, …). Every white-label callback lands here and
- * is then relayed back to the originating domain (see `oauth-referer.ts`), so the
- * code exchange and cookie write happen where the user's session actually lives.
- *
- * Webhook *receive* URLs for providers that validate the registered host (e.g.
- * WhatsApp/Meta, TikTok) also use this broker origin, not just OAuth redirects —
- * the provider cannot reach an unregistered white-label custom domain.
+ * used as the `redirect_uri` for inherited/platform-owned OAuth credentials
+ * and self-hosted editions. A tenant-owned credential (a reseller's own
+ * provider app, `Credential.userId` set) instead uses that reseller's active
+ * custom domain — see `lib/provider-origin.ts`, the actual source of truth
+ * for "which origin does this credential's redirect_uri use". Either way, a
+ * callback that lands on a host different from where the flow started is
+ * relayed back to the originating domain (see `oauth-referer.ts`), so the
+ * code exchange and cookie write happen where the user's session actually
+ * lives.
  *
  * Falls back to `NEXT_PUBLIC_BUILDER_URL` when no dedicated broker is configured,
  * keeping single-domain deployments unchanged.

--- a/apps/builder/src/lib/oauth-referer.ts
+++ b/apps/builder/src/lib/oauth-referer.ts
@@ -38,14 +38,19 @@ export async function sanitizeReferer(referer: string): Promise<string> {
 }
 
 /**
- * Social (Google/Facebook) and integration (TikTok/…) OAuth always land on the
- * fixed broker host — the only registered redirect_uri. When the flow originated
- * on a different domain (a reseller custom domain or the builder app URL), return
- * the URL to relay the callback to — same path + query, on the originating domain
- * — so the rest of the handler runs where the user's session cookie lives.
+ * OAuth redirect_uris are pinned per-credential: the broker host for
+ * inherited/platform credentials, or the reseller's own custom domain for a
+ * tenant-owned credential (see `lib/provider-origin.ts`). Either way, the
+ * callback can land on a host different from the one the flow originated on
+ * — e.g. a reseller on the platform host authorizes through their own app,
+ * whose registered redirect_uri is their custom domain. When the callback
+ * host differs from the originating `referer` host, return the URL to relay
+ * the callback to — same path + query, on the originating domain — so the
+ * rest of the handler runs where the user's session cookie lives.
  *
- * Returns `null` when no relay is needed: the callback already ran on the
- * originating domain, or the `referer` is not an origin we control.
+ * Returns `null` when no relay is needed: the callback already landed on the
+ * originating host (loop-safe — the relayed request has equal hosts and
+ * won't match again), or the `referer` is not an origin we control.
  */
 export async function resolveRelayTarget(
   url: URL,
@@ -58,9 +63,7 @@ export async function resolveRelayTarget(
     return null
   }
 
-  const brokerHost = new URL(getBrokerOrigin()).host
-  // Only relay from the broker host, and never to the broker itself.
-  if (url.host !== brokerHost || refererUrl.host === brokerHost) {
+  if (url.host === refererUrl.host) {
     return null
   }
 

--- a/apps/builder/src/lib/provider-origin.ts
+++ b/apps/builder/src/lib/provider-origin.ts
@@ -1,0 +1,74 @@
+import "server-only"
+import { customDomainService, tenantService } from "@chatbotx.io/business"
+import { cache } from "react"
+import { isCloud } from "@/env"
+import { getBrokerOrigin } from "@/lib/oauth-broker"
+
+/**
+ * A tenant-owned platform credential (`Credential.userId` set) belongs to a
+ * reseller who registered their own provider app — they can (and must)
+ * whitelist their own custom domain instead of the broker. Everything else
+ * (inherited credentials, `"platform"` scope, self-hosted editions, a
+ * suspended tenant, or a tenant with no active domain) stays on the broker,
+ * because the reseller either doesn't control a distinct app or isn't
+ * reachable on a domain of their own.
+ */
+
+/**
+ * The reseller's active custom domain origin, or `null` when they don't have
+ * one (self-hosted, suspended tenant, no active domain). Cached per-request
+ * on the primitive `ownerId` — see `resolveTenantOwnerIdCached` in
+ * `lib/platform-credential-owner.ts` for why the cache key must be a string.
+ */
+export const resolveTenantCustomDomainOrigin = cache(
+  async (ownerId: string): Promise<string | null> => {
+    if (!isCloud()) {
+      return null
+    }
+
+    const tenant = await tenantService.findByOwner(ownerId)
+    if (tenant?.status !== "active") {
+      return null
+    }
+
+    const domain = await customDomainService.findActiveByTenantId(tenant.id)
+    return domain ? `https://${domain.domain}` : null
+  },
+)
+
+/**
+ * The concrete origin a server-side OAuth/webhook URL must use for this
+ * owner: the tenant's custom domain when they have one, else the broker.
+ * Always returns a usable origin — callers that build an actual
+ * `redirect_uri` never need to special-case "no domain".
+ */
+export async function resolveTenantProviderOrigin(
+  ownerId: string,
+): Promise<string> {
+  return (await resolveTenantCustomDomainOrigin(ownerId)) ?? getBrokerOrigin()
+}
+
+/** Display-only placeholder shown when a tenant-owned credential has no active domain yet. */
+export const PLACEHOLDER_DOMAIN_ORIGIN = "https://<your-domain.com>"
+
+/**
+ * The origin to use for a given credential: the owning tenant's custom
+ * domain for tenant-owned credentials (`userId` set), the broker for
+ * platform-owned ones (`userId` null).
+ */
+export function resolveProviderOriginForCredential(credential?: {
+  userId: string | null
+}): Promise<string> {
+  return credential?.userId
+    ? resolveTenantProviderOrigin(credential.userId)
+    : Promise.resolve(getBrokerOrigin())
+}
+
+/** Build an absolute callback URL on the correct origin for the given credential. */
+export async function buildProviderCallbackUrl(
+  credential: { userId: string | null } | undefined,
+  path: string,
+): Promise<string> {
+  const origin = await resolveProviderOriginForCredential(credential)
+  return new URL(path, origin).toString()
+}

--- a/docs/tenancy.md
+++ b/docs/tenancy.md
@@ -60,19 +60,24 @@ Tenant scoping lives in `packages/auth/src/tenant-context.ts` and `server.ts`.
   `Account.tenantId` has `onDelete: "restrict"`, so a mismatched stamp would block
   that reseller tenant's deletion.
 - **OAuth state recovery** (`resolveTenantFromOAuthState`) — OAuth providers redirect
-  to a fixed, pre-registered redirect URI (the **broker host**, see below), so on
-  `/callback/*` the request's `x-domain` is the broker host. The tenant is instead
+  to a redirect URI pinned per-credential (the reseller's own active custom domain for
+  a tenant-owned credential, else the **broker host**, see below), so on `/callback/*`
+  the request's `x-domain` may not match where the flow started. The tenant is instead
   recovered from the persisted OAuth `state` (its `callbackURL` carries the
   originating reseller origin, exposed by `resolveOAuthStateCallbackURL`). Fails safe
   to the root tenant.
-- **Callback relay** — because the provider lands on the broker host, the session
-  cookie would otherwise be minted there and never reach the reseller's domain. So
-  on the `/callback/*` leg the auth route bounces the callback (same `code` + `state`)
-  back to the originating branded host before better-auth processes it, so the
-  session cookie is set on the host the user is actually on. `skipStateCookieCheck`
-  makes this cross-host hand-off safe (state lives in the DB, not only the cookie).
-  This mirrors `resolveRelayTarget` in `apps/builder/src/lib/oauth-referer.ts`, the
-  same relay the channel integrations use (`integrations/[...integration]/callback.ts`).
+- **Callback relay** — the registered callback host can differ from the originating
+  branded host (inherited/platform credentials always land on the broker; a
+  tenant-owned credential lands on the reseller's own domain even when the flow
+  started on the platform host). Landing anywhere but the originating host would mint
+  the session cookie somewhere the user isn't. So on the `/callback/*` leg the auth
+  route bounces the callback (same `code` + `state`) back to the originating branded
+  host before better-auth processes it, so the session cookie is set on the host the
+  user is actually on. `skipStateCookieCheck` makes this cross-host hand-off safe
+  (state lives in the DB, not only the cookie). This mirrors `resolveRelayTarget` in
+  `apps/builder/src/lib/oauth-referer.ts`, the same relay the channel integrations use
+  (`integrations/[...integration]/callback.ts`) — it relays whenever the callback host
+  differs from the originating `referer` host.
 
 The auth route (`apps/builder/src/app/api/auth/[...all]/route.ts`) binds the tenant
 with `withTenant` around the whole better-auth pipeline.
@@ -94,66 +99,94 @@ sees a provider's button only when its credential resolves
 credential** stored under `type: "messenger"`, so resellers don't register a second
 Facebook app just to sign in.
 
-The OAuth `redirect_uri` is always the broker host (each social provider's
-`redirectURI` is pinned to it in `buildSocialProviders`), so a reseller using their
-**own** provider app must register the *broker* callback URL
-(`{broker}/api/auth/callback/<provider>`) in that app's console. The callback then
-relays back to the branded host (see "Callback relay" above) so the session lands
-there.
+The OAuth `redirect_uri` is pinned per-credential in `buildSocialProviders`
+(`packages/auth/src/server.ts`, via `AuthConfig.socialRedirectOrigin`):
+`apps/builder/src/lib/auth/auth-instances.ts` resolves it to the reseller's active
+custom domain for a tenant-owned credential (their own app, on a non-root tenant),
+else the broker host. A reseller using their own provider app registers the callback
+URL on **their own domain** (`{their-domain}/api/auth/callback/<provider>`) when they
+have an active custom domain, otherwise the *broker* callback URL
+(`{broker}/api/auth/callback/<provider>`) — the manage-credentials UI shows the exact
+URL to register. The instance cache key folds in the redirect origin, so activating a
+custom domain resolves to a fresh instance instead of reusing one pinned to the
+broker. Either way, when the callback lands on a host different from where the flow
+started, it relays back to the originating host (see "Callback relay" above) so the
+session lands there.
 
 ## OAuth broker (the "white-label URL")
 
 OAuth providers (Google, Facebook, TikTok, …) only accept a fixed allowlist of
-redirect URIs — wildcards and per-reseller domains are rejected. So every OAuth flow
-(social SSO **and** channel integrations) lands on a single dedicated, brand-neutral
-host — the **broker** — which then relays the callback back to the originating
-reseller domain. This is the same pattern GoHighLevel uses with
-`marketplace.leadconnectorhq.com`.
+redirect URIs — wildcards are rejected, so a URI must be registered explicitly. Every
+OAuth flow (social SSO **and** channel integrations) uses the origin registered for
+the credential in use: the **broker** — a dedicated, brand-neutral host, same pattern
+as GoHighLevel's `marketplace.leadconnectorhq.com` — for inherited/platform
+credentials and self-hosted editions, or the reseller's **own active custom domain**
+for a credential they configured themselves (`Credential.userId` set). Either way, if
+the callback lands on a host different from where the flow started, it relays back to
+the originating host so the code exchange and cookie write happen where the user's
+session actually lives.
 
 - **Config** — `NEXT_PUBLIC_BROKER_URL` (env). Optional; defaults to
   `NEXT_PUBLIC_BUILDER_URL` so single-domain deployments are unaffected. Resolved via
-  `getBrokerUrl()` (`packages/auth/src/keys.ts`) and `getBrokerOrigin()` /
-  `buildBrokerCallbackUrl()` (`apps/builder/src/lib/oauth-broker.ts`).
-- **Where redirect URIs come from** — SSO pins each provider's `redirectURI` in
-  `buildSocialProviders` (`packages/auth/src/server.ts`); integrations build theirs
-  with `buildBrokerCallbackUrl()` in each `features/integration-*/libs/*.ts` and in
+  `getBrokerUrl()` (`packages/auth/src/keys.ts`) and `getBrokerOrigin()`
+  (`apps/builder/src/lib/oauth-broker.ts`).
+- **Where redirect URIs come from** — `apps/builder/src/lib/provider-origin.ts` is the
+  single source of truth: `resolveProviderOriginForCredential`/`buildProviderCallbackUrl`
+  resolve to the reseller's active custom domain when the credential is tenant-owned
+  (`userId` set) and their tenant has one, else the broker. SSO threads the same
+  resolution through `AuthConfig.socialRedirectOrigin` (see "Per-tenant social OAuth"
+  above); integrations call `buildProviderCallbackUrl()` in each
+  `features/integration-*/libs/*.ts`, their connect/reconnect actions, and in
   `integrations/[...integration]/callback.ts` (the token-exchange `redirect_uri` must
-  match the authorize-time one). `trustedOrigins` includes the broker, the builder
-  URL, and every active custom domain.
-- **Relay targets** — `resolveRelayTarget` only relays *from* the broker host, and
-  only *to* an origin we control: the builder URL or an active custom domain.
-  `sanitizeReferer` enforces the same allowlist, so an attacker-controlled `state`
-  cannot drive an open redirect. (Integration `state` is not HMAC-signed; integrity
-  rests on this origin allowlist plus the `workspace.ownerId === userId` ownership
-  check in the callback. Signing `state` is a possible future hardening.)
+  match the authorize-time one — always the same credential resolved on both legs).
+  `trustedOrigins` includes the broker, the builder URL, and every active custom
+  domain.
+- **Relay targets** — `resolveRelayTarget` relays whenever the callback's host differs
+  from the originating `referer` host, and only *to* an origin we control: the builder
+  URL or an active custom domain. `sanitizeReferer` enforces the same allowlist, so an
+  attacker-controlled `state` cannot drive an open redirect. (Integration `state` is
+  not HMAC-signed; integrity rests on this origin allowlist plus the
+  `workspace.ownerId === userId` ownership check in the callback. Signing `state` is a
+  possible future hardening.)
+- **No active domain** — a tenant-owned credential with no active custom domain falls
+  back to the broker server-side (there's nothing else to register with the
+  provider); the manage-credentials UI instead shows a literal
+  `https://<your-domain.com>` placeholder so the reseller isn't misled into
+  registering a host they don't control.
 
 ### Provider-console registration runbook
 
-Register these exact URIs in each provider's developer console (platform-owned app,
-and any reseller-owned app). `{broker}` = `NEXT_PUBLIC_BROKER_URL`:
+Register these exact URIs in each provider's developer console. For the
+platform-owned app (or a self-hosted edition), `{origin}` = `NEXT_PUBLIC_BROKER_URL`
+(or the builder URL). For a reseller-owned app, `{origin}` = the reseller's own active
+custom domain:
 
 | Provider | URI to register |
 |----------|--------------------------|
-| Google SSO | `{broker}/api/auth/callback/google` |
-| Facebook SSO | `{broker}/api/auth/callback/facebook` |
-| Google Sheets | `{broker}/integrations/google/callback` |
-| TikTok | `{broker}/integrations/tiktok/callback` |
-| Messenger | `{broker}/integrations/messenger/callback` |
-| Instagram | `{broker}/integrations/instagram/callback` |
-| Zalo | `{broker}/integrations/zalo/callback` |
-| WhatsApp webhook | `{broker}/integrations/whatsapp/webhook` |
-| TikTok webhook | `{broker}/integrations/tiktok/webhook` |
+| Google SSO | `{origin}/api/auth/callback/google` |
+| Facebook SSO | `{origin}/api/auth/callback/facebook` |
+| Google Sheets | `{origin}/integrations/google-sheets/callback` |
+| Google Calendar | `{origin}/integrations/google-calendar/callback` |
+| TikTok | `{origin}/integrations/tiktok/callback` |
+| Messenger | `{origin}/integrations/messenger/callback` |
+| Instagram | `{origin}/integrations/instagram/callback` |
+| Zalo | `{origin}/integrations/zalo/callback` |
+| WhatsApp webhook | `{origin}/integrations/whatsapp/webhook` |
+| TikTok webhook | `{origin}/integrations/tiktok/webhook` |
 
 (The WhatsApp manual-connect flow registers a per-integration variant,
-`{broker}/integrations/whatsapp/webhook/{integrationId}`, sent to Meta as
+`{origin}/integrations/whatsapp/webhook/{integrationId}`, sent to Meta as
 `override_callback_uri`.)
 
-The platform-credential settings UI surfaces these URLs per provider so resellers can
-copy the exact value into their own console. Receive-side webhook URLs for providers
-that validate the registered host (e.g. WhatsApp/Meta, TikTok) **also use the broker
-host** — the provider cannot reach an unregistered white-label custom domain. Only
-purely internal receive endpoints (no provider-side host validation) stay on the
-reseller's own domain.
+The platform-credential settings UI surfaces these URLs per provider (already resolved
+to the correct origin) so resellers can copy the exact value into their own console.
+Receive-side webhook URLs follow the same per-credential origin as OAuth callbacks —
+inherited/platform credentials on the broker host, tenant-owned credentials on the
+reseller's own active custom domain — since the provider cannot reach an unregistered
+host either way. Webhook *receive* routing itself still dispatches by request host
+(`app/integrations/[...integration]/webhook.ts`): the broker host resolves the
+platform credential, any other (now correctly-registered) host resolves the tenant
+credential for that domain.
 
 ## Branding
 

--- a/docs/tenancy.md
+++ b/docs/tenancy.md
@@ -46,8 +46,19 @@ Tenant scoping lives in `packages/auth/src/tenant-context.ts` and `server.ts`.
 - **Reseller-owner fallback** — on the reseller's own domain the bound tenant is
   their reseller `Tenant`, but the reseller's own account lives in the root tenant
   (they signed up on the main site). When a scoped email lookup misses, the adapter
-  resolves `Tenant.ownerId` and retries by primary key — so a reseller signs in on
+  resolves `Tenant.ownerId` and retries by primary key, additionally constrained to
+  `tenantId = ROOT_TENANT_ID` — the fallback resolves only the owner's root-tenant
+  account, never a user row parked in any other tenant. So a reseller signs in on
   both the platform URL and their own domain; their sub-accounts only on the domain.
+  This applies to every auth method, including OAuth social sign-in: a social
+  sign-in with the owner's email links to the owner's existing root-tenant account
+  instead of creating a tenant-scoped duplicate (both social providers verify
+  mailbox ownership, so whoever presents the owner's email via OAuth is the owner).
+  Correspondingly, the adapter's `create` wrapper stamps a newly-linked `Account`
+  row with `ROOT_TENANT_ID` (not the bound tenant) whenever its `userId` is the
+  bound tenant's owner, so the row matches the root-tenant `User` it belongs to —
+  `Account.tenantId` has `onDelete: "restrict"`, so a mismatched stamp would block
+  that reseller tenant's deletion.
 - **OAuth state recovery** (`resolveTenantFromOAuthState`) — OAuth providers redirect
   to a fixed, pre-registered redirect URI (the **broker host**, see below), so on
   `/callback/*` the request's `x-domain` is the broker host. The tenant is instead

--- a/packages/auth/__tests__/social-redirect-origin.test.ts
+++ b/packages/auth/__tests__/social-redirect-origin.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+
+/**
+ * Hoisted mock handles. `vi.mock` factories run before module top-level, so any
+ * value a factory references must be created with `vi.hoisted`.
+ */
+const { listActiveDomains, betterAuthMock } = vi.hoisted(() => ({
+  listActiveDomains: vi.fn(),
+  betterAuthMock: vi.fn((config: Record<string, unknown>) => config),
+}))
+
+vi.mock("better-auth", async () => {
+  const actual =
+    await vi.importActual<typeof import("better-auth")>("better-auth")
+  return {
+    ...actual,
+    betterAuth: betterAuthMock,
+  }
+})
+
+vi.mock("better-auth/adapters/drizzle", () => ({
+  drizzleAdapter: () => ({}),
+}))
+
+vi.mock("better-auth/next-js", () => ({
+  nextCookies: () => ({ id: "next-cookies" }),
+}))
+
+vi.mock("better-auth/plugins", () => ({
+  anonymous: () => ({ id: "anonymous" }),
+  magicLink: () => ({ id: "magic-link" }),
+  oneTimeToken: () => ({ id: "one-time-token" }),
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {},
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  accountModel: {},
+  sessionModel: {},
+  userModel: {},
+  verificationModel: {},
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  customDomainService: { listActiveDomains },
+  platformCredentialService: {
+    findDecryptedPlatform: vi.fn(),
+    findPlatform: vi.fn(),
+  },
+  resolveTenantSettingsByDomain: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/utils", () => ({
+  createId: () => "test-id",
+  getPublicOriginFromRequest: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/mail", () => ({
+  DEFAULT_FORGOT_PASSWORD_SUBJECT: "reset",
+  DEFAULT_MAGIC_LINK_SUBJECT: "magic",
+  DEFAULT_SIGNUP_SUBJECT: "signup",
+  sendMagicLink: vi.fn(),
+  sendResetPassword: vi.fn(),
+  sendSignUpVerification: vi.fn(),
+}))
+
+const BROKER_URL = "https://broker.example.com"
+const BUILDER_URL = "https://app.example.com"
+
+type SocialProvidersConfig = {
+  socialProviders?: Record<string, { redirectURI: string }>
+}
+
+describe("buildSocialProviders — socialRedirectOrigin", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    betterAuthMock.mockClear()
+    listActiveDomains.mockReset()
+    vi.stubEnv("SKIP_ENV_CHECK", "true")
+    vi.stubEnv("NEXT_PUBLIC_BUILDER_URL", BUILDER_URL)
+    vi.stubEnv("NEXT_PUBLIC_BROKER_URL", BROKER_URL)
+    vi.stubEnv("BETTER_AUTH_SECRET", "test-secret")
+    vi.stubEnv("NEXT_PHASE", "")
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  test("pins redirectURI to the broker origin when socialRedirectOrigin is omitted", async () => {
+    const { createAuth } = await import("../src/server")
+    createAuth({
+      socialCredentials: {
+        google: { clientId: "id-1", clientSecret: "secret-1" },
+      },
+    })
+
+    const config = betterAuthMock.mock.calls[0]?.[0] as SocialProvidersConfig
+    expect(config.socialProviders?.google?.redirectURI).toBe(
+      `${BROKER_URL}/api/auth/callback/google`,
+    )
+  })
+
+  test("pins redirectURI to the caller-supplied socialRedirectOrigin (tenant custom domain)", async () => {
+    const { createAuth } = await import("../src/server")
+    createAuth({
+      socialCredentials: {
+        google: { clientId: "id-1", clientSecret: "secret-1" },
+      },
+      socialRedirectOrigin: "https://chat.acme.com",
+    })
+
+    const config = betterAuthMock.mock.calls[0]?.[0] as SocialProvidersConfig
+    expect(config.socialProviders?.google?.redirectURI).toBe(
+      "https://chat.acme.com/api/auth/callback/google",
+    )
+  })
+
+  test("applies socialRedirectOrigin to every enabled provider", async () => {
+    const { createAuth } = await import("../src/server")
+    createAuth({
+      socialCredentials: {
+        google: { clientId: "id-1", clientSecret: "secret-1" },
+        facebook: { clientId: "id-2", clientSecret: "secret-2" },
+      },
+      socialRedirectOrigin: "https://chat.acme.com",
+    })
+
+    const config = betterAuthMock.mock.calls[0]?.[0] as SocialProvidersConfig
+    expect(config.socialProviders?.google?.redirectURI).toBe(
+      "https://chat.acme.com/api/auth/callback/google",
+    )
+    expect(config.socialProviders?.facebook?.redirectURI).toBe(
+      "https://chat.acme.com/api/auth/callback/facebook",
+    )
+  })
+})

--- a/packages/auth/__tests__/tenant-scoping.test.ts
+++ b/packages/auth/__tests__/tenant-scoping.test.ts
@@ -312,6 +312,54 @@ describe("tenant-scoped adapter", () => {
     )
   })
 
+  test("stamps ROOT_TENANT_ID on an account insert linking to the bound tenant's owner", async () => {
+    const { scoped, create } = buildScoped()
+    tenantFindById.mockResolvedValueOnce({ ownerId: "200" })
+
+    await withTenant("42", () =>
+      scoped.create({
+        model: "account",
+        data: { accountId: "g-1", providerId: "google", userId: "200" },
+      }),
+    )
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "account",
+        data: {
+          accountId: "g-1",
+          providerId: "google",
+          userId: "200",
+          tenantId: ROOT,
+        },
+      }),
+    )
+  })
+
+  test("stamps the bound tenant on an account insert for a non-owner userId", async () => {
+    const { scoped, create } = buildScoped()
+    tenantFindById.mockResolvedValueOnce({ ownerId: "200" })
+
+    await withTenant("42", () =>
+      scoped.create({
+        model: "account",
+        data: { accountId: "g-2", providerId: "google", userId: "7" },
+      }),
+    )
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "account",
+        data: {
+          accountId: "g-2",
+          providerId: "google",
+          userId: "7",
+          tenantId: "42",
+        },
+      }),
+    )
+  })
+
   test("does not touch inserts for non-user/account models", async () => {
     const { scoped, create } = buildScoped()
 
@@ -405,28 +453,47 @@ describe("tenant-scoped adapter", () => {
     expect(result).toEqual({ id: "200" })
     const secondWhere = (findOne.mock.calls[1]?.[0] as AdapterCall).where
     expect(secondWhere).toContainEqual({ field: "id", value: "200" })
-    expect(secondWhere?.some((c) => c.field === "tenantId")).toBe(false)
+    // The fallback resolves only the owner's ROOT-tenant account.
+    expect(secondWhere).toContainEqual({ field: "tenantId", value: ROOT })
   })
 
-  test("suppresses the owner fallback under strict scope (OAuth social path)", async () => {
+  test("owner fallback misses when the owner row is not in the root tenant", async () => {
     const { scoped, findOne } = buildScoped()
-    findOne.mockResolvedValueOnce(null)
+    // Scoped lookup misses; the root-constrained owner retry misses too (the
+    // owner row is parked in some non-root tenant — data drift).
+    findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null)
+    tenantFindById.mockResolvedValueOnce({ ownerId: "200" })
 
-    const result = await withTenant(
-      "400",
-      () =>
-        scoped.findOne({
-          model: "user",
-          where: [{ field: "email", value: "owner@b.com" }],
-        }),
-      { strictScope: true },
+    const result = await withTenant("400", () =>
+      scoped.findOne({
+        model: "user",
+        where: [{ field: "email", value: "owner@b.com" }],
+      }),
     )
 
-    // Only the scoped lookup ran; the owner fallback is disabled so the owner's
-    // root-tenant account is never matched and a tenant-scoped user is created.
     expect(result).toBeNull()
-    expect(findOne).toHaveBeenCalledTimes(1)
-    expect(tenantFindById).not.toHaveBeenCalled()
+    const secondWhere = (findOne.mock.calls[1]?.[0] as AdapterCall).where
+    expect(secondWhere).toContainEqual({ field: "tenantId", value: ROOT })
+  })
+
+  test("applies the owner fallback on the OAuth social path too", async () => {
+    const { scoped, findOne } = buildScoped()
+    findOne.mockResolvedValueOnce(null).mockResolvedValueOnce({ id: "200" })
+    tenantFindById.mockResolvedValueOnce({ ownerId: "200" })
+
+    const result = await withTenant("400", () =>
+      scoped.findOne({
+        model: "user",
+        where: [{ field: "email", value: "owner@b.com" }],
+      }),
+    )
+
+    // A social sign-in with the owner's email resolves the owner's existing
+    // root-tenant account instead of creating a tenant-scoped duplicate.
+    expect(result).toEqual({ id: "200" })
+    const secondWhere = (findOne.mock.calls[1]?.[0] as AdapterCall).where
+    expect(secondWhere).toContainEqual({ field: "id", value: "200" })
+    expect(secondWhere).toContainEqual({ field: "tenantId", value: ROOT })
   })
 
   test("does not fall back on the root tenant (no owner)", async () => {

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -6,6 +6,7 @@ import {
 import { db } from "@chatbotx.io/database/client"
 import {
   accountModel,
+  ROOT_TENANT_ID,
   sessionModel,
   userModel,
   verificationModel,
@@ -27,11 +28,7 @@ import { anonymous, magicLink, oneTimeToken } from "better-auth/plugins"
 import { PHASE_PRODUCTION_BUILD } from "next/constants"
 import { env, getBrokerUrl } from "./keys"
 import { logger } from "./logger"
-import {
-  getTenantId,
-  isStrictTenantScope,
-  resolveTenantOwnerId,
-} from "./tenant-context"
+import { getTenantId, resolveTenantOwnerId } from "./tenant-context"
 
 const getTenantSettings = async (request: Request) => {
   const domain = request.headers.get("x-domain") ?? ""
@@ -153,18 +150,21 @@ export function createTenantScopedAdapter(
         // tenant is their reseller `Tenant`, but the reseller's account lives in
         // the root tenant (they signed up on the main site) and so is missed by
         // the scoped lookup above. Resolve the bound tenant's owner and retry by
-        // primary key. `Tenant.ownerId` resolves only this tenant's owner — never
-        // another tenant's user — and `id` is unique, so the match is exact.
+        // primary key, additionally constrained to the ROOT tenant — the fallback
+        // resolves only the owner's root-tenant account, never a user parked in
+        // any other tenant. `Tenant.ownerId` resolves only this tenant's owner —
+        // never another tenant's user — and `id` is unique, so the match is exact.
         // Sub-account lookups are tried first, so they keep priority.
         //
-        // Suppressed under `strictScope` (the OAuth social-callback path): a social
-        // sign-in on a reseller domain must always stay tenant-scoped, so even the
-        // owner's email resolves to a tenant-scoped user (created when absent)
-        // rather than matching their root-tenant platform account.
+        // Applies to every email lookup, including the OAuth social path: a social
+        // sign-in with the owner's email links to the owner's root-tenant account
+        // (via better-auth account linking, `trustedProviders` below) instead of
+        // creating a tenant-scoped duplicate. Both social providers verify mailbox
+        // ownership, so whoever presents the owner's email via OAuth is the owner.
         const filtersByEmail = data.where.some(
           (clause) => clause.field === "email",
         )
-        if (!filtersByEmail || isStrictTenantScope()) {
+        if (!filtersByEmail) {
           return result
         }
         const tenantId = getTenantId()
@@ -173,6 +173,7 @@ export function createTenantScopedAdapter(
           const ownerWhere: WhereClause[] = [
             ...data.where.filter((clause) => clause.field !== "tenantId"),
             { field: "id", value: ownerId },
+            { field: "tenantId", value: ROOT_TENANT_ID },
           ]
           return adapter.findOne<T>({ ...data, where: ownerWhere })
         }
@@ -191,17 +192,38 @@ export function createTenantScopedAdapter(
       // Stamp the bound tenant on every `user` and `account` insert so a row's
       // ownership matches the tenant it was created under. `tenantId` is declared
       // as a (non-input) field on both models so better-auth keeps the value.
-      create: <T extends Record<string, unknown>, R = T>(data: {
+      //
+      // Exception: an `account` row linking to the bound tenant's OWNER (matched
+      // via the cache-backed `resolveTenantOwnerId`) is stamped `ROOT_TENANT_ID`
+      // instead — the owner's first social sign-in on their own reseller domain
+      // creates this row for their root-tenant `User`, and `Account.tenantId` has
+      // `onDelete: "restrict"`, so stamping the reseller tenant here would leave a
+      // row that blocks that tenant's deletion while referencing a root-tenant
+      // user. See `auth-account.ts` and the reseller-owner fallback above.
+      create: async <T extends Record<string, unknown>, R = T>(data: {
         model: string
         data: Omit<T, "id">
         select?: string[]
         forceAllowId?: boolean
-      }) =>
-        adapter.create<T, R>(
-          data.model === "user" || data.model === "account"
-            ? { ...data, data: { ...data.data, tenantId: getTenantId() } }
-            : data,
-        ),
+      }) => {
+        if (data.model !== "user" && data.model !== "account") {
+          return adapter.create<T, R>(data)
+        }
+        const tenantId = getTenantId()
+        if (data.model === "account") {
+          const ownerId = await resolveTenantOwnerId(tenantId)
+          if (ownerId && data.data.userId === ownerId) {
+            return adapter.create<T, R>({
+              ...data,
+              data: { ...data.data, tenantId: ROOT_TENANT_ID },
+            })
+          }
+        }
+        return adapter.create<T, R>({
+          ...data,
+          data: { ...data.data, tenantId },
+        })
+      },
     }
   }
 
@@ -616,8 +638,9 @@ export function createAuth(config: AuthConfig) {
 
           const tenantId = getTenantId()
           // Match the tenant's users by email, plus the reseller-owner on their
-          // own custom domain (the owner's account lives in the root tenant).
-          // Mirrors the findOne reseller-owner fallback above.
+          // own custom domain (the owner's account lives in the root tenant, so
+          // the owner arm is constrained to it). Mirrors the findOne
+          // reseller-owner fallback above.
           //
           // NOTE: this only gates whether a link is *sent*. The token better-auth
           // stores in `Verification` carries no tenant, so a token issued in one
@@ -630,7 +653,10 @@ export function createAuth(config: AuthConfig) {
           const user = await db.query.userModel.findFirst({
             where: {
               email,
-              OR: [{ tenantId }, ...(ownerId ? [{ id: ownerId }] : [])],
+              OR: [
+                { tenantId },
+                ...(ownerId ? [{ id: ownerId, tenantId: ROOT_TENANT_ID }] : []),
+              ],
             },
           })
           if (!user) {

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -319,6 +319,13 @@ export type AuthConfig = {
    * (self-hosted, tests) to disable.
    */
   onUserCreated?: (user: AuthCreatedUser) => Promise<void> | void
+  /**
+   * Origin to pin social `redirectURI`s to, in place of the broker. The
+   * builder passes the reseller's active custom domain for a tenant-owned
+   * credential; omit to keep the broker (inherited/platform credentials,
+   * self-hosted).
+   */
+  socialRedirectOrigin?: string
 }
 
 /**
@@ -329,6 +336,7 @@ export type AuthConfig = {
 function buildSocialProviders(
   socialCredentials: AuthConfig["socialCredentials"],
   socialScopes: AuthConfig["socialScopes"],
+  redirectOrigin: AuthConfig["socialRedirectOrigin"],
 ) {
   if (process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD || !socialCredentials) {
     return
@@ -345,7 +353,7 @@ function buildSocialProviders(
       } & SocialAuthCredential
     >
   > = {}
-  const brokerOrigin = new URL(getBrokerUrl()).origin
+  const pinnedOrigin = new URL(redirectOrigin ?? getBrokerUrl()).origin
   for (const provider of SOCIAL_PROVIDERS) {
     const credential = socialCredentials[provider]
     if (credential?.clientId && credential.clientSecret) {
@@ -354,13 +362,15 @@ function buildSocialProviders(
         enabled: true,
         clientId: credential.clientId,
         clientSecret: credential.clientSecret,
-        // Pin the redirect_uri to the broker host. Without this, better-auth
-        // infers it from the request origin (the reseller domain), which is NOT
-        // registered with the provider. The broker is the single registered URI;
-        // the callback relays back to the reseller domain afterwards.
+        // Pin the redirect_uri to a single registered host — the broker by
+        // default, or the reseller's own custom domain for a tenant-owned
+        // credential (`socialRedirectOrigin`). Without this, better-auth
+        // infers it from the request origin, which may not be registered
+        // with the provider. When pinned to the broker, the callback relays
+        // back to the reseller domain afterwards.
         redirectURI: new URL(
           `/api/auth/callback/${provider}`,
-          brokerOrigin,
+          pinnedOrigin,
         ).toString(),
         // Replace (not append to) better-auth's own default scope list when the
         // caller supplies one, so the caller-provided scopes are the single
@@ -451,6 +461,7 @@ export function createAuth(config: AuthConfig) {
   const socialProviders = buildSocialProviders(
     config.socialCredentials,
     config.socialScopes,
+    config.socialRedirectOrigin,
   )
 
   return betterAuth({

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -83,6 +83,16 @@ type AuthAdapter = ReturnType<AdapterFactory>
 type WhereClause = Parameters<AuthAdapter["findOne"]>[0]["where"][number]
 
 /**
+ * Match a reseller owner's own account, which lives in the ROOT tenant (they
+ * signed up on the main site). Shared by the reseller-owner fallback in the
+ * adapter; the magic-link gate mirrors it in Drizzle relational form.
+ */
+const ownerRootClauses = (ownerId: string): WhereClause[] => [
+  { field: "id", value: ownerId },
+  { field: "tenantId", value: ROOT_TENANT_ID },
+]
+
+/**
  * Wrap the drizzle adapter so white-label isolation holds at the data layer:
  * every `User` lookup *by email* and every `User` insert is constrained to the
  * current tenant (`getTenantId()` — `ROOT_TENANT_ID` = platform). Lookups by
@@ -97,8 +107,12 @@ export function createTenantScopedAdapter(
   //   • `user` lookups *by email* — the same email is a separate account per
   //     tenant.
   //   • `account` lookups *by social identity* (`accountId`) — the same provider
-  //     identity links to a separate account row per tenant, so social sign-in on
-  //     a reseller domain never resolves the owner's root-tenant account.
+  //     identity links to a separate account row per tenant, so sub-accounts stay
+  //     isolated. The reseller owner's own row is stamped `ROOT_TENANT_ID` (see
+  //     `create` below) and so misses here on their domain; better-auth then
+  //     falls through to the email lookup, where the reseller-owner fallback
+  //     resolves their root-tenant account and the unscoped `userId` account list
+  //     shows the identity as already linked.
   // Lookups by id/token/userId are left untouched, so sessions and a user's own
   // account list stay tenant-neutral.
   const scopeByTenant = (
@@ -172,8 +186,7 @@ export function createTenantScopedAdapter(
         if (ownerId) {
           const ownerWhere: WhereClause[] = [
             ...data.where.filter((clause) => clause.field !== "tenantId"),
-            { field: "id", value: ownerId },
-            { field: "tenantId", value: ROOT_TENANT_ID },
+            ...ownerRootClauses(ownerId),
           ]
           return adapter.findOne<T>({ ...data, where: ownerWhere })
         }
@@ -210,18 +223,15 @@ export function createTenantScopedAdapter(
           return adapter.create<T, R>(data)
         }
         const tenantId = getTenantId()
-        if (data.model === "account") {
-          const ownerId = await resolveTenantOwnerId(tenantId)
-          if (ownerId && data.data.userId === ownerId) {
-            return adapter.create<T, R>({
-              ...data,
-              data: { ...data.data, tenantId: ROOT_TENANT_ID },
-            })
-          }
-        }
+        const ownerId =
+          data.model === "account" ? await resolveTenantOwnerId(tenantId) : null
+        const isOwnerAccount = ownerId !== null && data.data.userId === ownerId
         return adapter.create<T, R>({
           ...data,
-          data: { ...data.data, tenantId },
+          data: {
+            ...data.data,
+            tenantId: isOwnerAccount ? ROOT_TENANT_ID : tenantId,
+          },
         })
       },
     }
@@ -640,7 +650,7 @@ export function createAuth(config: AuthConfig) {
           // Match the tenant's users by email, plus the reseller-owner on their
           // own custom domain (the owner's account lives in the root tenant, so
           // the owner arm is constrained to it). Mirrors the findOne
-          // reseller-owner fallback above.
+          // reseller-owner fallback above (`ownerRootClauses`).
           //
           // NOTE: this only gates whether a link is *sent*. The token better-auth
           // stores in `Verification` carries no tenant, so a token issued in one

--- a/packages/auth/src/tenant-context.ts
+++ b/packages/auth/src/tenant-context.ts
@@ -17,16 +17,7 @@ import { ROOT_TENANT_ID, verificationModel } from "@chatbotx.io/database/schema"
  * accounts across tenants. See `server.ts` for the adapter wrapper that reads
  * `getTenantId()`.
  */
-/**
- * `strictScope` disables the reseller-owner fallback in the adapter (see
- * `server.ts`). It is set on the OAuth social-callback path so that signing in
- * with a social provider on a reseller's domain always resolves to a
- * tenant-scoped user — even for the reseller owner, whose root-tenant account
- * the fallback would otherwise match. Email/password and magic-link keep the
- * fallback (they don't run with this flag), so the owner can still sign in to
- * their platform account on their own domain by those methods.
- */
-type TenantStore = { tenantId: string; strictScope?: boolean }
+type TenantStore = { tenantId: string }
 
 /**
  * The tenant ALS instance MUST be a process-wide singleton. `withTenant` (called
@@ -50,20 +41,8 @@ if (!globalForTenant.__chatbotxTenantStorage) {
 const tenantStorage = globalForTenant.__chatbotxTenantStorage
 
 /** Run `fn` with the given tenant bound for the duration of the async call. */
-export function withTenant<T>(
-  tenantId: string,
-  fn: () => T,
-  options?: { strictScope?: boolean },
-): T {
-  return tenantStorage.run({ tenantId, strictScope: options?.strictScope }, fn)
-}
-
-/**
- * Whether the current context forbids the reseller-owner fallback — true only on
- * the OAuth social-callback path, where every sign-in must stay tenant-scoped.
- */
-export function isStrictTenantScope(): boolean {
-  return tenantStorage.getStore()?.strictScope ?? false
+export function withTenant<T>(tenantId: string, fn: () => T): T {
+  return tenantStorage.run({ tenantId }, fn)
 }
 
 /**

--- a/packages/business/__tests__/custom-domain-service.test.ts
+++ b/packages/business/__tests__/custom-domain-service.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockFindFirst, mockWithCache } = vi.hoisted(() => ({
+  mockFindFirst: vi.fn(),
+  mockWithCache: vi.fn(
+    async (
+      _key: string,
+      callback: () => Promise<unknown> | unknown,
+      options: {
+        tags?: string[]
+        dynamicTags?: (result: unknown) => string[] | undefined
+      },
+    ) => {
+      const result = await callback()
+      // Exercise the same tag-derivation path the real withCache uses, so a
+      // dynamicTags bug (e.g. throwing on `undefined`) surfaces in tests.
+      options.dynamicTags?.(result)
+      return result
+    },
+  ),
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      customDomainModel: {
+        findFirst: mockFindFirst,
+      },
+    },
+  },
+}))
+
+vi.mock("@chatbotx.io/redis", () => ({
+  withCache: mockWithCache,
+}))
+
+async function loadModule() {
+  vi.resetModules()
+  return await import("../src/enterprise/custom-domain/service")
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("customDomainService.findActiveByTenantId", () => {
+  test("returns the active domain row for the tenant", async () => {
+    const row = {
+      id: "cd1",
+      tenantId: "t1",
+      domain: "chat.acme.com",
+      status: "active",
+    }
+    mockFindFirst.mockResolvedValue(row)
+    const { customDomainService } = await loadModule()
+
+    expect(await customDomainService.findActiveByTenantId("t1")).toBe(row)
+    expect(mockFindFirst).toHaveBeenCalledWith({
+      where: { tenantId: "t1", status: "active" },
+    })
+  })
+
+  test("returns undefined when the tenant has no active domain", async () => {
+    mockFindFirst.mockResolvedValue(undefined)
+    const { customDomainService } = await loadModule()
+
+    expect(await customDomainService.findActiveByTenantId("t1")).toBeUndefined()
+  })
+
+  test("caches under a tenant-scoped key and tags", async () => {
+    mockFindFirst.mockResolvedValue({
+      id: "cd1",
+      tenantId: "t1",
+      domain: "chat.acme.com",
+      status: "active",
+    })
+    const { customDomainService } = await loadModule()
+
+    await customDomainService.findActiveByTenantId("t1")
+
+    expect(mockWithCache).toHaveBeenCalledWith(
+      "custom-domain:active-tenant:t1",
+      expect.any(Function),
+      expect.objectContaining({ tags: ["cd:tenant:t1"] }),
+    )
+  })
+
+  test("derives a domain-scoped dynamic tag only when a domain resolved", async () => {
+    mockFindFirst.mockResolvedValue({
+      id: "cd1",
+      tenantId: "t1",
+      domain: "chat.acme.com",
+      status: "active",
+    })
+    const { customDomainService } = await loadModule()
+    await customDomainService.findActiveByTenantId("t1")
+
+    const dynamicTags = mockWithCache.mock.calls[0]?.[2]?.dynamicTags
+    expect(dynamicTags?.({ domain: "chat.acme.com" })).toEqual([
+      "cd:domain:chat.acme.com",
+    ])
+    expect(dynamicTags?.(undefined)).toEqual([])
+  })
+})

--- a/packages/business/src/enterprise/custom-domain/service.ts
+++ b/packages/business/src/enterprise/custom-domain/service.ts
@@ -49,4 +49,22 @@ export const customDomainService = {
       },
     )
   },
+
+  /**
+   * The tenant's active custom domain, if any. `CustomDomain.tenantId` is
+   * unique, so there is at most one — no "first active" picking needed.
+   */
+  findActiveByTenantId(tenantId: string) {
+    return withCache(
+      `custom-domain:active-tenant:${tenantId}`,
+      () =>
+        db.query.customDomainModel.findFirst({
+          where: { tenantId, status: "active" },
+        }),
+      {
+        tags: [`cd:tenant:${tenantId}`],
+        dynamicTags: (result) => (result ? [`cd:domain:${result.domain}`] : []),
+      },
+    )
+  },
 }

--- a/packages/database/src/schema/auth-account.ts
+++ b/packages/database/src/schema/auth-account.ts
@@ -35,9 +35,13 @@ export const accountModel = pgTable(
       }),
     // Tenant key for white-label isolation, mirroring `User.tenantId`. A social
     // identity (`providerId` + `accountId`) links to a *separate* account row per
-    // tenant, so signing in with the same provider on a reseller domain resolves a
-    // tenant-scoped user instead of the owner's root-tenant account. The OAuth
-    // identity lookup is scoped by this column in the auth adapter.
+    // tenant, so the same provider identity signing in under two different
+    // tenants' users gets two account rows. The OAuth identity lookup is scoped
+    // by this column in the auth adapter. Exception: a row linking to the bound
+    // tenant's owner is stamped `ROOT_TENANT_ID` instead of the bound tenant —
+    // the owner's account lives in the root tenant, and this column has
+    // `onDelete: "restrict"`, so stamping the reseller tenant would leave a row
+    // that blocks that tenant's deletion. See the auth adapter's `create` wrapper.
     tenantId: bigintAsString()
       .notNull()
       .default(ROOT_TENANT_ID)


### PR DESCRIPTION
## Summary
- A reseller signing in with Google/Facebook on their own white-label domain got a tenant-scoped duplicate user instead of their platform account: the OAuth social path ran under a `strictScope` flag that suppressed the reseller-owner fallback. Drop the flag so the fallback applies to every email lookup — both social providers verify mailbox ownership, so whoever presents the owner's email via OAuth is the owner.
- Tenant-owned platform credentials (a reseller's own OAuth app) always used the brand-neutral broker for redirect_uri/webhook URLs, even though the reseller controls their own app console. This broke webhooks entirely (a reseller registering the broker URL had events verified against the platform's secret) and forced resellers to whitelist a host they don't own. Tenant-owned credentials now use the reseller's active custom domain instead.

## Changes

### Root-tenant SSO fallback
- `packages/auth/src/tenant-context.ts` — remove `strictScope` / `isStrictTenantScope`; `withTenant` back to `(tenantId, fn)`.
- `packages/auth/src/server.ts` — owner fallback applies on the social path and is ROOT-constrained (findOne + magic-link); `create` wrapper stamps owner-linked `account` rows with `ROOT_TENANT_ID`.
- `apps/builder/src/app/api/auth/[...all]/route.ts` — drop the `strictScope` binding on social legs.
- `packages/database/src/schema/auth-account.ts` — `tenantId` column comment reflects the owner exception.

### Per-credential OAuth/webhook/SSO origins
- New `apps/builder/src/lib/provider-origin.ts` — single source of truth for resolving a credential's origin: the reseller's active custom domain for tenant-owned credentials (`Credential.userId` set), the broker otherwise.
- `packages/business/src/enterprise/custom-domain/service.ts` — new `findActiveByTenantId`.
- `packages/auth/src/server.ts` — `AuthConfig.socialRedirectOrigin` lets `buildSocialProviders` pin `redirectURI` per-instance.
- `apps/builder/src/lib/auth/auth-instances.ts` — resolves and caches the per-tenant SSO redirect origin alongside the credential.
- Every integration authorize/exchange leg (Messenger, Instagram, Instagram-via-Facebook, TikTok, Zalo, Google Sheets/Calendar, WhatsApp, Facebook Ads/Lead Ads, Meta Catalog) now builds `redirect_uri` from the resolved credential instead of always the broker.
- `apps/builder/src/lib/oauth-referer.ts` — the relay now fires whenever the callback host differs from the originating host, not just from the broker.
- Platform-credential settings cards (`MessengerSettings`, `InstagramSettings`, `InstagramFacebookSettings`, `GoogleSettings`, `WhatsappSettings`, `ZaloSettings`, `TiktokSettings`) show the correct origin, with a `https://<your-domain.com>` placeholder when no domain is active yet; also fixes a pre-existing bug where the Google card showed the wrong callback path.
- WhatsApp embedded-signup client/server flows updated to pass the resolved callback origin through instead of hardcoding the broker.
- `docs/tenancy.md` and `fields.authCallbackUrl`/`fields.webhookUrl` i18n hints updated.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [x] `pnpm --filter @chatbotx.io/auth check-types` / `pnpm --filter @chatbotx.io/business check-types`
- [x] `pnpm --filter @chatbotx.io/auth test` — 44/44 passing
- [x] `pnpm --filter @chatbotx.io/business test` — 1063/1063 passing
- [x] `pnpm --filter builder test` — 1633/1633 passing
- [ ] Manual: reseller owner signs in with Google on their custom domain → lands in their existing platform account (no duplicate `User`); their `Account` row has `tenantId = 1`
- [ ] Manual: a sub-account on the reseller domain still signs in tenant-scoped; owner fallback never matches a non-root row
- [ ] Manual: reseller with an own Messenger app + active custom domain opens `/manage/platform-credentials` → URLs show the custom domain; a reseller with inherited credentials still sees the broker
- [ ] Manual: connect a Messenger page from the custom domain and from the platform host (relay path) — both complete