### PR TITLE
fix(builder): make zodBigintAsString test mocks fully chainable

### DIFF
--- a/apps/builder/__tests__/update-contact-field.action.test.ts
+++ b/apps/builder/__tests__/update-contact-field.action.test.ts
@@ -64,9 +64,24 @@ vi.mock("@chatbotx.io/database/partials", async () => {
   return actual
 })
 
-vi.mock("@chatbotx.io/utils", () => ({
-  zodBigintAsString: () => ({}),
-}))
+vi.mock("@chatbotx.io/utils", () => {
+  // The `importActual` above for `@chatbotx.io/database/partials` still
+  // resolves that module's own `zodBigintAsString` import through this same
+  // mock registry — and its barrel re-exports every partial schema
+  // (including unrelated ones, e.g. minigame.ts) whose module-eval-time
+  // `.nullable()`/`.optional()` chains would break against a stub that only
+  // has `{}`. This proxy chains any further method call back to itself so
+  // it never breaks regardless of which Zod methods a schema happens to use.
+  const proxy = new Proxy(
+    {},
+    {
+      get() {
+        return () => proxy
+      },
+    },
+  )
+  return { zodBigintAsString: () => proxy }
+})
 
 vi.mock("@/features/custom-fields/queries", () => ({
   listCustomFields: mocks.listCustomFields,

--- a/apps/builder/__tests__/workspace-owner-quota.test.ts
+++ b/apps/builder/__tests__/workspace-owner-quota.test.ts
@@ -38,9 +38,27 @@ vi.mock("@chatbotx.io/sdk", () => ({
   SdkException: class SdkException extends Error {},
 }))
 
-vi.mock("@chatbotx.io/utils", () => ({
-  zodBigintAsString: () => ({ safeParse: () => ({ data: null }) }),
-}))
+vi.mock("@chatbotx.io/utils", () => {
+  // `@chatbotx.io/database/partials` re-exports every partial schema
+  // (including ones unrelated to this test, e.g. minigame.ts) through one
+  // barrel, and some of those call `zodBigintAsString().nullable()` /
+  // `.optional()` at module-eval time. A stub with only `safeParse` breaks
+  // that eval the moment any test pulls in the real partials barrel — this
+  // proxy chains any further method call back to itself so it never breaks
+  // regardless of which Zod methods a schema happens to chain.
+  const chainable: Record<string, unknown> = {
+    safeParse: () => ({ data: null }),
+  }
+  const proxy = new Proxy(chainable, {
+    get(target, prop) {
+      if (prop in target) {
+        return target[prop as string]
+      }
+      return () => proxy
+    },
+  })
+  return { zodBigintAsString: () => proxy }
+})
 
 vi.mock("@/env", () => ({ isCloud }))
 vi.mock("@/features/workspace-members/queries", () => ({


### PR DESCRIPTION
## Summary
- PR #1023 (minigames) added `packages/database/src/partials/minigame.ts`, which calls `zodBigintAsString().nullable().default(null)` at module-eval time.
- `@chatbotx.io/database/partials` re-exports every partial schema through one barrel (`export * from`), so any test that mocks `@chatbotx.io/utils`'s `zodBigintAsString` with an incomplete stub now crashes as soon as it imports anything from that barrel — even if the test has nothing to do with minigames.
- `apps/builder/__tests__/workspace-owner-quota.test.ts` and `update-contact-field.action.test.ts` had exactly this incomplete stub (`{ safeParse }` / `{}`), breaking CI on `main` after #1023 merged.
- Replaced both stubs with a chainable `Proxy` so any Zod method call (`.nullable()`, `.optional()`, `.default()`, etc.) resolves back to itself, regardless of which methods a schema happens to chain — future-proof against any other partial schema hitting the same pattern.

## Test plan
- [x] `pnpm --filter builder test` — 264 test files / 1673 tests pass (previously 2 files failed)
- [x] `pnpm --filter builder check-types`
- [x] `pnpm lint`