### PR TITLE
fix(webchat): fail closed when no authorized domains are configured

### DIFF
--- a/apps/builder/__tests__/create-webchat-message-action.test.ts
+++ b/apps/builder/__tests__/create-webchat-message-action.test.ts
@@ -165,10 +165,10 @@ vi.mock("@/features/integration-webchat/lib/authorized-domain", () => ({
     origin: string | null | undefined,
     authorizedDomains: string[],
   ) => {
-    if (authorizedDomains.length === 0) {
+    if (!origin) {
       return true
     }
-    if (!origin) {
+    if (authorizedDomains.length === 0) {
       return false
     }
     const host = origin

--- a/apps/builder/__tests__/webchat-guest-session.test.ts
+++ b/apps/builder/__tests__/webchat-guest-session.test.ts
@@ -192,8 +192,11 @@ describe("webchat guest session store", () => {
 })
 
 describe("webchat authorized domains", () => {
-  test("allows all origins when no domains are configured", () => {
-    expect(isOriginAuthorized("https://example.com", [])).toBe(true)
+  test("rejects origins when no domains are configured (fail closed)", () => {
+    expect(isOriginAuthorized("https://example.com", [])).toBe(false)
+  })
+
+  test("allows a missing origin even when no domains are configured (direct, non-embedded access)", () => {
     expect(isOriginAuthorized(null, [])).toBe(true)
   })
 

--- a/apps/builder/__tests__/webchat-page-guards.test.tsx
+++ b/apps/builder/__tests__/webchat-page-guards.test.tsx
@@ -174,7 +174,7 @@ describe("WebchatPage", () => {
     )
   })
 
-  test("still renders the chat for a third-party referer when authorizedDomains is empty", async () => {
+  test("shows the unauthorized-domain message for a third-party referer when authorizedDomains is empty (fail closed)", async () => {
     mockFindFirst.mockResolvedValue({ ...targetWebchat, authorizedDomains: [] })
     setReferer("https://anyone.example")
 
@@ -182,8 +182,11 @@ describe("WebchatPage", () => {
       searchParams: Promise.resolve(searchParams),
     })
 
-    expect((element as { type: { name: string } }).type.name).toBe(
-      "GuestSessionStoreProvider",
+    expect(isValidElement<{ children: unknown }>(element)).toBe(true)
+    const rendered = JSON.stringify(element)
+    expect(rendered).toContain("Webchat unavailable")
+    expect(rendered).toContain(
+      "This website is not authorized to load this chat widget.",
     )
   })
 

--- a/apps/builder/src/features/integration-webchat/lib/authorized-domain.ts
+++ b/apps/builder/src/features/integration-webchat/lib/authorized-domain.ts
@@ -43,7 +43,7 @@ export const isOriginAuthorized = (
 
   const domains = authorizedDomains.map(normalizeHost).filter(Boolean)
   if (domains.length === 0) {
-    return true
+    return false
   }
 
   const host = getHostFromOrigin(origin)


### PR DESCRIPTION
## Summary
- `isOriginAuthorized` allowed any origin to embed the webchat widget when `authorizedDomains` was empty, so a widget with no allow-list configured yet accepted cross-origin embeds instead of rejecting them.
- Changed the empty-list case to fail closed (reject cross-origin embeds); a missing `origin` (direct, non-embedded access) is still allowed.
- Updated tests to match the fail-closed behavior across the guest-session store, the webchat page guard, and the message-create action's local test mock.
- Follow-up: `/webchat` had been excluded via the proxy middleware's negative-lookahead matcher instead of being listed in `publicRoutes`, so it never went through the same public-route handling as other unauthenticated surfaces (booking, portal/redeem, etc). Moved it into `publicRoutes` and dropped it from the matcher exclusion.

## Changes
- `apps/builder/src/features/integration-webchat/lib/authorized-domain.ts` — `isOriginAuthorized` returns `false` (not `true`) when `authorizedDomains` is empty and an origin is present.
- `apps/builder/__tests__/webchat-guest-session.test.ts` — split the old "allows all" test into a fail-closed rejection test and a separate "missing origin still allowed" test.
- `apps/builder/__tests__/webchat-page-guards.test.tsx` — updated the empty-`authorizedDomains` + third-party-referer case to expect the "Webchat unavailable" unauthorized-domain message instead of a rendered chat provider.
- `apps/builder/__tests__/create-webchat-message-action.test.ts` — reordered the local mock's origin/domain checks to match the real fail-closed precedence.
- `apps/builder/src/proxy.ts` — moved `/webchat` into `publicRoutes` and removed it from the matcher's negative-lookahead exclusion so it's handled consistently with other public routes.

## Test plan
- [x] `pnpm --filter builder exec vitest run __tests__/create-webchat-message-action.test.ts __tests__/webchat-guest-session.test.ts __tests__/webchat-page-guards.test.tsx` — 60/60 passing
- [x] Pre-commit hooks (ultracite fix + full monorepo typecheck) passed
- [ ] Manual verification: confirm an embedded webchat with no `authorizedDomains` configured now shows "Webchat unavailable" for cross-origin embeds, and still works for direct (non-embedded) access
- [ ] Manual verification: confirm `/webchat` loads without requiring sign-in