### PR TITLE
fix(minigames): show live jackpot machine preview in type picker

### DIFF
--- a/apps/builder/src/features/minigames/components/create-minigame-type-dialog.tsx
+++ b/apps/builder/src/features/minigames/components/create-minigame-type-dialog.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { JackpotMachineArt } from "@chatbotx.io/minigame-ui"
 import { Card, CardContent } from "@chatbotx.io/ui/components/ui/card"
 import {
   Dialog,
@@ -10,11 +11,15 @@ import {
 import { cn } from "@chatbotx.io/ui/lib/utils"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
+import type { KeyboardEvent } from "react"
 import { useCallback } from "react"
 import {
+  getDefaultMinigameAppearance,
   MINIGAME_TYPE_CONFIGS,
   MINIGAME_TYPES_ENABLED_FOR_CREATION,
 } from "../constants"
+
+const JACKPOT_PREVIEW_APPEARANCE = getDefaultMinigameAppearance("jackpot")
 
 type CreateMinigameTypeDialogProps = {
   open: boolean
@@ -52,35 +57,78 @@ export function CreateMinigameTypeDialog({
             const isEnabled = MINIGAME_TYPES_ENABLED_FOR_CREATION.includes(
               config.type,
             )
+            const isJackpot = config.type === "jackpot"
+
+            const cardButtonProps = {
+              "aria-disabled": !isEnabled,
+              "aria-label": t(config.labelKey),
+              onClick: isEnabled ? () => handleSelect(config.type) : undefined,
+              onKeyDown: isEnabled
+                ? (event: KeyboardEvent) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault()
+                      handleSelect(config.type)
+                    }
+                  }
+                : undefined,
+              role: "button" as const,
+              tabIndex: isEnabled ? 0 : -1,
+            }
+
+            if (isJackpot) {
+              return (
+                <Card
+                  className={cn(
+                    "relative h-44 w-36 overflow-hidden p-0",
+                    isEnabled
+                      ? "cursor-pointer hover:shadow-md"
+                      : "cursor-not-allowed opacity-50",
+                  )}
+                  key={config.type}
+                  {...cardButtonProps}
+                >
+                  <CardContent
+                    className="relative flex h-full w-full items-center justify-center bg-center bg-cover p-0"
+                    style={{
+                      backgroundColor:
+                        JACKPOT_PREVIEW_APPEARANCE.backgroundColor,
+                      backgroundImage: JACKPOT_PREVIEW_APPEARANCE
+                        .backgroundImage.url
+                        ? `url(${JACKPOT_PREVIEW_APPEARANCE.backgroundImage.url})`
+                        : undefined,
+                    }}
+                  >
+                    <div className="w-20">
+                      <JackpotMachineArt
+                        decorativeColor={
+                          JACKPOT_PREVIEW_APPEARANCE.decorativeColor
+                        }
+                        machineColor={JACKPOT_PREVIEW_APPEARANCE.machineColor}
+                      />
+                    </div>
+
+                    <div className="absolute inset-x-0 bottom-0 bg-linear-to-t from-black/80 to-transparent px-2 pt-8 pb-2">
+                      <span className="block text-center font-medium text-sm text-white">
+                        {t(config.labelKey)}
+                      </span>
+                    </div>
+                  </CardContent>
+                </Card>
+              )
+            }
 
             return (
               <Card
-                aria-disabled={!isEnabled}
-                aria-label={t(config.labelKey)}
                 className={cn(
-                  "w-36",
+                  "h-44 w-36",
                   isEnabled
                     ? "cursor-pointer hover:shadow-md"
                     : "cursor-not-allowed opacity-50",
                 )}
                 key={config.type}
-                onClick={
-                  isEnabled ? () => handleSelect(config.type) : undefined
-                }
-                onKeyDown={
-                  isEnabled
-                    ? (event) => {
-                        if (event.key === "Enter" || event.key === " ") {
-                          event.preventDefault()
-                          handleSelect(config.type)
-                        }
-                      }
-                    : undefined
-                }
-                role="button"
-                tabIndex={isEnabled ? 0 : -1}
+                {...cardButtonProps}
               >
-                <CardContent className="flex flex-col items-center gap-3 py-6">
+                <CardContent className="flex h-full flex-col items-center justify-center gap-3">
                   <config.icon className="text-primary" size={30} />
                   <span className="text-center font-medium text-sm">
                     {t(config.labelKey)}


### PR DESCRIPTION
## Summary
- The Jackpot card in "Choose a minigame type" showed a generic coin icon + label; it now shows a live preview of the actual jackpot machine (default background + JackpotMachineArt) so users see what they're picking.
- The Jackpot label overlays the preview image at the bottom with a dark gradient scrim for readability.
- All type cards (enabled and "coming soon") now share the same fixed card height for a consistent grid.

## Changes
- `apps/builder/src/features/minigames/components/create-minigame-type-dialog.tsx`

## Test plan
- [x] pnpm lint (biome check on the changed file)
- [x] pnpm --filter builder check-types
- [ ] manual verification in the browser