### PR TITLE
fix(minigames): extend play link token TTL from 1 hour to 1 day

### DIFF
--- a/packages/encryption/src/minigame-play-token.ts
+++ b/packages/encryption/src/minigame-play-token.ts
@@ -5,7 +5,7 @@ import {
 } from "./appointment-token-utils"
 
 const TOKEN_AAD = "minigame-play-token"
-const DEFAULT_TOKEN_TTL_MS = 60 * 60 * 1000
+const DEFAULT_TOKEN_TTL_MS = 24 * 60 * 60 * 1000
 
 export const minigamePlayPayloadSchema = z.object({
   workspaceId: z.string().min(1),


### PR DESCRIPTION
## Summary
- The signed minigame play link (`{{minigame_play_token}}`) expired after only 1 hour, which was often too short for a contact to click a shared link and actually play — even while the minigame's own active window (`playedAtFrom`/`playedAtTo`, defaults to 7 days) was still open.
- Extends the default token TTL to 1 day so shared play links stay usable longer, independent of the minigame's own active window.

## Changes
- `packages/encryption/src/minigame-play-token.ts` — `DEFAULT_TOKEN_TTL_MS` changed from `60 * 60 * 1000` (1 hour) to `24 * 60 * 60 * 1000` (1 day).

## Test plan
- [x] pnpm lint (biome check on the changed file)
- [x] pnpm --filter @chatbotx.io/encryption check-types
- [ ] manual verification (share a minigame play link and confirm it still works after 1 hour but expires after 1 day)