### PR TITLE
fix(templates): restrict shareable template categories to flows only

### DIFF
--- a/packages/database/src/partials/template.ts
+++ b/packages/database/src/partials/template.ts
@@ -18,7 +18,7 @@ import { z } from "zod"
 export const templateManifestOnlyCategories = z.enum([
   "customFields",
   "tags",
-  "productCategories",
+  // "productCategories",
 ])
 export type TemplateManifestOnlyCategory = z.infer<
   typeof templateManifestOnlyCategories
@@ -26,16 +26,16 @@ export type TemplateManifestOnlyCategory = z.infer<
 
 export const templateResourceCategories = z.enum([
   "flows",
-  "products",
-  "aiFunctions",
-  "aiAgents",
-  "calendars",
-  "webchats",
-  "keywords",
-  "entryPointLinks",
-  "triggers",
-  "fbCommentAutomations",
-  "settings",
+  // "products",
+  // "aiFunctions",
+  // "aiAgents",
+  // "calendars",
+  // "webchats",
+  // "keywords",
+  // "entryPointLinks",
+  // "triggers",
+  // "fbCommentAutomations",
+  // "settings",
 ])
 export type TemplateResourceCategory = z.infer<
   typeof templateResourceCategories


### PR DESCRIPTION
## Summary
- Comments out non-flow template resource categories (products, aiFunctions, aiAgents, calendars, webchats, keywords, entryPointLinks, triggers, fbCommentAutomations, settings) leaving only `flows` active
- Comments out `productCategories` in the manifest-only categories list

## Changes
- `packages/database/src/partials/template.ts`: reduces `templateResourceCategories` and `templateManifestOnlyCategories` enums to a minimal set for testing purposes

## Test plan
- [ ] pnpm lint
- [ ] pnpm --filter builder check-types
- [ ] manual verification of template install/share flow scoped to flows only