### PR TITLE
fix(whatsapp): open website buttons now open their link

### DIFF
--- a/integrations/whatsapp/__tests__/outgoing-link-buttons.test.ts
+++ b/integrations/whatsapp/__tests__/outgoing-link-buttons.test.ts
@@ -1,0 +1,269 @@
+import { decodeButtonPayload, getButtonLinkUrl } from "@chatbotx.io/flow-config"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { mockGetWhatsappClient, mockSendMessage, mockLogger } = vi.hoisted(
+  () => {
+    const sendMessage = vi.fn()
+    return {
+      mockGetWhatsappClient: vi.fn(() => ({ sendMessage })),
+      mockSendMessage: sendMessage,
+      mockLogger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    }
+  },
+)
+
+vi.mock("../src/client", () => ({
+  getWhatsappClient: mockGetWhatsappClient,
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: mockLogger,
+}))
+
+const { sendFlowStep } = await import(
+  "../src/handlers/message/outgoing-message"
+)
+
+const FLOW_ID = "1000000000001"
+const FLOW_VERSION_ID = "1000000000002"
+const PHONE_NUMBER_ID = "pn-1"
+const IMAGE_URL = "https://example.com/photo.png"
+const MAGIC_LINK_URL = "https://app.example.com/r/workspace-1/promo"
+
+const ctx = {
+  auth: { metadata: { phoneNumber: { id: PHONE_NUMBER_ID } } },
+} as never
+
+// `decodeButtonPayload` requires `contactInboxId` to be strictly numeric, so
+// this stays a bigint-shaped id rather than the "contact-1" style used by
+// mocks that never round-trip the code through decode.
+const CONTACT_INBOX_ID = "1000000000030"
+const contact = { id: CONTACT_INBOX_ID, sourceId: "84123456789" } as never
+
+const makeButton = (index: number, label = `Button ${index}`) => ({
+  id: `${1_000_000_000_010 + index}`,
+  label,
+  buttonType: null,
+  beforeStep: null,
+  steps: [],
+})
+
+const makeButtons = (count: number) =>
+  Array.from({ length: count }, (_, index) => makeButton(index))
+
+const makeLinkButton = (index: number, label: string, url: string) => ({
+  id: `${1_000_000_000_020 + index}`,
+  label,
+  buttonType: "openWebsite",
+  beforeStep: {
+    id: `${1_000_000_000_020 + index}-open`,
+    stepType: "openWebsite",
+    url,
+    browserSize: 100,
+  },
+  steps: [],
+})
+
+const sendStep = (step: Record<string, unknown>) =>
+  sendFlowStep({
+    ctx,
+    data: { contact, flowId: FLOW_ID, flowVersionId: FLOW_VERSION_ID, step },
+  } as never)
+
+const sendTextStep = (buttons: Record<string, unknown>[], text = "Pick one") =>
+  sendStep({
+    id: "text-1",
+    stepType: "sendText",
+    text,
+    buttons,
+  })
+
+const sendImageStep = (buttons: Record<string, unknown>[]) =>
+  sendStep({
+    id: "image-1",
+    stepType: "sendImage",
+    mode: "file",
+    url: IMAGE_URL,
+    buttons,
+  })
+
+const messageAt = (index: number) =>
+  mockSendMessage.mock.calls[index]?.[2] as Record<string, unknown>
+
+const lastMessage = () =>
+  mockSendMessage.mock.lastCall?.[2] as Record<string, unknown>
+
+describe("getButtonLinkUrl", () => {
+  const baseButton = {
+    id: "1000000000010",
+    label: "Button",
+    steps: [] as never[],
+  }
+
+  test("returns the url for an openWebsite button", () => {
+    const button = {
+      ...baseButton,
+      buttonType: "openWebsite" as const,
+      beforeStep: {
+        id: "1000000000011",
+        stepType: "openWebsite" as const,
+        url: "https://example.com/promo",
+        browserSize: 100 as const,
+      },
+    }
+
+    expect(getButtonLinkUrl(button as never)).toBe("https://example.com/promo")
+  })
+
+  test("returns undefined for every other buttonType", () => {
+    const nonLinkButtonTypes = [
+      null,
+      "sendMessage",
+      "performAction",
+      "startExternalFlow",
+      "startExternalNode",
+      "startAnotherNode",
+      "whatsappOptionList",
+    ] as const
+
+    for (const buttonType of nonLinkButtonTypes) {
+      const button = { ...baseButton, buttonType, beforeStep: null }
+      expect(getButtonLinkUrl(button as never)).toBeUndefined()
+    }
+  })
+})
+
+describe("whatsapp link button messages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSendMessage.mockResolvedValue({
+      messaging_product: "whatsapp",
+      messages: [{ id: "wamid.provider-1" }],
+    })
+  })
+
+  test("sends a single openWebsite button as a cta_url message with the magic link", async () => {
+    await sendTextStep([makeLinkButton(0, "Visit us", MAGIC_LINK_URL)])
+
+    expect(mockSendMessage).toHaveBeenCalledOnce()
+    const message = lastMessage()
+    expect(message).toMatchObject({
+      _type: "interactive",
+      type: "cta_url",
+      body: { text: "Pick one" },
+    })
+
+    const action = message.action as {
+      name: string
+      parameters: { display_text: string; url: string }
+    }
+    expect(action.name).toBe("cta_url")
+    expect(action.parameters.display_text).toBe("Visit us")
+
+    const url = new URL(action.parameters.url)
+    expect(url.origin + url.pathname).toBe(MAGIC_LINK_URL)
+    // The redirect route (`apps/builder/src/app/r/[workspaceId]/[name]/route.ts`)
+    // rejects a code with no `contactInboxId` segment, so a link button's code
+    // must carry the contact inbox id the same way the carousel's does.
+    expect(url.searchParams.get("code")).toBe(
+      `${FLOW_ID}:${FLOW_VERSION_ID}:1000000000020:::${CONTACT_INBOX_ID}`,
+    )
+  })
+
+  test("encodes the contact inbox id into the cta_url magic-link code so the redirect route can resolve it", async () => {
+    await sendTextStep([makeLinkButton(0, "Visit us", MAGIC_LINK_URL)])
+
+    const action = lastMessage().action as {
+      parameters: { url: string }
+    }
+    const code = new URL(action.parameters.url).searchParams.get("code")
+    const decoded = decodeButtonPayload(code ?? "")
+
+    expect(decoded?.contactInboxId).toBe(CONTACT_INBOX_ID)
+  })
+
+  // `whatsapp-api-js`'s `Interactive` constructor throws unless a `cta_url`
+  // header is text, so an image can never be the cta_url message's header —
+  // it is sent as its own message immediately ahead of it instead, the same
+  // way an image is sent ahead of a reply list past three buttons.
+  test("sends the image as its own message ahead of the cta_url message", async () => {
+    await sendImageStep([makeLinkButton(0, "Visit us", MAGIC_LINK_URL)])
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(2)
+    expect(messageAt(0)).toMatchObject({ _type: "image", link: IMAGE_URL })
+    expect(messageAt(1)).toMatchObject({ type: "cta_url" })
+  })
+
+  test("emits both a reply interactive and a cta_url message when link and reply buttons are mixed", async () => {
+    await sendTextStep([
+      makeButton(0, "Reply"),
+      makeLinkButton(0, "Visit us", MAGIC_LINK_URL),
+    ])
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(2)
+    expect(messageAt(0)).toMatchObject({
+      type: "button",
+      body: { text: "Pick one" },
+    })
+    expect(messageAt(1)).toMatchObject({ type: "cta_url" })
+
+    const replyAction = messageAt(0).action as { buttons: unknown[] }
+    expect(replyAction.buttons).toHaveLength(1)
+  })
+
+  test("sends multiple link buttons as multiple cta_url messages", async () => {
+    await sendTextStep([
+      makeLinkButton(0, "First", MAGIC_LINK_URL),
+      makeLinkButton(1, "Second", MAGIC_LINK_URL),
+    ])
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(2)
+    expect(messageAt(0)).toMatchObject({
+      type: "cta_url",
+      body: { text: "Pick one" },
+    })
+    expect(messageAt(1)).toMatchObject({ type: "cta_url" })
+
+    const firstAction = messageAt(0).action as {
+      parameters: { display_text: string }
+    }
+    const secondAction = messageAt(1).action as {
+      parameters: { display_text: string }
+    }
+    expect(firstAction.parameters.display_text).toBe("First")
+    expect(secondAction.parameters.display_text).toBe("Second")
+  })
+
+  test("falls back to the placeholder body when there is no text", async () => {
+    await sendImageStep([makeLinkButton(0, "Visit us", MAGIC_LINK_URL)])
+
+    expect(lastMessage()).toMatchObject({ body: { text: "." } })
+  })
+
+  test("clamps a link button label longer than 20 characters", async () => {
+    await sendTextStep([makeLinkButton(0, "L".repeat(30), MAGIC_LINK_URL)])
+
+    const action = lastMessage().action as {
+      parameters: { display_text: string }
+    }
+    expect(action.parameters.display_text).toHaveLength(20)
+  })
+
+  test("regression: a reply-only step still renders reply buttons, not a cta_url message", async () => {
+    await sendTextStep(makeButtons(3))
+
+    expect(mockSendMessage).toHaveBeenCalledOnce()
+    expect(lastMessage()).toMatchObject({ type: "button" })
+  })
+
+  test("regression: more than three reply-only buttons still render a list", async () => {
+    await sendTextStep(makeButtons(4))
+
+    expect(lastMessage()).toMatchObject({ type: "list" })
+  })
+})

--- a/integrations/whatsapp/__tests__/quick-replies-attachment.test.ts
+++ b/integrations/whatsapp/__tests__/quick-replies-attachment.test.ts
@@ -30,6 +30,7 @@ describe("whatsapp quick replies attachment", () => {
       convertFlowStepText({
         data: {
           flowId: "flow-1",
+          contact: { id: "1000000000030", sourceId: "84123456789" },
           step: {
             id: "step-1",
             stepType: "sendText",
@@ -68,6 +69,7 @@ describe("whatsapp quick replies attachment", () => {
       convertFlowStepText({
         data: {
           flowId: "flow-1",
+          contact: { id: "1000000000030", sourceId: "84123456789" },
           step: {
             id: "step-1",
             stepType: "sendText",
@@ -114,6 +116,7 @@ describe("whatsapp quick replies attachment", () => {
       convertFlowStepText({
         data: {
           flowId: "flow-1",
+          contact: { id: "1000000000030", sourceId: "84123456789" },
           step: {
             id: "step-1",
             stepType: "sendText",

--- a/integrations/whatsapp/src/handlers/message/outgoing-message/send-card.ts
+++ b/integrations/whatsapp/src/handlers/message/outgoing-message/send-card.ts
@@ -100,6 +100,7 @@ const cardRenderers: Record<
       bodyText: content.body,
       media: content.imageUrl ? new Image(content.imageUrl) : undefined,
       footer: content.footer ? generateFooter(content.footer) : undefined,
+      contactInboxId: props.contactInboxId,
     }),
 
   [cardLayouts.captionedImage]: (_props, content) => {

--- a/integrations/whatsapp/src/handlers/message/outgoing-message/send-carousel.ts
+++ b/integrations/whatsapp/src/handlers/message/outgoing-message/send-carousel.ts
@@ -34,6 +34,7 @@ export function* generateOutgoingMessages(
       flowVersionId: props.flowVersionId,
       metadata: props.metadata,
       quickReplies: isLastCard ? props.quickReplies : undefined,
+      contactInboxId: props.contactInboxId,
       payload: card,
     })
   }

--- a/integrations/whatsapp/src/handlers/message/outgoing-message/send-image.ts
+++ b/integrations/whatsapp/src/handlers/message/outgoing-message/send-image.ts
@@ -10,7 +10,7 @@ export function* convertFlowStepImage(
   >[0],
 ) {
   const {
-    data: { step },
+    data: { step, contact },
   } = props
   const quickReplies = props.data.quickReplies ?? []
   if (step.buttons.length + quickReplies.length === 0) {
@@ -28,6 +28,7 @@ export function* convertFlowStepImage(
     metadata: props.data.metadata,
     bodyText: "",
     media: new Image(step.url),
+    contactInboxId: contact.id,
   })) {
     yield message
   }

--- a/integrations/whatsapp/src/handlers/message/outgoing-message/send-text.ts
+++ b/integrations/whatsapp/src/handlers/message/outgoing-message/send-text.ts
@@ -10,7 +10,7 @@ export function* convertFlowStepText(
   >[0],
 ) {
   const {
-    data: { step },
+    data: { step, contact },
   } = props
   const buttonCount =
     step.buttons.length + (props.data.quickReplies?.length ?? 0)
@@ -26,6 +26,7 @@ export function* convertFlowStepText(
     quickReplies: props.data.quickReplies,
     metadata: props.data.metadata,
     bodyText: step.text,
+    contactInboxId: contact.id,
   })) {
     yield message
   }

--- a/integrations/whatsapp/src/handlers/message/outgoing-message/shared.ts
+++ b/integrations/whatsapp/src/handlers/message/outgoing-message/shared.ts
@@ -1,7 +1,9 @@
 import {
+  appendCodeToMagicLink,
   type ButtonStepProps,
   encodeButtonPayload,
   extractMetadata,
+  getButtonLinkUrl,
   type MetadataPayload,
 } from "@chatbotx.io/flow-config"
 import {
@@ -10,6 +12,7 @@ import {
 } from "@chatbotx.io/sdk"
 import {
   ActionButtons,
+  ActionCTA,
   ActionList,
   type Footer,
   Header,
@@ -42,6 +45,19 @@ type WhatsappReplyButton = {
   id: string
   label: string
 }
+
+type WhatsappLinkButton = {
+  id: string
+  label: string
+  url: string
+}
+
+/**
+ * Meta requires a body on every interactive message, including a `cta_url`
+ * one, but a link button carries no body text of its own — mirrors the
+ * carousel's `CAROUSEL_MAIN_BODY` convention for the same requirement.
+ */
+const EMPTY_BODY_PLACEHOLDER = "."
 
 /**
  * `contactInboxId` only reaches the payload of a link button, whose code is read
@@ -139,6 +155,36 @@ function selectReplyButtons(props: {
   return selected
 }
 
+/**
+ * `openWebsite` buttons are pulled out before `selectReplyButtons` ever sees
+ * them: Meta renders a link as its own `cta_url` message, never as a reply, so
+ * treating one as a reply candidate would keep silently dropping its URL.
+ */
+function selectLinkButtons(props: {
+  flowId: string
+  flowVersionId?: string
+  buttons: ButtonStepProps[]
+  metadata?: MetadataPayload
+  contactInboxId?: string
+}): WhatsappLinkButton[] {
+  return props.buttons.flatMap((button) => {
+    const url = getButtonLinkUrl(button)
+    if (!url) {
+      return []
+    }
+
+    const { id, label } = normalizeRawButton({
+      flowId: props.flowId,
+      flowVersionId: props.flowVersionId,
+      button,
+      metadata: props.metadata,
+      contactInboxId: props.contactInboxId,
+    })
+
+    return [{ id, label, url }]
+  })
+}
+
 function chunkList<T>(items: T[], size: number): T[][] {
   return Array.from({ length: Math.ceil(items.length / size) }, (_, index) =>
     items.slice(index * size, index * size + size),
@@ -146,42 +192,17 @@ function chunkList<T>(items: T[], size: number): T[][] {
 }
 
 /**
- * Builds the message sequence that carries `bodyText`, an optional image and a
- * set of replies.
- *
- * Nothing is discarded to fit a WhatsApp limit: overflowing text and overflowing
- * replies each become additional messages. Only values with nowhere to overflow
- * to — a button title, a footer — are clamped.
+ * The reply-buttons/list half of the message sequence — unchanged behavior,
+ * extracted so `buildWhatsappButtonMessages` can place it beside the `cta_url`
+ * messages a link button now also produces.
  */
-export function buildWhatsappButtonMessages(props: {
-  flowId: string
-  flowVersionId?: string
-  buttons: ButtonStepProps[]
-  quickReplies?: MessageButtonTemplate[]
-  metadata?: MetadataPayload
+function buildReplyMessages(props: {
+  replies: WhatsappReplyButton[]
   bodyText: string
   media?: Image
   footer?: Footer
 }): ClientMessage[] {
-  const replies = selectReplyButtons({
-    flowId: props.flowId,
-    flowVersionId: props.flowVersionId,
-    buttons: props.buttons,
-    quickReplies: props.quickReplies,
-    metadata: props.metadata,
-  })
-
-  if (replies.length === 0) {
-    return []
-  }
-
-  // Only the closing chunk becomes the interactive body; anything before it
-  // leads as plain text so a long message keeps all of its content.
-  const bodyChunks = splitText(props.bodyText, messageLimits.bodyText)
-  const bodyText = bodyChunks.at(-1) ?? ""
-  const leading: ClientMessage[] = bodyChunks
-    .slice(0, -1)
-    .map((chunk) => new Text(chunk))
+  const { replies, bodyText, media, footer } = props
 
   // Reply buttons can carry the image inline, which reads best when it all fits.
   if (replies.length <= MAX_BUTTONS) {
@@ -190,12 +211,11 @@ export function buildWhatsappButtonMessages(props: {
     )
 
     return [
-      ...leading,
       new Interactive(
         new ActionButtons(firstButton, ...restButtons),
         generateBody(bodyText),
-        props.media ? new Header(props.media) : undefined,
-        props.footer,
+        media ? new Header(media) : undefined,
+        footer,
       ),
     ]
   }
@@ -204,8 +224,7 @@ export function buildWhatsappButtonMessages(props: {
   // three replies the image is sent on its own and the replies are spread over
   // as many lists as they need instead of being cut off.
   return [
-    ...leading,
-    ...(props.media ? [props.media] : []),
+    ...(media ? [media] : []),
     ...chunkList(replies, MAX_LIST_ROWS).map((chunk) => {
       const [firstRow, ...restRows] = chunk.map(({ id, label }) =>
         generateRow({ id, title: label }),
@@ -218,8 +237,128 @@ export function buildWhatsappButtonMessages(props: {
         ),
         generateBody(bodyText),
         undefined,
-        props.footer,
+        footer,
       )
     }),
+  ]
+}
+
+/**
+ * One `cta_url` message for a single link button. Meta allows exactly one url
+ * button per message and forbids mixing it with reply buttons, so every link
+ * button becomes its own bubble rather than being combined with another.
+ *
+ * No `media` parameter on purpose: `whatsapp-api-js`'s `Interactive`
+ * constructor throws unless a `cta_url` action's header is text (same
+ * restriction it applies to `ActionList`), so an image can never be this
+ * message's header — see the standalone-`Image` handling in
+ * `buildWhatsappButtonMessages` instead.
+ *
+ * The magic-link code is the button's own encoded id — the same one a reply
+ * would have carried — so the redirect route can still resolve `steps` on
+ * click; see `appendCodeToMagicLink` and `normalizeRawButton`.
+ */
+function buildCtaUrlMessage(props: {
+  linkButton: WhatsappLinkButton
+  bodyText: string
+  footer?: Footer
+}): Interactive {
+  return new Interactive(
+    new ActionCTA(
+      clampText(props.linkButton.label, messageLimits.buttonTitle),
+      appendCodeToMagicLink(props.linkButton.url, props.linkButton.id),
+    ),
+    generateBody(props.bodyText.trim() || EMPTY_BODY_PLACEHOLDER),
+    undefined,
+    props.footer,
+  )
+}
+
+/**
+ * Builds the message sequence that carries `bodyText`, an optional image and a
+ * set of buttons — reply buttons/quick replies plus any `openWebsite` link
+ * buttons.
+ *
+ * Nothing is discarded to fit a WhatsApp limit: overflowing text and overflowing
+ * replies each become additional messages. Only values with nowhere to overflow
+ * to — a button title, a footer — are clamped.
+ *
+ * Meta allows only one body per message and forbids mixing a `cta_url` action
+ * with reply buttons, so only one message — the "primary" one — carries the
+ * real body text; every other button becomes an additional bubble whose body
+ * is just its own label. Reply buttons win the primary slot when present,
+ * since they can hold more than one button and (up to three of them) can still
+ * carry the image inline; otherwise the first link button takes the primary
+ * slot and the image is sent as its own message ahead of it, the same way it
+ * is ahead of a reply list past three buttons.
+ */
+export function buildWhatsappButtonMessages(props: {
+  flowId: string
+  flowVersionId?: string
+  buttons: ButtonStepProps[]
+  quickReplies?: MessageButtonTemplate[]
+  metadata?: MetadataPayload
+  bodyText: string
+  media?: Image
+  footer?: Footer
+  /** Only a link button's magic-link code carries this — see `normalizeRawButton`. */
+  contactInboxId?: string
+}): ClientMessage[] {
+  const linkButtons = selectLinkButtons({
+    flowId: props.flowId,
+    flowVersionId: props.flowVersionId,
+    buttons: props.buttons,
+    metadata: props.metadata,
+    contactInboxId: props.contactInboxId,
+  })
+
+  const replies = selectReplyButtons({
+    flowId: props.flowId,
+    flowVersionId: props.flowVersionId,
+    buttons: props.buttons.filter((button) => !getButtonLinkUrl(button)),
+    quickReplies: props.quickReplies,
+    metadata: props.metadata,
+  })
+
+  if (replies.length === 0 && linkButtons.length === 0) {
+    return []
+  }
+
+  // Only the closing chunk becomes the interactive body; anything before it
+  // leads as plain text so a long message keeps all of its content.
+  const bodyChunks = splitText(props.bodyText, messageLimits.bodyText)
+  const bodyText = bodyChunks.at(-1) ?? ""
+  const leading: ClientMessage[] = bodyChunks
+    .slice(0, -1)
+    .map((chunk) => new Text(chunk))
+
+  if (replies.length > 0) {
+    return [
+      ...leading,
+      ...buildReplyMessages({
+        replies,
+        bodyText,
+        media: props.media,
+        footer: props.footer,
+      }),
+      ...linkButtons.map((linkButton) =>
+        buildCtaUrlMessage({ linkButton, bodyText: linkButton.label }),
+      ),
+    ]
+  }
+
+  const [primaryLink, ...extraLinks] = linkButtons
+
+  return [
+    ...leading,
+    ...(props.media ? [props.media] : []),
+    buildCtaUrlMessage({
+      linkButton: primaryLink,
+      bodyText,
+      footer: props.footer,
+    }),
+    ...extraLinks.map((linkButton) =>
+      buildCtaUrlMessage({ linkButton, bodyText: linkButton.label }),
+    ),
   ]
 }

--- a/packages/flow-config/src/steps/button.ts
+++ b/packages/flow-config/src/steps/button.ts
@@ -71,6 +71,19 @@ export const buttonStepSchema = z
 export type ButtonStepProps = z.infer<typeof buttonStepSchema>
 export type ButtonStepInput = z.input<typeof buttonStepSchema>
 
+/**
+ * The URL an `openWebsite` button opens, or `undefined` for every other
+ * button type. Channel-neutral on purpose — WhatsApp's cta_url message and
+ * the carousel card link both narrow the same discriminated union to decide
+ * whether a button carries a link instead of a reply.
+ */
+export const getButtonLinkUrl = (
+  button: ButtonStepProps,
+): string | undefined =>
+  button.buttonType === buttonTypes.enum.openWebsite
+    ? button.beforeStep.url
+    : undefined
+
 export const buttonStepDefaultFn = (
   props?: Pick<ButtonStepProps, "label">,
 ): ButtonStepProps => ({


### PR DESCRIPTION
## Summary
- Flow "open website" buttons now open their link on WhatsApp instead of appearing as tappable reply buttons that go nowhere
- Each link button is sent as a WhatsApp CTA URL message; reply/quick-reply buttons keep their existing rendering
- Click attribution is preserved so a link button's follow-up steps still run when tapped

## Changes
- `packages/flow-config/src/steps/button.ts`: add `getButtonLinkUrl` helper to read a button's link URL, channel-neutral
- `integrations/whatsapp/src/handlers/message/outgoing-message/shared.ts`: send open-website buttons as CTA URL messages, leave reply-button/list rendering unchanged, and thread the contact inbox id onto link buttons
- `integrations/whatsapp/src/handlers/message/outgoing-message/{send-text,send-image,send-card,send-carousel}.ts`: pass the contact inbox id through so link clicks attribute correctly
- `integrations/whatsapp/__tests__/outgoing-link-buttons.test.ts` (new) and `quick-replies-attachment.test.ts`: cover link-button rendering, mixed link/reply buttons, multiple links, body fallback, label clamping, attribution, and reply-only regressions

## Test plan
- [x] pnpm --filter @chatbotx.io/integration-whatsapp test (211 passed)
- [x] pnpm --filter @chatbotx.io/integration-whatsapp check-types
- [x] pnpm --filter @chatbotx.io/flow-config check-types
- [ ] manual: a WhatsApp flow with an open-website button opens the link on tap

> Note: the repo-wide typecheck currently fails in `packages/business/src/template/snapshot.service.ts`, which is pre-existing on `main` (fallout from #1034) and unrelated to this change; the touched packages type-check clean.
