### PR TITLE
fix(templates): restore full category enum, gate share UI via explicit list

### DIFF
--- a/apps/builder/__tests__/message-item-avatar.test.tsx
+++ b/apps/builder/__tests__/message-item-avatar.test.tsx
@@ -9,6 +9,16 @@ vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
 }))
 
+// MessageItem -> MessageActions -> MediaLibraryTrigger, which imports its
+// `"use server"` query modules at module scope. Next.js rewrites those to RPC
+// stubs, but vitest evaluates them for real, dragging in the
+// `@chatbotx.io/business` barrel and a live pg Pool — which throws on
+// `env.DATABASE_URL` under the browser-conditions preset. Stubbing the
+// trigger cuts that chain and keeps this test about avatar gating.
+vi.mock("@/features/media-library/components/media-library-trigger", () => ({
+  MediaLibraryTrigger: () => null,
+}))
+
 // Base UI's Avatar.Image only mounts once the underlying <img> actually
 // fires a load/error event (see useImageLoadingStatus), which jsdom never
 // dispatches for a src that isn't really fetched. Mock it down to plain

--- a/apps/builder/src/features/templates/components/template-contents-card.tsx
+++ b/apps/builder/src/features/templates/components/template-contents-card.tsx
@@ -1,10 +1,7 @@
 "use client"
 
 import type { TemplateCategory } from "@chatbotx.io/database/partials"
-import {
-  templateCategories,
-  templateResourceCategories,
-} from "@chatbotx.io/database/partials"
+import { templateCategories } from "@chatbotx.io/database/partials"
 import {
   Accordion,
   AccordionContent,
@@ -28,27 +25,43 @@ import { EMPTY_SELECTION, selectionCount } from "../lib/selection"
 import { CategoryResourceList } from "./category-resource-list"
 
 /**
- * Categories with a working `listSelectableResources` picker query +
- * `ResourceCollector.resolveIds`/`collect` — derived from
- * `templateResourceCategories` (`packages/database/src/partials/template.ts`)
- * so this list cannot drift from the adapter registry it mirrors: every
- * resource category has an adapter (`registry.ts`'s
- * `satisfies Record<TemplateResourceCategory, ResourceAdapter>` with no
- * `Partial` guarantees that at compile time), so every resource category is
- * available here too. `tags`/`customFields` are added on top since those two
- * manifest-only categories also have their own picker + ownership check
- * (`snapshot.service.ts`'s inline `assertIdsBelongToWorkspace` path).
- * `productCategories` stays excluded — it is never independently selectable;
- * a product's category comes along automatically via `productsAdapter`'s
- * collector.
+ * Categories currently exposed for sharing. This is a deliberate **product**
+ * restriction, not a technical one: every category in `ALL_CATEGORIES` still
+ * has a working adapter and picker query (`registry.ts` enforces adapter
+ * completeness at compile time via
+ * `satisfies Record<TemplateResourceCategory, ResourceAdapter>`), so the rest
+ * are fully implemented — they are just held back from the share flow for now
+ * and render disabled with a "Coming soon" badge.
+ *
+ * Kept as an explicit list rather than derived from
+ * `templateResourceCategories` so that narrowing what users can share never
+ * requires touching the enum: that enum feeds a `pgEnum`
+ * (`schema/template-installed-resource.ts`) and the adapter registry, so
+ * editing it to gate the UI breaks the build and drifts from the database.
+ * To release a category, add it back to this array — nothing else.
+ *
+ * `productCategories` is excluded for a different, permanent reason: it is
+ * never independently selectable — a product's category comes along
+ * automatically via `productsAdapter`'s collector.
  */
 const AVAILABLE_CATEGORIES: readonly TemplateCategory[] = [
-  ...templateResourceCategories.options,
+  "flows",
   "tags",
   "customFields",
 ]
 
-const ALL_CATEGORIES: readonly TemplateCategory[] = templateCategories.options
+/**
+ * Display order: the available categories first, in the order above, then
+ * every remaining category. The tail is derived from `templateCategories`
+ * rather than hand-listed so a newly added category still shows up here (as
+ * "Coming soon") instead of silently vanishing from the form.
+ */
+const ALL_CATEGORIES: readonly TemplateCategory[] = [
+  ...AVAILABLE_CATEGORIES,
+  ...templateCategories.options.filter(
+    (category) => !AVAILABLE_CATEGORIES.includes(category),
+  ),
+]
 
 type TemplateContentsCardProps = {
   workspaceId: string

--- a/packages/database/src/partials/template.ts
+++ b/packages/database/src/partials/template.ts
@@ -18,7 +18,7 @@ import { z } from "zod"
 export const templateManifestOnlyCategories = z.enum([
   "customFields",
   "tags",
-  // "productCategories",
+  "productCategories",
 ])
 export type TemplateManifestOnlyCategory = z.infer<
   typeof templateManifestOnlyCategories
@@ -26,16 +26,16 @@ export type TemplateManifestOnlyCategory = z.infer<
 
 export const templateResourceCategories = z.enum([
   "flows",
-  // "products",
-  // "aiFunctions",
-  // "aiAgents",
-  // "calendars",
-  // "webchats",
-  // "keywords",
-  // "entryPointLinks",
-  // "triggers",
-  // "fbCommentAutomations",
-  // "settings",
+  "products",
+  "aiFunctions",
+  "aiAgents",
+  "calendars",
+  "webchats",
+  "keywords",
+  "entryPointLinks",
+  "triggers",
+  "fbCommentAutomations",
+  "settings",
 ])
 export type TemplateResourceCategory = z.infer<
   typeof templateResourceCategories


### PR DESCRIPTION
## Summary
- Uncomments the remaining `templateResourceCategories` (products, aiFunctions, aiAgents, calendars, webchats, keywords, entryPointLinks, triggers, fbCommentAutomations, settings) and `productCategories` now that their adapters exist — the enum backs a `pgEnum` and the adapter registry, so it should reflect what's implemented, not what's exposed in the UI.
- Moves the share-flow restriction out of the enum and into an explicit `AVAILABLE_CATEGORIES` list (`flows`, `tags`, `customFields`) in `template-contents-card.tsx`, with the remaining categories shown disabled as "Coming soon" (derived from `templateCategories` so new categories can't silently vanish from the form).
- Fixes `message-item-avatar.test.tsx`, which was transitively pulling in `MediaLibraryTrigger`'s `"use server"` query modules and opening a live pg `Pool` under vitest; stubs the trigger to keep the test scoped to avatar gating.

## Changes
- `packages/database/src/partials/template.ts` — restore full `templateResourceCategories`/`templateManifestOnlyCategories` enums
- `apps/builder/src/features/templates/components/template-contents-card.tsx` — explicit `AVAILABLE_CATEGORIES` gate, `ALL_CATEGORIES` derived with available-first ordering
- `apps/builder/__tests__/message-item-avatar.test.tsx` — mock `MediaLibraryTrigger` to avoid live DB pool in test

## Test plan
- [x] `pnpm lint` (pre-commit hook)
- [x] `pnpm --filter builder check-types` (pre-commit hook)
- [ ] manual verification of the template share dialog (flows/tags/customFields selectable, rest shown as "Coming soon")