### PR TITLE
fix(coexist): handle oversized attachments and message id collisions in historical import

### DIFF
--- a/apps/worker/__tests__/bulk-import-messages.test.ts
+++ b/apps/worker/__tests__/bulk-import-messages.test.ts
@@ -340,6 +340,52 @@ describe("bulkImportMessages", () => {
     expect(result.importedMessages).toBe(1)
   })
 
+  test("converges a multi-row PK collision by splitting and re-minting only the colliding row", async () => {
+    // Batch of two distinct messages; only src-2 collides with an existing DB
+    // row on (id, createdAt). The bulk insert fails, the batch is split, the
+    // src-1 half inserts cleanly, and only src-2 is re-minted to a free slot.
+    const pkError = Object.assign(new Error("duplicate key value"), {
+      cause: { code: "23505", constraint: "173_Message_pkey" },
+    })
+
+    let call = 0
+    mockBulkCreate.mockImplementation(
+      (rows: { id: string; sourceId: string | null }[]) => {
+        call++
+        // call 1: the full batch [src-1, src-2] — collides.
+        // call 3: the isolated original src-2 — still collides.
+        if (call === 1 || call === 3) {
+          throw pkError
+        }
+        // call 2: [src-1] inserts; call 4: [re-minted src-2] inserts.
+        return rows.map((r) => ({ id: r.id, sourceId: r.sourceId }))
+      },
+    )
+
+    const result = await bulkImportMessages({
+      ...BASE_PROPS,
+      messages: [makeMessage("src-1"), makeMessage("src-2")],
+    })
+
+    expect(mockBulkCreate).toHaveBeenCalledTimes(4)
+    // Both messages land — no data loss from the collision.
+    expect(result.importedMessages).toBe(2)
+
+    const originalSrc2Id = (
+      mockBulkCreate.mock.calls[2][0] as { id: string; sourceId: string }[]
+    )[0].id
+    const remintedSrc2Id = (
+      mockBulkCreate.mock.calls[3][0] as { id: string; sourceId: string }[]
+    )[0].id
+    // The isolated collider is re-minted to a different id; src-1 is untouched.
+    expect(remintedSrc2Id).not.toBe(originalSrc2Id)
+    const src1Call = mockBulkCreate.mock.calls[1][0] as {
+      id: string
+      sourceId: string
+    }[]
+    expect(src1Call[0].sourceId).toBe("src-1")
+  })
+
   test("does not bump activity itself — returns message timestamps for the caller to batch", async () => {
     // Activity bumps (lastMessageAt / lastActivityAt) are the caller's job now;
     // bulkImportMessages only inserts and reports the newest message time.
@@ -419,6 +465,22 @@ describe("bulkImportMessages", () => {
     expect(result.newestMessageAt).toEqual(newerOutgoingTimestamp)
     expect(result.oldestMessageAt).toEqual(incomingTimestamp)
     expect(result.newestIncomingMessageAt).toEqual(incomingTimestamp)
+  })
+
+  test("fails loudly when a single row cannot find a free slot after the re-mint cap", async () => {
+    // A row that keeps colliding on every re-mint must eventually give up with a
+    // clear error rather than looping forever.
+    const pkError = Object.assign(new Error("duplicate key value"), {
+      cause: { code: "23505", constraint: "173_Message_pkey" },
+    })
+    mockBulkCreate.mockRejectedValue(pkError)
+
+    await expect(
+      bulkImportMessages({ ...BASE_PROPS, messages: [makeMessage("src-1")] }),
+    ).rejects.toThrow("unresolved after")
+    // Initial bulk insert plus the bounded re-mint attempts — proves it looped
+    // and gave up, not that it tried once.
+    expect(mockBulkCreate.mock.calls.length).toBeGreaterThan(2)
   })
 
   test("does NOT retry on non-PK errors — they propagate", async () => {

--- a/apps/worker/__tests__/coexist-attachment-download.test.ts
+++ b/apps/worker/__tests__/coexist-attachment-download.test.ts
@@ -122,7 +122,10 @@ vi.mock("../src/lib/logger", () => ({
 // Import the handler AFTER mocks
 // ---------------------------------------------------------------------------
 
-import { coexistAttachmentDownload } from "../src/integration/handlers/coexist/attachment-download"
+import {
+  coexistAttachmentDownload,
+  MAX_ATTACHMENT_BYTES,
+} from "../src/integration/handlers/coexist/attachment-download"
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -358,10 +361,13 @@ describe("coexistAttachmentDownload", () => {
   })
 
   // ─────────────────────────────────────────────────────────────────────────
-  // SECURITY: size cap
+  // SIZE CAP: an oversized attachment is a PERMANENT condition, so the handler
+  // must skip it terminally (log a warning and return) rather than throw —
+  // throwing would burn all BullMQ retry attempts on a job that can never
+  // succeed. See AttachmentTooLargeError.
   // ─────────────────────────────────────────────────────────────────────────
 
-  it("rejects Messenger response with content-length exceeding MAX_ATTACHMENT_BYTES", async () => {
+  it("skips (no throw) a Messenger response whose content-length exceeds the cap", async () => {
     wireSelectChain({
       id: "att-001",
       originPath: "https://example.com/media/huge.mp4",
@@ -369,19 +375,27 @@ describe("coexistAttachmentDownload", () => {
     })
     wireIntegrationLookup()
 
-    const OVER_LIMIT = String(51 * 1024 * 1024) // 51 MB
+    const OVER_LIMIT = String(MAX_ATTACHMENT_BYTES + 1)
     const fetchMock = vi.fn(() =>
       Promise.resolve(makeFetchResponse({ contentLength: OVER_LIMIT })),
     )
     vi.stubGlobal("fetch", fetchMock)
 
-    await expect(coexistAttachmentDownload(BASE_DATA)).rejects.toThrow()
+    // Must resolve (terminal skip), never reject — a reject would trigger retry.
+    await expect(coexistAttachmentDownload(BASE_DATA)).resolves.toBeUndefined()
     expect(mockPutObject).not.toHaveBeenCalled()
+    expect(mockUpdateAttachment).not.toHaveBeenCalled()
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ attachmentId: BASE_DATA.attachmentId }),
+      expect.stringContaining("exceeds size cap"),
+    )
+    // Terminal skip must NOT be logged as an error (that reads as a failure).
+    expect(mockLoggerError).not.toHaveBeenCalled()
 
     vi.unstubAllGlobals()
   })
 
-  it("rejects Messenger response whose body bytes exceed MAX_ATTACHMENT_BYTES (no content-length)", async () => {
+  it("skips (no throw) a Messenger response whose streamed body exceeds the cap (no content-length)", async () => {
     wireSelectChain({
       id: "att-001",
       originPath: "https://example.com/media/huge.mp4",
@@ -393,19 +407,24 @@ describe("coexistAttachmentDownload", () => {
       Promise.resolve(
         makeFetchResponse({
           contentLength: undefined, // no header — must be caught by streaming cap
-          totalBytes: 51 * 1024 * 1024, // 51 MB streamed
+          totalBytes: MAX_ATTACHMENT_BYTES + 1, // one byte past the cap
+          chunkSize: 10 * 1024 * 1024,
         }),
       ),
     )
     vi.stubGlobal("fetch", fetchMock)
 
-    await expect(coexistAttachmentDownload(BASE_DATA)).rejects.toThrow()
+    await expect(coexistAttachmentDownload(BASE_DATA)).resolves.toBeUndefined()
     expect(mockPutObject).not.toHaveBeenCalled()
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ attachmentId: BASE_DATA.attachmentId }),
+      expect.stringContaining("exceeds size cap"),
+    )
 
     vi.unstubAllGlobals()
   })
 
-  it("rejects WhatsApp response with content-length exceeding MAX_ATTACHMENT_BYTES", async () => {
+  it("skips (no throw) a WhatsApp response whose content-length exceeds the cap", async () => {
     wireSelectChain({
       id: "att-001",
       originPath: "wa-media:media-id-xyz",
@@ -413,14 +432,35 @@ describe("coexistAttachmentDownload", () => {
     })
     wireIntegrationLookup({ ...FAKE_INTEGRATION_ROW, channel: "whatsapp" })
 
-    const OVER_LIMIT = String(51 * 1024 * 1024)
+    const OVER_LIMIT = String(MAX_ATTACHMENT_BYTES + 1)
     const fetchMock = vi.fn(() =>
       Promise.resolve(makeFetchResponse({ contentLength: OVER_LIMIT })),
     )
     vi.stubGlobal("fetch", fetchMock)
 
-    await expect(coexistAttachmentDownload(WA_DATA)).rejects.toThrow()
+    await expect(coexistAttachmentDownload(WA_DATA)).resolves.toBeUndefined()
     expect(mockPutObject).not.toHaveBeenCalled()
+
+    vi.unstubAllGlobals()
+  })
+
+  it("still throws (retryable) on a transient download failure — non-size errors keep retrying", async () => {
+    wireSelectChain({
+      id: "att-001",
+      originPath: "https://example.com/media/photo.jpg",
+      mimeType: "image/jpeg",
+    })
+    wireIntegrationLookup()
+
+    // A 5xx is transient: the handler must rethrow so BullMQ retries it.
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(makeFetchResponse({ ok: false })),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    await expect(coexistAttachmentDownload(BASE_DATA)).rejects.toThrow()
+    expect(mockPutObject).not.toHaveBeenCalled()
+    expect(mockLoggerError).toHaveBeenCalled()
 
     vi.unstubAllGlobals()
   })

--- a/apps/worker/src/integration/handlers/coexist/attachment-download.ts
+++ b/apps/worker/src/integration/handlers/coexist/attachment-download.ts
@@ -62,8 +62,23 @@ const getStorageExtension = (
   return MIME_EXTENSION_MAP[mimeType] ?? ""
 }
 
-/** Maximum allowed attachment size in bytes (50 MiB). */
-const MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024
+/** Maximum allowed attachment size in bytes (100 MiB). */
+export const MAX_ATTACHMENT_BYTES = 100 * 1024 * 1024
+
+/**
+ * Thrown when an attachment is genuinely larger than `MAX_ATTACHMENT_BYTES`.
+ * This is a PERMANENT condition — the same bytes exceed the cap on every
+ * retry — so the download handler treats it as a terminal skip (logs and
+ * returns) instead of rethrowing, which would burn all 5 BullMQ attempts and
+ * spam identical error logs for a job that can never succeed. Transient
+ * failures (network, 5xx, timeout) keep throwing so they still retry.
+ */
+export class AttachmentTooLargeError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "AttachmentTooLargeError"
+  }
+}
 
 const isPendingOriginPath = (path: string): boolean =>
   path.startsWith("http://") ||
@@ -91,7 +106,7 @@ const readBodyWithCap = async (
   if (declaredHeader !== null) {
     const declared = Number.parseInt(declaredHeader, 10)
     if (!Number.isNaN(declared) && declared > MAX_ATTACHMENT_BYTES) {
-      throw new SdkException(
+      throw new AttachmentTooLargeError(
         `[coexist-attachment] ${label} exceeds size limit: ${declared} bytes (max ${MAX_ATTACHMENT_BYTES})`,
       )
     }
@@ -116,7 +131,7 @@ const readBodyWithCap = async (
     total += value.byteLength
     if (total > MAX_ATTACHMENT_BYTES) {
       await reader.cancel()
-      throw new SdkException(
+      throw new AttachmentTooLargeError(
         `[coexist-attachment] ${label} body exceeds size limit: >${MAX_ATTACHMENT_BYTES} bytes`,
       )
     }
@@ -293,6 +308,18 @@ export const coexistAttachmentDownload = async (
       row.mimeType,
     )
   } catch (err) {
+    // An oversized attachment is a permanent condition: retrying re-downloads
+    // the same too-large bytes and fails identically, burning every BullMQ
+    // attempt. Terminate the job cleanly (no rethrow → no retry) and leave the
+    // row pending; a future coexist sync may re-enqueue it, but it never enters
+    // a retry storm. All other failures stay retryable.
+    if (err instanceof AttachmentTooLargeError) {
+      logger.warn(
+        { attachmentId, channel, err },
+        "[coexist-attachment] attachment exceeds size cap — skipping (permanent)",
+      )
+      return
+    }
     logger.error(
       { err, attachmentId, channel },
       "[coexist-attachment] download failed",

--- a/apps/worker/src/integration/handlers/coexist/bulk-historical-import.ts
+++ b/apps/worker/src/integration/handlers/coexist/bulk-historical-import.ts
@@ -176,6 +176,121 @@ const isUniqueMessagePkViolation = (err: unknown): boolean => {
   return false
 }
 
+/**
+ * Cap on how many times a single row's id is re-minted while probing past
+ * DB-occupied `(id, createdAt)` slots. Each attempt advances the factory's
+ * disambiguator; 64 is far beyond any realistic same-second slot occupancy, so
+ * exhausting it signals something genuinely wrong and is surfaced loudly.
+ */
+const MAX_PK_REMINT_ATTEMPTS = 64
+
+/**
+ * Insert a single row that PK-collided, re-minting its id until it lands in a
+ * free `(id, createdAt)` slot. Each `makeMessageId` call advances the factory's
+ * in-process `used` set, so successive attempts probe forward instead of
+ * re-emitting the colliding id. Genuine duplicates never reach here — they
+ * match the arbiter and are swallowed silently by `bulkCreate`.
+ */
+const remintRow = async (
+  repository: IMessageRepository,
+  row: CreateMessageInput,
+  makeMessageId: HistoricalIdFactory,
+  contactInboxId: string,
+  runId: string,
+): Promise<{ id: string; sourceId: string | null }[]> => {
+  for (let attempt = 0; attempt < MAX_PK_REMINT_ATTEMPTS; attempt++) {
+    const reminted: CreateMessageInput = {
+      ...row,
+      id: makeMessageId(
+        row.createdAt as Date,
+        row.sourceId ?? "",
+        contactInboxId,
+      ),
+    }
+    try {
+      return await repository.bulkCreate([reminted])
+    } catch (err) {
+      if (!isUniqueMessagePkViolation(err)) {
+        throw err
+      }
+      // Still colliding — loop; the next mint advances to another slot.
+    }
+  }
+  logger.error(
+    {
+      runId,
+      sourceId: row.sourceId,
+      createdAt: row.createdAt,
+      attempts: MAX_PK_REMINT_ATTEMPTS,
+    },
+    "[coexist] Message PK collision unresolved after re-minting — giving up on row",
+  )
+  throw new Error(
+    `[coexist] Message PK collision unresolved after ${MAX_PK_REMINT_ATTEMPTS} re-mints (sourceId=${row.sourceId})`,
+  )
+}
+
+/**
+ * Converge a batch that is KNOWN to contain at least one PK `(id, createdAt)`
+ * collision the repository's arbiter `(contactInboxId, sourceId, createdAt)`
+ * does not catch.
+ *
+ * A PK-thrown row is ALWAYS a distinct message: a genuine re-import matches the
+ * arbiter and is swallowed by `onConflictDoNothing`, never throwing. The clash
+ * is a rare 14-bit id-hash collision with a row already in the DB — invisible
+ * to `makeMessageId`'s in-process `used` set. We isolate the colliders by
+ * splitting the batch in halves (a half whose rows are all fine still inserts
+ * in one bulk call), and re-mint only the single rows that truly collide. This
+ * shifts only the offending rows and provably converges, unlike the previous
+ * whole-batch re-mint which just traded one collision for another.
+ *
+ * Re-minting is safe for idempotency: the stored id no longer equals the
+ * deterministic id, but a future re-import is deduped by the arbiter tuple, not
+ * the id.
+ */
+const convergePkCollisions = async (
+  repository: IMessageRepository,
+  inputs: CreateMessageInput[],
+  makeMessageId: HistoricalIdFactory,
+  contactInboxId: string,
+  runId: string,
+): Promise<{ id: string; sourceId: string | null }[]> => {
+  if (inputs.length === 1) {
+    return await remintRow(
+      repository,
+      inputs[0],
+      makeMessageId,
+      contactInboxId,
+      runId,
+    )
+  }
+
+  const mid = Math.floor(inputs.length / 2)
+  const halves = [inputs.slice(0, mid), inputs.slice(mid)]
+  const out: { id: string; sourceId: string | null }[] = []
+  // Sequential, not parallel: all rows share one factory `used` set, so
+  // concurrent minting would race on slot assignment.
+  for (const half of halves) {
+    try {
+      out.push(...(await repository.bulkCreate(half)))
+    } catch (err) {
+      if (!isUniqueMessagePkViolation(err)) {
+        throw err
+      }
+      out.push(
+        ...(await convergePkCollisions(
+          repository,
+          half,
+          makeMessageId,
+          contactInboxId,
+          runId,
+        )),
+      )
+    }
+  }
+  return out
+}
+
 export type HistoricalMessage = IncomingMessage & { createdAt?: Date }
 
 export type ContactImportLink = {
@@ -1009,8 +1124,12 @@ export const bulkImportMessages = async (props: {
   })
 
   // Insert messages via repository — always shard-aware (ShardedMessageRepository).
-  // PK collision (snowflake id clash across runs) triggers a one-time retry with
-  // fresh IDs; the onConflictDoNothing inside bulkCreate handles sourceId dupes.
+  // A PK `(id, createdAt)` collision (a rare 14-bit id-hash clash with a row
+  // already in the DB) is NOT caught by bulkCreate's arbiter onConflictDoNothing
+  // on (contactInboxId, sourceId, createdAt), so it surfaces as 23505. It is
+  // resolved by `remintingBulkInsert`, which re-mints ONLY the colliding rows
+  // until they find a free slot; genuine duplicates are still swallowed by the
+  // arbiter.
   //
   // Atomicity trade-off: bulkCreate runs outside any transaction wrapping the
   // surrounding conversation/contactInbox updates. A crash mid-batch leaves
@@ -1039,40 +1158,25 @@ export const bulkImportMessages = async (props: {
         )
         throw err
       }
-      // A PK collision is an anticipated, self-healing condition (rare 14-bit
-      // disambiguator clash with an existing row) — warn, then retry with
-      // re-minted ids. Only escalate to error if the retry also fails (below).
+      // A PK collision is an anticipated, self-healing condition. Converge by
+      // re-minting only the colliding rows (see remintingBulkInsert) instead of
+      // reshuffling the whole batch — the latter just traded one collision for
+      // another and never converged.
       logger.warn(
         {
           runId,
           total: messageInputs.length,
           dbCause: describeDatabaseError(err),
         },
-        "[coexist] Message PK collision — regenerating IDs and retrying",
+        "[coexist] Message PK collision — re-minting colliding rows and retrying",
       )
-      const retried = messageInputs.map((input) => ({
-        ...input,
-        // Re-call advances past the colliding slot via the factory's used-set.
-        id: makeMessageId(
-          input.createdAt as Date,
-          input.sourceId ?? "",
-          contactInboxId,
-        ),
-      }))
-      try {
-        insertedRows = await repository.bulkCreate(retried)
-      } catch (retryErr) {
-        logger.error(
-          {
-            runId,
-            total: retried.length,
-            dbCause: describeDatabaseError(retryErr),
-            sampleIds: retried.slice(0, 5).map((m) => m.id),
-          },
-          "[coexist] Message bulkCreate retry ALSO failed after re-minting IDs",
-        )
-        throw retryErr
-      }
+      insertedRows = await convergePkCollisions(
+        repository,
+        messageInputs,
+        makeMessageId,
+        contactInboxId,
+        runId,
+      )
     }
   }
 


### PR DESCRIPTION
## Summary

Two reliability fixes for the coexist historical import worker. Both previously turned a permanent condition into a repeating failure that never resolved.

- **Oversized attachments** are now skipped once instead of retried five times. The size cap is raised to 100 MiB, and an attachment larger than the cap is treated as a terminal skip (logged and left as-is) rather than an error that burns every retry attempt. Transient download failures (network, 5xx, timeout) still retry as before.
- **Historical message imports** no longer fail on a primary-key collision. When an imported message's generated id clashes with an existing row, only the colliding rows are re-minted to a free slot and retried; genuine duplicates are still deduplicated exactly as before. The previous whole-batch re-mint reshuffled every id into a new collision and never converged, leaving the import failing.

## Changes

- `apps/worker/src/integration/handlers/coexist/attachment-download.ts` — raise the attachment size cap to 100 MiB; skip oversized attachments terminally instead of throwing, while keeping transient failures retryable.
- `apps/worker/src/integration/handlers/coexist/bulk-historical-import.ts` — replace the whole-batch id re-mint with a convergent split-and-re-mint that touches only the colliding rows and fails loudly if a row cannot find a free slot.
- `apps/worker/__tests__/coexist-attachment-download.test.ts` — cover terminal skip on oversize (declared and streamed size) and that transient failures still retry.
- `apps/worker/__tests__/bulk-import-messages.test.ts` — cover multi-row collision convergence and the fail-loud cap.

## Test plan

- [x] `pnpm --filter worker check-types`
- [x] `pnpm lint` on changed files
- [x] `pnpm --filter worker exec vitest run` for the coexist import and attachment suites
- [ ] Manual verification on a workspace that reproduced the duplicate-key import failure and the oversized-attachment retry loop
