### PR TITLE
fix(ai-agent): fix bug ai gent slow reply

### DIFF
--- a/apps/worker/__tests__/automated-response-rich-response.test.ts
+++ b/apps/worker/__tests__/automated-response-rich-response.test.ts
@@ -184,7 +184,7 @@ vi.mock("../src/trigger/services/handoff-executor.service", () => ({
 }))
 
 vi.mock("../src/lib/logger", () => ({
-  logger: { warn: warnMock, error: errorMock, info: vi.fn() },
+  logger: { warn: warnMock, error: errorMock, info: vi.fn(), debug: vi.fn() },
 }))
 
 vi.mock("@chatbotx.io/event-bus", () => ({

--- a/apps/worker/__tests__/automated-response-tracking-context.test.ts
+++ b/apps/worker/__tests__/automated-response-tracking-context.test.ts
@@ -1,0 +1,228 @@
+import type {
+  AIAgentModel,
+  ContactInboxModel,
+  ConversationModel,
+} from "@chatbotx.io/database/types"
+import type { ModelMessage } from "ai"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import { replyByAI } from "../src/integration/handlers/automated-response/replies"
+
+// ---------------------------------------------------------------------------
+// Regression coverage for the shared `trackingContextRef` "send once" guard:
+// the `sendMessage` system tool can be invoked more than once by the model in
+// a single multi-step run (stopWhen: stepCountIs(5)) — tracking must attach
+// to at most one of those sends, not one per invocation.
+// ---------------------------------------------------------------------------
+
+const sendMessageAndWaitMock = vi.hoisted(() => vi.fn(async () => undefined))
+const appendHistoryMock = vi.hoisted(() => vi.fn(async () => undefined))
+const createAIProviderInstanceMock = vi.hoisted(() =>
+  vi.fn(() => () => ({ type: "fake-model" })),
+)
+const getAIIntegrationInDBMock = vi.hoisted(() =>
+  vi.fn(async () => ({ id: "integration-1", apiKey: "key" })),
+)
+
+// Captures the resolved `systemFunctionContextGetter()` result so tests can
+// invoke `sendMessage` directly, simulating the AI SDK calling the tool.
+const capturedContext = vi.hoisted(() => ({
+  current: null as null | { sendMessage: (text: string) => Promise<void> },
+}))
+
+vi.mock("@chatbotx.io/ai", () => ({
+  aiProviders: { openai: "openai" },
+  aiTimeouts: { aiTotal: 30_000, aiStep: 10_000, aiChunk: 5000 },
+  helpTexts: {
+    richResponseFormat: "",
+    unavailable: "Sorry, I cannot help right now.",
+    fallbackLookup: "fallback",
+  },
+  processStreamingText: vi.fn(async () => ({ fullText: "", messageCount: 0 })),
+  systemFunctionNames: {
+    webSearch: "webSearch",
+    connectUserToHuman: "connectUserToHuman",
+    documentReader: "documentReader",
+    imageReader: "imageReader",
+    urlReader: "urlReader",
+  },
+  toolPrefixes: { enum: { sys: "sys", file: "file", fn: "fn", mcp: "mcp" } },
+  appendFabricationGuard: (p: string) => p,
+  appendHandoffPolicy: (p: string) => p,
+  appendKnowledgeBaseGuard: (p: string) => p,
+  appendToolOutputGuard: (p: string) => p,
+  appendUnavailableWebSearchPolicy: (p: string) => p,
+}))
+
+vi.mock("@chatbotx.io/ai/server", () => ({
+  aiContextService: { appendHistory: appendHistoryMock },
+  appendFabricationGuard: (p: string) => p,
+  appendHandoffPolicy: (p: string) => p,
+  appendKnowledgeBaseGuard: (p: string) => p,
+  appendToolOutputGuard: (p: string) => p,
+  appendUnavailableWebSearchPolicy: (p: string) => p,
+  createAIProviderInstance: createAIProviderInstanceMock,
+  createOpenaiCompatibleModelInstance: vi.fn(),
+  getAIIntegrationInDB: getAIIntegrationInDBMock,
+  getAIToolset: vi.fn(
+    async (options: {
+      systemFunctionContextGetter: () => Promise<{
+        sendMessage: (text: string) => Promise<void>
+      }>
+    }) => {
+      capturedContext.current = await options.systemFunctionContextGetter()
+      return { tools: {}, cleanup: undefined, webSearchOmitReason: undefined }
+    },
+  ),
+  McpClient: vi.fn(),
+  normalizeAuthorizedWebSearchDomains: vi.fn(() => []),
+  normalizeMcpContent: vi.fn((c: unknown) => c),
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  integrationOpenaiCompatibleService: {
+    findByWorkspaceIdAndId: vi.fn(),
+  },
+}))
+
+async function* emptyAsyncIterable() {
+  // intentionally empty — fake textStream for tests
+}
+
+vi.mock("ai", () => ({
+  streamText: vi.fn(async () => ({
+    textStream: emptyAsyncIterable(),
+    usage: Promise.resolve({ totalTokens: 0 }),
+  })),
+  stepCountIs: vi.fn(() => () => false),
+}))
+
+vi.mock(
+  "../src/integration/handlers/automated-response/replies",
+  (importOriginal) => importOriginal(),
+)
+
+vi.mock("../src/integration/utils/message", () => ({
+  sendMessageAndWait: sendMessageAndWaitMock,
+  sendMessageWithRender: vi.fn(async () => undefined),
+}))
+
+vi.mock("@chatbotx.io/variables", () => ({
+  contactVariableService: {
+    getAll: vi.fn(async () => []),
+    replaceAll: vi.fn(async ({ text }: { text: string }) => text),
+  },
+}))
+
+vi.mock("@chatbotx.io/worker-config", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@chatbotx.io/worker-config")>()
+  return {
+    ...actual,
+    integrationQueue: { add: vi.fn(async () => undefined) },
+  }
+})
+
+vi.mock("../src/trigger/services/handoff-executor.service", () => ({
+  handoffExecutorService: { execute: vi.fn(async () => undefined) },
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock(
+  "../src/integration/handlers/automated-response/system-tools/document-reader",
+  () => ({ createDocumentReaderExecutor: vi.fn(() => vi.fn()) }),
+)
+vi.mock(
+  "../src/integration/handlers/automated-response/system-tools/image-reader",
+  () => ({ createImageReaderExecutor: vi.fn(() => vi.fn()) }),
+)
+vi.mock(
+  "../src/integration/handlers/automated-response/system-tools/url-reader",
+  () => ({ createUrlReaderExecutor: vi.fn(() => vi.fn()) }),
+)
+
+function makeAIAgent(overrides?: Partial<AIAgentModel>): AIAgentModel {
+  return {
+    id: "agent-1",
+    workspaceId: "ws-1",
+    name: "Test Agent",
+    prompt: "You are a helpful assistant.",
+    messages: [],
+    isDefault: false,
+    isRichResponse: false,
+    tools: [],
+    webSearchAuthorizedDomains: [],
+    models: [{ provider: "openai", model: "gpt-4o" }] as AIAgentModel["models"],
+    temperature: 0.7,
+    maxOutputTokens: 1000,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as AIAgentModel
+}
+
+function makeConversation(
+  overrides?: Partial<ConversationModel>,
+): ConversationModel {
+  return {
+    id: "conv-1",
+    workspaceId: "ws-1",
+    contactId: "contact-1",
+    channel: "webchat",
+    status: "open",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as ConversationModel
+}
+
+const baseProps = {
+  conversation: makeConversation(),
+  contactInbox: {
+    id: "inbox-1",
+    contactId: "contact-1",
+    inboxId: "channel-inbox-1",
+    channel: "webchat",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as ContactInboxModel,
+  channel: "webchat",
+  messages: [] as ModelMessage[],
+  fileOnlyTrigger: false,
+  triggerMessageId: "msg-trigger-1",
+  defaultReplyFrequency: "always" as const,
+}
+
+describe("replyByAI — sendMessage tool tracking-context guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    capturedContext.current = null
+  })
+
+  test("attaches tracking context to only the first of two sendMessage tool calls in one run", async () => {
+    await replyByAI({ ...baseProps, aiAgent: makeAIAgent() })
+
+    expect(capturedContext.current).not.toBeNull()
+
+    await capturedContext.current?.sendMessage("first message")
+    await capturedContext.current?.sendMessage("second message")
+
+    expect(sendMessageAndWaitMock).toHaveBeenNthCalledWith(
+      1,
+      "conv-1",
+      "first message",
+      expect.objectContaining({
+        triggerType: "bot_response_ai_agent_success",
+        messageId: "msg-trigger-1",
+      }),
+    )
+    expect(sendMessageAndWaitMock).toHaveBeenNthCalledWith(
+      2,
+      "conv-1",
+      "second message",
+      undefined,
+    )
+  })
+})

--- a/apps/worker/__tests__/summarize-conversation.test.ts
+++ b/apps/worker/__tests__/summarize-conversation.test.ts
@@ -1,0 +1,293 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  aiAgentQueueAdd: vi.fn(),
+  findFirstConversation: vi.fn(),
+  get: vi.fn(),
+  loggerError: vi.fn(),
+  loggerWarn: vi.fn(),
+  runExclusive: vi.fn(),
+  summarizeConversation: vi.fn(),
+  update: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/ai/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@chatbotx.io/ai/server")>()
+  return {
+    ...actual,
+    aiContextStore: {
+      get: mocks.get,
+      runExclusive: mocks.runExclusive,
+      update: mocks.update,
+    },
+    summarizeConversation: mocks.summarizeConversation,
+  }
+})
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      conversationModel: {
+        findFirst: mocks.findFirstConversation,
+      },
+    },
+  },
+}))
+vi.mock("@chatbotx.io/worker-config", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@chatbotx.io/worker-config")>()
+  return {
+    ...actual,
+    AIJobAction: { summarizeConversation: "summarizeConversation" },
+    aiAgentQueue: { add: mocks.aiAgentQueueAdd },
+  }
+})
+vi.mock("../src/lib/logger", () => ({
+  logger: { error: mocks.loggerError, warn: mocks.loggerWarn },
+}))
+
+const { handleSummarizeConversation } = await import(
+  "../src/ai-agent/handlers/summarize-conversation"
+)
+
+describe("handleSummarizeConversation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.runExclusive.mockImplementation(
+      (_conversationId: string, fn: () => Promise<unknown>) => fn(),
+    )
+    mocks.update.mockResolvedValue(undefined)
+  })
+
+  test("resets the 'summarizing' flag before rethrowing when the AI summarization call fails", async () => {
+    mocks.get
+      .mockResolvedValueOnce({
+        summarizing: false,
+        needsResummarize: false,
+        summary: "old summary",
+        history: Array.from({ length: 25 }, (_, i) => ({
+          role: "user",
+          content: `msg-${i}`,
+          messageId: `msg-${i}`,
+        })),
+      })
+      .mockResolvedValueOnce({
+        summarizing: true,
+        needsResummarize: false,
+        summary: "old summary",
+        history: Array.from({ length: 25 }, (_, i) => ({
+          role: "user",
+          content: `msg-${i}`,
+          messageId: `msg-${i}`,
+        })),
+      })
+    mocks.findFirstConversation.mockResolvedValue({
+      id: "conv-1",
+      workspaceId: "ws-1",
+    })
+    mocks.summarizeConversation.mockRejectedValue(
+      new Error("provider unavailable"),
+    )
+
+    await expect(
+      handleSummarizeConversation({ conversationId: "conv-1" }),
+    ).rejects.toThrow("provider unavailable")
+
+    // The first update marks the job in-flight; the fix must add a second
+    // update that clears it again once the AI call fails, so the *next*
+    // appendHistory call is free to enqueue a fresh summarize job instead of
+    // being permanently blocked by a flag no job will ever clear.
+    expect(mocks.update).toHaveBeenCalledWith(
+      "conv-1",
+      expect.objectContaining({
+        summarizing: true,
+        needsResummarize: false,
+        summarizingStartedAt: expect.any(Number),
+      }),
+    )
+    expect(mocks.update).toHaveBeenCalledWith("conv-1", {
+      summarizing: false,
+      summarizingStartedAt: null,
+    })
+    const resetCallIndex = mocks.update.mock.calls.findIndex(
+      ([, payload]) =>
+        (payload as { summarizing?: boolean }).summarizing === false,
+    )
+    expect(resetCallIndex).toBeGreaterThan(-1)
+  })
+
+  test("does not throw when the reset-on-failure update itself fails, and still rethrows the original error", async () => {
+    mocks.get.mockResolvedValue({
+      summarizing: false,
+      needsResummarize: false,
+      summary: "",
+      history: Array.from({ length: 25 }, (_, i) => ({
+        role: "user",
+        content: `msg-${i}`,
+        messageId: `msg-${i}`,
+      })),
+    })
+    mocks.findFirstConversation.mockResolvedValue({
+      id: "conv-1",
+      workspaceId: "ws-1",
+    })
+    mocks.summarizeConversation.mockRejectedValue(new Error("original error"))
+    mocks.update.mockImplementation((_id: string, payload: object) => {
+      if ("summarizing" in payload && payload.summarizing === false) {
+        return Promise.reject(new Error("redis down"))
+      }
+      return Promise.resolve()
+    })
+
+    await expect(
+      handleSummarizeConversation({ conversationId: "conv-1" }),
+    ).rejects.toThrow("original error")
+
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: "conv-1" }),
+      expect.stringContaining("Failed to reset stuck 'summarizing' flag"),
+    )
+  })
+
+  test("does not re-enter summarization while 'summarizing' is fresh (not stale)", async () => {
+    mocks.get.mockResolvedValueOnce({
+      summarizing: true,
+      summarizingStartedAt: Date.now() - 1000, // 1s ago, well under the stale threshold
+      needsResummarize: false,
+      summary: "old",
+      history: Array.from({ length: 25 }, (_, i) => ({
+        role: "user",
+        content: `msg-${i}`,
+        messageId: `msg-${i}`,
+      })),
+    })
+
+    await handleSummarizeConversation({ conversationId: "conv-1" })
+
+    expect(mocks.update).toHaveBeenCalledWith("conv-1", {
+      needsResummarize: true,
+    })
+    expect(mocks.summarizeConversation).not.toHaveBeenCalled()
+    expect(mocks.loggerWarn).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining("stale"),
+    )
+  })
+
+  test("self-heals from a stale 'summarizing' flag left by a crashed job", async () => {
+    mocks.get
+      .mockResolvedValueOnce({
+        summarizing: true,
+        summarizingStartedAt: Date.now() - 10 * 60 * 1000, // 10 min ago
+        needsResummarize: false,
+        summary: "old",
+        history: Array.from({ length: 25 }, (_, i) => ({
+          role: "user",
+          content: `msg-${i}`,
+          messageId: `msg-${i}`,
+        })),
+      })
+      .mockResolvedValueOnce({
+        summarizing: true,
+        needsResummarize: false,
+        summary: "old",
+        history: Array.from({ length: 25 }, (_, i) => ({
+          role: "user",
+          content: `msg-${i}`,
+          messageId: `msg-${i}`,
+        })),
+      })
+    mocks.findFirstConversation.mockResolvedValue({
+      id: "conv-1",
+      workspaceId: "ws-1",
+    })
+    mocks.summarizeConversation.mockResolvedValue("recovered summary")
+
+    await handleSummarizeConversation({ conversationId: "conv-1" })
+
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: "conv-1" }),
+      expect.stringContaining("stale"),
+    )
+    expect(mocks.summarizeConversation).toHaveBeenCalled()
+    expect(mocks.update).toHaveBeenCalledWith(
+      "conv-1",
+      expect.objectContaining({ summary: "recovered summary" }),
+    )
+  })
+
+  test("logs and does not throw when the follow-up requeue fails after a successful summarize", async () => {
+    mocks.get
+      .mockResolvedValueOnce({
+        summarizing: false,
+        needsResummarize: false,
+        summary: "old",
+        history: Array.from({ length: 25 }, (_, i) => ({
+          role: "user",
+          content: `msg-${i}`,
+          messageId: `msg-${i}`,
+        })),
+      })
+      .mockResolvedValueOnce({
+        summarizing: true,
+        needsResummarize: true, // forces shouldRequeue = true
+        summary: "old",
+        history: Array.from({ length: 25 }, (_, i) => ({
+          role: "user",
+          content: `msg-${i}`,
+          messageId: `msg-${i}`,
+        })),
+      })
+    mocks.findFirstConversation.mockResolvedValue({
+      id: "conv-1",
+      workspaceId: "ws-1",
+    })
+    mocks.summarizeConversation.mockResolvedValue("new summary")
+    mocks.aiAgentQueueAdd.mockRejectedValue(new Error("queue down"))
+
+    await expect(
+      handleSummarizeConversation({ conversationId: "conv-1" }),
+    ).resolves.toBeUndefined()
+
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: "conv-1" }),
+      expect.stringContaining("Failed to requeue"),
+    )
+  })
+
+  test("succeeds normally and leaves 'summarizing' false when summarization succeeds", async () => {
+    mocks.get
+      .mockResolvedValueOnce({
+        summarizing: false,
+        needsResummarize: false,
+        summary: "old",
+        history: Array.from({ length: 25 }, (_, i) => ({
+          role: "user",
+          content: `msg-${i}`,
+          messageId: `msg-${i}`,
+        })),
+      })
+      .mockResolvedValueOnce({
+        summarizing: true,
+        needsResummarize: false,
+        summary: "old",
+        history: Array.from({ length: 25 }, (_, i) => ({
+          role: "user",
+          content: `msg-${i}`,
+          messageId: `msg-${i}`,
+        })),
+      })
+    mocks.findFirstConversation.mockResolvedValue({
+      id: "conv-1",
+      workspaceId: "ws-1",
+    })
+    mocks.summarizeConversation.mockResolvedValue("new summary")
+
+    await handleSummarizeConversation({ conversationId: "conv-1" })
+
+    expect(mocks.update).toHaveBeenCalledWith(
+      "conv-1",
+      expect.objectContaining({ summary: "new summary", summarizing: false }),
+    )
+    expect(mocks.loggerError).not.toHaveBeenCalled()
+  })
+})

--- a/apps/worker/src/ai-agent/handlers/summarize-conversation.ts
+++ b/apps/worker/src/ai-agent/handlers/summarize-conversation.ts
@@ -1,4 +1,10 @@
-import { aiContextStore, summarizeConversation } from "@chatbotx.io/ai/server"
+import {
+  type AIContext,
+  type AIMessage,
+  aiContextStore,
+  isSameContextMessage,
+  summarizeConversation,
+} from "@chatbotx.io/ai/server"
 import { db } from "@chatbotx.io/database/client"
 import {
   AIJobAction,
@@ -10,6 +16,38 @@ import { logger } from "../../lib/logger"
 
 const HISTORY_LIMIT = 20
 const SUMMARY_BATCH_SIZE = 10
+
+// A healthy summarize call self-aborts within `aiTimeouts.aiStep` (60s, see
+// packages/ai/src/constants/index.ts). If `summarizing` has been true for
+// much longer than that, the job that set it almost certainly crashed
+// (OOM/SIGKILL/redeploy) before it could reach its own `.then`/`.catch`
+// reset — no code path is coming to clear the flag. Treat it as stale and
+// self-heal instead of leaving it stuck forever.
+const STALE_SUMMARIZING_THRESHOLD_MS = 5 * 60 * 1000
+
+function removeSummarizedMessages(
+  history: AIMessage[],
+  messagesToSummarize: AIMessage[],
+): AIMessage[] {
+  const consumedSeqs = new Set<number>()
+  const legacyConsumed: AIMessage[] = []
+  for (const msg of messagesToSummarize) {
+    if (msg.seq === undefined) {
+      legacyConsumed.push(msg)
+    } else {
+      consumedSeqs.add(msg.seq)
+    }
+  }
+
+  return history.filter((h) => {
+    // Entries cached before `seq` existed (24h Redis TTL) — fall back to the
+    // old identity check for just these stragglers.
+    if (h.seq === undefined) {
+      return !legacyConsumed.some((s) => isSameContextMessage(s, h))
+    }
+    return !consumedSeqs.has(h.seq)
+  })
+}
 
 export async function handleSummarizeConversation(
   data: AIJobSummarizeConversation["data"],
@@ -33,16 +71,32 @@ export async function handleSummarizeConversation(
       }
 
       if (context.summarizing) {
-        await aiContextStore.update(conversationId, {
-          needsResummarize: true,
-        })
-        return null
+        const startedAt = context.summarizingStartedAt
+        const staleForMs = startedAt === null ? null : Date.now() - startedAt
+        const isStale =
+          staleForMs !== null && staleForMs > STALE_SUMMARIZING_THRESHOLD_MS
+
+        if (!isStale) {
+          await aiContextStore.update(conversationId, {
+            needsResummarize: true,
+          })
+          return null
+        }
+
+        // The job that set `summarizing: true` never reached its own
+        // `.then`/`.catch` (worker crash, redeploy, OOM) — no other code path
+        // will clear this flag. Recover by proceeding as if it were false.
+        logger.warn(
+          { conversationId, staleForMs },
+          "[summarizer-worker] 'summarizing' flag stale for longer than a healthy summarize call can take — recovering from a likely crashed job",
+        )
       }
 
       if (context.history.length <= HISTORY_LIMIT) {
         if (context.needsResummarize || context.summarizing) {
           await aiContextStore.update(conversationId, {
             summarizing: false,
+            summarizingStartedAt: null,
             needsResummarize: false,
           })
         }
@@ -56,6 +110,7 @@ export async function handleSummarizeConversation(
 
       await aiContextStore.update(conversationId, {
         summarizing: true,
+        summarizingStartedAt: Date.now(),
         needsResummarize: false,
       })
 
@@ -74,8 +129,11 @@ export async function handleSummarizeConversation(
       })
 
       if (!conversation) {
-        await aiContextStore.update(conversationId, {
-          summarizing: false,
+        await aiContextStore.runExclusive(conversationId, async () => {
+          await aiContextStore.update(conversationId, {
+            summarizing: false,
+            summarizingStartedAt: null,
+          })
         })
         return
       }
@@ -93,11 +151,15 @@ export async function handleSummarizeConversation(
           return
         }
 
-        const consumed = Math.min(
-          SUMMARY_BATCH_SIZE,
-          latestContext.history.length,
+        // Filter by identity rather than slicing the first N entries: the
+        // hard-cap truncation in appendHistory can drop messages from the
+        // front of history while this summarize job is in flight, so the
+        // current front-of-array entries are not reliably the ones that
+        // were actually summarized.
+        const remainingHistory = removeSummarizedMessages(
+          latestContext.history,
+          snapshot.messagesToSummarize,
         )
-        const remainingHistory = latestContext.history.slice(consumed)
 
         shouldRequeue =
           latestContext.needsResummarize ||
@@ -107,30 +169,79 @@ export async function handleSummarizeConversation(
           summary: newSummary,
           history: remainingHistory,
           summarizing: false,
+          summarizingStartedAt: null,
           needsResummarize: false,
         })
       })
 
       if (shouldRequeue) {
-        await aiAgentQueue.add(
-          AIJobAction.summarizeConversation,
-          {
-            type: AIJobAction.summarizeConversation,
-            data: {
-              conversationId,
+        // The summary/history commit above already succeeded — a failure to
+        // requeue must not be reported as "failed to summarize" nor trigger
+        // a full BullMQ retry (which would redundantly re-run the AI
+        // summarization call for work that's already done). It's safe to
+        // just log and move on: `summarizing` is already `false`, so the
+        // next `appendHistory` call past the threshold enqueues a fresh job
+        // organically.
+        await aiAgentQueue
+          .add(
+            AIJobAction.summarizeConversation,
+            {
+              type: AIJobAction.summarizeConversation,
+              data: {
+                conversationId,
+              },
             },
-          },
-          {
-            jobId: `summarize-${conversationId}`,
-            removeOnComplete: true,
-            removeOnFail: true,
-          },
-        )
+            {
+              jobId: `summarize-${conversationId}`,
+              removeOnComplete: true,
+              removeOnFail: true,
+            },
+          )
+          .catch((requeueErr) => {
+            logger.error(
+              { err: requeueErr, conversationId },
+              "[summarizer-worker] Failed to requeue follow-up summarize job after a successful summarize — will retry via next appendHistory trigger instead",
+            )
+          })
       }
     })
-    .catch((err) => {
+    .catch(async (err) => {
+      // Never leave `summarizing` stuck true on a failed attempt — BullMQ
+      // will retry this job from scratch, and if retries are exhausted the
+      // flag must still be clear so the *next* appendHistory call is free to
+      // enqueue a fresh summarize job. Without this, a permanently failing
+      // summarize call (e.g. bad AI integration) permanently blocks
+      // summarization and `history` grows unbounded.
+      // Read-then-reset under the same lock as every other
+      // summarizing/needsResummarize mutation, so the diagnostic snapshot
+      // below reflects the state actually being reset, and neither can race
+      // with a concurrent appendHistory reading a stale `summarizing` value.
+      const contextSnapshotRef: { current: AIContext | null } = {
+        current: null,
+      }
+      await aiContextStore
+        .runExclusive(conversationId, async () => {
+          contextSnapshotRef.current = await aiContextStore.get(conversationId)
+          await aiContextStore.update(conversationId, {
+            summarizing: false,
+            summarizingStartedAt: null,
+          })
+        })
+        .catch((resetErr) => {
+          logger.error(
+            { err: resetErr, conversationId },
+            "[summarizer-worker] Failed to reset stuck 'summarizing' flag after summarize failure",
+          )
+        })
+
       logger.error(
-        { err, conversationId },
+        {
+          err,
+          conversationId,
+          historyLengthAtFailure:
+            contextSnapshotRef.current?.history.length ?? null,
+          summarizingAtFailure: contextSnapshotRef.current?.summarizing ?? null,
+        },
         "[summarizer-worker] Failed to summarize conversation",
       )
       throw err // Rethrow for BullMQ retry

--- a/apps/worker/src/integration/handlers/automated-response/replies.ts
+++ b/apps/worker/src/integration/handlers/automated-response/replies.ts
@@ -37,6 +37,7 @@ import type {
 import { webhookChannelOrigin } from "@chatbotx.io/events/context"
 import { contactVariableService } from "@chatbotx.io/variables"
 import {
+  type BotResponseTrackingContext,
   IntegrationJobAction,
   integrationQueue,
 } from "@chatbotx.io/worker-config"
@@ -51,11 +52,17 @@ import { normalizeError } from "universal-error-normalizer"
 import { logger } from "../../../lib/logger"
 import { handoffExecutorService } from "../../../trigger/services/handoff-executor.service"
 import { sendMessageAndWait, sendMessageWithRender } from "../../utils/message"
+import { logProviderAttempt } from "../shared/provider-attempt-logger"
 import { triggerDefaultReplyFlow } from "./default-reply"
 import { handleRichAIReply } from "./rich-reply"
 import { createDocumentReaderExecutor } from "./system-tools/document-reader"
 import { createImageReaderExecutor } from "./system-tools/image-reader"
 import { createUrlReaderExecutor } from "./system-tools/url-reader"
+import {
+  buildTrackingContext,
+  consumeTrackingContext,
+  type TrackingContextRef,
+} from "./tracking-context"
 
 export type ReplyByAIProps = {
   conversation: ConversationModel
@@ -95,15 +102,37 @@ export type ReplyAIProvider = AIAgentProvider | "openaiCompatible"
 export async function replyByAI(
   props: ReplyByAIProps,
 ): Promise<null | ReplyByAIExecutionResult> {
-  const { aiAgent } = props
+  const { aiAgent, conversation } = props
   const providers = aiAgent.models as AIAgentProviderModels
 
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), aiTimeouts.aiTotal)
 
   try {
-    for (const providerInfo of providers) {
+    for (const [index, providerInfo] of providers.entries()) {
+      const attemptStartedAt = Date.now()
       const result = await runAIReply(props, providerInfo, controller.signal)
+      const durationMs = Date.now() - attemptStartedAt
+      // A `null` result can also mean the provider was intentionally skipped
+      // (not configured / auto-reply off) or an empty completion / error —
+      // those are already logged at the right level inside
+      // runAIReply/createReplyModel, so this summary log shouldn't re-flag
+      // them as warnings.
+      logProviderAttempt(
+        logger,
+        durationMs,
+        {
+          conversationId: conversation.id,
+          workspaceId: conversation.workspaceId,
+          agentId: aiAgent.id,
+          provider: getProviderName(providerInfo),
+          providerIndex: index,
+          providerCount: providers.length,
+          durationMs,
+          responded: Boolean(result?.responded),
+        },
+        "[automated-response] fallback chain provider attempt",
+      )
       if (result?.responded) {
         return result
       }
@@ -112,6 +141,16 @@ export async function replyByAI(
     clearTimeout(timeoutId)
   }
 
+  logger.warn(
+    {
+      conversationId: conversation.id,
+      workspaceId: conversation.workspaceId,
+      agentId: aiAgent.id,
+      providerCount: providers.length,
+      providers: providers.map((p) => getProviderName(p)),
+    },
+    "[automated-response] all fallback providers exhausted without a response",
+  )
   return null
 }
 
@@ -230,6 +269,7 @@ function createReplyToolset(options: {
   props: ReplyByAIProps
   provider: ReplyAIProvider
   providerInstance?: AIProviderInstance
+  trackingContextRef: TrackingContextRef
 }) {
   const { conversation, aiAgent } = options.props
   const tools = filterToolsByAllowedSystemFunctions(
@@ -275,7 +315,11 @@ function createReplyToolset(options: {
         options.directSendTracker.sent = true
         options.directSendTracker.sentText = text
         if (text) {
-          await sendMessageAndWait(conversation.id, text)
+          await sendMessageAndWait(
+            conversation.id,
+            text,
+            consumeTrackingContext(options.trackingContextRef),
+          )
         }
       },
       triggerFlow: async (flowId: string) => {
@@ -579,6 +623,16 @@ async function createReplyModel(props: {
       })
 
     if (!(integration?.enabled && integration.autoReply)) {
+      logger.debug(
+        {
+          workspaceId,
+          integrationId: providerInfo.integrationId,
+          integrationFound: Boolean(integration),
+          enabled: integration?.enabled ?? null,
+          autoReply: integration?.autoReply ?? null,
+        },
+        "[automated-response] openaiCompatible provider skipped: integration missing, disabled, or auto-reply off",
+      )
       return null
     }
 
@@ -597,6 +651,10 @@ async function createReplyModel(props: {
   })
 
   if (!integration) {
+    logger.debug(
+      { workspaceId, provider: providerInfo.provider },
+      "[automated-response] provider skipped: no auto-reply-enabled integration found",
+    )
     return null
   }
 
@@ -633,6 +691,25 @@ async function runAIReply(
 
     const startTime = Date.now()
 
+    const successTrackingContext: BotResponseTrackingContext | undefined =
+      props.triggerMessageId
+        ? buildTrackingContext({
+            conversationId: conversation.id,
+            messageId: props.triggerMessageId,
+            provider,
+            responseType: "ai_agent",
+            startTime,
+            triggerType: "bot_response_ai_agent_success",
+            workspaceId: conversation.workspaceId,
+          })
+        : undefined
+    // Shared across the `sendMessage` tool (which the model may invoke more
+    // than once in a multi-step tool loop) and the plain-text streaming
+    // reply below, so tracking attaches to exactly one outbound message per
+    // run no matter which path sends it first.
+    const trackingContextRef: TrackingContextRef = {
+      current: successTrackingContext,
+    }
     const directSendTracker = { sent: false, sentText: "" }
     const toolset = await createReplyToolset({
       abortSignal,
@@ -642,6 +719,7 @@ async function runAIReply(
       props,
       provider,
       providerInstance: modelConfig.providerInstance,
+      trackingContextRef,
     })
     const tools = toolset.tools
     cleanup = toolset.cleanup
@@ -797,7 +875,11 @@ async function runAIReply(
           return
         }
         for (const part of parts) {
-          await sendMessageAndWait(conversation.id, part)
+          await sendMessageAndWait(
+            conversation.id,
+            part,
+            consumeTrackingContext(trackingContextRef),
+          )
         }
       },
       { sendParts: true },
@@ -901,6 +983,18 @@ async function runAIReply(
       }
     }
 
+    logger.warn(
+      {
+        provider,
+        modelId: selectedModelId,
+        conversationId: conversation.id,
+        workspaceId: conversation.workspaceId,
+        historyMessageCount: messages.length,
+        hasSummary: Boolean(props.summary),
+        ...buildToolStats(),
+      },
+      "[automated-response] AI produced an empty completion (no text, no tool calls)",
+    )
     return null
   } catch (error) {
     const normalizedError = normalizeError(error)

--- a/apps/worker/src/integration/handlers/automated-response/rich-reply.ts
+++ b/apps/worker/src/integration/handlers/automated-response/rich-reply.ts
@@ -2,7 +2,6 @@ import { processStreamingText } from "@chatbotx.io/ai"
 import { aiContextService } from "@chatbotx.io/ai/server"
 import { emit } from "@chatbotx.io/event-bus"
 import { createId } from "@chatbotx.io/utils"
-import type { BotResponseTrackingContext } from "@chatbotx.io/worker-config"
 import { normalizeError } from "universal-error-normalizer"
 import { logger } from "../../../lib/logger"
 import { sendMessageAndWait } from "../../utils/message"
@@ -14,6 +13,7 @@ import type {
   ReplyByAIExecutionResult,
   ReplyByAIProps,
 } from "./replies"
+import { buildTrackingContext } from "./tracking-context"
 
 type DirectSendTracker = {
   sent: boolean
@@ -78,9 +78,11 @@ export async function handleRichAIReply({
   const executionId = props.triggerMessageId as string
   const trackingContext = buildTrackingContext({
     conversationId: conversation.id,
-    executionId,
+    messageId: executionId,
     provider,
+    responseType: "ai_agent",
     startTime,
+    triggerType: "rich_response",
     workspaceId: conversation.workspaceId,
   })
 
@@ -184,24 +186,6 @@ async function appendAssistantHistory(
       },
     ],
   })
-}
-
-function buildTrackingContext(input: {
-  conversationId: string
-  executionId: string
-  provider: ReplyAIProvider
-  startTime: number
-  workspaceId: string
-}): BotResponseTrackingContext {
-  return {
-    aiProvider: input.provider,
-    conversationId: input.conversationId,
-    messageId: input.executionId,
-    responseType: "ai_agent",
-    startTime: input.startTime,
-    triggerType: "rich_response",
-    workspaceId: input.workspaceId,
-  }
 }
 
 async function emitStreamFailureAnalytics(input: {

--- a/apps/worker/src/integration/handlers/automated-response/tracking-context.ts
+++ b/apps/worker/src/integration/handlers/automated-response/tracking-context.ts
@@ -1,0 +1,38 @@
+import type { BotResponseTrackingContext } from "@chatbotx.io/worker-config"
+import type { ReplyAIProvider } from "./replies"
+
+// Mutable box for a tracking context that must be attached to at most one
+// outbound message per AI run, regardless of whether that message comes from
+// the `sendMessage` system tool (possibly invoked more than once across a
+// multi-step tool loop) or the plain-text streaming reply.
+export type TrackingContextRef = {
+  current: BotResponseTrackingContext | undefined
+}
+
+export function consumeTrackingContext(
+  ref: TrackingContextRef,
+): BotResponseTrackingContext | undefined {
+  const trackingContext = ref.current
+  ref.current = undefined
+  return trackingContext
+}
+
+export function buildTrackingContext(input: {
+  conversationId: string
+  messageId: string
+  provider: ReplyAIProvider
+  responseType: BotResponseTrackingContext["responseType"]
+  startTime: number
+  triggerType: string
+  workspaceId: string
+}): BotResponseTrackingContext {
+  return {
+    aiProvider: input.provider,
+    conversationId: input.conversationId,
+    messageId: input.messageId,
+    responseType: input.responseType,
+    startTime: input.startTime,
+    triggerType: input.triggerType,
+    workspaceId: input.workspaceId,
+  }
+}

--- a/apps/worker/src/integration/handlers/shared/ai-agent-runner.ts
+++ b/apps/worker/src/integration/handlers/shared/ai-agent-runner.ts
@@ -33,6 +33,7 @@ import { contactVariableService } from "@chatbotx.io/variables"
 import { type ModelMessage, stepCountIs, streamText, type ToolSet } from "ai"
 import { normalizeError } from "universal-error-normalizer"
 import { logger } from "../../../lib/logger"
+import { logProviderAttempt } from "./provider-attempt-logger"
 
 export type ReplyByAIProps = {
   conversation: ConversationModel
@@ -106,12 +107,29 @@ export async function runAIAgentRunner(
   const timeoutId = setTimeout(() => controller.abort(), aiTimeouts.aiTotal)
 
   try {
-    for (const providerInfo of providersToRun) {
+    for (const [index, providerInfo] of providersToRun.entries()) {
+      const attemptStartedAt = Date.now()
       const result = await runAIReplyInternal(
         props,
         providerInfo,
         tools,
         controller.signal,
+      )
+      const durationMs = Date.now() - attemptStartedAt
+      logProviderAttempt(
+        logger,
+        durationMs,
+        {
+          conversationId: props.conversation.id,
+          workspaceId: props.conversation.workspaceId,
+          agentId: props.aiAgent.id,
+          provider: getProviderName(providerInfo),
+          providerIndex: index,
+          providerCount: providersToRun.length,
+          durationMs,
+          responded: Boolean(result?.responded),
+        },
+        "[ai-agent-runner] fallback chain provider attempt",
       )
       if (result?.responded) {
         return result

--- a/apps/worker/src/integration/handlers/shared/provider-attempt-logger.ts
+++ b/apps/worker/src/integration/handlers/shared/provider-attempt-logger.ts
@@ -1,0 +1,23 @@
+import type { logger as workerLogger } from "../../../lib/logger"
+
+type WorkerLogger = typeof workerLogger
+
+// Threshold for promoting a single provider attempt's log from `debug` to
+// `warn` so slow calls stay visible in prod (LOG_LEVEL defaults to "info").
+// Well below `aiTimeouts.aiTotal` (120s) so it flags degradation early.
+export const SLOW_PROVIDER_ATTEMPT_MS = 20_000
+
+export function logProviderAttempt(
+  logger: WorkerLogger,
+  durationMs: number,
+  payload: Record<string, unknown>,
+  logMessage: string,
+): void {
+  // `debug` is dropped by default in prod (LOG_LEVEL defaults to "info"),
+  // so promote to `warn` when the attempt is slow.
+  if (durationMs > SLOW_PROVIDER_ATTEMPT_MS) {
+    logger.warn(payload, `${logMessage} (slow)`)
+  } else {
+    logger.debug(payload, logMessage)
+  }
+}

--- a/packages/ai/__tests__/ai-context-service.test.ts
+++ b/packages/ai/__tests__/ai-context-service.test.ts
@@ -2,12 +2,14 @@ import { MessageShardUnavailableError } from "@chatbotx.io/database/errors"
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
+  aiAgentQueueAdd: vi.fn(),
   createMessageRepository: vi.fn(),
   delete: vi.fn(),
   findConversationAIContextState: vi.fn(),
   getSafeSinceTime: vi.fn(),
   get: vi.fn(),
   loggerError: vi.fn(),
+  loggerWarn: vi.fn(),
   runExclusive: vi.fn(),
   summarizeConversation: vi.fn(),
   update: vi.fn(),
@@ -20,7 +22,7 @@ vi.mock("@chatbotx.io/database/repositories", () => ({
 }))
 vi.mock("@chatbotx.io/worker-config", () => ({
   AIJobAction: { summarizeConversation: "summarizeConversation" },
-  aiAgentQueue: { add: vi.fn() },
+  aiAgentQueue: { add: mocks.aiAgentQueueAdd },
 }))
 vi.mock("../src/server/cache/ai-context-store", () => ({
   aiContextStore: {
@@ -34,7 +36,7 @@ vi.mock("../src/server/services/summarizer", () => ({
   summarizeConversation: mocks.summarizeConversation,
 }))
 vi.mock("../src/logger", () => ({
-  logger: { error: mocks.loggerError },
+  logger: { error: mocks.loggerError, warn: mocks.loggerWarn },
 }))
 
 const { aiContextService } = await import(
@@ -127,6 +129,29 @@ describe("aiContextService.getOrInitContext", () => {
     expect(result?.history.map((message) => message.messageId)).toEqual(["10"])
   })
 
+  test("assigns a unique, monotonic seq to each initial history entry", async () => {
+    const createdAt = new Date("2026-06-01T00:00:00.000Z")
+    const findAIContextMessages = vi.fn().mockResolvedValue([
+      { id: "1", text: "first", senderType: "contact", createdAt },
+      { id: "2", text: "second", senderType: "bot", createdAt },
+      { id: "3", text: "third", senderType: "contact", createdAt },
+    ])
+    mocks.createMessageRepository.mockResolvedValue({ findAIContextMessages })
+    mocks.findConversationAIContextState.mockResolvedValue({
+      aiContextLastMessageId: null,
+      lastActivityAt: createdAt,
+    })
+    mocks.summarizeConversation.mockResolvedValue("summary")
+
+    const result = await aiContextService.getOrInitContext({
+      workspaceId: "ws-1",
+      conversationId: "conv-1",
+    })
+
+    expect(result?.history.map((m) => m.seq)).toEqual([0, 1, 2])
+    expect(result?.nextSeq).toBe(3)
+  })
+
   test("reinitializes cached context when its marker is stale", async () => {
     const findAIContextMessages = vi.fn().mockResolvedValue([])
     mocks.createMessageRepository.mockResolvedValue({ findAIContextMessages })
@@ -198,5 +223,166 @@ describe("aiContextService.getOrInitContext", () => {
     expect(mocks.createMessageRepository).not.toHaveBeenCalled()
     expect(findAIContextMessages).not.toHaveBeenCalled()
     expect(mocks.update).not.toHaveBeenCalled()
+  })
+})
+
+describe("aiContextService.appendHistory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.runExclusive.mockImplementation(
+      (_conversationId: string, fn: () => Promise<unknown>) => fn(),
+    )
+    mocks.update.mockResolvedValue(undefined)
+  })
+
+  test("enqueues a summarize job when history exceeds the trigger threshold and no job is in flight", async () => {
+    mocks.get
+      .mockResolvedValueOnce({
+        markerMessageId: null,
+        summary: "",
+        history: Array.from({ length: 100 }, (_, i) => ({
+          role: "user" as const,
+          content: `old-${i}`,
+          messageId: `old-${i}`,
+          createdAt: i,
+        })),
+        summarizing: false,
+        needsResummarize: false,
+        updatedAt: Date.now(),
+      })
+      .mockResolvedValueOnce(null)
+
+    await aiContextService.appendHistory({
+      conversationId: "conv-1",
+      newMessages: [
+        { message: { role: "user", content: "new" }, messageId: "new-1" },
+      ],
+    })
+
+    expect(mocks.aiAgentQueueAdd).toHaveBeenCalledTimes(1)
+    expect(mocks.update).toHaveBeenCalledWith(
+      "conv-1",
+      expect.objectContaining({
+        history: expect.arrayContaining([
+          expect.objectContaining({ messageId: "new-1" }),
+        ]),
+      }),
+    )
+  })
+
+  test("does not enqueue a second summarize job while one is already marked in-flight, and warns", async () => {
+    mocks.get
+      .mockResolvedValueOnce({
+        markerMessageId: null,
+        summary: "",
+        history: Array.from({ length: 100 }, (_, i) => ({
+          role: "user" as const,
+          content: `old-${i}`,
+          messageId: `old-${i}`,
+          createdAt: i,
+        })),
+        summarizing: true,
+        needsResummarize: false,
+        updatedAt: Date.now(),
+      })
+      .mockResolvedValueOnce(null)
+
+    await aiContextService.appendHistory({
+      conversationId: "conv-1",
+      newMessages: [
+        { message: { role: "user", content: "new" }, messageId: "new-1" },
+      ],
+    })
+
+    expect(mocks.aiAgentQueueAdd).not.toHaveBeenCalled()
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: "conv-1" }),
+      expect.stringContaining("summarize job is already marked in-flight"),
+    )
+  })
+
+  test("assigns increasing seq values to newly appended messages, starting from nextSeq", async () => {
+    mocks.get
+      .mockResolvedValueOnce({
+        markerMessageId: null,
+        summary: "",
+        history: [{ role: "user", content: "old", messageId: "old-1", seq: 0 }],
+        nextSeq: 1,
+        summarizing: false,
+        needsResummarize: false,
+        updatedAt: Date.now(),
+      })
+      .mockResolvedValueOnce(null)
+
+    await aiContextService.appendHistory({
+      conversationId: "conv-1",
+      newMessages: [
+        { message: { role: "user", content: "a" }, messageId: "new-a" },
+        { message: { role: "user", content: "b" }, messageId: "new-b" },
+      ],
+    })
+
+    expect(mocks.update).toHaveBeenCalledWith(
+      "conv-1",
+      expect.objectContaining({
+        nextSeq: 3,
+        history: [
+          expect.objectContaining({ messageId: "old-1", seq: 0 }),
+          expect.objectContaining({ messageId: "new-a", seq: 1 }),
+          expect.objectContaining({ messageId: "new-b", seq: 2 }),
+        ],
+      }),
+    )
+  })
+
+  test("truncates history to the hard cap when it is stuck growing past the trigger threshold, regardless of the summarizing flag", async () => {
+    const existingHistory = Array.from({ length: 149 }, (_, i) => ({
+      role: "user" as const,
+      content: `old-${i}`,
+      messageId: `old-${i}`,
+      createdAt: i,
+    }))
+    mocks.get
+      .mockResolvedValueOnce({
+        markerMessageId: null,
+        summary: "",
+        history: existingHistory,
+        summarizing: true,
+        needsResummarize: false,
+        updatedAt: Date.now(),
+      })
+      .mockResolvedValueOnce(null)
+
+    await aiContextService.appendHistory({
+      conversationId: "conv-1",
+      newMessages: Array.from({ length: 5 }, (_, i) => ({
+        message: { role: "user" as const, content: `new-${i}` },
+        messageId: `new-${i}`,
+      })),
+    })
+
+    expect(mocks.update).toHaveBeenCalledTimes(1)
+    const [, updatePayload] = mocks.update.mock.calls[0] as [
+      string,
+      { history: Array<{ messageId?: string }> },
+    ]
+    // 149 existing + 5 new = 154, capped to 150 — the oldest 4 are dropped,
+    // the most recent messages (including all 5 new ones) are kept.
+    expect(updatePayload.history).toHaveLength(150)
+    expect(updatePayload.history.at(-1)?.messageId).toBe("new-4")
+    expect(updatePayload.history.some((m) => m.messageId === "old-0")).toBe(
+      false,
+    )
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: "conv-1",
+        historyLengthBeforeTruncate: 154,
+        hardCap: 150,
+        droppedCount: 4,
+      }),
+      expect.stringContaining("history exceeded hard cap"),
+    )
+    // Stuck-detection warn should still fire independently of the hard cap.
+    expect(mocks.loggerWarn).toHaveBeenCalled()
   })
 })

--- a/packages/ai/src/constants/index.ts
+++ b/packages/ai/src/constants/index.ts
@@ -151,5 +151,12 @@ export const aiPolicies = {
 export const toolPrefixes = z.enum(["file", "fn", "mcp", "sys"])
 
 export const MAX_CONVERSATION_HISTORY = 100
+// Absolute ceiling on cached AI context history, enforced unconditionally in
+// `appendHistory` regardless of summarizer health. Unlike
+// `MAX_CONVERSATION_HISTORY` (which only triggers a summarize job), this is
+// the last-resort guard against unbounded prompt growth if summarization is
+// ever stuck/broken — 50% headroom above the trigger point so it never clips
+// history while a healthy summarize job is still catching up asynchronously.
+export const MAX_CONVERSATION_HISTORY_HARD_CAP = 150
 export const MAX_SUMMARY_LENGTH = 1000
 export const AI_MESSAGE_HISTORY_LOOKBACK_MS = 365 * 24 * 60 * 60 * 1000

--- a/packages/ai/src/server/cache/schema.ts
+++ b/packages/ai/src/server/cache/schema.ts
@@ -4,6 +4,14 @@ export const aiMessageSchema = z.object({
   role: z.enum(["system", "user", "assistant", "tool"]),
   messageId: z.string().optional(),
   createdAt: z.number().int().optional(),
+  // Monotonic per-conversation append order, assigned once when the message
+  // is actually pushed into `history[]` (see `aiContextSchema.nextSeq`).
+  // Unlike `messageId` (which can fall back to a content hash and therefore
+  // collide between distinct messages with identical role/content/createdAt),
+  // `seq` is always unique — it's the authoritative identity for telling two
+  // history entries apart. Optional only for backward-compat with contexts
+  // cached before this field existed (24h Redis TTL).
+  seq: z.number().int().optional(),
   content: z.union([
     z.string(),
     z.array(
@@ -23,7 +31,15 @@ export const aiContextSchema = z.object({
   markerMessageId: z.string().nullable().default(null),
   summary: z.string().max(1000).default(""),
   history: z.array(aiMessageSchema).default([]),
+  // Next `seq` value to assign to a newly-appended history entry. Always
+  // `>= history.length`; kept as an explicit counter (not re-derived from
+  // history length) so `seq` stays unique even across truncation/removal.
+  nextSeq: z.number().int().default(0),
   summarizing: z.boolean().default(false),
+  // Set alongside `summarizing: true`; lets a summarize job self-heal from a
+  // worker crash that left `summarizing` stuck true with no process left to
+  // clear it (see `handleSummarizeConversation`'s stale-lock check).
+  summarizingStartedAt: z.number().nullable().default(null),
   needsResummarize: z.boolean().default(false),
   updatedAt: z.number().default(() => Date.now()),
 })

--- a/packages/ai/src/server/services/ai-context-service.ts
+++ b/packages/ai/src/server/services/ai-context-service.ts
@@ -16,6 +16,7 @@ import { normalizeError } from "universal-error-normalizer"
 import {
   AI_MESSAGE_HISTORY_LOOKBACK_MS,
   MAX_CONVERSATION_HISTORY,
+  MAX_CONVERSATION_HISTORY_HARD_CAP,
   MAX_SUMMARY_LENGTH,
 } from "../../constants"
 import { logger } from "../../logger"
@@ -67,10 +68,19 @@ function fallbackMessageId(props: {
     .digest("hex")
 }
 
-function isSameContextMessage(
+export function isSameContextMessage(
   existing: AIMessage,
   incoming: AIMessage,
 ): boolean {
+  // `seq` is assigned once, at append time, from a monotonic per-conversation
+  // counter — it can never collide between two distinct history entries,
+  // unlike `messageId`'s content-hash fallback below. Prefer it whenever both
+  // sides already have one (i.e. both are stored history entries, not a
+  // freshly-normalized incoming message still being deduped).
+  if (existing.seq !== undefined && incoming.seq !== undefined) {
+    return existing.seq === incoming.seq
+  }
+
   if (existing.messageId && incoming.messageId) {
     return existing.messageId === incoming.messageId
   }
@@ -266,7 +276,11 @@ export const aiContextService = {
             sinceTime,
           })
 
-          const aiHistory = this.mapDbMessagesToContext(dbMessages)
+          const aiHistoryUnseq = this.mapDbMessagesToContext(dbMessages)
+          const aiHistory = aiHistoryUnseq.map((msg, index) => ({
+            ...msg,
+            seq: index,
+          }))
           const modelMessages = this.mapContextToModelMessages(aiHistory)
 
           const summary =
@@ -282,6 +296,7 @@ export const aiContextService = {
             markerMessageId: conversation.aiContextLastMessageId,
             summary: summary.slice(0, MAX_SUMMARY_LENGTH),
             history: aiHistory,
+            nextSeq: aiHistory.length,
             summarizing: false,
             needsResummarize: false,
             updatedAt: Date.now(),
@@ -339,6 +354,7 @@ export const aiContextService = {
           )
           .filter((msg): msg is AIMessage => msg !== null)
 
+        let nextSeq = context.nextSeq
         let hasNewHistory = false
         for (const msg of normalizedNewMessages) {
           const isDuplicate = currentHistory.some((h) =>
@@ -346,7 +362,8 @@ export const aiContextService = {
           )
           if (!isDuplicate) {
             hasNewHistory = true
-            currentHistory.push(msg)
+            currentHistory.push({ ...msg, seq: nextSeq })
+            nextSeq += 1
           }
         }
 
@@ -354,11 +371,47 @@ export const aiContextService = {
           return await aiContextStore.get(conversationId)
         }
 
-        const shouldSummarize = currentHistory.length > MAX_CONVERSATION_HISTORY
+        // Last-resort guard: cap history unconditionally, independent of
+        // whether the summarize job (below) is healthy. If `summarizing` is
+        // stuck (bug, race, Redis hiccup during reset), this is what actually
+        // prevents unbounded prompt growth rather than just detecting it.
+        // Applied before the summarize-trigger check below so that check
+        // (and the persisted history) always agree on the same array.
+        let boundedHistory = currentHistory
+        if (currentHistory.length > MAX_CONVERSATION_HISTORY_HARD_CAP) {
+          const droppedCount =
+            currentHistory.length - MAX_CONVERSATION_HISTORY_HARD_CAP
+          boundedHistory = currentHistory.slice(
+            -MAX_CONVERSATION_HISTORY_HARD_CAP,
+          )
+          logger.error(
+            {
+              conversationId,
+              historyLengthBeforeTruncate: currentHistory.length,
+              hardCap: MAX_CONVERSATION_HISTORY_HARD_CAP,
+              droppedCount,
+            },
+            "[ai-context-service] history exceeded hard cap — the summarizer safety net already failed; truncating to protect the AI prompt from unbounded growth",
+          )
+        }
+
+        const shouldSummarize = boundedHistory.length > MAX_CONVERSATION_HISTORY
         const isSummarizing = context.summarizing === true
 
+        if (shouldSummarize && isSummarizing) {
+          logger.warn(
+            {
+              conversationId,
+              historyLength: boundedHistory.length,
+              maxConversationHistory: MAX_CONVERSATION_HISTORY,
+            },
+            "[ai-context-service] history exceeds cap while a summarize job is already marked in-flight — if this repeats across messages, the 'summarizing' flag is likely stuck and history is growing unbounded",
+          )
+        }
+
         await aiContextStore.update(conversationId, {
-          history: currentHistory,
+          history: boundedHistory,
+          nextSeq,
           needsResummarize: shouldSummarize && isSummarizing,
         })
 

--- a/packages/redis/__tests__/distributed-store.test.ts
+++ b/packages/redis/__tests__/distributed-store.test.ts
@@ -14,6 +14,34 @@ describe("distributedStoreFactory.exists", () => {
   })
 })
 
+describe("distributedStoreFactory.merge", () => {
+  test("writes an explicit null field instead of silently skipping it", async () => {
+    const hset = vi.fn(async () => 1)
+    const expire = vi.fn(async () => 1)
+    const store = distributedStoreFactory(
+      async () => ({ hset, expire }) as unknown as Redis,
+    )
+
+    await store.merge("ctx:conv-1", { summarizing: false, startedAt: null })
+
+    expect(hset).toHaveBeenCalledWith("ctx:conv-1", {
+      summarizing: "false",
+      startedAt: "null",
+    })
+  })
+
+  test("skips undefined fields — the 'don't touch this field' signal", async () => {
+    const hset = vi.fn(async () => 1)
+    const store = distributedStoreFactory(
+      async () => ({ hset }) as unknown as Redis,
+    )
+
+    await store.merge("ctx:conv-1", { a: 1, b: undefined })
+
+    expect(hset).toHaveBeenCalledWith("ctx:conv-1", { a: "1" })
+  })
+})
+
 describe("distributedStoreFactory.setNumber", () => {
   test("always writes via plain SET key val EX ttl (no NX)", async () => {
     const set = vi.fn(async () => "OK")

--- a/packages/redis/src/distributed-store.ts
+++ b/packages/redis/src/distributed-store.ts
@@ -157,6 +157,15 @@ export const distributedStoreFactory = (
     return result as T
   },
 
+  /**
+   * Partial hash update. A field with value `undefined` (or simply omitted
+   * from `value`) is left untouched — that's the "don't touch this field"
+   * signal a `Partial<T>` update relies on. A field explicitly set to `null`
+   * IS written (serialized as the JSON string `"null"`, which `hgetJson`
+   * parses back to `null`) — that's how a caller clears a nullable field
+   * back to its schema default; skipping it here would make every `null`
+   * write to an already-populated field a silent no-op.
+   */
   async merge<T extends Record<string, unknown>>(
     key: string,
     value: T,
@@ -166,7 +175,7 @@ export const distributedStoreFactory = (
     const serializedFields: Record<string, string> = {}
 
     for (const [field, fieldValue] of Object.entries(value)) {
-      if (fieldValue === null || fieldValue === undefined) {
+      if (fieldValue === undefined) {
         continue
       }
       serializedFields[field] = JSON.stringify(fieldValue)


### PR DESCRIPTION
**Summary**
Fixes AI agent replies getting progressively slower over long conversations. Root cause: when the summarize job failed, the summarizing flag was never reset, so appendHistory could never enqueue a new summarize job again — conversation history grew unbounded and every reply carried an ever-larger prompt. Also fixed post-summarize truncation slicing history by count instead of message identity, which could drop/keep the wrong messages when a new message arrived mid-summarize.

**Changes**
summarize-conversation.ts — reset summarizing: false on failure (under lock); filter remaining history by message identity instead of slicing.
ai-context-service.ts / constants/index.ts — add hard cap (150 msgs) as last-resort truncation guard; warn-log when the flag looks stuck.
replies.ts — log per-provider attempt duration (warn if >20s), log when all fallback providers fail or return empty; wire response-time tracking into the AI-agent reply path.
Tests added/updated for the above.