### PR TITLE
fix(ads): request the WhatsApp connect scope only for click-to-whatsapp

### DIFF
--- a/apps/builder/__tests__/messaging-ads-scopes.test.ts
+++ b/apps/builder/__tests__/messaging-ads-scopes.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest"
+import { messagingAdsScopesForChannel } from "@/features/ads-campaign/lib/messaging-ads-scopes"
+
+describe("messagingAdsScopesForChannel", () => {
+  test("whatsapp (CTWA) requests whatsapp_business_management", () => {
+    expect(messagingAdsScopesForChannel("whatsapp")).toContain(
+      "whatsapp_business_management",
+    )
+  })
+
+  test("messenger (CTM) does NOT request any WhatsApp scope", () => {
+    expect(messagingAdsScopesForChannel("messenger")).not.toContain(
+      "whatsapp_business_management",
+    )
+  })
+
+  test("instagram (CTID) adds instagram_basic but no WhatsApp scope", () => {
+    const scopes = messagingAdsScopesForChannel("instagram")
+    expect(scopes).toContain("instagram_basic")
+    expect(scopes).not.toContain("whatsapp_business_management")
+  })
+
+  test("every channel keeps the confirmed base ads/page scopes", () => {
+    for (const channel of ["whatsapp", "messenger", "instagram"] as const) {
+      const scopes = messagingAdsScopesForChannel(channel)
+      for (const base of [
+        "ads_read",
+        "ads_management",
+        "pages_manage_ads",
+        "pages_read_engagement",
+        "pages_show_list",
+      ]) {
+        expect(scopes).toContain(base)
+      }
+    }
+  })
+})

--- a/apps/builder/src/features/ads-campaign/lib/messaging-ads-scopes.ts
+++ b/apps/builder/src/features/ads-campaign/lib/messaging-ads-scopes.ts
@@ -3,17 +3,20 @@ import { FACEBOOK_ADS_SCOPES } from "@chatbotx.io/integration-facebook-ads"
 
 /**
  * Per-channel scope additions on top of the base `FACEBOOK_ADS_SCOPES` — v3
- * correction #1 (out/plan/ctwa-ctm-ctid-box-merge.md). The base list already
- * covers `pages_manage_ads`/`pages_read_engagement`/`pages_show_list`
- * (CTM/CTWA Page access) and `whatsapp_business_management` (CTWA,
- * Phase-0-pinned hypothesis) — only CTID needs an extra scope
- * (`instagram_basic`) to read the connected Instagram account's identity.
+ * correction #1 (out/plan/ctwa-ctm-ctid-box-merge.md). The base list covers
+ * `pages_manage_ads`/`pages_read_engagement`/`pages_show_list` (CTM/CTWA
+ * Page access). Channel extras:
+ * - whatsapp: `whatsapp_business_management` (Phase-0-pinned hypothesis for
+ *   CTWA promoted_object WhatsApp-number resolution) — WhatsApp-only so a
+ *   CTM/CTID connect never asks for a WhatsApp permission it does not use.
+ * - instagram: `instagram_basic` to read the connected Instagram account's
+ *   identity.
  */
 const MESSAGING_ADS_EXTRA_SCOPES: Record<
   MessagingAdChannel,
   readonly string[]
 > = {
-  whatsapp: [],
+  whatsapp: ["whatsapp_business_management"],
   messenger: [],
   instagram: ["instagram_basic"],
 }

--- a/integrations/facebook-ads/__tests__/audience-users.test.ts
+++ b/integrations/facebook-ads/__tests__/audience-users.test.ts
@@ -174,7 +174,7 @@ describe("generateAdsAuthUrl", () => {
 
     expect(url.origin).toBe("https://www.facebook.com")
     expect(url.searchParams.get("scope")).toBe(
-      "ads_read,ads_management,pages_manage_ads,pages_read_engagement,pages_show_list,whatsapp_business_management",
+      "ads_read,ads_management,pages_manage_ads,pages_read_engagement,pages_show_list",
     )
     expect(url.searchParams.get("client_id")).toBe("client-1")
     expect(

--- a/integrations/facebook-ads/src/constants.ts
+++ b/integrations/facebook-ads/src/constants.ts
@@ -8,13 +8,14 @@ export const DEFAULT_API_VERSION = "v23.0"
  * create CTM/CTID/CTWA ads (page_id/instagram_actor_id in object_story_spec,
  * promoted_object.page_id, page_welcome_message). `pages_manage_ads` /
  * `pages_read_engagement` / `pages_show_list` are confirmed required by the
- * CTM/CTID guide. `whatsapp_business_management` is a Phase-0 HYPOTHESIS for
- * CTWA's promoted_object WhatsApp-number resolution — out/plan/ctwa-ads-manager.md
- * "CTWA prerequisite/asset linkage" — kept here so the OAuth consent screen
- * asks once, but the real CTWA gate is the (ad account, Page, WABA, phone
- * number) tuple-authorization check in Phase 0, not this scope alone.
- * // Phase 0 confirm: verify all 4 scopes are actually granted/required against
- * a live v23.0 token before removing this comment.
+ * CTM/CTID guide.
+ *
+ * CHANNEL-SPECIFIC scopes do NOT belong here: `whatsapp_business_management`
+ * (CTWA-only, Phase-0 hypothesis for promoted_object WhatsApp-number
+ * resolution) lives in the per-channel additions map
+ * (`messaging-ads-scopes.ts` `MESSAGING_ADS_EXTRA_SCOPES.whatsapp`) so a
+ * CTM/CTID connect never asks the user for a WhatsApp permission it does not
+ * use.
  */
 export const FACEBOOK_ADS_SCOPES = [
   "ads_read",
@@ -22,7 +23,6 @@ export const FACEBOOK_ADS_SCOPES = [
   "pages_manage_ads",
   "pages_read_engagement",
   "pages_show_list",
-  "whatsapp_business_management",
 ]
 
 /** Facebook caps `limit` at 500 for these edges; 499 mirrors the legacy product. */


### PR DESCRIPTION
## Summary

The messaging-ads connect flow (per-integration Meta OAuth for CTWA/CTM/CTID) requested `whatsapp_business_management` for **every** channel, because the scope sat in the shared base scope list. A Click-to-Messenger or Click-to-Instagram connect therefore asked the user to grant a WhatsApp permission it never uses — confusing on the consent screen and harder to justify in App Review.

- `whatsapp_business_management` moves out of the base `FACEBOOK_ADS_SCOPES` into the existing per-channel additions map (`MESSAGING_ADS_EXTRA_SCOPES.whatsapp`), alongside CTID's `instagram_basic`.
- Click-to-WhatsApp connects (and reconnects) still request the scope; Messenger/Instagram connects request only the confirmed ads/pages scopes.
- The workspace-wide Facebook Ads OAuth (dashboard insights, custom audiences) also stops requesting it — nothing on that path uses it.
- Already-connected integrations are unaffected: existing tokens keep their granted permissions.

## Changes

- `integrations/facebook-ads/src/constants.ts` — drop the channel-specific scope from the shared base list.
- `apps/builder/src/features/ads-campaign/lib/messaging-ads-scopes.ts` — add it to the WhatsApp entry of the per-channel scope map.
- `apps/builder/__tests__/messaging-ads-scopes.test.ts` — per-channel scope coverage (WhatsApp has it, Messenger/Instagram don't, base scopes everywhere).
- `integrations/facebook-ads/__tests__/audience-users.test.ts` — updated OAuth scope-string assertion.

## Test plan

- [x] `pnpm --filter @chatbotx.io/integration-facebook-ads test` (59 passed)
- [x] `pnpm --filter builder test messaging-ads-scopes connect-redirect`
- [x] `pnpm --filter builder check-types`, lint clean on changed files
- [ ] Manual: start a CTM connect and confirm the Meta consent screen no longer lists WhatsApp business management
- [ ] Manual: start a CTWA connect and confirm the scope is still requested
