### PR TITLE
feat(inbox): add private reply and fix Instagram/Messenger delivery gaps

### DIFF
--- a/apps/builder/messages/ar.json
+++ b/apps/builder/messages/ar.json
@@ -2925,6 +2925,7 @@
     "disconnectFeatureDescription": "هل أنت متأكد من رغبتك في قطع اتصال {feature}؟",
     "disconnectSuccess": "تم قطع اتصال {feature} بنجاح",
     "reply": "رد",
+    "privateReply": "رد خاص",
     "viewMessage": "عرض الرسالة",
     "changeLikeState": "تغيير حالة الإعجاب",
     "changeHideState": "تغيير حالة الإخفاء",

--- a/apps/builder/messages/da.json
+++ b/apps/builder/messages/da.json
@@ -2925,6 +2925,7 @@
     "disconnectFeatureDescription": "Er du sikker du want til afbryd den {feature}?",
     "disconnectSuccess": "{feature} disconnected successfully",
     "reply": "Svar",
+    "privateReply": "Privat svar",
     "viewMessage": "Vis besked",
     "changeLikeState": "Change like state",
     "changeHideState": "Change hide state",

--- a/apps/builder/messages/de.json
+++ b/apps/builder/messages/de.json
@@ -2925,6 +2925,7 @@
     "disconnectFeatureDescription": "Möchten Sie die Verbindung mit {feature} wirklich trennen?",
     "disconnectSuccess": "Verbindung mit {feature} erfolgreich getrennt",
     "reply": "Antworten",
+    "privateReply": "Private Antwort",
     "viewMessage": "Nachricht anzeigen",
     "changeLikeState": "Gefällt-mir-Status ändern",
     "changeHideState": "Sichtbarkeitsstatus ändern",

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -3039,6 +3039,7 @@
     "disconnectFeatureDescription": "Are you sure you want to disconnect the {feature}?",
     "disconnectSuccess": "{feature} disconnected successfully",
     "reply": "Reply",
+    "privateReply": "Private reply",
     "viewMessage": "View message",
     "changeLikeState": "Change like state",
     "changeHideState": "Change hide state",

--- a/apps/builder/messages/es.json
+++ b/apps/builder/messages/es.json
@@ -2925,6 +2925,7 @@
     "disconnectFeatureDescription": "Are tú sure tú want un Desconectar el {feature}?",
     "disconnectSuccess": "{feature} disconnected correctamente",
     "reply": "Respuesta",
+    "privateReply": "Respuesta privada",
     "viewMessage": "View mensaje",
     "changeLikeState": "Cambiar estado de Me gusta",
     "changeHideState": "Cambiar estado de visibilidad",

--- a/apps/builder/messages/fi.json
+++ b/apps/builder/messages/fi.json
@@ -2925,6 +2925,7 @@
     "disconnectFeatureDescription": "Haluatko varmasti katkaista kohteen {feature} yhteyden?",
     "disconnectSuccess": "Kohteen {feature} yhteys katkaistiin",
     "reply": "Vastaa",
+    "privateReply": "Yksityinen vastaus",
     "viewMessage": "Näytä viesti",
     "changeLikeState": "Vaihda tykkäystilaa",
     "changeHideState": "Vaihda piilotustilaa",

--- a/apps/builder/messages/fr.json
+++ b/apps/builder/messages/fr.json
@@ -2925,6 +2925,7 @@
     "disconnectFeatureDescription": "Voulez-vous vraiment déconnecter {feature} ?",
     "disconnectSuccess": "{feature} déconnecté",
     "reply": "Répondre",
+    "privateReply": "Réponse privée",
     "viewMessage": "Afficher le message",
     "changeLikeState": "Modifier l’état J’aime",
     "changeHideState": "Modifier l’état masqué",

--- a/apps/builder/messages/he.json
+++ b/apps/builder/messages/he.json
@@ -1153,6 +1153,7 @@
     "disconnectFeatureDescription": "האם לנתק את {feature}?",
     "disconnectSuccess": "{feature} נותק בהצלחה",
     "reply": "תשובה",
+    "privateReply": "תגובה פרטית",
     "viewMessage": "הצגת הודעה",
     "changeLikeState": "שינוי מצב לייק",
     "changeHideState": "שינוי מצב הסתרה",

--- a/apps/builder/messages/id.json
+++ b/apps/builder/messages/id.json
@@ -2925,6 +2925,7 @@
     "disconnectFeatureDescription": "Apakah Anda yakin ingin memutuskan {feature}?",
     "disconnectSuccess": "{feature} berhasil diputuskan",
     "reply": "Balas",
+    "privateReply": "Balasan pribadi",
     "viewMessage": "Lihat pesan",
     "changeLikeState": "Ubah status suka",
     "changeHideState": "Ubah status sembunyikan",

--- a/apps/builder/messages/it.json
+++ b/apps/builder/messages/it.json
@@ -2925,6 +2925,7 @@
     "disconnectFeatureDescription": "Vuoi davvero disconnettere {feature}?",
     "disconnectSuccess": "{feature} disconnesso correttamente",
     "reply": "Rispondi",
+    "privateReply": "Risposta privata",
     "viewMessage": "Visualizza messaggio",
     "changeLikeState": "Cambia stato del Mi piace",
     "changeHideState": "Cambia stato di visibilità",

--- a/apps/builder/messages/ja.json
+++ b/apps/builder/messages/ja.json
@@ -2904,6 +2904,7 @@
     "disconnectFeatureDescription": "{feature}を切断してもよろしいですか？",
     "disconnectSuccess": "{feature}を切断しました",
     "reply": "返信",
+    "privateReply": "プライベート返信",
     "viewMessage": "メッセージを表示",
     "changeLikeState": "「いいね！」の状態を変更",
     "changeHideState": "非表示状態を変更",

--- a/apps/builder/messages/nl.json
+++ b/apps/builder/messages/nl.json
@@ -2925,6 +2925,7 @@
     "disconnectFeatureDescription": "Weet je zeker dat je {feature} wilt loskoppelen?",
     "disconnectSuccess": "{feature} losgekoppeld",
     "reply": "Beantwoorden",
+    "privateReply": "Privé antwoord",
     "viewMessage": "Bericht bekijken",
     "changeLikeState": "Vind-ik-leukstatus wijzigen",
     "changeHideState": "Verbergstatus wijzigen",

--- a/apps/builder/messages/pt-BR.json
+++ b/apps/builder/messages/pt-BR.json
@@ -2904,6 +2904,7 @@
     "disconnectFeatureDescription": "Tem certeza de que deseja desconectar {feature}?",
     "disconnectSuccess": "{feature} desconectado com sucesso",
     "reply": "Responder",
+    "privateReply": "Resposta privada",
     "viewMessage": "Ver mensagem",
     "changeLikeState": "Alterar estado da curtida",
     "changeHideState": "Alterar estado de ocultação",

--- a/apps/builder/messages/pt-PT.json
+++ b/apps/builder/messages/pt-PT.json
@@ -2925,6 +2925,7 @@
     "disconnectFeatureDescription": "Tem a certeza de que pretende desligar {feature}?",
     "disconnectSuccess": "{feature} desligado com sucesso",
     "reply": "Responder",
+    "privateReply": "Resposta privada",
     "viewMessage": "Ver mensagem",
     "changeLikeState": "Alterar estado do gosto",
     "changeHideState": "Alterar estado de ocultação",

--- a/apps/builder/messages/ro.json
+++ b/apps/builder/messages/ro.json
@@ -2925,6 +2925,7 @@
     "disconnectFeatureDescription": "Ești sigur că vrei să deconectezi {feature}?",
     "disconnectSuccess": "{feature} deconectat cu succes",
     "reply": "Răspunde",
+    "privateReply": "Răspuns privat",
     "viewMessage": "Vezi mesajul",
     "changeLikeState": "Schimbă starea de apreciere",
     "changeHideState": "Schimbă starea de ascundere",

--- a/apps/builder/messages/sv.json
+++ b/apps/builder/messages/sv.json
@@ -3509,6 +3509,7 @@
     "noVersionsFound": "Inga publicerade versioner hittades",
     "poweredBy": "Drivs av {name}",
     "publishVersionSuccess": "En ny version har publicerats",
+    "privateReply": "Privat svar",
     "redoHistoryCleared": "Historiken för Gör om har rensats",
     "refreshTokenSuccessfully": "Token för {feature} har uppdaterats",
     "repliedToStory": "Svarade på din story",

--- a/apps/builder/messages/tr.json
+++ b/apps/builder/messages/tr.json
@@ -2925,6 +2925,7 @@
     "disconnectFeatureDescription": "{feature} bağlantısını kesmek istediğinizden emin misiniz?",
     "disconnectSuccess": "{feature} bağlantısı başarıyla kesildi",
     "reply": "Yanıtla",
+    "privateReply": "Özel yanıt",
     "viewMessage": "Mesajı görüntüle",
     "changeLikeState": "Beğeni durumunu değiştir",
     "changeHideState": "Gizleme durumunu değiştir",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -2925,6 +2925,7 @@
     "disconnectFeatureDescription": "Bạn có chắc chắn muốn ngắt kết nối {feature}?",
     "disconnectSuccess": "Đã ngắt kết nối {feature} thành công",
     "reply": "Trả lời",
+    "privateReply": "Trả lời riêng tư",
     "viewMessage": "Xem tin nhắn",
     "changeLikeState": "Thay đổi trạng thái thích",
     "changeHideState": "Thay đổi trạng thái ẩn",

--- a/apps/builder/messages/zh-CN.json
+++ b/apps/builder/messages/zh-CN.json
@@ -3507,6 +3507,7 @@
     "none": "无",
     "poweredBy": "由 {name} 提供技术支持",
     "publishVersionSuccess": "新版本已发布",
+    "privateReply": "私信回复",
     "redoHistoryCleared": "重做历史记录已清除",
     "refreshTokenSuccessfully": "{feature} 权杖更新成功",
     "repliedToStory": "回复了你的故事",

--- a/apps/builder/messages/zh-TW.json
+++ b/apps/builder/messages/zh-TW.json
@@ -1451,6 +1451,7 @@
     "disconnectFeatureDescription": "您確定要中斷 {feature} 的連線嗎？",
     "disconnectSuccess": "{feature} 已中斷連線",
     "reply": "回覆",
+    "privateReply": "私訊回覆",
     "viewMessage": "檢視訊息",
     "changeLikeState": "更改類似狀態",
     "changeHideState": "更改隱藏狀態",

--- a/apps/builder/src/features/chat/store/chat-store.ts
+++ b/apps/builder/src/features/chat/store/chat-store.ts
@@ -53,6 +53,9 @@ export type ChatState = {
 
   // message reply selection
   replyToMessage: MessageResourceWithRelations | null
+  // true when replyToMessage should be sent as a private-reply DM instead of
+  // a public comment reply
+  isPrivateReply: boolean
 
   // active facebook post (for comment conversations)
   activePost: PostDetails | null
@@ -113,7 +116,10 @@ export type ChatActions = {
   ) => void
   loadMoreMessages: (workspaceId: string, perPage: number) => Promise<void>
   handleNewMessage: (message: MessageResourceWithRelations) => void
-  setReplyToMessage: (message: MessageResourceWithRelations | null) => void
+  setReplyToMessage: (
+    message: MessageResourceWithRelations | null,
+    isPrivate?: boolean,
+  ) => void
 
   // Post actions
   loadActivePost: (workspaceId: string) => Promise<void>
@@ -169,6 +175,7 @@ export const createChatStore = () => {
     isLoadMoreMessage: false,
     hasNextMessagePage: true,
     replyToMessage: null,
+    isPrivateReply: false,
     activePost: null,
 
     prependConversation: (newConversation: ListConversationItemResource) =>
@@ -314,6 +321,7 @@ export const createChatStore = () => {
           hasNextMessagePage: true,
           isLoadMoreMessage: false,
           replyToMessage: null,
+          isPrivateReply: false,
           activePost: null,
         })
       }
@@ -406,7 +414,11 @@ export const createChatStore = () => {
       }
     },
 
-    setReplyToMessage: (message) => set({ replyToMessage: message }),
+    setReplyToMessage: (message, isPrivate = false) =>
+      set({
+        replyToMessage: message,
+        isPrivateReply: message ? isPrivate : false,
+      }),
 
     appendMessage: (message: MessageResourceWithRelations) => {
       const { updateConversationViaMessage } = get()

--- a/apps/builder/src/features/messages/actions/create-message.action.ts
+++ b/apps/builder/src/features/messages/actions/create-message.action.ts
@@ -2,6 +2,7 @@
 
 import {
   contactInboxService,
+  conversationService,
   resolveTenantSettings,
 } from "@chatbotx.io/business"
 import { ChatbotXException } from "@chatbotx.io/business/errors"
@@ -102,11 +103,24 @@ export const createMessage = async (props: {
     workspaceId: conversation.workspaceId,
   })
 
+  // A private reply is a DM to the commenter, not a reply within the
+  // post/comment thread — Meta delivers it to the contact's inbox, not the
+  // post. Route the outgoing message row (and its conversation-scoped side
+  // effects below) to the contact's DM conversation instead of whichever
+  // conversation is currently open, creating it if this is their first DM.
+  const targetConversation = parsedInput.isPrivateReply
+    ? await conversationService.findOrCreate({
+        workspaceId: conversation.workspaceId,
+        contactId: contactInbox.contactId,
+        sourceId: null,
+      })
+    : conversation
+
   let uploadedFiles: UploadedFile[] = []
   if ("files" in parsedInput && parsedInput.files.length > 0) {
     uploadedFiles = await uploadMultipleFiles(
       parsedInput.files,
-      `public/space/${conversation.workspaceId}/conversations/${conversation.id}`,
+      `public/space/${conversation.workspaceId}/conversations/${targetConversation.id}`,
     )
   } else if ("mediaFile" in parsedInput && parsedInput.mediaFile) {
     const mediaLibraryFile = await findMediaLibraryFileByPath({
@@ -122,7 +136,7 @@ export const createMessage = async (props: {
     // file they were picked from, since deleting that file (or its folder)
     // later must not break an already-sent message.
     const attachmentPath = pathJoin(
-      `public/space/${conversation.workspaceId}/conversations/${conversation.id}`,
+      `public/space/${conversation.workspaceId}/conversations/${targetConversation.id}`,
       createId(),
     )
     await uploader.copyObject(mediaLibraryFile.path, attachmentPath)
@@ -147,7 +161,7 @@ export const createMessage = async (props: {
     text: "text" in parsedInput ? parsedInput.text : null,
     messageType: "outgoing" as const,
     workspaceId: conversation.workspaceId,
-    conversationId: conversation.id,
+    conversationId: targetConversation.id,
     senderType: user ? ("user" as const) : ("api" as const),
     senderId: user?.id ?? null,
     contactInboxId: contactInbox.id,
@@ -157,12 +171,14 @@ export const createMessage = async (props: {
       ? ("comment" as const)
       : ("message" as const),
     parentId,
-    contentAttributes: null,
+    contentAttributes: parsedInput.isPrivateReply
+      ? { isPrivateReply: true }
+      : null,
   }
 
   const attachmentInputs = uploadedFiles.map((file) => ({
     workspaceId: conversation.workspaceId,
-    conversationId: conversation.id,
+    conversationId: targetConversation.id,
     ...file,
   }))
 
@@ -178,7 +194,7 @@ export const createMessage = async (props: {
       lastActivityAt: now,
       adminRepliedAt: now,
     })
-    .where(eq(conversationModel.id, conversation.id))
+    .where(eq(conversationModel.id, targetConversation.id))
 
   await contactInboxService.updateTracking({
     contactInboxId: contactInbox.id,
@@ -219,7 +235,7 @@ export const createMessage = async (props: {
     chatQueue.add(ChatJobAction.sendChannelMessage, {
       type: ChatJobAction.sendChannelMessage,
       data: {
-        conversation,
+        conversation: targetConversation,
         contactInbox,
         message: {
           ...messageWithAttachments,
@@ -234,7 +250,7 @@ export const createMessage = async (props: {
           chatQueue.add(ChatJobAction.checkOutboundAutomatedResponse, {
             type: ChatJobAction.checkOutboundAutomatedResponse,
             data: {
-              conversation,
+              conversation: targetConversation,
               contactInbox,
               message: { id: message.id, text: messageInput.text },
             },

--- a/apps/builder/src/features/messages/components/message-input.tsx
+++ b/apps/builder/src/features/messages/components/message-input.tsx
@@ -20,6 +20,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hooks"
 import {
   ImageIcon,
+  LockIcon,
   PaperclipIcon,
   ReplyIcon,
   SendHorizonalIcon,
@@ -82,6 +83,7 @@ export const MessageInput = () => {
     updateConversation,
     replyToMessage,
     setReplyToMessage,
+    isPrivateReply,
     messages,
   } = useChatStore((state) => state)
 
@@ -136,12 +138,19 @@ export const MessageInput = () => {
       {
         actionProps: {
           onExecute: ({ input }: { input: unknown }) => {
-            // try to push raw message to store
+            // try to push raw message to store — skipped for a private
+            // reply, since that message belongs to the contact's DM
+            // conversation, not whichever post/comment conversation is
+            // currently open here.
             if (
               typeof input === "object" &&
               input !== null &&
               "text" in input &&
-              input.text
+              input.text &&
+              !(
+                "isPrivateReply" in input &&
+                (input as { isPrivateReply?: boolean }).isPrivateReply
+              )
             ) {
               const typedInput = input as { text: string; clientId: string }
               appendMessage({
@@ -188,6 +197,7 @@ export const MessageInput = () => {
             clientId: createId(),
             replyToMessageId: undefined,
             replyToMessageCreatedAt: undefined,
+            isPrivateReply: undefined,
           },
         },
         errorMapProps: {},
@@ -201,10 +211,11 @@ export const MessageInput = () => {
       "replyToMessageCreatedAt",
       replyToMessage?.createdAt ?? undefined,
     )
+    form.setValue("isPrivateReply", replyToMessage ? isPrivateReply : undefined)
     if (replyToMessage) {
       textareaRef.current?.focus()
     }
-  }, [form, replyToMessage])
+  }, [form, replyToMessage, isPrivateReply])
 
   // Memoize emoji selection handler
   const setContent = useCallback(
@@ -455,8 +466,17 @@ export const MessageInput = () => {
         >
           {replyToMessage && (
             <div className="mx-2.5 mb-1 flex items-start gap-2 rounded-lg border-primary bg-muted px-3 py-2 text-sm">
-              <ReplyIcon className="mt-0.5 size-3.5 shrink-0 text-primary" />
+              {isPrivateReply ? (
+                <LockIcon className="mt-0.5 size-3.5 shrink-0 text-primary" />
+              ) : (
+                <ReplyIcon className="mt-0.5 size-3.5 shrink-0 text-primary" />
+              )}
               <span className="flex-1 truncate text-muted-foreground">
+                {isPrivateReply && (
+                  <span className="me-1 font-medium text-foreground">
+                    {t("messages.privateReply")}:
+                  </span>
+                )}
                 {replyToMessage.text || t("messages.facebookComment")}
               </span>
               <Button

--- a/apps/builder/src/features/messages/components/message-item.tsx
+++ b/apps/builder/src/features/messages/components/message-item.tsx
@@ -31,6 +31,7 @@ import {
   BotIcon,
   ExternalLinkIcon,
   ImageIcon,
+  LockIcon,
   PaperclipIcon,
   ReplyIcon,
   ThumbsUp,
@@ -71,6 +72,7 @@ type MessageItemProps = {
   }) => void
   onPostback?: (button: MessageButtonTemplate) => void
   onReply?: (comment: { commentId: string; text: string }) => void
+  onPrivateReply?: (comment: { commentId: string; text: string }) => void
 }
 
 export const MessageItem = (props: MessageItemProps) => {
@@ -81,6 +83,7 @@ export const MessageItem = (props: MessageItemProps) => {
     onChangeLike,
     onChangeHide,
     onReply,
+    onPrivateReply,
     onDelete,
     onEdit,
   } = props
@@ -250,6 +253,36 @@ export const MessageItem = (props: MessageItemProps) => {
             >
               <ReplyIcon className="size-4" />
             </Button>
+          )}
+
+        {isComment &&
+          !isEditing &&
+          onPrivateReply &&
+          message.messageType === "incoming" &&
+          message.sourceId && (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    className="self-center opacity-0 transition-opacity group-hover:opacity-100"
+                    onClick={() =>
+                      onPrivateReply({
+                        commentId: message.sourceId as string,
+                        text: message.text ?? "",
+                      })
+                    }
+                    size="icon"
+                    type="button"
+                    variant="ghost"
+                  >
+                    <LockIcon className="size-4" />
+                  </Button>
+                }
+              />
+              <TooltipContent>
+                <p>{t("privateReply")}</p>
+              </TooltipContent>
+            </Tooltip>
           )}
 
         {isComment && !isEditing && (

--- a/apps/builder/src/features/messages/message-list.tsx
+++ b/apps/builder/src/features/messages/message-list.tsx
@@ -110,6 +110,16 @@ export function MessageList() {
     }
   }
 
+  const handlePrivateReplyComment = (comment: {
+    commentId: string
+    text: string
+  }) => {
+    const message = messages.find((m) => m.sourceId === comment.commentId)
+    if (message) {
+      setReplyToMessage(message, true)
+    }
+  }
+
   const handleDeleteComment = ({
     id,
     createdAt,
@@ -250,6 +260,7 @@ export function MessageList() {
               })
             }}
             onEdit={handleEditMessage}
+            onPrivateReply={handlePrivateReplyComment}
             onReply={handleReplyComment}
           />
         )}

--- a/apps/builder/src/features/messages/schema/mutation.ts
+++ b/apps/builder/src/features/messages/schema/mutation.ts
@@ -58,6 +58,9 @@ export const createMessageRequest = z
       clientId: zodBigintAsString().optional(),
       replyToMessageId: z.string().optional(),
       replyToMessageCreatedAt: z.coerce.date().optional(),
+      // When true, the outgoing comment is sent as a comment-anchored private
+      // reply DM instead of a public comment reply.
+      isPrivateReply: z.boolean().optional(),
     }),
   )
 export type CreateMessageRequest = z.infer<typeof createMessageRequest>

--- a/apps/worker/src/chat/handlers/send-message.ts
+++ b/apps/worker/src/chat/handlers/send-message.ts
@@ -101,17 +101,29 @@ export async function sendMessageToChannel(
       },
     }
 
-    const result = isComment
-      ? await integration.runChannelHandler(
-          "comment",
-          "sendComment",
-          handlerData,
-        )
-      : await integration.runChannelHandler(
-          "message",
-          "sendMessage",
-          handlerData,
-        )
+    const isPrivateReply =
+      isComment && handlerMessage.contentAttributes?.isPrivateReply === true
+
+    let result: Awaited<ReturnType<typeof integration.runChannelHandler>>
+    if (isPrivateReply) {
+      result = await integration.runChannelHandler(
+        "comment",
+        "sendPrivateReply",
+        handlerData,
+      )
+    } else if (isComment) {
+      result = await integration.runChannelHandler(
+        "comment",
+        "sendComment",
+        handlerData,
+      )
+    } else {
+      result = await integration.runChannelHandler(
+        "message",
+        "sendMessage",
+        handlerData,
+      )
+    }
 
     if (isComment) {
       // When the outgoing message is a comment reply, store the Facebook comment

--- a/apps/worker/src/integration/handlers/received-message.ts
+++ b/apps/worker/src/integration/handlers/received-message.ts
@@ -72,6 +72,8 @@ import {
   chatQueue,
   IntegrationJobAction,
   type IntegrationJobDeleteIncomingComment,
+  type IntegrationJobDeleteIncomingMessage,
+  type IntegrationJobMessageReaction,
   type IntegrationJobReceiveComment,
   type IntegrationJobReceiveMessage,
   type IntegrationJobUpdateIncomingComment,
@@ -1040,6 +1042,44 @@ export const deleteIncomingComment = async (
   }
 }
 
+// When a contact unsends a previously-sent DM, soft-delete it in the DB and
+// broadcast the deletion to the inbox — mirrors deleteIncomingComment, keyed
+// on the message's `mid` (already stored as Message.sourceId, see
+// saveAndBroadcastMessage above).
+export const deleteIncomingMessage = async (
+  props: IntegrationJobDeleteIncomingMessage["data"],
+): Promise<void> => {
+  const { integrationType, integrationIdentifier, messageId } = props
+
+  const { inbox } =
+    await integrationService.identifyInboxAndIntegrationAuthFromIdentifier(
+      integrationType as IntegrationType,
+      integrationIdentifier,
+    )
+
+  const repository = await createMessageRepository()
+  const deleted = await repository.deleteBySourceId(
+    messageId,
+    inbox.workspaceId,
+    new Date(),
+  )
+
+  if (deleted.length === 0) {
+    logger.warn({ messageId }, "deleteIncomingMessage: message not found")
+    return
+  }
+
+  const messageIds = deleted.map((row) => row.id)
+  try {
+    await broadcastToWorkspaceParty(inbox.workspaceId, {
+      eventType: RealtimeEventType.messageDeleted,
+      data: { messageIds },
+    })
+  } catch (error) {
+    logger.warn(error, "deleteIncomingMessage: unable to broadcast")
+  }
+}
+
 type ContactInboxWithContact = ContactInboxModel & { contact: ContactModel }
 
 type ContactInboxResolverProps = {
@@ -1061,6 +1101,117 @@ const resolveExistingContactInbox = async ({
       with: { contact: true },
     }),
   )
+
+// When a contact reacts (or removes a reaction) to a DM, record it as an
+// activity-type message in the conversation timeline. A reaction only ever
+// happens within an existing conversation, so — unlike a real inbound
+// message — a reaction from an unrecognized contact is skipped rather than
+// creating a new contact, and never consumes MAC quota.
+export const processMessageReaction = async (
+  props: IntegrationJobMessageReaction["data"],
+): Promise<void> => {
+  const {
+    integrationType,
+    integrationIdentifier,
+    messageId,
+    action,
+    emoji,
+    contactSourceId,
+  } = props
+
+  const { inbox } =
+    await integrationService.identifyInboxAndIntegrationAuthFromIdentifier(
+      integrationType as IntegrationType,
+      integrationIdentifier,
+    )
+
+  const existingContactInbox = await resolveExistingContactInbox({
+    inbox,
+    incomingContact: { sourceId: contactSourceId },
+  })
+  if (!existingContactInbox) {
+    logger.warn(
+      { contactSourceId, messageId },
+      "processMessageReaction: contact not found — skipping",
+    )
+    return
+  }
+
+  const conversation = await conversationService.findOrCreate({
+    workspaceId: inbox.workspaceId,
+    contactId: existingContactInbox.contactId,
+    sourceId: null,
+  })
+
+  // Deliberately bypasses saveAndBroadcastMessage: that helper treats any
+  // non-"outgoing" messageType as a genuine inbound message, which would
+  // refresh ContactInbox.lastIncomingMessageAt (corrupting the messaging-window
+  // check) and fire the unconditional message:received event that MAC billing
+  // and ads-conversion listeners consume with no way to exclude an activity
+  // row. A reaction only ever inserts/updates one lightweight activity
+  // message — persist + broadcast, nothing else.
+  const repository = await createMessageRepository()
+  // Stable (no wall-clock component) so a BullMQ retry of this same job
+  // upserts the same activity row instead of creating a duplicate. Must not
+  // reuse the reacted-to message's mid: that would collide with
+  // createOrUpdate's dedup-by-sourceId and corrupt the original message.
+  const reactionSourceId = `${messageId}-reaction-${action}`
+  const reactionText =
+    action === "react"
+      ? `Reacted${emoji ? ` ${emoji}` : ""}`
+      : "Removed a reaction"
+
+  const { message: reactionRow, isNew } = await repository.createOrUpdate({
+    id: createId(),
+    conversationId: conversation.id,
+    contactInboxId: existingContactInbox.id,
+    workspaceId: inbox.workspaceId,
+    senderType: "contact",
+    senderId: existingContactInbox.contactId,
+    sourceId: reactionSourceId,
+    messageType: messageTypes.enum.activity,
+    contentType: contentTypes.enum.text,
+    text: reactionText,
+    createdAt: new Date(),
+  })
+
+  if (isNew) {
+    try {
+      broadcastToWorkspaceParty(inbox.workspaceId, {
+        eventType: RealtimeEventType.messageCreated,
+        data: reactionRow,
+      })
+    } catch (error) {
+      logger.warn(error, "processMessageReaction: unable to broadcast")
+    }
+    return
+  }
+
+  // Same action reused within createOrUpdate's dedup window (e.g. a changed
+  // emoji) — update the existing row instead of silently ignoring it.
+  if (reactionRow.text !== reactionText) {
+    const updated = await repository.updateMessageText(
+      reactionRow.id,
+      inbox.workspaceId,
+      reactionText,
+      reactionRow.createdAt,
+    )
+    if (updated) {
+      try {
+        broadcastToWorkspaceParty(inbox.workspaceId, {
+          eventType: RealtimeEventType.messageUpdated,
+          data: {
+            messageId: updated.id,
+            newText: reactionText,
+            removedAttachment: false,
+          },
+        })
+      } catch (error) {
+        logger.warn(error, "processMessageReaction: unable to broadcast update")
+      }
+    }
+  }
+}
 
 // Shared by the direct-hit path and the unique-violation race recovery below
 // (D8): syncs newly-learned identity fields onto the matched row, then
@@ -1382,10 +1533,18 @@ const createNewContactAndContactInbox = async (props: {
     // The MAC (billing) cap is a deterministic business outcome, not a
     // transient failure: retrying never succeeds. Throw UnrecoverableError so
     // BullMQ fails the job once without retry/backoff instead of dead-lettering
-    // the inbound message after exhausting attempts. Logged at `warn` so the
-    // cap is observable without paging on expected behavior.
-    logger.warn(
-      { workspaceId: inbox.workspaceId, ownerId: ws.ownerId },
+    // the inbound message after exhausting attempts. Logged at `error` (with
+    // enough context to identify the dropped contact) so a brand-new
+    // contact's first-ever message being silently dropped is discoverable via
+    // alerting, not just the account-level MAC banner (which only reflects
+    // the aggregate cap, not this specific drop).
+    logger.error(
+      {
+        workspaceId: inbox.workspaceId,
+        ownerId: ws.ownerId,
+        channel: inbox.channel,
+        sourceId: incomingContact.sourceId,
+      },
       "Inbound new-contact rejected: MAC limit reached",
     )
     throw new UnrecoverableError("contact_mac_limit_reached")

--- a/apps/worker/src/integration/worker.ts
+++ b/apps/worker/src/integration/worker.ts
@@ -43,6 +43,8 @@ import { handleMessageStatus } from "./handlers/message-status"
 import { handleSendMetaCapiEvent } from "./handlers/meta-conversions/send-meta-capi-event"
 import {
   deleteIncomingComment,
+  deleteIncomingMessage,
+  processMessageReaction,
   receiveComment,
   receiveMessage,
   updateIncomingComment,
@@ -195,6 +197,14 @@ async function startIntegrationWorker() {
               }
               case IntegrationJobAction.deleteIncomingComment: {
                 await deleteIncomingComment(job.data.data)
+                return
+              }
+              case IntegrationJobAction.deleteIncomingMessage: {
+                await deleteIncomingMessage(job.data.data)
+                return
+              }
+              case IntegrationJobAction.messageReaction: {
+                await processMessageReaction(job.data.data)
                 return
               }
               case IntegrationJobAction.sendFlow: {

--- a/integrations/instagram-facebook/src/handlers/comment/index.ts
+++ b/integrations/instagram-facebook/src/handlers/comment/index.ts
@@ -1,8 +1,10 @@
 import { deleteComment, editComment, hideComment, likeComment } from "./actions"
 import { sendComment } from "./outgoing-comment"
+import { sendPrivateReply } from "./outgoing-private-reply"
 
 export const commentHandlers = {
   sendComment,
+  sendPrivateReply,
   editComment,
   deleteComment,
   likeComment,

--- a/integrations/instagram-facebook/src/handlers/comment/outgoing-private-reply/index.ts
+++ b/integrations/instagram-facebook/src/handlers/comment/outgoing-private-reply/index.ts
@@ -1,0 +1,56 @@
+import {
+  ChannelError,
+  ChannelErrorCategory,
+  type CommentHandlers,
+} from "@chatbotx.io/sdk"
+import { sendPrivateReplyMessage } from "../../../apis/comment"
+import { mapToChannelError } from "../../../lib/error-mapper"
+import { logger } from "../../../lib/logger"
+import type { InstagramAuthValue } from "../../../schemas"
+import { convertMessageToInstagramMessage } from "../../message/outgoing-message"
+
+export const sendPrivateReply: CommentHandlers<InstagramAuthValue>["sendPrivateReply"] =
+  async (props) => {
+    const {
+      ctx,
+      data: { message },
+    } = props
+
+    const replyToCommentId = message.contentAttributes?.replyToCommentId
+    if (typeof replyToCommentId !== "string") {
+      throw new ChannelError(
+        "Cannot send private reply: replyToCommentId is missing. The outgoing message must be linked to a parent comment.",
+        ChannelErrorCategory.PAYLOAD_INVALID,
+      )
+    }
+
+    // Same text/attachment-to-Send-API-message conversion the regular
+    // sendMessage handler uses — one yielded item per text/attachment, since
+    // Meta's Send API only accepts one of either per call.
+    const instagramMessages = [...convertMessageToInstagramMessage(message)]
+    if (instagramMessages.length === 0) {
+      logger.warn(
+        { replyToCommentId },
+        "sendPrivateReply: message has no text or attachments — skipping API call",
+      )
+      return { messageIds: [] }
+    }
+
+    const messageIds: string[] = []
+    try {
+      for (const instagramMessage of instagramMessages) {
+        const result = await sendPrivateReplyMessage(
+          ctx.auth,
+          replyToCommentId,
+          instagramMessage,
+        )
+        if (result.message_id) {
+          messageIds.push(result.message_id)
+        }
+      }
+      return { messageIds }
+    } catch (error) {
+      logger.error(error, "An error occurred while sending the private reply")
+      throw mapToChannelError(error)
+    }
+  }

--- a/integrations/instagram-facebook/src/handlers/webhook.ts
+++ b/integrations/instagram-facebook/src/handlers/webhook.ts
@@ -56,7 +56,22 @@ const handleWebhookEvent = async (
       throw new InstagramWebhookException("Invalid webhook signature")
     }
 
-    const webhookData = instagramWebhookEventSchema.parse(JSON.parse(body))
+    const parsedWebhook = instagramWebhookEventSchema.safeParse(
+      JSON.parse(body),
+    )
+    if (!parsedWebhook.success) {
+      logger.warn(
+        {
+          issues: parsedWebhook.error.issues.map(({ code, path }) => ({
+            code,
+            path,
+          })),
+        },
+        "instagram facebook webhook payload unrecognized — skipping",
+      )
+      return
+    }
+    const webhookData = parsedWebhook.data
     if (webhookData.object !== "instagram") {
       throw new InstagramWebhookException(
         `Unsupported webhook object type: ${webhookData.object}`,
@@ -64,101 +79,144 @@ const handleWebhookEvent = async (
       )
     }
 
-    const entry = webhookData.entry[0]
-    if (!entry) {
-      return
-    }
-
-    // Handle Instagram post comment events (changes.comments).
-    // Instagram only sends webhooks for new comments — no edit/delete events.
-    const commentChange = entry.changes?.find(
-      (c: { field: string }) => c.field === "comments",
-    )
-    if (commentChange) {
-      const parsed = instagramCommentEventValueSchema.safeParse(
-        commentChange.value,
+    // Meta batches multiple entries — and multiple messaging events per
+    // entry — into a single webhook POST (e.g. a contact sending several DMs
+    // quickly). Every entry/event must be processed, not just the first.
+    for (const entry of webhookData.entry) {
+      // Handle Instagram post comment events (changes.comments).
+      // Instagram only sends webhooks for new comments — no edit/delete events.
+      const commentChange = entry.changes?.find(
+        (c: { field: string }) => c.field === "comments",
       )
-      if (!parsed.success) {
-        logger.warn(
-          { error: parsed.error, value: commentChange.value },
-          "comment event parse failed — skipping",
+      if (commentChange) {
+        const parsed = instagramCommentEventValueSchema.safeParse(
+          commentChange.value,
         )
-        return
-      }
-      const value = parsed.data
-      if (!value.media?.id) {
-        logger.warn(
-          { commentId: value.id },
-          "comment webhook missing media.id — skipping",
-        )
-        return
-      }
-      await queue?.add("incomingComment", {
-        type: "incomingComment",
-        data: {
-          integrationType: "instagramFacebook",
-          integrationIdentifier: entry.id,
-          commentData: {
-            commentId: value.id,
-            postId: value.media.id,
-            parentId: value.parent_id,
-            fromId: value.from.id,
-            fromName: value.from.username ?? value.from.id,
-            message: value.text,
-            createdTime: entry.time,
+        if (!parsed.success) {
+          logger.warn(
+            { error: parsed.error, value: commentChange.value },
+            "comment event parse failed — skipping",
+          )
+          continue
+        }
+        const value = parsed.data
+        if (!value.media?.id) {
+          logger.warn(
+            { commentId: value.id },
+            "comment webhook missing media.id — skipping",
+          )
+          continue
+        }
+        await queue?.add("incomingComment", {
+          type: "incomingComment",
+          data: {
+            integrationType: "instagramFacebook",
+            integrationIdentifier: entry.id,
+            commentData: {
+              commentId: value.id,
+              postId: value.media.id,
+              parentId: value.parent_id,
+              fromId: value.from.id,
+              fromName: value.from.username ?? value.from.id,
+              message: value.text,
+              createdTime: entry.time,
+            },
           },
-        },
-      })
-      return
+        })
+        continue
+      }
+
+      // Handle DM messaging events
+      const messaging = entry.messaging
+      if (!messaging || messaging.length === 0) {
+        continue
+      }
+
+      for (const messagingEvent of messaging) {
+        // Reshape to a single-entry, single-messaging-event payload so
+        // downstream consumers — which only ever read entry[0]/messaging[0] —
+        // see exactly the one event this job is for.
+        const singleEventPayload = {
+          object: webhookData.object,
+          entry: [
+            { id: entry.id, time: entry.time, messaging: [messagingEvent] },
+          ],
+        }
+
+        if (messagingEvent.read) {
+          await queue?.add("contactMarkAsRead", {
+            type: "contactMarkAsRead",
+            data: {
+              integrationType: "instagram",
+              integrationIdentifier: entry.id,
+              sourceConversationId: messagingEvent.sender.id,
+              payload: singleEventPayload,
+            },
+          })
+          continue
+        }
+
+        if (messagingEvent.reaction) {
+          await queue?.add("messageReaction", {
+            type: "messageReaction",
+            data: {
+              integrationType: "instagram",
+              integrationIdentifier: entry.id,
+              messageId: messagingEvent.reaction.mid,
+              action: messagingEvent.reaction.action,
+              emoji: messagingEvent.reaction.emoji,
+              contactSourceId: messagingEvent.sender.id,
+            },
+          })
+          continue
+        }
+
+        if (messagingEvent.message?.is_deleted) {
+          await queue?.add("deleteIncomingMessage", {
+            type: "deleteIncomingMessage",
+            data: {
+              integrationType: "instagram",
+              integrationIdentifier: entry.id,
+              messageId: messagingEvent.message.mid,
+            },
+          })
+          continue
+        }
+
+        // Skip if this event is not a message, postback, or standalone referral
+        if (
+          !(
+            messagingEvent.message ||
+            messagingEvent.postback ||
+            messagingEvent.referral
+          )
+        ) {
+          continue
+        }
+
+        if (
+          messagingEvent.message?.is_echo === true &&
+          messagingEvent.message?.metadata === INSTAGRAM_MESSAGE_METADATA
+        ) {
+          // Skip if this message is from our own bot
+          continue
+        }
+
+        // Calculate integration identifier
+        const integrationIdentifier = messagingEvent.message?.is_echo
+          ? messagingEvent.sender.id
+          : messagingEvent.recipient.id
+
+        await queue?.add("incomingMessage", {
+          type: "incomingMessage",
+          data: {
+            integrationType: "instagram",
+            integrationIdentifier,
+            payload: singleEventPayload,
+          },
+        })
+      }
     }
-
-    // Handle DM messaging events
-    const messaging = entry.messaging
-    if (!messaging || messaging.length === 0) {
-      return
-    }
-
-    if (messaging[0]?.read) {
-      await queue?.add("contactMarkAsRead", {
-        type: "contactMarkAsRead",
-        data: {
-          integrationType: "instagram",
-          integrationIdentifier: entry.id,
-          sourceConversationId: messaging[0].sender.id,
-          payload: webhookData,
-        },
-      })
-      return
-    }
-
-    // Skip if this event is not a message, postback, or standalone referral
-    if (
-      !(messaging[0].message || messaging[0].postback || messaging[0].referral)
-    ) {
-      return
-    }
-
-    if (
-      messaging[0].message?.is_echo === true &&
-      messaging[0].message?.metadata === INSTAGRAM_MESSAGE_METADATA
-    ) {
-      // Skip if this message is from our own bot
-      return
-    }
-
-    // Calculate integration identifier
-    const integrationIdentifier = messaging[0].message?.is_echo
-      ? messaging[0].sender.id
-      : messaging[0].recipient.id
-
-    await queue?.add("incomingMessage", {
-      type: "incomingMessage",
-      data: {
-        integrationType: "instagram",
-        integrationIdentifier,
-        payload: webhookData,
-      },
-    })
   } catch (error) {
     const errorMessage =
       error instanceof Error

--- a/integrations/instagram-facebook/src/schemas.ts
+++ b/integrations/instagram-facebook/src/schemas.ts
@@ -27,17 +27,28 @@ export type InstagramActions = {
   }) => Promise<import("./apis/post").InstagramMediaDetails>
 }
 
-// Common attachment types — includes all types Instagram may send in a webhook
-const attachmentTypeSchema = z.enum([
-  "image",
-  "video",
-  "audio",
-  "file",
-  "sticker",
-  "location",
-  "share",
-  "fallback",
-])
+// Common attachment types — includes all types Instagram may send in a webhook.
+// `.catch("fallback")` is defense-in-depth: if Meta ships a type we haven't
+// enumerated yet, only this one field falls back to "fallback" instead of
+// failing validation for the entire webhook payload (which, after batching
+// multiple entries/messaging events per POST, could contain several unrelated
+// messages) and silently dropping every message in that batch.
+const attachmentTypeSchema = z
+  .enum([
+    "image",
+    "video",
+    "audio",
+    "file",
+    "sticker",
+    "location",
+    "share",
+    "fallback",
+    "story_mention",
+    "ig_reel",
+    "reel",
+    "template",
+  ])
+  .catch("fallback")
 
 // Base attachment payload — url optional because location/share have no url
 const baseAttachmentPayloadSchema = z.object({
@@ -59,6 +70,9 @@ export const instagramMessageSchema = z.object({
   mid: z.string(),
   text: z.string().optional(),
   is_echo: z.boolean().optional(),
+  // Set (with no other message fields besides `mid`) when the sender unsends
+  // a previously-sent DM.
+  is_deleted: z.boolean().optional(),
   attachments: z.array(instagramAttachmentSchema).optional(),
   metadata: z.string().optional(),
   quick_reply: z
@@ -116,6 +130,16 @@ export const instagramPostbackSchema = z.object({
   referral: instagramReferralSchema.optional(),
 })
 
+// Sent when a contact reacts (or removes a reaction) to a message we sent
+// them or they sent us. `mid` identifies the reacted-to message.
+export const instagramReactionSchema = z.object({
+  mid: z.string(),
+  action: z.enum(["react", "unreact"]),
+  reaction: z.string().optional(),
+  emoji: z.string().optional(),
+})
+export type InstagramReaction = z.infer<typeof instagramReactionSchema>
+
 export const instagramMessagingEventSchema = z.object({
   sender: idSchema,
   recipient: idSchema,
@@ -124,6 +148,7 @@ export const instagramMessagingEventSchema = z.object({
   read: instagramReadSchema.optional(),
   postback: instagramPostbackSchema.optional(),
   referral: instagramReferralSchema.optional(),
+  reaction: instagramReactionSchema.optional(),
 })
 export type InstagramMessagingEvent = z.infer<
   typeof instagramMessagingEventSchema

--- a/integrations/instagram/src/handlers/comment/index.ts
+++ b/integrations/instagram/src/handlers/comment/index.ts
@@ -1,8 +1,10 @@
 import { deleteComment, editComment, hideComment, likeComment } from "./actions"
 import { sendComment } from "./outgoing-comment"
+import { sendPrivateReply } from "./outgoing-private-reply"
 
 export const commentHandlers = {
   sendComment,
+  sendPrivateReply,
   editComment,
   deleteComment,
   likeComment,

--- a/integrations/instagram/src/handlers/comment/outgoing-private-reply/index.ts
+++ b/integrations/instagram/src/handlers/comment/outgoing-private-reply/index.ts
@@ -1,0 +1,56 @@
+import {
+  ChannelError,
+  ChannelErrorCategory,
+  type CommentHandlers,
+} from "@chatbotx.io/sdk"
+import { sendPrivateReplyMessage } from "../../../apis/comment"
+import { mapToChannelError } from "../../../lib/error-mapper"
+import { logger } from "../../../lib/logger"
+import type { InstagramAuthValue } from "../../../schemas"
+import { convertMessageToInstagramMessage } from "../../message/outgoing-message"
+
+export const sendPrivateReply: CommentHandlers<InstagramAuthValue>["sendPrivateReply"] =
+  async (props) => {
+    const {
+      ctx,
+      data: { message },
+    } = props
+
+    const replyToCommentId = message.contentAttributes?.replyToCommentId
+    if (typeof replyToCommentId !== "string") {
+      throw new ChannelError(
+        "Cannot send private reply: replyToCommentId is missing. The outgoing message must be linked to a parent comment.",
+        ChannelErrorCategory.PAYLOAD_INVALID,
+      )
+    }
+
+    // Same text/attachment-to-Send-API-message conversion the regular
+    // sendMessage handler uses — one yielded item per text/attachment, since
+    // Meta's Send API only accepts one of either per call.
+    const instagramMessages = [...convertMessageToInstagramMessage(message)]
+    if (instagramMessages.length === 0) {
+      logger.warn(
+        { replyToCommentId },
+        "sendPrivateReply: message has no text or attachments — skipping API call",
+      )
+      return { messageIds: [] }
+    }
+
+    const messageIds: string[] = []
+    try {
+      for (const instagramMessage of instagramMessages) {
+        const result = await sendPrivateReplyMessage(
+          ctx.auth,
+          replyToCommentId,
+          instagramMessage,
+        )
+        if (result.message_id) {
+          messageIds.push(result.message_id)
+        }
+      }
+      return { messageIds }
+    } catch (error) {
+      logger.error(error, "An error occurred while sending the private reply")
+      throw mapToChannelError(error)
+    }
+  }

--- a/integrations/instagram/src/handlers/webhook.ts
+++ b/integrations/instagram/src/handlers/webhook.ts
@@ -78,104 +78,148 @@ const handleWebhookEvent = async (
       )
     }
 
-    const entry = webhookData.entry[0]
-    if (!entry) {
-      return
-    }
-
-    const commentValue =
-      entry.field === "comments"
-        ? entry.value
-        : entry.changes?.find((c: { field: string }) => c.field === "comments")
-            ?.value
-    if (commentValue !== undefined) {
-      const parsed = instagramCommentEventValueSchema.safeParse(commentValue)
-      if (!parsed.success) {
-        logger.warn(
-          {
-            issues: parsed.error.issues.map(({ code, path }) => ({
-              code,
-              path,
-            })),
+    // Meta batches multiple entries — and multiple messaging events per
+    // entry — into a single webhook POST (e.g. a contact sending several DMs
+    // quickly). Every entry/event must be processed, not just the first.
+    for (const entry of webhookData.entry) {
+      const commentValue =
+        entry.field === "comments"
+          ? entry.value
+          : entry.changes?.find(
+              (c: { field: string }) => c.field === "comments",
+            )?.value
+      if (commentValue !== undefined) {
+        const parsed = instagramCommentEventValueSchema.safeParse(commentValue)
+        if (!parsed.success) {
+          logger.warn(
+            {
+              issues: parsed.error.issues.map(({ code, path }) => ({
+                code,
+                path,
+              })),
+            },
+            "comment event parse failed — skipping",
+          )
+          continue
+        }
+        const value = parsed.data
+        if (!value.media?.id) {
+          logger.warn(
+            { commentId: value.id },
+            "comment webhook missing media.id — skipping",
+          )
+          continue
+        }
+        await queue?.add("incomingComment", {
+          type: "incomingComment",
+          data: {
+            integrationType: "instagram",
+            integrationIdentifier: entry.id,
+            commentData: {
+              commentId: value.id,
+              postId: value.media.id,
+              parentId: value.parent_id,
+              fromId: value.from.id,
+              fromName: value.from.username ?? value.from.id,
+              message: value.text,
+              createdTime: entry.time,
+            },
           },
-          "comment event parse failed — skipping",
-        )
-        return
+        })
+        continue
       }
-      const value = parsed.data
-      if (!value.media?.id) {
-        logger.warn(
-          { commentId: value.id },
-          "comment webhook missing media.id — skipping",
-        )
-        return
+
+      // Handle DM messaging events
+      const messaging = entry.messaging
+      if (!messaging || messaging.length === 0) {
+        continue
       }
-      await queue?.add("incomingComment", {
-        type: "incomingComment",
-        data: {
-          integrationType: "instagram",
-          integrationIdentifier: entry.id,
-          commentData: {
-            commentId: value.id,
-            postId: value.media.id,
-            parentId: value.parent_id,
-            fromId: value.from.id,
-            fromName: value.from.username ?? value.from.id,
-            message: value.text,
-            createdTime: entry.time,
+
+      for (const messagingEvent of messaging) {
+        // Reshape to a single-entry, single-messaging-event payload so
+        // downstream consumers — which only ever read entry[0]/messaging[0] —
+        // see exactly the one event this job is for.
+        const singleEventPayload = {
+          object: webhookData.object,
+          entry: [
+            { id: entry.id, time: entry.time, messaging: [messagingEvent] },
+          ],
+        }
+
+        if (messagingEvent.read) {
+          await queue?.add("contactMarkAsRead", {
+            type: "contactMarkAsRead",
+            data: {
+              integrationType: "instagram",
+              integrationIdentifier: entry.id,
+              sourceConversationId: messagingEvent.sender.id,
+              payload: singleEventPayload,
+            },
+          })
+          continue
+        }
+
+        if (messagingEvent.reaction) {
+          await queue?.add("messageReaction", {
+            type: "messageReaction",
+            data: {
+              integrationType: "instagram",
+              integrationIdentifier: entry.id,
+              messageId: messagingEvent.reaction.mid,
+              action: messagingEvent.reaction.action,
+              emoji: messagingEvent.reaction.emoji,
+              contactSourceId: messagingEvent.sender.id,
+            },
+          })
+          continue
+        }
+
+        if (messagingEvent.message?.is_deleted) {
+          await queue?.add("deleteIncomingMessage", {
+            type: "deleteIncomingMessage",
+            data: {
+              integrationType: "instagram",
+              integrationIdentifier: entry.id,
+              messageId: messagingEvent.message.mid,
+            },
+          })
+          continue
+        }
+
+        // Skip if this event is not a message, postback, or standalone referral
+        if (
+          !(
+            messagingEvent.message ||
+            messagingEvent.postback ||
+            messagingEvent.referral
+          )
+        ) {
+          continue
+        }
+
+        if (
+          messagingEvent.message?.is_echo === true &&
+          messagingEvent.message?.metadata === INSTAGRAM_MESSAGE_METADATA
+        ) {
+          // Skip if this message is from our own bot
+          continue
+        }
+
+        // Calculate integration identifier
+        const integrationIdentifier = messagingEvent.message?.is_echo
+          ? messagingEvent.sender.id
+          : messagingEvent.recipient.id
+
+        await queue?.add("incomingMessage", {
+          type: "incomingMessage",
+          data: {
+            integrationType: "instagram",
+            integrationIdentifier,
+            payload: singleEventPayload,
           },
-        },
-      })
-      return
+        })
+      }
     }
-
-    // Handle DM messaging events
-    const messaging = entry.messaging
-    if (!messaging || messaging.length === 0) {
-      return
-    }
-
-    if (messaging[0]?.read) {
-      await queue?.add("contactMarkAsRead", {
-        type: "contactMarkAsRead",
-        data: {
-          integrationType: "instagram",
-          integrationIdentifier: entry.id,
-          sourceConversationId: messaging[0].sender.id,
-          payload: webhookData,
-        },
-      })
-      return
-    }
-
-    // Skip if this event is not a message, postback, or standalone referral
-    if (
-      !(messaging[0].message || messaging[0].postback || messaging[0].referral)
-    ) {
-      return
-    }
-
-    if (
-      messaging[0].message?.is_echo === true &&
-      messaging[0].message?.metadata === INSTAGRAM_MESSAGE_METADATA
-    ) {
-      // Skip if this message is from our own bot
-      return
-    }
-
-    // Calculate integration identifier
-    const integrationIdentifier = messaging[0].message?.is_echo
-      ? messaging[0].sender.id
-      : messaging[0].recipient.id
-
-    await queue?.add("incomingMessage", {
-      type: "incomingMessage",
-      data: {
-        integrationType: "instagram",
-        integrationIdentifier,
-        payload: webhookData,
-      },
-    })
   } catch (error) {
     const errorMessage =
       error instanceof Error

--- a/integrations/instagram/src/schemas.ts
+++ b/integrations/instagram/src/schemas.ts
@@ -27,17 +27,28 @@ export type InstagramActions = {
   }) => Promise<import("./apis/post").InstagramMediaDetails>
 }
 
-// Common attachment types — includes all types Instagram may send in a webhook
-const attachmentTypeSchema = z.enum([
-  "image",
-  "video",
-  "audio",
-  "file",
-  "sticker",
-  "location",
-  "share",
-  "fallback",
-])
+// Common attachment types — includes all types Instagram may send in a webhook.
+// `.catch("fallback")` is defense-in-depth: if Meta ships a type we haven't
+// enumerated yet, only this one field falls back to "fallback" instead of
+// failing validation for the entire webhook payload (which, after batching
+// multiple entries/messaging events per POST, could contain several unrelated
+// messages) and silently dropping every message in that batch.
+const attachmentTypeSchema = z
+  .enum([
+    "image",
+    "video",
+    "audio",
+    "file",
+    "sticker",
+    "location",
+    "share",
+    "fallback",
+    "story_mention",
+    "ig_reel",
+    "reel",
+    "template",
+  ])
+  .catch("fallback")
 
 // Base attachment payload — url optional because location/share have no url
 const baseAttachmentPayloadSchema = z.object({
@@ -67,6 +78,9 @@ export const instagramMessageSchema = z.object({
   mid: z.string(),
   text: z.string().optional(),
   is_echo: z.boolean().optional(),
+  // Set (with no other message fields besides `mid`) when the sender unsends
+  // a previously-sent DM.
+  is_deleted: z.boolean().optional(),
   attachments: z.array(instagramAttachmentSchema).optional(),
   metadata: z.string().optional(),
   quick_reply: z
@@ -125,6 +139,16 @@ export const instagramPostbackSchema = z.object({
   referral: instagramReferralSchema.optional(),
 })
 
+// Sent when a contact reacts (or removes a reaction) to a message we sent
+// them or they sent us. `mid` identifies the reacted-to message.
+export const instagramReactionSchema = z.object({
+  mid: z.string(),
+  action: z.enum(["react", "unreact"]),
+  reaction: z.string().optional(),
+  emoji: z.string().optional(),
+})
+export type InstagramReaction = z.infer<typeof instagramReactionSchema>
+
 export const instagramMessagingEventSchema = z.object({
   sender: idSchema,
   recipient: idSchema,
@@ -133,6 +157,7 @@ export const instagramMessagingEventSchema = z.object({
   read: instagramReadSchema.optional(),
   postback: instagramPostbackSchema.optional(),
   referral: instagramReferralSchema.optional(),
+  reaction: instagramReactionSchema.optional(),
 })
 export type InstagramMessagingEvent = z.infer<
   typeof instagramMessagingEventSchema

--- a/integrations/messenger/src/handlers/comment/index.ts
+++ b/integrations/messenger/src/handlers/comment/index.ts
@@ -1,8 +1,10 @@
 import { deleteComment, editComment, hideComment, likeComment } from "./actions"
 import { sendComment } from "./outgoing-comment"
+import { sendPrivateReply } from "./outgoing-private-reply"
 
 export const commentHandlers = {
   sendComment,
+  sendPrivateReply,
   editComment,
   deleteComment,
   likeComment,

--- a/integrations/messenger/src/handlers/comment/outgoing-private-reply/index.ts
+++ b/integrations/messenger/src/handlers/comment/outgoing-private-reply/index.ts
@@ -1,0 +1,56 @@
+import {
+  ChannelError,
+  ChannelErrorCategory,
+  type CommentHandlers,
+} from "@chatbotx.io/sdk"
+import { sendPrivateReplyMessage } from "../../../apis/comment"
+import { mapToChannelError } from "../../../lib/error-mapper"
+import { logger } from "../../../lib/logger"
+import type { MessengerAuthValue } from "../../../schema"
+import { convertMessageToFacebookMessage } from "../../message/outgoing-message"
+
+export const sendPrivateReply: CommentHandlers<MessengerAuthValue>["sendPrivateReply"] =
+  async (props) => {
+    const {
+      ctx,
+      data: { message },
+    } = props
+
+    const replyToCommentId = message.contentAttributes?.replyToCommentId
+    if (typeof replyToCommentId !== "string") {
+      throw new ChannelError(
+        "Cannot send private reply: replyToCommentId is missing. The outgoing message must be linked to a parent comment.",
+        ChannelErrorCategory.PAYLOAD_INVALID,
+      )
+    }
+
+    // Same text/attachment-to-Send-API-message conversion the regular
+    // sendMessage handler uses — one yielded item per text/attachment, since
+    // Meta's Send API only accepts one of either per call.
+    const facebookMessages = [...convertMessageToFacebookMessage(message)]
+    if (facebookMessages.length === 0) {
+      logger.warn(
+        { replyToCommentId },
+        "sendPrivateReply: message has no text or attachments — skipping API call",
+      )
+      return { messageIds: [] }
+    }
+
+    const messageIds: string[] = []
+    try {
+      for (const facebookMessage of facebookMessages) {
+        const result = await sendPrivateReplyMessage(
+          ctx.auth,
+          replyToCommentId,
+          facebookMessage,
+        )
+        if (result.message_id) {
+          messageIds.push(result.message_id)
+        }
+      }
+      return { messageIds }
+    } catch (error) {
+      logger.error(error, "An error occurred while sending the private reply")
+      throw mapToChannelError(error)
+    }
+  }

--- a/integrations/messenger/src/handlers/message/outgoing-message/index.ts
+++ b/integrations/messenger/src/handlers/message/outgoing-message/index.ts
@@ -262,7 +262,7 @@ export const sendFlowStep: MessageHandlers<MessengerAuthValue>["sendFlowStep"] =
     }
   }
 
-function* convertMessageToFacebookMessage(
+export function* convertMessageToFacebookMessage(
   message: OutgoingMessage,
 ): Generator<FacebookMessage> {
   if (message.contentType === contentTypes.enum.text) {

--- a/integrations/messenger/src/handlers/webhook.ts
+++ b/integrations/messenger/src/handlers/webhook.ts
@@ -78,165 +78,218 @@ const handleWebhookEvent = async (
       )
     }
 
-    const entry = webhookData.entry[0]
-    if (!entry) {
-      return
-    }
-
-    const labelChange = entry.changes?.find(
-      (c: { field: string }) => c.field === "inbox_labels",
-    )
-    if (labelChange) {
-      await queue?.add("channelLabelChange", {
-        type: "channelLabelChange",
-        data: {
-          integrationType: "messenger",
-          integrationIdentifier: entry.id,
-          payload: webhookData,
-        },
-      })
-      return
-    }
-
-    const feedChanges =
-      entry.changes?.filter((c: { field: string }) => c.field === "feed") ?? []
-    if (feedChanges.length > 0) {
-      for (const feedChange of feedChanges) {
-        const parsed = messengerFeedCommentValueSchema.safeParse(
-          feedChange.value,
-        )
-        if (!parsed.success) {
-          logger.warn(
-            { issues: parsed.error.issues, value: feedChange.value },
-            "Unrecognized feed webhook payload",
-          )
-          continue
-        }
-        const value = parsed.data
-        if (value.verb === "add" && value.from.id !== entry.id) {
-          // New comment from an external user — route to inbox
-          await queue?.add("incomingComment", {
-            type: "incomingComment",
-            data: {
-              integrationType: "messenger",
-              integrationIdentifier: entry.id,
-              commentData: {
-                commentId: value.comment_id,
-                postId: value.post_id,
-                parentId: value.parent_id,
-                fromId: value.from.id,
-                fromName: value.from.name,
-                message: value.message,
-                createdTime: value.created_time,
-              },
-            },
-          })
-        } else if (value.verb === "edited" && value.from.id !== entry.id) {
-          // Commenter edited their comment — sync the new text to the DB
-          await queue?.add("updateIncomingComment", {
-            type: "updateIncomingComment",
-            data: {
-              integrationType: "messenger",
-              integrationIdentifier: entry.id,
-              commentId: value.comment_id,
-              newText: value.message ?? "",
-            },
-          })
-        } else if (value.verb === "remove") {
-          // Commenter or page deleted the comment — soft-delete in the DB
-          await queue?.add("deleteIncomingComment", {
-            type: "deleteIncomingComment",
-            data: {
-              integrationType: "messenger",
-              integrationIdentifier: entry.id,
-              commentId: value.comment_id,
-            },
-          })
-        }
-      }
-      return
-    }
-
-    const leadgenChanges =
-      entry.changes?.filter((c: { field: string }) => c.field === "leadgen") ??
-      []
-    if (leadgenChanges.length > 0) {
-      for (const leadgenChange of leadgenChanges) {
-        const parsed = messengerLeadgenValueSchema.safeParse(
-          leadgenChange.value,
-        )
-        if (!parsed.success) {
-          logger.warn(
-            { issues: parsed.error.issues, value: leadgenChange.value },
-            "Unrecognized leadgen webhook payload",
-          )
-          continue
-        }
-        const value = parsed.data
-        await queue?.add("processLeadgen", {
-          type: "processLeadgen",
+    // Meta batches multiple entries — and multiple messaging events per
+    // entry — into a single webhook POST (e.g. a contact sending several DMs
+    // quickly). Every entry/event must be processed, not just the first.
+    for (const entry of webhookData.entry) {
+      const labelChange = entry.changes?.find(
+        (c: { field: string }) => c.field === "inbox_labels",
+      )
+      if (labelChange) {
+        await queue?.add("channelLabelChange", {
+          type: "channelLabelChange",
           data: {
             integrationType: "messenger",
             integrationIdentifier: entry.id,
-            leadgenId: value.leadgen_id,
-            formId: value.form_id,
+            payload: { object: webhookData.object, entry: [entry] },
+          },
+        })
+        continue
+      }
+
+      const feedChanges =
+        entry.changes?.filter((c: { field: string }) => c.field === "feed") ??
+        []
+      if (feedChanges.length > 0) {
+        for (const feedChange of feedChanges) {
+          const parsed = messengerFeedCommentValueSchema.safeParse(
+            feedChange.value,
+          )
+          if (!parsed.success) {
+            logger.warn(
+              { issues: parsed.error.issues, value: feedChange.value },
+              "Unrecognized feed webhook payload",
+            )
+            continue
+          }
+          const value = parsed.data
+          if (value.verb === "add" && value.from.id !== entry.id) {
+            // New comment from an external user — route to inbox
+            await queue?.add("incomingComment", {
+              type: "incomingComment",
+              data: {
+                integrationType: "messenger",
+                integrationIdentifier: entry.id,
+                commentData: {
+                  commentId: value.comment_id,
+                  postId: value.post_id,
+                  parentId: value.parent_id,
+                  fromId: value.from.id,
+                  fromName: value.from.name,
+                  message: value.message,
+                  createdTime: value.created_time,
+                },
+              },
+            })
+          } else if (value.verb === "edited" && value.from.id !== entry.id) {
+            // Commenter edited their comment — sync the new text to the DB
+            await queue?.add("updateIncomingComment", {
+              type: "updateIncomingComment",
+              data: {
+                integrationType: "messenger",
+                integrationIdentifier: entry.id,
+                commentId: value.comment_id,
+                newText: value.message ?? "",
+              },
+            })
+          } else if (value.verb === "remove") {
+            // Commenter or page deleted the comment — soft-delete in the DB
+            await queue?.add("deleteIncomingComment", {
+              type: "deleteIncomingComment",
+              data: {
+                integrationType: "messenger",
+                integrationIdentifier: entry.id,
+                commentId: value.comment_id,
+              },
+            })
+          }
+        }
+        continue
+      }
+
+      const leadgenChanges =
+        entry.changes?.filter(
+          (c: { field: string }) => c.field === "leadgen",
+        ) ?? []
+      if (leadgenChanges.length > 0) {
+        for (const leadgenChange of leadgenChanges) {
+          const parsed = messengerLeadgenValueSchema.safeParse(
+            leadgenChange.value,
+          )
+          if (!parsed.success) {
+            logger.warn(
+              { issues: parsed.error.issues, value: leadgenChange.value },
+              "Unrecognized leadgen webhook payload",
+            )
+            continue
+          }
+          const value = parsed.data
+          await queue?.add("processLeadgen", {
+            type: "processLeadgen",
+            data: {
+              integrationType: "messenger",
+              integrationIdentifier: entry.id,
+              leadgenId: value.leadgen_id,
+              formId: value.form_id,
+            },
+          })
+        }
+        continue
+      }
+
+      if (!entry.messaging || entry.messaging.length === 0) {
+        continue
+      }
+
+      for (const messagingEvent of entry.messaging) {
+        // Reshape to a single-entry, single-messaging-event payload so
+        // downstream consumers — which only ever read entry[0]/messaging[0] —
+        // see exactly the one event this job is for.
+        const singleEventPayload = {
+          object: webhookData.object,
+          entry: [
+            { id: entry.id, time: entry.time, messaging: [messagingEvent] },
+          ],
+        }
+
+        if (messagingEvent.read) {
+          await queue?.add("contactMarkAsRead", {
+            type: "contactMarkAsRead",
+            data: {
+              integrationType: "messenger",
+              integrationIdentifier: entry.id,
+              sourceConversationId: messagingEvent.sender.id,
+              payload: singleEventPayload,
+            },
+          })
+          continue
+        }
+
+        if (messagingEvent.reaction) {
+          await queue?.add("messageReaction", {
+            type: "messageReaction",
+            data: {
+              integrationType: "messenger",
+              integrationIdentifier: entry.id,
+              messageId: messagingEvent.reaction.mid,
+              action: messagingEvent.reaction.action,
+              emoji: messagingEvent.reaction.emoji,
+              contactSourceId: messagingEvent.sender.id,
+            },
+          })
+          continue
+        }
+
+        if (messagingEvent.message?.is_deleted) {
+          await queue?.add("deleteIncomingMessage", {
+            type: "deleteIncomingMessage",
+            data: {
+              integrationType: "messenger",
+              integrationIdentifier: entry.id,
+              messageId: messagingEvent.message.mid,
+            },
+          })
+          continue
+        }
+
+        // Skip events that carry none of message/postback/referral (e.g. a
+        // pure delivery receipt) — nothing downstream can process them.
+        if (
+          !(
+            messagingEvent.message ||
+            messagingEvent.postback ||
+            messagingEvent.referral
+          )
+        ) {
+          continue
+        }
+
+        // Calculate integration identifier
+        const integrationIdentifier = messagingEvent.message?.is_echo
+          ? messagingEvent.sender.id
+          : messagingEvent.recipient.id
+
+        if (messagingEvent.postback) {
+          await queue?.add("incomingMessage", {
+            type: "incomingMessage",
+            data: {
+              integrationType: "messenger",
+              integrationIdentifier,
+              payload: singleEventPayload,
+              action: messagingEvent.postback.payload,
+            },
+          })
+          continue
+        }
+
+        if (
+          messagingEvent.message?.is_echo === true &&
+          messagingEvent.message?.metadata === MESSENGER_MESSAGE_METADATA
+        ) {
+          // Skip other echoes that passed schema validation
+          continue
+        }
+
+        await queue?.add("incomingMessage", {
+          type: "incomingMessage",
+          data: {
+            integrationType: "messenger",
+            integrationIdentifier,
+            payload: singleEventPayload,
           },
         })
       }
-      return
     }
-
-    if (!entry.messaging || entry.messaging.length === 0) {
-      return
-    }
-
-    if (entry.messaging[0]?.read) {
-      await queue?.add("contactMarkAsRead", {
-        type: "contactMarkAsRead",
-        data: {
-          integrationType: "messenger",
-          integrationIdentifier: entry.id,
-          sourceConversationId: entry.messaging[0].sender.id,
-          payload: webhookData,
-        },
-      })
-      return
-    }
-
-    // Calculate integration identifier
-    const integrationIdentifier = entry.messaging[0].message?.is_echo
-      ? entry.messaging[0].sender.id
-      : entry.messaging[0].recipient.id
-
-    if (entry.messaging[0].postback) {
-      await queue?.add("incomingMessage", {
-        type: "incomingMessage",
-        data: {
-          integrationType: "messenger",
-          integrationIdentifier,
-          payload: webhookData,
-          action: entry.messaging[0].postback.payload,
-        },
-      })
-      return
-    }
-
-    if (
-      entry.messaging[0].message?.is_echo === true &&
-      entry.messaging[0].message?.metadata === MESSENGER_MESSAGE_METADATA
-    ) {
-      // Skip other echoes that passed schema validation
-      return
-    }
-
-    await queue?.add("incomingMessage", {
-      type: "incomingMessage",
-      data: {
-        integrationType: "messenger",
-        integrationIdentifier,
-        payload: webhookData,
-      },
-    })
   } catch (error) {
     const errorMessage =
       error instanceof Error

--- a/integrations/messenger/src/schema.ts
+++ b/integrations/messenger/src/schema.ts
@@ -84,18 +84,25 @@ export type MessengerActions<
   >
 }
 
-// Common attachment types — includes all types Facebook may send in a webhook
-const attachmentTypeSchema = z.enum([
-  "image",
-  "video",
-  "audio",
-  "file",
-  "template",
-  "sticker",
-  "location",
-  "share",
-  "fallback",
-])
+// Common attachment types — includes all types Facebook may send in a webhook.
+// `.catch("fallback")` is defense-in-depth: if Meta ships a type we haven't
+// enumerated yet, only this one field falls back to "fallback" instead of
+// failing validation for the entire webhook payload (which, after batching
+// multiple entries/messaging events per POST, could contain several unrelated
+// messages) and silently dropping every message in that batch.
+const attachmentTypeSchema = z
+  .enum([
+    "image",
+    "video",
+    "audio",
+    "file",
+    "template",
+    "sticker",
+    "location",
+    "share",
+    "fallback",
+  ])
+  .catch("fallback")
 
 // Base attachment payload — url optional because template attachments have no url
 const baseAttachmentPayloadSchema = z.object({
@@ -125,6 +132,9 @@ export const messengerMessageSchema = z.object({
   mid: z.string(),
   text: z.string().optional(),
   is_echo: z.boolean().optional(),
+  // Set (with no other message fields besides `mid`) when the sender unsends
+  // a previously-sent DM.
+  is_deleted: z.boolean().optional(),
   attachments: z.array(messengerAttachmentSchema).optional(),
   metadata: z.string().optional(),
   quick_reply: z
@@ -174,6 +184,16 @@ export const messengerPostbackSchema = z.object({
   referral: messengerReferralSchema.optional(),
 })
 
+// Sent when a contact reacts (or removes a reaction) to a message we sent
+// them or they sent us. `mid` identifies the reacted-to message.
+export const messengerReactionSchema = z.object({
+  mid: z.string(),
+  action: z.enum(["react", "unreact"]),
+  reaction: z.string().optional(),
+  emoji: z.string().optional(),
+})
+export type MessengerReaction = z.infer<typeof messengerReactionSchema>
+
 export const messengerMessagingEventSchema = z.object({
   sender: idSchema,
   recipient: idSchema,
@@ -183,6 +203,7 @@ export const messengerMessagingEventSchema = z.object({
   read: messengerReadSchema.optional(),
   postback: messengerPostbackSchema.optional(),
   referral: messengerReferralSchema.optional(),
+  reaction: messengerReactionSchema.optional(),
 })
 export type MessengerMessagingEvent = z.infer<
   typeof messengerMessagingEventSchema

--- a/packages/database/__tests__/sharded-message-repository.test.ts
+++ b/packages/database/__tests__/sharded-message-repository.test.ts
@@ -1,3 +1,4 @@
+import { startOfHour } from "date-fns"
 import { beforeEach, describe, expect, test, vi } from "vitest"
 import { MessageShardUnavailableError } from "../src/errors"
 import type {
@@ -1570,5 +1571,111 @@ describe("ShardedMessageRepository.createOrUpdateWithAttachments — idempotent 
 
     expect(result.isNew).toBe(false)
     expect(shardDb.transaction).not.toHaveBeenCalled()
+  })
+})
+
+describe("ShardedMessageRepository.deleteBySourceId", () => {
+  test("falls back to a full-history shard scan when the createdAt hint misses, and re-searches children using the row's real createdAt", async () => {
+    // Caller only knows "now" (e.g. a webhook-driven unsend with no known
+    // original timestamp) — the message was actually created months earlier,
+    // in a shard the narrow hint-based search never looks at.
+    const staleHint = new Date("2026-06-15T00:00:00Z")
+    const realCreatedAt = new Date("2026-01-01T00:00:00Z")
+
+    const narrowShard = makeShardInfo("tr:narrow", "narrow")
+    const oldShard = makeShardInfo("tr:old", "old")
+
+    const emptySelectChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([]),
+    }
+    const foundSelectChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi
+        .fn()
+        .mockResolvedValue([{ id: "msg-old", createdAt: realCreatedAt }]),
+    }
+    const updateChain = {
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue([{ id: "msg-old" }]),
+    }
+
+    const narrowShardClient = {
+      select: vi.fn().mockReturnValue(emptySelectChain),
+    }
+    const oldShardClient = {
+      select: vi.fn().mockReturnValue(foundSelectChain),
+      update: vi.fn().mockReturnValue(updateChain),
+    }
+
+    const getShardsForTimeRange = vi.fn((start: Date) => {
+      // The narrow, hint-scoped search (createdAt..endOfHour(createdAt))
+      // only ever sees the shard that doesn't hold the row.
+      if (start.getTime() === startOfHour(staleHint).getTime()) {
+        return Promise.resolve([narrowShard])
+      }
+      // Both the full-history fallback (epoch..now) and the real-createdAt
+      // children search land on the shard that actually holds the row.
+      return Promise.resolve([oldShard])
+    })
+
+    const shardManager = {
+      getShardsForTimeRange,
+      getWriteShardInfo: vi.fn().mockResolvedValue(null),
+      getShardClient: vi.fn((shard: { id: string }) =>
+        shard.id === "narrow" ? narrowShardClient : oldShardClient,
+      ),
+    }
+
+    const repo = new ShardedMessageRepository(shardManager as never)
+    const result = await repo.deleteBySourceId("src-old", "ws-1", staleHint)
+
+    expect(result).toEqual([{ id: "msg-old" }])
+
+    // Step 2 (children search) must have used the row's REAL createdAt, not
+    // the caller's stale hint.
+    const childRangeCall = getShardsForTimeRange.mock.calls.find(
+      ([start]: [Date]) =>
+        start.getTime() === startOfHour(realCreatedAt).getTime(),
+    )
+    expect(childRangeCall).toBeDefined()
+  })
+
+  test("does not fall back when the narrow createdAt-hinted search already finds the row", async () => {
+    const createdAt = new Date("2026-06-01T00:00:00Z")
+    const shard = makeShardInfo("tr:s1", "s1")
+
+    const foundSelectChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([{ id: "msg-1", createdAt }]),
+    }
+    const updateChain = {
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue([{ id: "msg-1" }]),
+    }
+    const shardClient = {
+      select: vi.fn().mockReturnValue(foundSelectChain),
+      update: vi.fn().mockReturnValue(updateChain),
+    }
+
+    const getShardsForTimeRange = vi.fn().mockResolvedValue([shard])
+    const shardManager = {
+      getShardsForTimeRange,
+      getWriteShardInfo: vi.fn().mockResolvedValue(null),
+      getShardClient: vi.fn().mockResolvedValue(shardClient),
+    }
+
+    const repo = new ShardedMessageRepository(shardManager as never)
+    const result = await repo.deleteBySourceId("src-1", "ws-1", createdAt)
+
+    expect(result).toEqual([{ id: "msg-1" }])
+    // Only the narrow parent search + the children search — no full-history
+    // fallback scan when the hint already found the row.
+    expect(getShardsForTimeRange).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/database/src/sharding/message/repository/sharded-message-repository.ts
+++ b/packages/database/src/sharding/message/repository/sharded-message-repository.ts
@@ -692,7 +692,7 @@ export class ShardedMessageRepository implements IMessageRepository {
   ): Promise<{ id: string }[]> {
     const writeShard = await this.shardManager.getWriteShardInfo(workspaceId)
 
-    // Step 1: find parent DB id — search in createdAt shard + write shard only.
+    // Step 1: find parent DB id — search in createdAt shard + write shard first.
     const parentTimeShards = await this.getShardsForRange(
       createdAt,
       endOfHour(createdAt),
@@ -700,11 +700,18 @@ export class ShardedMessageRepository implements IMessageRepository {
     const parentShards = this.mergeWriteShard(parentTimeShards, writeShard)
 
     let parentDbId: string | null = null
+    // The caller's `createdAt` is only ever a hint (e.g. "now", for a
+    // webhook-driven unsend/delete with no known original timestamp) — once
+    // the row is actually found, its real createdAt replaces it below so
+    // Step 2 searches the shard(s) the row truly lives in.
+    let realCreatedAt: Date = createdAt
+    const triedShardIds = new Set<string>()
     for (const shardInfo of parentShards) {
+      triedShardIds.add(shardInfo.shard.id)
       try {
         const client = await this.shardManager.getShardClient(shardInfo.shard)
         const [parent] = await client
-          .select({ id: messageModel.id })
+          .select({ id: messageModel.id, createdAt: messageModel.createdAt })
           .from(messageModel)
           .where(
             and(
@@ -715,6 +722,7 @@ export class ShardedMessageRepository implements IMessageRepository {
           .limit(1)
         if (parent) {
           parentDbId = parent.id
+          realCreatedAt = parent.createdAt
           break
         }
       } catch (error) {
@@ -725,10 +733,56 @@ export class ShardedMessageRepository implements IMessageRepository {
       }
     }
 
+    // The narrow, createdAt-hinted search above misses a row whenever the
+    // hint doesn't match the row's real creation time closely enough (e.g. a
+    // webhook-driven unsend/delete for a message created hours or days ago).
+    // Before giving up, fall back to every shard that has ever existed —
+    // `getShardsForRange` is cached, so this only costs extra work on the
+    // miss path, never on the already-correct-createdAt path.
+    if (!parentDbId) {
+      const allTimeShards = await this.getShardsForRange(
+        new Date(0),
+        new Date(),
+      )
+      const fallbackShards = this.mergeWriteShard(
+        allTimeShards,
+        writeShard,
+      ).filter((shardInfo) => !triedShardIds.has(shardInfo.shard.id))
+
+      for (const shardInfo of fallbackShards) {
+        try {
+          const client = await this.shardManager.getShardClient(shardInfo.shard)
+          const [parent] = await client
+            .select({ id: messageModel.id, createdAt: messageModel.createdAt })
+            .from(messageModel)
+            .where(
+              and(
+                eq(messageModel.workspaceId, workspaceId),
+                eq(messageModel.sourceId, sourceId),
+              ),
+            )
+            .limit(1)
+          if (parent) {
+            parentDbId = parent.id
+            realCreatedAt = parent.createdAt
+            break
+          }
+        } catch (error) {
+          logger.warn(
+            { err: error, shardId: shardInfo.shard.id },
+            "Shard query failed while looking up parent in deleteBySourceId (fallback scan)",
+          )
+        }
+      }
+    }
+
     // Step 2: soft-delete parent + children.
-    // Parent lives in its createdAt shard; children (replies) can be in any
-    // shard from createdAt onwards.
-    const childTimeShards = await this.getShardsForRange(createdAt, new Date())
+    // Parent lives in its (real) createdAt shard; children (replies) can be
+    // in any shard from there onwards.
+    const childTimeShards = await this.getShardsForRange(
+      realCreatedAt,
+      new Date(),
+    )
     const shards = this.mergeWriteShard(childTimeShards, writeShard)
 
     if (shards.length === 0) {

--- a/packages/sdk/src/lib/integration.ts
+++ b/packages/sdk/src/lib/integration.ts
@@ -156,6 +156,23 @@ export type CommentHandlers<IAuth extends AuthValue> = {
       messageIds: string[]
     }
   >
+  // Sends a comment-anchored private reply DM instead of a public comment
+  // reply. Same input/output shape as sendComment — `message.contentAttributes.
+  // replyToCommentId` identifies the comment being replied to.
+  sendPrivateReply: Handler<
+    {
+      ctx: Context<IAuth>
+      data: {
+        contact: OutgoingContact
+        message: OutgoingMessage
+        metadata?: MetadataPayload
+        sendFrom?: "inbox"
+      }
+    },
+    {
+      messageIds: string[]
+    }
+  >
   deleteComment: Handler<
     {
       ctx: Context<IAuth>

--- a/packages/worker-config/src/queues/integration/index.ts
+++ b/packages/worker-config/src/queues/integration/index.ts
@@ -26,6 +26,8 @@ export const IntegrationJobAction = {
   incomingComment: "incomingComment",
   updateIncomingComment: "updateIncomingComment",
   deleteIncomingComment: "deleteIncomingComment",
+  deleteIncomingMessage: "deleteIncomingMessage",
+  messageReaction: "messageReaction",
   messageStatus: "messageStatus",
   runFlowPostback: "runFlowPostback",
   runFlowQuickReply: "runFlowQuickReply",
@@ -106,6 +108,27 @@ export type IntegrationJobDeleteIncomingComment = {
     integrationType: string
     integrationIdentifier: string
     commentId: string
+  }
+}
+
+export type IntegrationJobDeleteIncomingMessage = {
+  type: typeof IntegrationJobAction.deleteIncomingMessage
+  data: {
+    integrationType: string
+    integrationIdentifier: string
+    messageId: string
+  }
+}
+
+export type IntegrationJobMessageReaction = {
+  type: typeof IntegrationJobAction.messageReaction
+  data: {
+    integrationType: string
+    integrationIdentifier: string
+    messageId: string
+    action: "react" | "unreact"
+    emoji?: string
+    contactSourceId: string
   }
 }
 
@@ -566,6 +589,8 @@ export type IntegrationJobData =
   | IntegrationJobReceiveComment
   | IntegrationJobUpdateIncomingComment
   | IntegrationJobDeleteIncomingComment
+  | IntegrationJobDeleteIncomingMessage
+  | IntegrationJobMessageReaction
   | IntegrationJobMessageStatus
   | IntegrationJobRunFlowNode
   | IntegrationJobSendFlowPostback


### PR DESCRIPTION
## Summary
- Instagram/Messenger webhooks now process every batched entry/messaging event (previously only the first was read), widen attachment-type schemas with a safe `.catch("fallback")`, and add unsend + reaction handling.
- Add a manual "Private reply" action in the inbox for post/comment conversations: sends a comment-anchored DM to the contact's own conversation instead of a public reply, with attachments forwarded correctly.
- Fix a sharded-repository shard-selection bug that silently no-op'd deleting/unsending messages older than the current hour, and stop DM reactions from corrupting messaging-window/MAC-billing tracking meant only for real inbound messages.

## Changes
- `integrations/{instagram,instagram-facebook,messenger}/src/handlers/webhook.ts` — loop over every batched entry/messaging event; dispatch new `messageReaction`/`deleteIncomingMessage` job types; add missing guards.
- `integrations/{instagram,instagram-facebook}/src/schemas.ts`, `integrations/messenger/src/schema.ts` — widen `attachmentTypeSchema` with `.catch("fallback")`; add `is_deleted`/`reaction` fields.
- `integrations/*/src/handlers/comment/outgoing-private-reply/index.ts` (new) + `packages/sdk/src/lib/integration.ts` — new `sendPrivateReply` channel handler, forwarding text and attachments.
- `apps/worker/src/integration/handlers/received-message.ts` — `deleteIncomingMessage` (unsend) and `processMessageReaction` handlers, with correct MAC/messaging-window isolation.
- `packages/database/src/sharding/message/repository/sharded-message-repository.ts` — `deleteBySourceId` falls back to a full-history shard scan and re-searches children using the row's real `createdAt`.
- `apps/worker/src/chat/handlers/send-message.ts`, `apps/builder/src/features/messages/**`, `apps/builder/src/features/chat/store/chat-store.ts` — manual "Private reply" icon, routing the message to the contact's DM conversation.
- `apps/builder/messages/*.json` — new `messages.privateReply` translation key across all 20 locales.
- `packages/database/__tests__/sharded-message-repository.test.ts` — new coverage for the shard fallback fix.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter worker --filter @chatbotx.io/database --filter @chatbotx.io/integration-instagram --filter @chatbotx.io/integration-instagram-facebook --filter @chatbotx.io/integration-messenger --filter builder check-types`
- [x] `pnpm --filter worker --filter @chatbotx.io/database --filter @chatbotx.io/integration-instagram --filter @chatbotx.io/integration-instagram-facebook --filter @chatbotx.io/integration-messenger test`
- [ ] Manual: send a private reply with an attachment-only message on each channel and confirm delivery
- [ ] Manual: react to an old DM and confirm the messaging window / MAC usage are unaffected
- [ ] Manual: unsend a DM older than 1 hour and confirm it's removed from the inbox