### PR TITLE
fix(inbox): cannot send media library image in conversation

### DIFF
--- a/apps/builder/__tests__/create-message-schema.test.ts
+++ b/apps/builder/__tests__/create-message-schema.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "vitest"
+import { createMessageRequest } from "@/features/messages/schema/mutation"
+
+describe("createMessageRequest", () => {
+  test("parses {text, mediaFileId} and retains mediaFileId — proves the union matches the mediaFileId branch before the text-only branch, which would otherwise silently strip it", () => {
+    const result = createMessageRequest.safeParse({
+      text: "hello",
+      mediaFileId: "123",
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toMatchObject({
+        text: "hello",
+        mediaFileId: "123",
+      })
+    }
+  })
+
+  test("parses {mediaFileId} alone", () => {
+    const result = createMessageRequest.safeParse({
+      mediaFileId: "123",
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toMatchObject({ mediaFileId: "123" })
+    }
+  })
+
+  test("still parses the legacy {text, mediaFile} path-based shape", () => {
+    const result = createMessageRequest.safeParse({
+      text: "hello",
+      mediaFile: {
+        path: "ws/1/a.png",
+        url: "https://cdn.example.test/ws/1/a.png",
+        mimeType: "image/png",
+        name: "a.png",
+        size: 1024,
+      },
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toMatchObject({
+        text: "hello",
+        mediaFile: { path: "ws/1/a.png" },
+      })
+    }
+  })
+
+  test("still parses the legacy {mediaFile} path-based shape alone", () => {
+    const result = createMessageRequest.safeParse({
+      mediaFile: {
+        path: "ws/1/a.png",
+        mimeType: "image/png",
+        size: 1024,
+      },
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toMatchObject({
+        mediaFile: { path: "ws/1/a.png" },
+      })
+    }
+  })
+
+  test("still parses plain {text}", () => {
+    const result = createMessageRequest.safeParse({
+      text: "hello",
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toMatchObject({ text: "hello" })
+    }
+  })
+})

--- a/apps/builder/src/features/media-library/queries/__tests__/media-library-files.test.ts
+++ b/apps/builder/src/features/media-library/queries/__tests__/media-library-files.test.ts
@@ -61,6 +61,7 @@ vi.mock("@chatbotx.io/database/client", () => ({
 
 vi.mock("@chatbotx.io/database/schema", () => ({
   mediaLibraryFileModel: {
+    id: "file.id",
     workspaceId: "file.workspaceId",
     folderId: "file.folderId",
     isFavourite: "file.isFavourite",
@@ -80,9 +81,11 @@ vi.mock("@/lib/auth/utils", () => ({
   assertCurrentUserCanAccessChatbot: mocks.assertCurrentUserCanAccessChatbot,
 }))
 
-const { listMediaLibraryFiles, findMediaLibraryFileByPath } = await import(
-  "../files"
-)
+const {
+  listMediaLibraryFiles,
+  findMediaLibraryFileByPath,
+  findMediaLibraryFileById,
+} = await import("../files")
 
 const WS = "workspace-1"
 
@@ -266,6 +269,51 @@ describe("findMediaLibraryFileByPath", () => {
     expect(whereArg).toEqual([
       ["file.workspaceId", WS],
       ["file.path", "ws/2/spoofed.png"],
+    ])
+  })
+})
+
+// ── findMediaLibraryFileById ───────────────────────────────────────────────────
+
+describe("findMediaLibraryFileById", () => {
+  test("returns the file when a row matches workspaceId and id", async () => {
+    const file = { id: "file-1", workspaceId: WS, path: "ws/1/a.png" }
+    const { chain } = createSelectChain([file])
+    dbSelect.mockReturnValue(chain)
+
+    const result = await findMediaLibraryFileById({
+      workspaceId: WS,
+      id: "file-1",
+    })
+
+    expect(result).toEqual(file)
+  })
+
+  test("returns null when no row matches", async () => {
+    const { chain } = createSelectChain([])
+    dbSelect.mockReturnValue(chain)
+
+    const result = await findMediaLibraryFileById({
+      workspaceId: WS,
+      id: "missing-id",
+    })
+
+    expect(result).toBeNull()
+  })
+
+  test("scopes the lookup by both workspaceId and id so an id from another workspace never matches", async () => {
+    const { chain } = createSelectChain([])
+    dbSelect.mockReturnValue(chain)
+
+    await findMediaLibraryFileById({
+      workspaceId: WS,
+      id: "file-from-ws-2",
+    })
+
+    const whereArg = chain.where.mock.calls[0]?.[0] as unknown[][]
+    expect(whereArg).toEqual([
+      ["file.workspaceId", WS],
+      ["file.id", "file-from-ws-2"],
     ])
   })
 })

--- a/apps/builder/src/features/media-library/queries/files.ts
+++ b/apps/builder/src/features/media-library/queries/files.ts
@@ -89,3 +89,26 @@ export async function findMediaLibraryFileByPath(input: {
 
   return file ?? null
 }
+
+/**
+ * Confirms a DB id belongs to a Media Library file owned by the given
+ * workspace, so a client-supplied id can't be used to reference another
+ * workspace's (or otherwise arbitrary) storage object.
+ */
+export async function findMediaLibraryFileById(input: {
+  workspaceId: string
+  id: string
+}) {
+  const [file] = await db
+    .select()
+    .from(mediaLibraryFileModel)
+    .where(
+      and(
+        eq(mediaLibraryFileModel.workspaceId, input.workspaceId),
+        eq(mediaLibraryFileModel.id, input.id),
+      ),
+    )
+    .limit(1)
+
+  return file ?? null
+}

--- a/apps/builder/src/features/messages/actions/create-message.action.ts
+++ b/apps/builder/src/features/messages/actions/create-message.action.ts
@@ -30,7 +30,10 @@ import {
   IntegrationJobAction,
   integrationQueue,
 } from "@chatbotx.io/worker-config"
-import { findMediaLibraryFileByPath } from "@/features/media-library/queries/files"
+import {
+  findMediaLibraryFileById,
+  findMediaLibraryFileByPath,
+} from "@/features/media-library/queries/files"
 import { workspaceActionClient } from "@/lib/safe-action"
 import {
   type CreateMessageRequest,
@@ -76,6 +79,41 @@ export const createMessageAction = workspaceActionClient
       user: ctx.user,
     })
   })
+
+/**
+ * Copies a Media Library file into a conversation-scoped path instead of
+ * reusing the Media Library file's own S3 key: attachments must outlive the
+ * Media Library file they were picked from, since deleting that file (or its
+ * folder) later must not break an already-sent message.
+ */
+type CopyableMediaLibraryFile = {
+  path: string
+  name: string
+  mimeType: string
+  size: number
+}
+
+const copyMediaLibraryFileToConversationAttachment = async (props: {
+  mediaLibraryFile: CopyableMediaLibraryFile
+  workspaceId: string
+  conversationId: string
+}): Promise<UploadedFile> => {
+  const { mediaLibraryFile, workspaceId, conversationId } = props
+
+  const attachmentPath = pathJoin(
+    `public/space/${workspaceId}/conversations/${conversationId}`,
+    createId(),
+  )
+  await uploader.copyObject(mediaLibraryFile.path, attachmentPath)
+
+  return {
+    name: mediaLibraryFile.name,
+    mimeType: mediaLibraryFile.mimeType,
+    originPath: attachmentPath,
+    size: mediaLibraryFile.size,
+    fileType: guessFileTypeFromMimeType(mediaLibraryFile.mimeType),
+  }
+}
 
 export const createMessage = async (props: {
   conversation: ConversationModel
@@ -123,6 +161,7 @@ export const createMessage = async (props: {
       `public/space/${conversation.workspaceId}/conversations/${targetConversation.id}`,
     )
   } else if ("mediaFile" in parsedInput && parsedInput.mediaFile) {
+    // Legacy path-based selection, still used by public oRPC APIs.
     const mediaLibraryFile = await findMediaLibraryFileByPath({
       workspaceId: conversation.workspaceId,
       path: parsedInput.mediaFile.path,
@@ -131,24 +170,28 @@ export const createMessage = async (props: {
       throw new ChatbotXException("Media library file not found")
     }
 
-    // Copy into a conversation-scoped path instead of reusing the Media
-    // Library file's own S3 key: attachments must outlive the Media Library
-    // file they were picked from, since deleting that file (or its folder)
-    // later must not break an already-sent message.
-    const attachmentPath = pathJoin(
-      `public/space/${conversation.workspaceId}/conversations/${targetConversation.id}`,
-      createId(),
-    )
-    await uploader.copyObject(mediaLibraryFile.path, attachmentPath)
+    uploadedFiles = [
+      await copyMediaLibraryFileToConversationAttachment({
+        mediaLibraryFile,
+        workspaceId: conversation.workspaceId,
+        conversationId: targetConversation.id,
+      }),
+    ]
+  } else if ("mediaFileId" in parsedInput && parsedInput.mediaFileId) {
+    const mediaLibraryFile = await findMediaLibraryFileById({
+      workspaceId: conversation.workspaceId,
+      id: parsedInput.mediaFileId,
+    })
+    if (!mediaLibraryFile) {
+      throw new ChatbotXException("Media library file not found")
+    }
 
     uploadedFiles = [
-      {
-        name: mediaLibraryFile.name,
-        mimeType: mediaLibraryFile.mimeType,
-        originPath: attachmentPath,
-        size: mediaLibraryFile.size,
-        fileType: guessFileTypeFromMimeType(mediaLibraryFile.mimeType),
-      },
+      await copyMediaLibraryFileToConversationAttachment({
+        mediaLibraryFile,
+        workspaceId: conversation.workspaceId,
+        conversationId: targetConversation.id,
+      }),
     ]
   }
 

--- a/apps/builder/src/features/messages/components/media-file-preview.tsx
+++ b/apps/builder/src/features/messages/components/media-file-preview.tsx
@@ -3,28 +3,22 @@
 import { Button } from "@chatbotx.io/ui/components/ui/button"
 import { PaperclipIcon, XCircleIcon } from "lucide-react"
 import Image from "next/image"
-import { useFormContext, useWatch } from "react-hook-form"
 
-type MediaFileFieldValue = {
-  path: string
-  url?: string
+type MediaFilePreviewValue = {
+  url: string
   mimeType: string
-  name?: string | null
-  size: number
+  name: string
 }
 
-export const MediaFilePreview = () => {
-  const { control, setValue } = useFormContext()
+type MediaFilePreviewProps = {
+  mediaFile: MediaFilePreviewValue
+  onRemove: () => void
+}
 
-  const mediaFile: MediaFileFieldValue | undefined = useWatch({
-    control,
-    name: "mediaFile",
-  })
-
-  if (!mediaFile) {
-    return null
-  }
-
+export const MediaFilePreview = ({
+  mediaFile,
+  onRemove,
+}: MediaFilePreviewProps) => {
   const isImage = mediaFile.mimeType.startsWith("image")
 
   return (
@@ -33,7 +27,7 @@ export const MediaFilePreview = () => {
         <div className="max-w-36 overflow-hidden rounded-md">
           {isImage && mediaFile.url ? (
             <Image
-              alt={mediaFile.name ?? "file"}
+              alt={mediaFile.name}
               className="h-16 w-auto"
               height={64}
               src={mediaFile.url}
@@ -49,9 +43,7 @@ export const MediaFilePreview = () => {
 
         <Button
           className="absolute -end-2 -top-2 h-auto rounded-full bg-white p-0 px-0 dark:bg-neutral-600"
-          onClick={() =>
-            setValue("mediaFile", undefined, { shouldValidate: true })
-          }
+          onClick={onRemove}
           type="button"
           variant="ghost"
         >

--- a/apps/builder/src/features/messages/components/message-input.tsx
+++ b/apps/builder/src/features/messages/components/message-input.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/features/conversations/utils/bot-state"
 import { InboxIcon } from "@/features/inboxes/components/inbox-icon"
 import { MediaLibraryTrigger } from "@/features/media-library/components/media-library-trigger"
+import type { ListFilesResponse } from "@/features/media-library/schemas"
 import { QuickRepliesPopover } from "@/features/saved-replies/quick-replies-popover"
 import { authClient } from "@/lib/auth/auth-client"
 import { useChatStore } from "../../chat/store/chat-store-provider"
@@ -69,12 +70,23 @@ const CHANNEL_WINDOW_SECONDS: Record<ChannelType, number> = {
 
 const MESSENGER_HUMAN_AGENT_WINDOW_SECONDS = 7 * 24 * 60 * 60
 
+// Media Library selection metadata kept for preview purposes only. The form
+// field only carries `mediaFileId` (the DB id sent to the server) — the
+// action submits the resolver-parsed form values directly, so display-only
+// fields like url/name can't live on the form.
+type SelectedMediaFile = Pick<
+  ListFilesResponse["data"][number],
+  "url" | "mimeType" | "name"
+>
+
 export const MessageInput = () => {
   const t = useTranslations()
   const session = authClient.useSession()
 
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileUploadRef = useRef<HTMLInputElement>(null)
+  const [selectedMediaFile, setSelectedMediaFile] =
+    useState<SelectedMediaFile | null>(null)
 
   const {
     appendMessage,
@@ -177,6 +189,7 @@ export const MessageInput = () => {
             }
 
             form.reset()
+            setSelectedMediaFile(null)
             textareaRef.current?.focus()
           },
           onSuccess: () => {
@@ -186,6 +199,7 @@ export const MessageInput = () => {
             setReplyToMessage(null)
             textareaRef.current?.focus()
             resetFormAndAction()
+            setSelectedMediaFile(null)
             form.setValue("clientId", createId())
           },
         },
@@ -193,7 +207,7 @@ export const MessageInput = () => {
           defaultValues: {
             text: "",
             files: [],
-            mediaFile: undefined,
+            mediaFileId: undefined,
             clientId: createId(),
             replyToMessageId: undefined,
             replyToMessageCreatedAt: undefined,
@@ -376,16 +390,12 @@ export const MessageInput = () => {
   )
 
   // Check if a media file (device upload or Media Library pick) is attached
-  const mediaFile = useWatch({
-    control: form.control,
-    name: "mediaFile",
-  })
   const files = useWatch({
     control: form.control,
     name: "files",
   })
   const hasFiles =
-    Boolean(mediaFile) || (Array.isArray(files) && files.length > 0)
+    Boolean(selectedMediaFile) || (Array.isArray(files) && files.length > 0)
 
   // Early return if no active conversation
   if (!activeConversationId) {
@@ -516,7 +526,15 @@ export const MessageInput = () => {
           {!isInstagramPostComment && (
             <div className="px-2">
               <FileUploadPreview ref={fileUploadRef} />
-              <MediaFilePreview />
+              {selectedMediaFile && (
+                <MediaFilePreview
+                  mediaFile={selectedMediaFile}
+                  onRemove={() => {
+                    setSelectedMediaFile(null)
+                    form.resetField("mediaFileId")
+                  }}
+                />
+              )}
             </div>
           )}
           <div className="flex w-full items-center ps-2.5">
@@ -536,7 +554,7 @@ export const MessageInput = () => {
                   <Button
                     aria-label="Attach file"
                     className="px-2 py-1.5 [&_svg]:size-5"
-                    disabled={Boolean(mediaFile)}
+                    disabled={Boolean(selectedMediaFile)}
                     onClick={onClickAttachment}
                     type="button"
                     variant="ghost"
@@ -545,17 +563,14 @@ export const MessageInput = () => {
                   </Button>
                   <MediaLibraryTrigger
                     onSelect={(file) => {
-                      form.setValue(
-                        "mediaFile",
-                        {
-                          path: file.path,
-                          url: file.url,
-                          mimeType: file.mimeType,
-                          name: file.name,
-                          size: file.size,
-                        },
-                        { shouldValidate: true },
-                      )
+                      form.setValue("mediaFileId", file.id, {
+                        shouldValidate: true,
+                      })
+                      setSelectedMediaFile({
+                        url: file.url,
+                        mimeType: file.mimeType,
+                        name: file.name,
+                      })
                     }}
                     workspaceId={conversation?.workspaceId ?? ""}
                   >

--- a/apps/builder/src/features/messages/schema/mutation.ts
+++ b/apps/builder/src/features/messages/schema/mutation.ts
@@ -29,6 +29,14 @@ export const createMessageRequest = z
       text: z.string().trim().min(1).max(1000),
       mediaFile: mediaLibraryFileRequest,
     }),
+    // Media Library selection identified by DB id — must be listed before
+    // the text-only branch below, since z.object() strips unknown keys: if
+    // the text-only branch matched first, mediaFileId would be silently
+    // dropped and the message would send as plain text.
+    z.object({
+      text: z.string().trim().min(1).max(1000),
+      mediaFileId: zodBigintAsString(),
+    }),
     z.object({
       text: z.string().trim().min(1).max(1000),
     }),
@@ -43,6 +51,9 @@ export const createMessageRequest = z
     }),
     z.object({
       mediaFile: mediaLibraryFileRequest,
+    }),
+    z.object({
+      mediaFileId: zodBigintAsString(),
     }),
     z.object({
       flowId: zodBigintAsString(),

--- a/packages/filesystem/__tests__/copy-source.test.ts
+++ b/packages/filesystem/__tests__/copy-source.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest"
+import { buildCopySource } from "../src/lib/copy-source"
+
+describe("buildCopySource", () => {
+  test("uses bucket/key when no endpoint is configured", () => {
+    expect(buildCopySource("public/space/1/file.jpg", "mybucket")).toBe(
+      "mybucket/public/space/1/file.jpg",
+    )
+  })
+
+  test("uses bucket/key when endpoint has no path", () => {
+    expect(
+      buildCopySource(
+        "public/space/1/file.jpg",
+        "mybucket",
+        "https://account.r2.cloudflarestorage.com",
+      ),
+    ).toBe("mybucket/public/space/1/file.jpg")
+  })
+
+  test("replicates the endpoint path prefix when endpoint includes it", () => {
+    // Endpoint mistakenly (or intentionally) carries the bucket in its path:
+    // every URL-addressed op stores objects under "chatconnectx/<key>", so the
+    // header-addressed CopySource must point at the same real key.
+    expect(
+      buildCopySource(
+        "public/space/1/file.jpg",
+        "chatconnectx",
+        "https://account.r2.cloudflarestorage.com/chatconnectx",
+      ),
+    ).toBe("chatconnectx/chatconnectx/public/space/1/file.jpg")
+  })
+
+  test("handles endpoint path with trailing slash", () => {
+    expect(
+      buildCopySource("a/b.png", "bkt", "https://host.example.com/prefix/"),
+    ).toBe("prefix/bkt/a/b.png")
+  })
+
+  test("URL-encodes each key segment", () => {
+    expect(buildCopySource("a b/c#d.png", "bkt")).toBe("bkt/a%20b/c%23d.png")
+  })
+})

--- a/packages/filesystem/src/lib/copy-source.ts
+++ b/packages/filesystem/src/lib/copy-source.ts
@@ -1,0 +1,27 @@
+/**
+ * Builds the `x-amz-copy-source` value for CopyObject.
+ *
+ * Every other S3 operation addresses objects through the request URL
+ * (`endpoint` + `/bucket/key` in path-style), so when `S3_ENDPOINT` carries a
+ * path of its own (e.g. an R2 endpoint that already includes the bucket name),
+ * objects are actually stored under that extra prefix. CopySource is sent as a
+ * header — the endpoint path never applies to it — so it must replicate the
+ * same prefix or it points at a key that does not exist (NoSuchKey).
+ */
+export function buildCopySource(
+  sourcePath: string,
+  bucket: string,
+  endpoint?: string,
+): string {
+  const encodedSource = sourcePath
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/")
+
+  const endpointPath = endpoint
+    ? new URL(endpoint).pathname.replace(/^\/+|\/+$/g, "")
+    : ""
+  const prefix = endpointPath ? `${endpointPath}/` : ""
+
+  return `${prefix}${bucket}/${encodedSource}`
+}

--- a/packages/filesystem/src/lib/uploader.ts
+++ b/packages/filesystem/src/lib/uploader.ts
@@ -12,6 +12,7 @@ import {
 } from "@aws-sdk/client-s3"
 import { AwsClient } from "aws4fetch"
 import { keys } from "../keys"
+import { buildCopySource } from "./copy-source"
 
 const env = keys()
 
@@ -182,15 +183,10 @@ export class Uploader {
   }
 
   async copyObject(sourcePath: string, destinationPath: string) {
-    const encodedSource = sourcePath
-      .split("/")
-      .map((segment) => encodeURIComponent(segment))
-      .join("/")
-
     const command = new CopyObjectCommand({
       Bucket: env.S3_BUCKET,
       Key: destinationPath,
-      CopySource: `${env.S3_BUCKET}/${encodedSource}`,
+      CopySource: buildCopySource(sourcePath, env.S3_BUCKET, env.S3_ENDPOINT),
     })
 
     return await this.#client.send(command)


### PR DESCRIPTION
## Summary
- Sending an image picked from the Media Library in the inbox failed with S3 `NoSuchKey` on storage providers whose `S3_ENDPOINT` includes a path (e.g. S3 endpoints carrying the bucket name): every URL-addressed operation stores objects under the endpoint's path prefix, but `CopyObject` addresses its source via the `x-amz-copy-source` header, which never received that prefix.
- The inbox message input now submits the Media Library file's DB id instead of a client-supplied `{path, url, mimeType, name, size}` object; the server resolves the file from a workspace-scoped lookup, so attachment metadata always comes from the database. The legacy `mediaFile` payload shape remains accepted for the public message APIs.

## Changes
- `packages/filesystem`: new `buildCopySource` helper replicates the endpoint URL's path prefix into `CopySource`; behavior is unchanged for endpoints without a path.
- `apps/builder/.../messages/schema/mutation.ts`: add `mediaFileId` union branches to `createMessageRequest` (ordered before the text-only branch so the id is never silently stripped); legacy `mediaFile` branches untouched.
- `apps/builder/.../media-library/queries/files.ts`: add `findMediaLibraryFileById` with the same workspace scoping as the path lookup.
- `apps/builder/.../messages/actions/create-message.action.ts`: shared `copyMediaLibraryFileToConversationAttachment` helper used by both the id and legacy path branches.
- `apps/builder/.../messages/components/message-input.tsx` + `media-file-preview.tsx`: form submits `mediaFileId` only; preview metadata moves to local state and the preview becomes a presentational component. UI/UX unchanged.

## Test plan
- [x] pnpm lint
- [x] pnpm --filter builder check-types
- [x] `buildCopySource` unit tests (no endpoint, endpoint without path, endpoint with bucket path, trailing slash, key encoding)
- [x] `createMessageRequest` schema tests (new `mediaFileId` branches parse, union ordering keeps the id, legacy `mediaFile` and text-only payloads still parse)
- [x] `findMediaLibraryFileById` query tests (workspace-scoped, null for other workspaces)
- [ ] Manually verify on an R2-backed environment: upload an image to the Media Library, send it from the inbox message input, confirm the message delivers and the attachment renders
- [ ] Manually verify sending a device-uploaded file and a plain text message still work