### PR TITLE
feat(messenger): show non-admin pages as disabled in page picker

### DIFF
--- a/apps/builder/__tests__/create-message-schema.test.ts
+++ b/apps/builder/__tests__/create-message-schema.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "vitest"
+import { createMessageRequest } from "@/features/messages/schema/mutation"
+
+describe("createMessageRequest", () => {
+  test("parses {text, mediaFileId} and retains mediaFileId — proves the union matches the mediaFileId branch before the text-only branch, which would otherwise silently strip it", () => {
+    const result = createMessageRequest.safeParse({
+      text: "hello",
+      mediaFileId: "123",
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toMatchObject({
+        text: "hello",
+        mediaFileId: "123",
+      })
+    }
+  })
+
+  test("parses {mediaFileId} alone", () => {
+    const result = createMessageRequest.safeParse({
+      mediaFileId: "123",
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toMatchObject({ mediaFileId: "123" })
+    }
+  })
+
+  test("still parses the legacy {text, mediaFile} path-based shape", () => {
+    const result = createMessageRequest.safeParse({
+      text: "hello",
+      mediaFile: {
+        path: "ws/1/a.png",
+        url: "https://cdn.example.test/ws/1/a.png",
+        mimeType: "image/png",
+        name: "a.png",
+        size: 1024,
+      },
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toMatchObject({
+        text: "hello",
+        mediaFile: { path: "ws/1/a.png" },
+      })
+    }
+  })
+
+  test("still parses the legacy {mediaFile} path-based shape alone", () => {
+    const result = createMessageRequest.safeParse({
+      mediaFile: {
+        path: "ws/1/a.png",
+        mimeType: "image/png",
+        size: 1024,
+      },
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toMatchObject({
+        mediaFile: { path: "ws/1/a.png" },
+      })
+    }
+  })
+
+  test("still parses plain {text}", () => {
+    const result = createMessageRequest.safeParse({
+      text: "hello",
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toMatchObject({ text: "hello" })
+    }
+  })
+})

--- a/apps/builder/__tests__/messenger-pages.test.tsx
+++ b/apps/builder/__tests__/messenger-pages.test.tsx
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import {
+  FacebookPages,
+  type PickerFacebookPage,
+} from "@/features/integration-messenger/components/messenger-pages"
+
+/** Echoes the key back so assertions never depend on the English copy. */
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+// FacebookPages only reads the submission machinery to wire up the form;
+// none of these tests submit, so a minimal stub keeps the adapter's
+// `useFormIntegration` (which reads `action.result`/`action.executeAsync`)
+// satisfied without pulling in the real safe-action runtime.
+vi.mock("next-safe-action/hooks", () => ({
+  useAction: () => ({
+    result: {},
+    reset: vi.fn(),
+    executeAsync: vi.fn(async () => ({})),
+    execute: vi.fn(),
+    isPending: false,
+  }),
+}))
+
+// The real action module is a "use server" file that imports the database
+// client and business services — unnecessary (and unsafe) to load for a
+// component test that never submits the form.
+vi.mock(
+  "../src/features/integration-messenger/actions/select-page.action",
+  () => ({
+    selectPageAction: vi.fn(),
+  }),
+)
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+// jsdom ships no ResizeObserver/PointerEvent constructors; Base UI's radio
+// group measures/dispatches through them even when nothing is clicked.
+Object.assign(globalThis, {
+  ResizeObserver: class {
+    observe = vi.fn()
+    unobserve = vi.fn()
+    disconnect = vi.fn()
+  },
+})
+if (typeof globalThis.PointerEvent === "undefined") {
+  class PointerEventPolyfill extends MouseEvent {
+    constructor(type: string, params: MouseEventInit = {}) {
+      super(type, params)
+    }
+  }
+  Object.assign(globalThis, { PointerEvent: PointerEventPolyfill })
+}
+
+const selectablePage: PickerFacebookPage = {
+  id: "page-selectable",
+  name: "Selectable Page",
+  access_token: "selectable-token",
+  isConnectable: true,
+  isAlreadyConnected: false,
+}
+
+const notAdminPage: PickerFacebookPage = {
+  id: "page-not-admin",
+  name: "Not Admin Page",
+  isConnectable: false,
+  isAlreadyConnected: false,
+}
+
+const connectedPage: PickerFacebookPage = {
+  id: "page-connected",
+  name: "Connected Page",
+  isConnectable: false,
+  isAlreadyConnected: true,
+}
+
+// Connect-eligible but already connected elsewhere: still disabled with the
+// already-connected note, and must not trigger the not-admin warning.
+const connectableButConnectedPage: PickerFacebookPage = {
+  id: "page-connectable-but-connected",
+  name: "Connectable But Connected Page",
+  isConnectable: true,
+  isAlreadyConnected: true,
+}
+
+describe("FacebookPages", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+    container = document.createElement("div")
+    document.body.append(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+  })
+
+  function renderPages(pages: PickerFacebookPage[]) {
+    act(() => {
+      root.render(
+        <FacebookPages
+          onCoexistRequired={vi.fn()}
+          pages={pages}
+          workspaceId="ws-1"
+        />,
+      )
+    })
+  }
+
+  test("renders a disabled radio input with the notAdminNote description for a non-admin page", () => {
+    renderPages([selectablePage, notAdminPage])
+
+    const radios = container.querySelectorAll<HTMLInputElement>(
+      'input[type="radio"]',
+    )
+    expect(radios).toHaveLength(2)
+    expect(radios[0]?.disabled).toBe(false)
+    expect(radios[1]?.disabled).toBe(true)
+
+    expect(container.textContent).toContain("messenger.selectPage.notAdminNote")
+  })
+
+  test("shows the no-connectable-pages warning when no page is selectable", () => {
+    renderPages([notAdminPage, connectedPage])
+
+    expect(container.textContent).toContain(
+      "messenger.selectPage.noConnectablePagesTitle",
+    )
+    expect(container.textContent).toContain(
+      "messenger.selectPage.noConnectablePagesDescription",
+    )
+
+    const tryAgainLink = Array.from(container.querySelectorAll("a")).find(
+      (link) => link.getAttribute("href") === "/channels/create",
+    )
+    expect(tryAgainLink).not.toBeUndefined()
+
+    const radios = container.querySelectorAll<HTMLInputElement>(
+      'input[type="radio"]',
+    )
+    expect(radios).toHaveLength(2)
+    for (const radio of Array.from(radios)) {
+      expect(radio.disabled).toBe(true)
+    }
+  })
+
+  test("does not show the not-admin warning when every page is merely already connected", () => {
+    renderPages([connectedPage, connectableButConnectedPage])
+
+    expect(container.textContent).not.toContain(
+      "messenger.selectPage.noConnectablePagesTitle",
+    )
+    // The rows' own notes already explain why nothing is selectable.
+    expect(container.textContent).toContain(
+      "messenger.selectPage.alreadyConnectedNote",
+    )
+
+    const radios = container.querySelectorAll<HTMLInputElement>(
+      'input[type="radio"]',
+    )
+    expect(radios).toHaveLength(2)
+    for (const radio of Array.from(radios)) {
+      expect(radio.disabled).toBe(true)
+    }
+  })
+
+  test("does not show the no-connectable-pages warning when at least one page is selectable", () => {
+    renderPages([selectablePage, notAdminPage])
+
+    expect(container.textContent).not.toContain(
+      "messenger.selectPage.noConnectablePagesTitle",
+    )
+  })
+})

--- a/apps/builder/__tests__/messenger-select-page.test.tsx
+++ b/apps/builder/__tests__/messenger-select-page.test.tsx
@@ -57,26 +57,39 @@ type SelectPageElementProps = {
   pages: Array<{
     id: string
     isAlreadyConnected: boolean
+    access_token?: string
   }>
 }
 
 const connectablePage: ConnectableFacebookPage = {
   id: "page-connectable",
   name: "Connectable Page",
-  access_token: "page-token",
+  access_token: "connectable-token",
   isConnectable: true,
 }
 
-const connectedWithoutPermissionPage: ConnectableFacebookPage = {
-  id: "page-connected",
-  name: "Connected Page",
+const notAdminPage: ConnectableFacebookPage = {
+  id: "page-not-admin",
+  name: "Not Admin Page",
+  access_token: "not-admin-token",
   isConnectable: false,
 }
 
-const unavailablePage: ConnectableFacebookPage = {
-  id: "page-unavailable",
-  name: "Unavailable Page",
+const alreadyConnectedPage: ConnectableFacebookPage = {
+  id: "page-connected",
+  name: "Connected Page",
+  access_token: "connected-token",
   isConnectable: false,
+}
+
+// Meta can report a page as both connect-eligible and already connected
+// elsewhere (e.g. reconnected under a different workspace) — this must still
+// rank last and lose its token, exactly like any other already-connected page.
+const connectableAndConnectedPage: ConnectableFacebookPage = {
+  id: "page-connectable-and-connected",
+  name: "Connectable But Connected Page",
+  access_token: "connectable-and-connected-token",
+  isConnectable: true,
 }
 
 describe("MessengerSelectPage", () => {
@@ -92,13 +105,21 @@ describe("MessengerSelectPage", () => {
       workspaceId: "ws-1",
     })
     mockGetUserPages.mockResolvedValue({
-      pages: [unavailablePage, connectedWithoutPermissionPage, connectablePage],
+      pages: [
+        notAdminPage,
+        alreadyConnectedPage,
+        connectablePage,
+        connectableAndConnectedPage,
+      ],
       bmLookupFailed: false,
     })
-    mockFindConnectedMessengerPageIds.mockResolvedValue(["page-connected"])
+    mockFindConnectedMessengerPageIds.mockResolvedValue([
+      "page-connected",
+      "page-connectable-and-connected",
+    ])
   })
 
-  test("passes only connectable or already-connected pages to the picker", async () => {
+  test("passes every page through, ranked connectable first, then non-admin, then already-connected", async () => {
     const element = await MessengerSelectPage()
 
     expect(isValidElement<SelectPageElementProps>(element)).toBe(true)
@@ -112,10 +133,35 @@ describe("MessengerSelectPage", () => {
         isAlreadyConnected: false,
       }),
       expect.objectContaining({
+        id: "page-not-admin",
+        isAlreadyConnected: false,
+      }),
+      expect.objectContaining({
         id: "page-connected",
         isAlreadyConnected: true,
       }),
+      expect.objectContaining({
+        id: "page-connectable-and-connected",
+        isAlreadyConnected: true,
+      }),
     ])
+  })
+
+  test("strips access_token from every non-selectable page and keeps it on selectable ones", async () => {
+    const element = await MessengerSelectPage()
+
+    if (!isValidElement<SelectPageElementProps>(element)) {
+      throw new Error("MessengerSelectPage did not return a valid element")
+    }
+
+    const tokensById = new Map(
+      element.props.pages.map((page) => [page.id, page.access_token]),
+    )
+
+    expect(tokensById.get("page-connectable")).toBe("connectable-token")
+    expect(tokensById.get("page-not-admin")).toBeUndefined()
+    expect(tokensById.get("page-connected")).toBeUndefined()
+    expect(tokensById.get("page-connectable-and-connected")).toBeUndefined()
   })
 
   test("redirects to channel creation when pending auth is missing", async () => {

--- a/apps/builder/messages/ar.json
+++ b/apps/builder/messages/ar.json
@@ -3093,10 +3093,12 @@
     "selectPage": {
       "noPagesTitle": "لم يتم العثور على صفحات Facebook",
       "noPagesDescription": "تتطلب الصفحات الموجودة داخل مدير الأعمال منح صلاحية الوصول إليه أثناء الاتصال. أعد ربط Messenger وامنح جميع الأذونات المطلوبة.",
+      "noConnectablePagesTitle": "لا توجد صفحات متاحة للربط",
+      "noConnectablePagesDescription": "أنت لست مسؤولاً عن هذه الصفحة",
       "bmLookupFailedTitle": "قد تكون بعض صفحات مدير الأعمال غير ظاهرة",
       "bmLookupFailedDescription": "أعد ربط Messenger وامنح صلاحية الوصول إلى مدير الأعمال حتى يمكن عرض الصفحات المُدارة من خلاله.",
       "alreadyConnectedNote": "هذه الصفحة مرتبطة بالفعل",
-      "notAdminNote": "يلزم امتلاك صلاحية مسؤول كاملة على الصفحة للربط",
+      "notAdminNote": "أنت لست مسؤولاً عن هذه الصفحة",
       "tryAgain": "محاولة إعادة الاتصال"
     },
     "title": "Facebook Messenger",

--- a/apps/builder/messages/da.json
+++ b/apps/builder/messages/da.json
@@ -3093,10 +3093,12 @@
     "selectPage": {
       "noPagesTitle": "Ingen Facebook Pages found",
       "noPagesDescription": "Pages inside a Business Manager require Business Manager access during forbindelse. Forbind igen Messenger og grant alle requested tilladelser.",
+      "noConnectablePagesTitle": "Ingen sider tilgængelige til tilslutning",
+      "noConnectablePagesDescription": "Du er ikke administrator for denne side",
       "bmLookupFailedTitle": "Business Manager pages may være missing",
       "bmLookupFailedDescription": "Forbind igen Messenger og grant Business Manager access so pages managed through a Business Manager kan være listed.",
       "alreadyConnectedNote": "Denne page er allerede forbundet",
-      "notAdminNote": "Full administrator permission på den page er påkrævet til forbind",
+      "notAdminNote": "Du er ikke administrator for denne side",
       "tryAgain": "Try reconnecting"
     },
     "title": "Facebook Messenger",

--- a/apps/builder/messages/de.json
+++ b/apps/builder/messages/de.json
@@ -3093,10 +3093,12 @@
     "selectPage": {
       "noPagesTitle": "Keine Facebook-Seiten gefunden",
       "noPagesDescription": "Seiten in einem Business Manager erfordern während der Verbindung Zugriff auf den Business Manager. Verbinden Sie Messenger erneut und erteilen Sie alle angeforderten Berechtigungen.",
+      "noConnectablePagesTitle": "Keine Seiten zum Verbinden verfügbar",
+      "noConnectablePagesDescription": "Sie sind kein Administrator dieser Seite",
       "bmLookupFailedTitle": "Business-Manager-Seiten fehlen möglicherweise",
       "bmLookupFailedDescription": "Verbinden Sie Messenger erneut und gewähren Sie Zugriff auf den Business Manager, damit über ihn verwaltete Seiten aufgelistet werden können.",
       "alreadyConnectedNote": "Diese Seite ist bereits verbunden",
-      "notAdminNote": "Zum Verbinden ist die vollständige Admin-Berechtigung für die Seite erforderlich",
+      "notAdminNote": "Sie sind kein Administrator dieser Seite",
       "tryAgain": "Erneute Verbindung versuchen"
     },
     "title": "Facebook Messenger",

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -3207,10 +3207,12 @@
     "selectPage": {
       "noPagesTitle": "No Facebook Pages found",
       "noPagesDescription": "Pages inside a Business Manager require Business Manager access during connection. Reconnect Messenger and grant all requested permissions.",
+      "noConnectablePagesTitle": "No Pages available to connect",
+      "noConnectablePagesDescription": "You are not an admin of this Page",
       "bmLookupFailedTitle": "Business Manager pages may be missing",
       "bmLookupFailedDescription": "Reconnect Messenger and grant Business Manager access so pages managed through a Business Manager can be listed.",
       "alreadyConnectedNote": "This page is already connected",
-      "notAdminNote": "Full admin permission on the page is required to connect",
+      "notAdminNote": "You are not an admin of this Page",
       "tryAgain": "Try reconnecting"
     },
     "title": "Facebook Messenger",

--- a/apps/builder/messages/es.json
+++ b/apps/builder/messages/es.json
@@ -3093,10 +3093,12 @@
     "selectPage": {
       "noPagesTitle": "No Facebook Páginas found",
       "noPagesDescription": "Páginas inside un Empresa Manager require Empresa Manager access during connection. ReConectar Messenger y grant todos requested permisos.",
+      "noConnectablePagesTitle": "No hay páginas disponibles para conectar",
+      "noConnectablePagesDescription": "No eres administrador de esta página",
       "bmLookupFailedTitle": "Empresa Manager páginas may be missing",
       "bmLookupFailedDescription": "ReConectar Messenger y grant Empresa Manager access so páginas managed through un Empresa Manager puede be listed.",
       "alreadyConnectedNote": "This página es already connected",
-      "notAdminNote": "Full admin permiso en el página es obligatorio un connect",
+      "notAdminNote": "No eres administrador de esta página",
       "tryAgain": "Intenta volver a conectar"
     },
     "title": "Facebook Messenger",

--- a/apps/builder/messages/fi.json
+++ b/apps/builder/messages/fi.json
@@ -3093,10 +3093,12 @@
     "selectPage": {
       "noPagesTitle": "Facebook-sivuja ei löytynyt",
       "noPagesDescription": "Business Managerin sivut edellyttävät Business Manager -käyttöoikeutta yhdistämisen aikana. Yhdistä Messenger uudelleen ja myönnä kaikki pyydetyt oikeudet.",
+      "noConnectablePagesTitle": "Ei yhdistettävissä olevia sivuja",
+      "noConnectablePagesDescription": "Et ole tämän sivun ylläpitäjä",
       "bmLookupFailedTitle": "Business Manager -sivuja saattaa puuttua",
       "bmLookupFailedDescription": "Yhdistä Messenger uudelleen ja myönnä Business Manager -käyttöoikeus, jotta Business Managerin kautta hallinnoidut sivut voidaan näyttää.",
       "alreadyConnectedNote": "Tämä sivu on jo yhdistetty",
-      "notAdminNote": "Yhdistäminen edellyttää sivun täysiä ylläpitäjän oikeuksia",
+      "notAdminNote": "Et ole tämän sivun ylläpitäjä",
       "tryAgain": "Yritä yhdistää uudelleen"
     },
     "title": "Facebook Messenger",

--- a/apps/builder/messages/fr.json
+++ b/apps/builder/messages/fr.json
@@ -3093,10 +3093,12 @@
     "selectPage": {
       "noPagesTitle": "Aucune Page Facebook trouvée",
       "noPagesDescription": "Les Pages d’un Business Manager nécessitent un accès à celui-ci pendant la connexion. Reconnectez Messenger et accordez toutes les autorisations demandées.",
+      "noConnectablePagesTitle": "Aucune Page disponible à connecter",
+      "noConnectablePagesDescription": "Vous n’êtes pas administrateur de cette Page",
       "bmLookupFailedTitle": "Certaines Pages du Business Manager peuvent manquer",
       "bmLookupFailedDescription": "Reconnectez Messenger et accordez l’accès au Business Manager afin de répertorier les Pages qu’il gère.",
       "alreadyConnectedNote": "Cette Page est déjà connectée",
-      "notAdminNote": "Une autorisation d’administration complète de la Page est requise",
+      "notAdminNote": "Vous n’êtes pas administrateur de cette Page",
       "tryAgain": "Réessayer la connexion"
     },
     "title": "Facebook Messenger",

--- a/apps/builder/messages/he.json
+++ b/apps/builder/messages/he.json
@@ -1291,10 +1291,12 @@
     "selectPage": {
       "noPagesTitle": "לא נמצאו דפי Facebook",
       "noPagesDescription": "דפים בתוך Business Manager דורשים גישה ל-Business Manager במהלך החיבור. חברו מחדש את Messenger והעניקו את כל ההרשאות המבוקשות.",
+      "noConnectablePagesTitle": "אין דפים זמינים לחיבור",
+      "noConnectablePagesDescription": "אינך מנהל של דף זה",
       "bmLookupFailedTitle": "ייתכן שחסרים דפי Business Manager",
       "bmLookupFailedDescription": "חברו מחדש את Messenger והעניקו גישה ל-Business Manager כדי שניתן יהיה להציג דפים המנוהלים דרכו.",
       "alreadyConnectedNote": "דף זה כבר מחובר",
-      "notAdminNote": "נדרשת הרשאת מנהל מלאה בדף כדי להתחבר",
+      "notAdminNote": "אינך מנהל של דף זה",
       "tryAgain": "ניסיון חיבור מחדש"
     },
     "title": "Facebook Messenger",

--- a/apps/builder/messages/id.json
+++ b/apps/builder/messages/id.json
@@ -3093,10 +3093,12 @@
     "selectPage": {
       "noPagesTitle": "Tidak ada Halaman Facebook yang ditemukan",
       "noPagesDescription": "Halaman di dalam Business Manager memerlukan akses Business Manager saat dihubungkan. Hubungkan kembali Messenger dan berikan semua izin yang diminta.",
+      "noConnectablePagesTitle": "Tidak ada Halaman yang tersedia untuk dihubungkan",
+      "noConnectablePagesDescription": "Anda bukan admin Halaman ini",
       "bmLookupFailedTitle": "Halaman Business Manager mungkin tidak ditampilkan",
       "bmLookupFailedDescription": "Hubungkan kembali Messenger dan berikan akses Business Manager agar halaman yang dikelola melalui Business Manager dapat ditampilkan.",
       "alreadyConnectedNote": "Halaman ini sudah terhubung",
-      "notAdminNote": "Izin admin penuh pada halaman diperlukan untuk menghubungkannya",
+      "notAdminNote": "Anda bukan admin Halaman ini",
       "tryAgain": "Coba hubungkan kembali"
     },
     "title": "Facebook Messenger",

--- a/apps/builder/messages/it.json
+++ b/apps/builder/messages/it.json
@@ -3093,10 +3093,12 @@
     "selectPage": {
       "noPagesTitle": "Nessuna Pagina Facebook trovata",
       "noPagesDescription": "Le Pagine in un Business Manager richiedono l'accesso a Business Manager durante la connessione. Ricollega Messenger e concedi tutte le autorizzazioni richieste.",
+      "noConnectablePagesTitle": "Nessuna Pagina disponibile da collegare",
+      "noConnectablePagesDescription": "Non sei amministratore di questa Pagina",
       "bmLookupFailedTitle": "Alcune Pagine di Business Manager potrebbero non essere disponibili",
       "bmLookupFailedDescription": "Ricollega Messenger e concedi l'accesso a Business Manager affinché possano essere elencate le Pagine gestite tramite Business Manager.",
       "alreadyConnectedNote": "Questa Pagina è già collegata",
-      "notAdminNote": "Per collegarsi è necessaria l'autorizzazione completa di amministratore della Pagina",
+      "notAdminNote": "Non sei amministratore di questa Pagina",
       "tryAgain": "Prova a ricollegarti"
     },
     "title": "Facebook Messenger",

--- a/apps/builder/messages/ja.json
+++ b/apps/builder/messages/ja.json
@@ -3072,10 +3072,12 @@
     "selectPage": {
       "noPagesTitle": "Facebookページが見つかりません",
       "noPagesDescription": "ビジネスマネージャ内のページに接続するには、ビジネスマネージャへのアクセス権が必要です。Messengerを再接続し、要求されたすべての権限を許可してください。",
+      "noConnectablePagesTitle": "接続できるページがありません",
+      "noConnectablePagesDescription": "あなたはこのページの管理者ではありません",
       "bmLookupFailedTitle": "ビジネスマネージャのページが一部表示されていない可能性があります",
       "bmLookupFailedDescription": "Messengerを再接続し、ビジネスマネージャへのアクセスを許可すると、ビジネスマネージャで管理されているページを一覧表示できます。",
       "alreadyConnectedNote": "このページはすでに接続されています",
-      "notAdminNote": "接続するにはページの完全な管理者権限が必要です",
+      "notAdminNote": "あなたはこのページの管理者ではありません",
       "tryAgain": "再接続を試す"
     },
     "title": "Facebook Messenger",

--- a/apps/builder/messages/nl.json
+++ b/apps/builder/messages/nl.json
@@ -3093,10 +3093,12 @@
     "selectPage": {
       "noPagesTitle": "Geen Facebook-pagina's gevonden",
       "noPagesDescription": "Voor pagina's in Bedrijfsmanager is tijdens het koppelen toegang tot Bedrijfsmanager vereist. Koppel Messenger opnieuw en verleen alle gevraagde machtigingen.",
+      "noConnectablePagesTitle": "Geen pagina's beschikbaar om te koppelen",
+      "noConnectablePagesDescription": "U bent geen beheerder van deze pagina",
       "bmLookupFailedTitle": "Pagina's uit Bedrijfsmanager ontbreken mogelijk",
       "bmLookupFailedDescription": "Koppel Messenger opnieuw en verleen toegang tot Bedrijfsmanager zodat pagina's die via Bedrijfsmanager worden beheerd kunnen worden vermeld.",
       "alreadyConnectedNote": "Deze pagina is al gekoppeld",
-      "notAdminNote": "Volledige beheerdersmachtiging voor de pagina is vereist om deze te koppelen",
+      "notAdminNote": "U bent geen beheerder van deze pagina",
       "tryAgain": "Probeer opnieuw te koppelen"
     },
     "title": "Facebook Messenger",

--- a/apps/builder/messages/pt-BR.json
+++ b/apps/builder/messages/pt-BR.json
@@ -3072,10 +3072,12 @@
     "selectPage": {
       "noPagesTitle": "Nenhuma Página do Facebook encontrada",
       "noPagesDescription": "Páginas dentro de um Gerenciador de Negócios exigem acesso a ele durante a conexão. Reconecte o Messenger e conceda todas as permissões solicitadas.",
+      "noConnectablePagesTitle": "Nenhuma Página disponível para conectar",
+      "noConnectablePagesDescription": "Você não é administrador desta Página",
       "bmLookupFailedTitle": "Algumas páginas do Gerenciador de Negócios podem não aparecer",
       "bmLookupFailedDescription": "Reconecte o Messenger e conceda acesso ao Gerenciador de Negócios para que as páginas gerenciadas por ele possam ser listadas.",
       "alreadyConnectedNote": "Esta página já está conectada",
-      "notAdminNote": "É necessária permissão total de administrador na página para conectá-la",
+      "notAdminNote": "Você não é administrador desta Página",
       "tryAgain": "Tentar reconectar"
     },
     "title": "Facebook Messenger",

--- a/apps/builder/messages/pt-PT.json
+++ b/apps/builder/messages/pt-PT.json
@@ -3093,10 +3093,12 @@
     "selectPage": {
       "noPagesTitle": "Não foram encontradas Páginas do Facebook",
       "noPagesDescription": "As Páginas num Gestor de Negócios exigem acesso ao Gestor de Negócios durante a ligação. Volte a ligar o Messenger e conceda todas as permissões solicitadas.",
+      "noConnectablePagesTitle": "Não há Páginas disponíveis para ligar",
+      "noConnectablePagesDescription": "Não é administrador desta Página",
       "bmLookupFailedTitle": "Poderão faltar páginas do Gestor de Negócios",
       "bmLookupFailedDescription": "Volte a ligar o Messenger e conceda acesso ao Gestor de Negócios para que as páginas geridas através dele possam ser apresentadas.",
       "alreadyConnectedNote": "Esta página já está ligada",
-      "notAdminNote": "É necessária permissão total de administrador na página para a ligar",
+      "notAdminNote": "Não é administrador desta Página",
       "tryAgain": "Tentar ligar novamente"
     },
     "title": "Facebook Messenger",

--- a/apps/builder/messages/ro.json
+++ b/apps/builder/messages/ro.json
@@ -3093,10 +3093,12 @@
     "selectPage": {
       "noPagesTitle": "Nicio pagină de Facebook găsită",
       "noPagesDescription": "Paginile din interiorul unui Business Manager necesită acces Business Manager în timpul conectării. Reconectează Messenger și acordă toate permisiunile solicitate.",
+      "noConnectablePagesTitle": "Nicio pagină disponibilă pentru conectare",
+      "noConnectablePagesDescription": "Nu ești administrator al acestei Pagini",
       "bmLookupFailedTitle": "Este posibil să lipsească paginile din Business Manager",
       "bmLookupFailedDescription": "Reconectează Messenger și acordă acces la Business Manager pentru ca paginile gestionate printr-un Business Manager să poată fi listate.",
       "alreadyConnectedNote": "Această pagină este deja conectată",
-      "notAdminNote": "Este necesară permisiunea completă de administrator pe pagină pentru a te conecta",
+      "notAdminNote": "Nu ești administrator al acestei Pagini",
       "tryAgain": "Încearcă să te reconectezi"
     },
     "title": "Facebook Messenger",

--- a/apps/builder/messages/sv.json
+++ b/apps/builder/messages/sv.json
@@ -3616,9 +3616,11 @@
       "alreadyConnectedNote": "Den här sidan är redan ansluten",
       "bmLookupFailedDescription": "Återanslut Messenger och bevilja åtkomst till Business Manager så att sidor som hanteras där kan visas.",
       "bmLookupFailedTitle": "Business Manager-sidor kan saknas",
+      "noConnectablePagesDescription": "Du är inte administratör för den här sidan",
+      "noConnectablePagesTitle": "Inga sidor tillgängliga att ansluta",
       "noPagesDescription": "Sidor i Business Manager kräver åtkomst till Business Manager under anslutningen. Återanslut Messenger och bevilja alla begärda behörigheter.",
       "noPagesTitle": "Inga Facebook-sidor hittades",
-      "notAdminNote": "Fullständig administratörsbehörighet på sidan krävs för att ansluta",
+      "notAdminNote": "Du är inte administratör för den här sidan",
       "tryAgain": "Försök återansluta"
     },
     "tabs": {

--- a/apps/builder/messages/tr.json
+++ b/apps/builder/messages/tr.json
@@ -3093,10 +3093,12 @@
     "selectPage": {
       "noPagesTitle": "Facebook Sayfası bulunamadı",
       "noPagesDescription": "Bir İşletme Yöneticisi içindeki sayfalar, bağlantı sırasında İşletme Yöneticisi erişimi gerektirir. Messenger'ı yeniden bağlayın ve istenen tüm izinleri verin.",
+      "noConnectablePagesTitle": "Bağlanabilecek Sayfa yok",
+      "noConnectablePagesDescription": "Bu Sayfanın yöneticisi değilsiniz",
       "bmLookupFailedTitle": "İşletme Yöneticisi sayfaları eksik olabilir",
       "bmLookupFailedDescription": "Bir İşletme Yöneticisi üzerinden yönetilen sayfaların listelenebilmesi için Messenger'ı yeniden bağlayın ve İşletme Yöneticisi erişimi verin.",
       "alreadyConnectedNote": "Bu sayfa zaten bağlı",
-      "notAdminNote": "Bağlanmak için sayfada tam yönetici izni gereklidir",
+      "notAdminNote": "Bu Sayfanın yöneticisi değilsiniz",
       "tryAgain": "Yeniden bağlanmayı dene"
     },
     "title": "Facebook Messenger",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -3093,10 +3093,12 @@
     "selectPage": {
       "noPagesTitle": "Không tìm thấy trang Facebook",
       "noPagesDescription": "Các trang nằm trong Business Manager cần được cấp quyền Business Manager khi kết nối. Hãy kết nối lại Messenger và cấp tất cả quyền được yêu cầu.",
+      "noConnectablePagesTitle": "Không có trang nào khả dụng để kết nối",
+      "noConnectablePagesDescription": "Bạn không phải là Admin của Page này",
       "bmLookupFailedTitle": "Có thể thiếu trang trong Business Manager",
       "bmLookupFailedDescription": "Hãy kết nối lại Messenger và cấp quyền Business Manager để liệt kê các trang được quản lý qua Business Manager.",
       "alreadyConnectedNote": "Trang này đã được kết nối",
-      "notAdminNote": "Cần quyền quản trị đầy đủ trên trang để kết nối",
+      "notAdminNote": "Bạn không phải là Admin của Page này",
       "tryAgain": "Kết nối lại"
     },
     "title": "Facebook Messenger",

--- a/apps/builder/messages/zh-CN.json
+++ b/apps/builder/messages/zh-CN.json
@@ -3616,9 +3616,11 @@
       "alreadyConnectedNote": "该页面已连接",
       "bmLookupFailedDescription": "重新连接Messenger 并授予商务管理平台访问权限，以便可以列出通过商务管理平台管理的页面。",
       "bmLookupFailedTitle": "业务管理平台页面可能遗失",
+      "noConnectablePagesDescription": "您不是此页面的管理员",
+      "noConnectablePagesTitle": "没有可连接的页面",
       "noPagesDescription": "商务管理平台内的页面需要在连接期间访问商务管理平台。重新连接Messenger并授予所有请求的权限。",
       "noPagesTitle": "找不到Facebook 页面",
-      "notAdminNote": "需要页面的完全管理员权限才能连接",
+      "notAdminNote": "您不是此页面的管理员",
       "tryAgain": "尝试重新连接"
     },
     "tabs": {

--- a/apps/builder/messages/zh-TW.json
+++ b/apps/builder/messages/zh-TW.json
@@ -3126,10 +3126,12 @@
     "selectPage": {
       "noPagesTitle": "找不到Facebook 頁面",
       "noPagesDescription": "商務管理平台內的頁面需要在連線期間存取商務管理平台。重新連線Messenger並授予所有請求的權限。",
+      "noConnectablePagesTitle": "沒有可連結的頁面",
+      "noConnectablePagesDescription": "您不是此頁面的管理員",
       "bmLookupFailedTitle": "業務管理平台頁面可能遺失",
       "bmLookupFailedDescription": "重新連接Messenger 並授予商務管理平台存取權限，以便可以列出透過商務管理平台管理的頁面。",
       "alreadyConnectedNote": "該頁面已連接",
-      "notAdminNote": "需要頁面的完全管理員權限才能連接",
+      "notAdminNote": "您不是此頁面的管理員",
       "tryAgain": "嘗試重新連接"
     },
     "title": "Facebook Messenger",

--- a/apps/builder/src/app/(no-sidebar)/channels/messenger/select/page.tsx
+++ b/apps/builder/src/app/(no-sidebar)/channels/messenger/select/page.tsx
@@ -1,5 +1,6 @@
 import { messengerIntegrationService } from "@chatbotx.io/business"
 import { getUserPages } from "@chatbotx.io/integration-messenger"
+import type { ConnectableFacebookPage } from "@chatbotx.io/integration-messenger/schema"
 import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
 import type { PickerFacebookPage } from "@/features/integration-messenger/components/messenger-pages"
@@ -13,15 +14,36 @@ import {
 export const dynamic = "force-dynamic"
 
 /**
- * Picker ordering: selectable pages first, then pages already connected
- * elsewhere. Unconnected pages without connect permission are hidden.
+ * Picker ordering: selectable pages first, then non-admin pages, then pages
+ * already connected elsewhere (matches `getPageOptionNote`'s precedence in
+ * messenger-pages.tsx). Nothing is hidden any more — non-admin pages render
+ * disabled with a note instead of disappearing — so every page needs a rank.
+ * Array.prototype.sort is stable, so Meta's own order survives within a rank.
  */
 function rankPickerPage(page: PickerFacebookPage): number {
-  return page.isAlreadyConnected ? 1 : 0
+  if (page.isAlreadyConnected) {
+    return 2
+  }
+  return page.isConnectable ? 0 : 1
 }
 
-function shouldShowPickerPage(page: PickerFacebookPage): boolean {
-  return page.isConnectable || page.isAlreadyConnected
+/**
+ * A page is only selectable when the user has full admin permission on it
+ * and it isn't already connected elsewhere. Every other page is rendered
+ * disabled, so its access_token must never reach the client.
+ */
+function toPickerPage(
+  page: ConnectableFacebookPage,
+  connectedPageIds: ReadonlySet<string>,
+): PickerFacebookPage {
+  const isAlreadyConnected = connectedPageIds.has(page.id)
+  const selectable = page.isConnectable && !isAlreadyConnected
+
+  return {
+    ...page,
+    isAlreadyConnected,
+    access_token: selectable ? page.access_token : undefined,
+  }
 }
 
 export default async function MessengerSelectPage() {
@@ -44,11 +66,7 @@ export default async function MessengerSelectPage() {
     ),
   )
   const pickerPages: PickerFacebookPage[] = pages
-    .map((page) => ({
-      ...page,
-      isAlreadyConnected: connectedPageIds.has(page.id),
-    }))
-    .filter(shouldShowPickerPage)
+    .map((page) => toPickerPage(page, connectedPageIds))
     .sort((current, next) => rankPickerPage(current) - rankPickerPage(next))
 
   return (

--- a/apps/builder/src/features/integration-messenger/components/messenger-pages.tsx
+++ b/apps/builder/src/features/integration-messenger/components/messenger-pages.tsx
@@ -96,6 +96,16 @@ export function FacebookPages({
     setValue("pageName", selectPage?.name ?? "")
   }, [watchedPageId, setValue, pages])
 
+  const hasSelectablePage = pages.some(
+    (page) => page.isConnectable && !page.isAlreadyConnected,
+  )
+  // The warning copy blames missing admin permission, so it must only appear
+  // when a non-admin page is actually the reason nothing is selectable. A list
+  // of solely already-connected pages explains itself via each row's note.
+  const showNotAdminWarning =
+    !hasSelectablePage &&
+    pages.some((page) => !(page.isConnectable || page.isAlreadyConnected))
+
   if (pages.length === 0) {
     return (
       <div className="space-y-4">
@@ -130,6 +140,23 @@ export function FacebookPages({
           <InputField name="accessToken" type="hidden" />
           <InputField name="pageName" type="hidden" />
         </div>
+
+        {showNotAdminWarning && (
+          <Alert variant="warning">
+            <AlertTitle>
+              {t("messenger.selectPage.noConnectablePagesTitle")}
+            </AlertTitle>
+            <AlertDescription>
+              <p>{t("messenger.selectPage.noConnectablePagesDescription")}</p>
+              <Link
+                className={buttonVariants({ size: "sm" })}
+                href="/channels/create"
+              >
+                {t("messenger.selectPage.tryAgain")}
+              </Link>
+            </AlertDescription>
+          </Alert>
+        )}
 
         {/* Styling ::-webkit-scrollbar opts out of the OS overlay scrollbar,
             so the bar stays visible whenever the list overflows. */}

--- a/apps/builder/src/features/media-library/queries/__tests__/media-library-files.test.ts
+++ b/apps/builder/src/features/media-library/queries/__tests__/media-library-files.test.ts
@@ -61,6 +61,7 @@ vi.mock("@chatbotx.io/database/client", () => ({
 
 vi.mock("@chatbotx.io/database/schema", () => ({
   mediaLibraryFileModel: {
+    id: "file.id",
     workspaceId: "file.workspaceId",
     folderId: "file.folderId",
     isFavourite: "file.isFavourite",
@@ -80,9 +81,11 @@ vi.mock("@/lib/auth/utils", () => ({
   assertCurrentUserCanAccessChatbot: mocks.assertCurrentUserCanAccessChatbot,
 }))
 
-const { listMediaLibraryFiles, findMediaLibraryFileByPath } = await import(
-  "../files"
-)
+const {
+  listMediaLibraryFiles,
+  findMediaLibraryFileByPath,
+  findMediaLibraryFileById,
+} = await import("../files")
 
 const WS = "workspace-1"
 
@@ -266,6 +269,51 @@ describe("findMediaLibraryFileByPath", () => {
     expect(whereArg).toEqual([
       ["file.workspaceId", WS],
       ["file.path", "ws/2/spoofed.png"],
+    ])
+  })
+})
+
+// ── findMediaLibraryFileById ───────────────────────────────────────────────────
+
+describe("findMediaLibraryFileById", () => {
+  test("returns the file when a row matches workspaceId and id", async () => {
+    const file = { id: "file-1", workspaceId: WS, path: "ws/1/a.png" }
+    const { chain } = createSelectChain([file])
+    dbSelect.mockReturnValue(chain)
+
+    const result = await findMediaLibraryFileById({
+      workspaceId: WS,
+      id: "file-1",
+    })
+
+    expect(result).toEqual(file)
+  })
+
+  test("returns null when no row matches", async () => {
+    const { chain } = createSelectChain([])
+    dbSelect.mockReturnValue(chain)
+
+    const result = await findMediaLibraryFileById({
+      workspaceId: WS,
+      id: "missing-id",
+    })
+
+    expect(result).toBeNull()
+  })
+
+  test("scopes the lookup by both workspaceId and id so an id from another workspace never matches", async () => {
+    const { chain } = createSelectChain([])
+    dbSelect.mockReturnValue(chain)
+
+    await findMediaLibraryFileById({
+      workspaceId: WS,
+      id: "file-from-ws-2",
+    })
+
+    const whereArg = chain.where.mock.calls[0]?.[0] as unknown[][]
+    expect(whereArg).toEqual([
+      ["file.workspaceId", WS],
+      ["file.id", "file-from-ws-2"],
     ])
   })
 })

--- a/apps/builder/src/features/media-library/queries/files.ts
+++ b/apps/builder/src/features/media-library/queries/files.ts
@@ -89,3 +89,26 @@ export async function findMediaLibraryFileByPath(input: {
 
   return file ?? null
 }
+
+/**
+ * Confirms a DB id belongs to a Media Library file owned by the given
+ * workspace, so a client-supplied id can't be used to reference another
+ * workspace's (or otherwise arbitrary) storage object.
+ */
+export async function findMediaLibraryFileById(input: {
+  workspaceId: string
+  id: string
+}) {
+  const [file] = await db
+    .select()
+    .from(mediaLibraryFileModel)
+    .where(
+      and(
+        eq(mediaLibraryFileModel.workspaceId, input.workspaceId),
+        eq(mediaLibraryFileModel.id, input.id),
+      ),
+    )
+    .limit(1)
+
+  return file ?? null
+}

--- a/apps/builder/src/features/messages/actions/create-message.action.ts
+++ b/apps/builder/src/features/messages/actions/create-message.action.ts
@@ -30,7 +30,10 @@ import {
   IntegrationJobAction,
   integrationQueue,
 } from "@chatbotx.io/worker-config"
-import { findMediaLibraryFileByPath } from "@/features/media-library/queries/files"
+import {
+  findMediaLibraryFileById,
+  findMediaLibraryFileByPath,
+} from "@/features/media-library/queries/files"
 import { workspaceActionClient } from "@/lib/safe-action"
 import {
   type CreateMessageRequest,
@@ -76,6 +79,41 @@ export const createMessageAction = workspaceActionClient
       user: ctx.user,
     })
   })
+
+/**
+ * Copies a Media Library file into a conversation-scoped path instead of
+ * reusing the Media Library file's own S3 key: attachments must outlive the
+ * Media Library file they were picked from, since deleting that file (or its
+ * folder) later must not break an already-sent message.
+ */
+type CopyableMediaLibraryFile = {
+  path: string
+  name: string
+  mimeType: string
+  size: number
+}
+
+const copyMediaLibraryFileToConversationAttachment = async (props: {
+  mediaLibraryFile: CopyableMediaLibraryFile
+  workspaceId: string
+  conversationId: string
+}): Promise<UploadedFile> => {
+  const { mediaLibraryFile, workspaceId, conversationId } = props
+
+  const attachmentPath = pathJoin(
+    `public/space/${workspaceId}/conversations/${conversationId}`,
+    createId(),
+  )
+  await uploader.copyObject(mediaLibraryFile.path, attachmentPath)
+
+  return {
+    name: mediaLibraryFile.name,
+    mimeType: mediaLibraryFile.mimeType,
+    originPath: attachmentPath,
+    size: mediaLibraryFile.size,
+    fileType: guessFileTypeFromMimeType(mediaLibraryFile.mimeType),
+  }
+}
 
 export const createMessage = async (props: {
   conversation: ConversationModel
@@ -123,6 +161,7 @@ export const createMessage = async (props: {
       `public/space/${conversation.workspaceId}/conversations/${targetConversation.id}`,
     )
   } else if ("mediaFile" in parsedInput && parsedInput.mediaFile) {
+    // Legacy path-based selection, still used by public oRPC APIs.
     const mediaLibraryFile = await findMediaLibraryFileByPath({
       workspaceId: conversation.workspaceId,
       path: parsedInput.mediaFile.path,
@@ -131,24 +170,28 @@ export const createMessage = async (props: {
       throw new ChatbotXException("Media library file not found")
     }
 
-    // Copy into a conversation-scoped path instead of reusing the Media
-    // Library file's own S3 key: attachments must outlive the Media Library
-    // file they were picked from, since deleting that file (or its folder)
-    // later must not break an already-sent message.
-    const attachmentPath = pathJoin(
-      `public/space/${conversation.workspaceId}/conversations/${targetConversation.id}`,
-      createId(),
-    )
-    await uploader.copyObject(mediaLibraryFile.path, attachmentPath)
+    uploadedFiles = [
+      await copyMediaLibraryFileToConversationAttachment({
+        mediaLibraryFile,
+        workspaceId: conversation.workspaceId,
+        conversationId: targetConversation.id,
+      }),
+    ]
+  } else if ("mediaFileId" in parsedInput && parsedInput.mediaFileId) {
+    const mediaLibraryFile = await findMediaLibraryFileById({
+      workspaceId: conversation.workspaceId,
+      id: parsedInput.mediaFileId,
+    })
+    if (!mediaLibraryFile) {
+      throw new ChatbotXException("Media library file not found")
+    }
 
     uploadedFiles = [
-      {
-        name: mediaLibraryFile.name,
-        mimeType: mediaLibraryFile.mimeType,
-        originPath: attachmentPath,
-        size: mediaLibraryFile.size,
-        fileType: guessFileTypeFromMimeType(mediaLibraryFile.mimeType),
-      },
+      await copyMediaLibraryFileToConversationAttachment({
+        mediaLibraryFile,
+        workspaceId: conversation.workspaceId,
+        conversationId: targetConversation.id,
+      }),
     ]
   }
 

--- a/apps/builder/src/features/messages/components/media-file-preview.tsx
+++ b/apps/builder/src/features/messages/components/media-file-preview.tsx
@@ -3,28 +3,22 @@
 import { Button } from "@chatbotx.io/ui/components/ui/button"
 import { PaperclipIcon, XCircleIcon } from "lucide-react"
 import Image from "next/image"
-import { useFormContext, useWatch } from "react-hook-form"
 
-type MediaFileFieldValue = {
-  path: string
-  url?: string
+type MediaFilePreviewValue = {
+  url: string
   mimeType: string
-  name?: string | null
-  size: number
+  name: string
 }
 
-export const MediaFilePreview = () => {
-  const { control, setValue } = useFormContext()
+type MediaFilePreviewProps = {
+  mediaFile: MediaFilePreviewValue
+  onRemove: () => void
+}
 
-  const mediaFile: MediaFileFieldValue | undefined = useWatch({
-    control,
-    name: "mediaFile",
-  })
-
-  if (!mediaFile) {
-    return null
-  }
-
+export const MediaFilePreview = ({
+  mediaFile,
+  onRemove,
+}: MediaFilePreviewProps) => {
   const isImage = mediaFile.mimeType.startsWith("image")
 
   return (
@@ -33,7 +27,7 @@ export const MediaFilePreview = () => {
         <div className="max-w-36 overflow-hidden rounded-md">
           {isImage && mediaFile.url ? (
             <Image
-              alt={mediaFile.name ?? "file"}
+              alt={mediaFile.name}
               className="h-16 w-auto"
               height={64}
               src={mediaFile.url}
@@ -49,9 +43,7 @@ export const MediaFilePreview = () => {
 
         <Button
           className="absolute -end-2 -top-2 h-auto rounded-full bg-white p-0 px-0 dark:bg-neutral-600"
-          onClick={() =>
-            setValue("mediaFile", undefined, { shouldValidate: true })
-          }
+          onClick={onRemove}
           type="button"
           variant="ghost"
         >

--- a/apps/builder/src/features/messages/components/message-input.tsx
+++ b/apps/builder/src/features/messages/components/message-input.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/features/conversations/utils/bot-state"
 import { InboxIcon } from "@/features/inboxes/components/inbox-icon"
 import { MediaLibraryTrigger } from "@/features/media-library/components/media-library-trigger"
+import type { ListFilesResponse } from "@/features/media-library/schemas"
 import { QuickRepliesPopover } from "@/features/saved-replies/quick-replies-popover"
 import { authClient } from "@/lib/auth/auth-client"
 import { useChatStore } from "../../chat/store/chat-store-provider"
@@ -69,12 +70,23 @@ const CHANNEL_WINDOW_SECONDS: Record<ChannelType, number> = {
 
 const MESSENGER_HUMAN_AGENT_WINDOW_SECONDS = 7 * 24 * 60 * 60
 
+// Media Library selection metadata kept for preview purposes only. The form
+// field only carries `mediaFileId` (the DB id sent to the server) — the
+// action submits the resolver-parsed form values directly, so display-only
+// fields like url/name can't live on the form.
+type SelectedMediaFile = Pick<
+  ListFilesResponse["data"][number],
+  "url" | "mimeType" | "name"
+>
+
 export const MessageInput = () => {
   const t = useTranslations()
   const session = authClient.useSession()
 
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileUploadRef = useRef<HTMLInputElement>(null)
+  const [selectedMediaFile, setSelectedMediaFile] =
+    useState<SelectedMediaFile | null>(null)
 
   const {
     appendMessage,
@@ -177,6 +189,7 @@ export const MessageInput = () => {
             }
 
             form.reset()
+            setSelectedMediaFile(null)
             textareaRef.current?.focus()
           },
           onSuccess: () => {
@@ -186,6 +199,7 @@ export const MessageInput = () => {
             setReplyToMessage(null)
             textareaRef.current?.focus()
             resetFormAndAction()
+            setSelectedMediaFile(null)
             form.setValue("clientId", createId())
           },
         },
@@ -193,7 +207,7 @@ export const MessageInput = () => {
           defaultValues: {
             text: "",
             files: [],
-            mediaFile: undefined,
+            mediaFileId: undefined,
             clientId: createId(),
             replyToMessageId: undefined,
             replyToMessageCreatedAt: undefined,
@@ -376,16 +390,12 @@ export const MessageInput = () => {
   )
 
   // Check if a media file (device upload or Media Library pick) is attached
-  const mediaFile = useWatch({
-    control: form.control,
-    name: "mediaFile",
-  })
   const files = useWatch({
     control: form.control,
     name: "files",
   })
   const hasFiles =
-    Boolean(mediaFile) || (Array.isArray(files) && files.length > 0)
+    Boolean(selectedMediaFile) || (Array.isArray(files) && files.length > 0)
 
   // Early return if no active conversation
   if (!activeConversationId) {
@@ -516,7 +526,15 @@ export const MessageInput = () => {
           {!isInstagramPostComment && (
             <div className="px-2">
               <FileUploadPreview ref={fileUploadRef} />
-              <MediaFilePreview />
+              {selectedMediaFile && (
+                <MediaFilePreview
+                  mediaFile={selectedMediaFile}
+                  onRemove={() => {
+                    setSelectedMediaFile(null)
+                    form.resetField("mediaFileId")
+                  }}
+                />
+              )}
             </div>
           )}
           <div className="flex w-full items-center ps-2.5">
@@ -536,7 +554,7 @@ export const MessageInput = () => {
                   <Button
                     aria-label="Attach file"
                     className="px-2 py-1.5 [&_svg]:size-5"
-                    disabled={Boolean(mediaFile)}
+                    disabled={Boolean(selectedMediaFile)}
                     onClick={onClickAttachment}
                     type="button"
                     variant="ghost"
@@ -545,17 +563,14 @@ export const MessageInput = () => {
                   </Button>
                   <MediaLibraryTrigger
                     onSelect={(file) => {
-                      form.setValue(
-                        "mediaFile",
-                        {
-                          path: file.path,
-                          url: file.url,
-                          mimeType: file.mimeType,
-                          name: file.name,
-                          size: file.size,
-                        },
-                        { shouldValidate: true },
-                      )
+                      form.setValue("mediaFileId", file.id, {
+                        shouldValidate: true,
+                      })
+                      setSelectedMediaFile({
+                        url: file.url,
+                        mimeType: file.mimeType,
+                        name: file.name,
+                      })
                     }}
                     workspaceId={conversation?.workspaceId ?? ""}
                   >

--- a/apps/builder/src/features/messages/schema/mutation.ts
+++ b/apps/builder/src/features/messages/schema/mutation.ts
@@ -29,6 +29,14 @@ export const createMessageRequest = z
       text: z.string().trim().min(1).max(1000),
       mediaFile: mediaLibraryFileRequest,
     }),
+    // Media Library selection identified by DB id — must be listed before
+    // the text-only branch below, since z.object() strips unknown keys: if
+    // the text-only branch matched first, mediaFileId would be silently
+    // dropped and the message would send as plain text.
+    z.object({
+      text: z.string().trim().min(1).max(1000),
+      mediaFileId: zodBigintAsString(),
+    }),
     z.object({
       text: z.string().trim().min(1).max(1000),
     }),
@@ -43,6 +51,9 @@ export const createMessageRequest = z
     }),
     z.object({
       mediaFile: mediaLibraryFileRequest,
+    }),
+    z.object({
+      mediaFileId: zodBigintAsString(),
     }),
     z.object({
       flowId: zodBigintAsString(),

--- a/packages/filesystem/__tests__/copy-source.test.ts
+++ b/packages/filesystem/__tests__/copy-source.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest"
+import { buildCopySource } from "../src/lib/copy-source"
+
+describe("buildCopySource", () => {
+  test("uses bucket/key when no endpoint is configured", () => {
+    expect(buildCopySource("public/space/1/file.jpg", "mybucket")).toBe(
+      "mybucket/public/space/1/file.jpg",
+    )
+  })
+
+  test("uses bucket/key when endpoint has no path", () => {
+    expect(
+      buildCopySource(
+        "public/space/1/file.jpg",
+        "mybucket",
+        "https://account.r2.cloudflarestorage.com",
+      ),
+    ).toBe("mybucket/public/space/1/file.jpg")
+  })
+
+  test("replicates the endpoint path prefix when endpoint includes it", () => {
+    // Endpoint mistakenly (or intentionally) carries the bucket in its path:
+    // every URL-addressed op stores objects under "chatconnectx/<key>", so the
+    // header-addressed CopySource must point at the same real key.
+    expect(
+      buildCopySource(
+        "public/space/1/file.jpg",
+        "chatconnectx",
+        "https://account.r2.cloudflarestorage.com/chatconnectx",
+      ),
+    ).toBe("chatconnectx/chatconnectx/public/space/1/file.jpg")
+  })
+
+  test("handles endpoint path with trailing slash", () => {
+    expect(
+      buildCopySource("a/b.png", "bkt", "https://host.example.com/prefix/"),
+    ).toBe("prefix/bkt/a/b.png")
+  })
+
+  test("URL-encodes each key segment", () => {
+    expect(buildCopySource("a b/c#d.png", "bkt")).toBe("bkt/a%20b/c%23d.png")
+  })
+})

--- a/packages/filesystem/src/lib/copy-source.ts
+++ b/packages/filesystem/src/lib/copy-source.ts
@@ -1,0 +1,27 @@
+/**
+ * Builds the `x-amz-copy-source` value for CopyObject.
+ *
+ * Every other S3 operation addresses objects through the request URL
+ * (`endpoint` + `/bucket/key` in path-style), so when `S3_ENDPOINT` carries a
+ * path of its own (e.g. an R2 endpoint that already includes the bucket name),
+ * objects are actually stored under that extra prefix. CopySource is sent as a
+ * header — the endpoint path never applies to it — so it must replicate the
+ * same prefix or it points at a key that does not exist (NoSuchKey).
+ */
+export function buildCopySource(
+  sourcePath: string,
+  bucket: string,
+  endpoint?: string,
+): string {
+  const encodedSource = sourcePath
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/")
+
+  const endpointPath = endpoint
+    ? new URL(endpoint).pathname.replace(/^\/+|\/+$/g, "")
+    : ""
+  const prefix = endpointPath ? `${endpointPath}/` : ""
+
+  return `${prefix}${bucket}/${encodedSource}`
+}

--- a/packages/filesystem/src/lib/uploader.ts
+++ b/packages/filesystem/src/lib/uploader.ts
@@ -12,6 +12,7 @@ import {
 } from "@aws-sdk/client-s3"
 import { AwsClient } from "aws4fetch"
 import { keys } from "../keys"
+import { buildCopySource } from "./copy-source"
 
 const env = keys()
 
@@ -182,15 +183,10 @@ export class Uploader {
   }
 
   async copyObject(sourcePath: string, destinationPath: string) {
-    const encodedSource = sourcePath
-      .split("/")
-      .map((segment) => encodeURIComponent(segment))
-      .join("/")
-
     const command = new CopyObjectCommand({
       Bucket: env.S3_BUCKET,
       Key: destinationPath,
-      CopySource: `${env.S3_BUCKET}/${encodedSource}`,
+      CopySource: buildCopySource(sourcePath, env.S3_BUCKET, env.S3_ENDPOINT),
     })
 
     return await this.#client.send(command)


### PR DESCRIPTION
## Summary
- The Messenger connect page picker previously hid Facebook Pages where the user lacks full admin permission, leaving no explanation for why a Page was missing. They now appear disabled with a "You are not an admin of this Page" note, in the same position as the existing "already connected" note.
- Pages are ordered selectable first, then non-admin, then already-connected, and page access tokens are no longer sent to the browser for any Page that cannot be selected.
- When nothing in the list is selectable because of missing admin permission, a warning alert with a reconnect link appears above the list; a list of only already-connected Pages relies on each row's own note instead.

## Changes
- `apps/builder/src/app/(no-sidebar)/channels/messenger/select/page.tsx` — stop filtering out non-admin Pages; rank pages selectable → non-admin → already-connected; strip `access_token` from non-selectable pages before they reach the client.
- `apps/builder/src/features/integration-messenger/components/messenger-pages.tsx` — show a warning alert (new `noConnectablePages*` keys + existing `tryAgain` link) when no Page is selectable and at least one is blocked by missing admin permission.
- `apps/builder/messages/*.json` — new `messenger.selectPage.noConnectablePagesTitle`/`noConnectablePagesDescription` keys across all 20 locales; `notAdminNote` shortened to the same sentence.
- `apps/builder/__tests__/messenger-select-page.test.tsx` — assert every page passes through in rank order and tokens are stripped from non-selectable pages.
- `apps/builder/__tests__/messenger-pages.test.tsx` (new) — disabled radio + note rendering, warning visibility per page-state combination.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [x] `pnpm --filter builder exec vitest run __tests__/messenger-select-page.test.tsx __tests__/messenger-pages.test.tsx`
- [ ] Manual: connect Messenger with an account that has a non-admin Page and confirm it renders disabled with the note instead of disappearing
- [ ] Manual: confirm a Page already connected in another workspace still renders disabled with the "already connected" note
