### PR TITLE
fix(ads): send required advantage audience flag when creating ad sets

### DIFF
--- a/integrations/facebook-ads/__tests__/adsets.test.ts
+++ b/integrations/facebook-ads/__tests__/adsets.test.ts
@@ -36,7 +36,10 @@ describe("createAdSet", () => {
         pageId: "pg_1",
         whatsappPhoneNumber: "15550001234",
       }),
-      targeting: { geo_locations: { countries: ["US"] } },
+      targeting: {
+        geo_locations: { countries: ["US"] },
+        targeting_automation: { advantage_audience: 1 },
+      },
     })
 
     expect(result.id).toBe("adset_1")
@@ -50,8 +53,11 @@ describe("createAdSet", () => {
       page_id: "pg_1",
       whatsapp_phone_number: "15550001234",
     })
+    // v23.0 rejects ad set creates without an explicit advantage_audience
+    // (code 100) — the flag must survive serialization into the POST body.
     expect(capturedBody.targeting).toEqual({
       geo_locations: { countries: ["US"] },
+      targeting_automation: { advantage_audience: 1 },
     })
   })
 })

--- a/integrations/facebook-ads/__tests__/messaging-ads-config.test.ts
+++ b/integrations/facebook-ads/__tests__/messaging-ads-config.test.ts
@@ -69,6 +69,7 @@ describe("special ad category enforcement", () => {
     expect(isRestrictedSpecialAdCategory(["NONE"])).toBe(false)
     const targeting = {
       geo_locations: { countries: ["US"] },
+      targeting_automation: { advantage_audience: 0 as const },
       age_min: 21,
       age_max: 45,
       genders: [1] as MessagingAdGender[],
@@ -86,12 +87,18 @@ describe("special ad category enforcement", () => {
     expect(isRestrictedSpecialAdCategory([category])).toBe(true)
     const targeting = {
       geo_locations: { countries: ["US"] },
+      targeting_automation: { advantage_audience: 0 as const },
       age_min: 21,
       age_max: 45,
       genders: [1, 2] as MessagingAdGender[],
     }
     const result = enforceSpecialAdCategoryTargeting(targeting, [category])
-    expect(result).toEqual({ geo_locations: { countries: ["US"] } })
+    // The stripped result must keep the advantage_audience flag — dropping it
+    // would reintroduce Meta's code-100 rejection for special-category ads.
+    expect(result).toEqual({
+      geo_locations: { countries: ["US"] },
+      targeting_automation: { advantage_audience: 0 },
+    })
     expect(result).not.toHaveProperty("age_min")
     expect(result).not.toHaveProperty("age_max")
     expect(result).not.toHaveProperty("genders")

--- a/integrations/facebook-ads/src/messaging-ads/constants.ts
+++ b/integrations/facebook-ads/src/messaging-ads/constants.ts
@@ -97,6 +97,13 @@ export function requiresSpecialAdCategoryCountry(
  * bidding — which requires NO `bid_amount` (docs: `bid_amount` is required only
  * for `*_BID_CAP`/`COST_CAP` strategies). This is the ONE place to change the
  * default if the desired optimization ever changes.
+ *
+ * NOTE (v23.0 enforcement, observed live): ad set CREATE additionally requires
+ * an explicit `targeting.targeting_automation.advantage_audience` (0|1) or
+ * Meta rejects with code 100 "Advantage Audience Flag Required" — even for
+ * countries-only targeting. The flag is set in `mapTargeting`
+ * (`@chatbotx.io/business` messaging-ads mappers), typed required on
+ * `MessagingAdTargeting`.
  */
 export const MESSAGING_AD_SET_OPTIMIZATION_GOAL = "CONVERSATIONS" as const
 export const MESSAGING_AD_SET_BILLING_EVENT = "IMPRESSIONS" as const

--- a/integrations/facebook-ads/src/messaging-ads/types.ts
+++ b/integrations/facebook-ads/src/messaging-ads/types.ts
@@ -14,6 +14,15 @@ export type MessagingAdGender = 1 | 2
 
 export type MessagingAdTargeting = {
   geo_locations: MessagingAdGeoLocations
+  /**
+   * REQUIRED on ad set CREATE since Graph v23.0 (error code 100 "Advantage
+   * Audience Flag Required" otherwise — Meta enforces this even for
+   * countries-only targeting despite the docs' "default setup" carve-out).
+   * `1` opts in to Advantage+ audience; NOTE: with `1` Meta rejects `age_max`
+   * and only allows `age_min` 18–25, so custom age/gender targeting must
+   * send `0`.
+   */
+  targeting_automation: { advantage_audience: 0 | 1 }
   age_min?: number
   age_max?: number
   genders?: MessagingAdGender[]

--- a/packages/business/src/messaging-ads/__tests__/mappers.test.ts
+++ b/packages/business/src/messaging-ads/__tests__/mappers.test.ts
@@ -1,6 +1,81 @@
 import type { MessagingAdCreativeMediaInput } from "@chatbotx.io/database/partials"
 import { describe, expect, test } from "vitest"
-import { mapCreativeMedia } from "../mappers"
+import { mapCreativeMedia, mapTargeting } from "../mappers"
+
+// ---------------------------------------------------------------------------
+// mapTargeting — Graph v23.0 requires an explicit
+// `targeting_automation.advantage_audience` on ad set CREATE (error code 100
+// "Advantage Audience Flag Required" otherwise). `1` (opt in) is only valid
+// for the default countries-only setup: Meta rejects `age_max` and caps
+// `age_min` at 25 when opted in, so any custom age/gender must send `0`.
+// ---------------------------------------------------------------------------
+
+describe("mapTargeting — advantage_audience flag", () => {
+  test("countries-only default setup opts in (advantage_audience: 1)", () => {
+    const result = mapTargeting({ countries: ["VN"] }, ["NONE"])
+
+    expect(result).toEqual({
+      geo_locations: { countries: ["VN"] },
+      targeting_automation: { advantage_audience: 1 },
+    })
+  })
+
+  test("custom age range opts out (advantage_audience: 0) and keeps the ages", () => {
+    const result = mapTargeting({ countries: ["VN"], ageMin: 30, ageMax: 50 }, [
+      "NONE",
+    ])
+
+    expect(result).toEqual({
+      geo_locations: { countries: ["VN"] },
+      targeting_automation: { advantage_audience: 0 },
+      age_min: 30,
+      age_max: 50,
+    })
+  })
+
+  test("gender targeting alone opts out (advantage_audience: 0)", () => {
+    const result = mapTargeting({ countries: ["VN"], genders: [2] }, ["NONE"])
+
+    expect(result).toEqual({
+      geo_locations: { countries: ["VN"] },
+      targeting_automation: { advantage_audience: 0 },
+      genders: [2],
+    })
+  })
+
+  test("locales opt out (advantage_audience: 0) — 1+locales is unverified live, so stay conservative", () => {
+    const result = mapTargeting({ countries: ["VN"], locales: [1033] }, [
+      "NONE",
+    ])
+
+    expect(result).toEqual({
+      geo_locations: { countries: ["VN"] },
+      targeting_automation: { advantage_audience: 0 },
+      locales: [1033],
+    })
+  })
+
+  test("restricted special ad category opts out AND strips age/gender, keeping the flag", () => {
+    const result = mapTargeting(
+      { countries: ["US"], ageMin: 30, ageMax: 50, genders: [1] },
+      ["HOUSING"],
+    )
+
+    expect(result).toEqual({
+      geo_locations: { countries: ["US"] },
+      targeting_automation: { advantage_audience: 0 },
+    })
+  })
+
+  test("restricted special ad category opts out even with default demographics", () => {
+    const result = mapTargeting({ countries: ["US"] }, ["EMPLOYMENT"])
+
+    expect(result).toEqual({
+      geo_locations: { countries: ["US"] },
+      targeting_automation: { advantage_audience: 0 },
+    })
+  })
+})
 
 const REQUIRES_RESOLVED_HASH_ERROR = /requires a resolved image_hash/
 

--- a/packages/business/src/messaging-ads/__tests__/service.test.ts
+++ b/packages/business/src/messaging-ads/__tests__/service.test.ts
@@ -580,6 +580,15 @@ describe("retryDraft", () => {
     // The already-persisted campaign id is never re-created on resume.
     const calledActions = mocks.runAction.mock.calls.map((call) => call[0])
     expect(calledActions).not.toContain("createMessagingCampaign")
+    // A resumed create re-runs mapTargeting from the persisted domain input —
+    // the v23.0-required advantage_audience flag must be present on retry too.
+    const adSetCall = mocks.runAction.mock.calls.find(
+      (call) => call[0] === "createMessagingAdSet",
+    )
+    expect(adSetCall?.[1]?.props?.targeting).toMatchObject({
+      geo_locations: { countries: ["US"] },
+      targeting_automation: { advantage_audience: 1 },
+    })
     expect(mocks.invalidateMessagingAdsCache).toHaveBeenCalledWith(
       "ws_1:messenger:im_1",
     )

--- a/packages/business/src/messaging-ads/mappers.ts
+++ b/packages/business/src/messaging-ads/mappers.ts
@@ -7,6 +7,7 @@ import {
 import {
   type CreativeMedia,
   enforceSpecialAdCategoryTargeting,
+  isRestrictedSpecialAdCategory,
   type MessagingAdTargeting,
   type PageWelcomeMessage,
   type SpecialAdCategory,
@@ -17,8 +18,27 @@ export function mapTargeting(
   input: MessagingAdTargetingInput,
   specialAdCategories: SpecialAdCategory[],
 ): MessagingAdTargeting {
+  // Graph v23.0 requires an explicit `advantage_audience` on ad set CREATE
+  // (code 100 otherwise). Opting in (1) makes Meta reject `age_max` and cap
+  // `age_min` at 25, and Advantage+ audience is only partially rolled out for
+  // restricted special ad categories — so opt out (0) whenever the user
+  // customized ANY targeting field (age/gender/locales) or a restricted
+  // category applies; opt in (1) only for the countries-only default setup,
+  // the one combination live-verified against v23.0. Locales are treated as
+  // customization out of caution: the docs list language as a non-negotiable
+  // constraint under Advantage+, but the 1+locales combo is unverified live.
+  const hasCustomTargeting =
+    input.ageMin !== undefined ||
+    input.ageMax !== undefined ||
+    Boolean(input.genders?.length) ||
+    Boolean(input.locales?.length)
+  const advantageAudience =
+    hasCustomTargeting || isRestrictedSpecialAdCategory(specialAdCategories)
+      ? 0
+      : 1
   const targeting: MessagingAdTargeting = {
     geo_locations: { countries: input.countries },
+    targeting_automation: { advantage_audience: advantageAudience },
     ...(input.ageMin === undefined ? {} : { age_min: input.ageMin }),
     ...(input.ageMax === undefined ? {} : { age_max: input.ageMax }),
     ...(input.genders?.length ? { genders: input.genders } : {}),


### PR DESCRIPTION
## Summary
- Creating a Messaging Ad failed at the final review step with Meta error code 100 ("Advantage Audience Flag Required"): since Graph API v23.0, ad set creation must explicitly opt in or out of Advantage+ audience via `targeting_automation.advantage_audience`, and the targeting spec never sent it.
- The flag is now always sent: opted out (`0`) whenever the user customized age, gender, or locale targeting or a restricted special ad category applies (opting in would make Meta reject the custom age range), and opted in (`1`) for the default countries-only setup, matching Meta's own default.
- The field is required on the targeting type, so any future code path that builds a targeting spec without the flag fails to compile instead of failing at the Graph API.

## Changes
- `integrations/facebook-ads/src/messaging-ads/types.ts` — `MessagingAdTargeting` now requires `targeting_automation: { advantage_audience: 0 | 1 }`.
- `packages/business/src/messaging-ads/mappers.ts` — `mapTargeting` computes the flag from the targeting input and special ad categories.
- `integrations/facebook-ads/src/messaging-ads/constants.ts` — document the v23.0 requirement next to the other live-verified ad set defaults.
- `packages/business/src/messaging-ads/__tests__/mappers.test.ts` (new `mapTargeting` suite) — flag value per targeting combination, including special-category stripping keeping the flag.
- `packages/business/src/messaging-ads/__tests__/service.test.ts` — retry/resume asserts the flag reaches the ad set create.
- `integrations/facebook-ads/__tests__/adsets.test.ts`, `__tests__/messaging-ads-config.test.ts` — the flag survives serialization into the Graph POST body and category enforcement.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter @chatbotx.io/business check-types` and `pnpm --filter @chatbotx.io/integration-facebook-ads check-types`
- [x] `vitest run` for business messaging-ads suites (47 tests) and facebook-ads adsets/config suites (13 tests)
- [ ] Manual: create a Messaging Ad from the Ads dashboard with countries-only targeting and confirm the paused draft is created without error code 100
- [ ] Manual: repeat with a custom age range/gender and confirm the ad set is created with the chosen targeting intact