### PR TITLE
fix(worker): reset DM AI history from comment flows

### DIFF
--- a/apps/worker/__tests__/ai-delete-message-history.test.ts
+++ b/apps/worker/__tests__/ai-delete-message-history.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   cacheDelete: vi.fn(),
   createMessageRepository: vi.fn(),
   findLastByConversation: vi.fn(),
+  findDMByContact: vi.fn(),
   loggerError: vi.fn(),
   runExclusive: vi.fn(),
   updateMarker: vi.fn(),
@@ -18,6 +19,7 @@ vi.mock("@chatbotx.io/ai/server", () => ({
 }))
 vi.mock("@chatbotx.io/business", () => ({
   conversationService: {
+    findDMByContact: mocks.findDMByContact,
     updateAIContextLastMessageId: mocks.updateMarker,
   },
 }))
@@ -36,8 +38,14 @@ const { handleAIDeleteMessageHistory } = await import(
 )
 
 const props = {
-  conversation: { id: "conv-1", workspaceId: "ws-1" },
+  conversation: {
+    id: "conv-1",
+    workspaceId: "ws-1",
+    contactId: "contact-1",
+    sourceId: null,
+  },
   contactInbox: {
+    channel: "instagram",
     lastMessageAt: new Date("2026-06-01T01:00:00.000Z"),
   },
 } as never
@@ -52,6 +60,7 @@ describe("handleAIDeleteMessageHistory", () => {
       (_conversationId: string, fn: () => Promise<unknown>) => fn(),
     )
     mocks.cacheDelete.mockResolvedValue(undefined)
+    mocks.findDMByContact.mockResolvedValue(undefined)
     mocks.updateMarker.mockResolvedValue(undefined)
   })
 
@@ -119,6 +128,59 @@ describe("handleAIDeleteMessageHistory", () => {
     await handleAIDeleteMessageHistory(props)
 
     expect(mocks.findLastByConversation).toHaveBeenCalledTimes(1)
+  })
+
+  test("also resets the canonical DM conversation from a comment conversation", async () => {
+    mocks.findLastByConversation
+      .mockResolvedValueOnce([{ id: "comment-last" }])
+      .mockResolvedValueOnce([{ id: "dm-last" }])
+    mocks.findDMByContact.mockResolvedValue({
+      id: "dm-conv-1",
+      workspaceId: "ws-1",
+    })
+
+    await expect(
+      handleAIDeleteMessageHistory({
+        ...props,
+        conversation: {
+          id: "comment-conv-1",
+          workspaceId: "ws-1",
+          contactId: "contact-1",
+          sourceId: "post-1",
+        },
+      } as never),
+    ).resolves.toEqual({
+      status: "success",
+      result: null,
+    })
+
+    expect(mocks.findDMByContact).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+      channel: "instagram",
+    })
+    expect(mocks.runExclusive).toHaveBeenNthCalledWith(
+      1,
+      "comment-conv-1",
+      expect.any(Function),
+    )
+    expect(mocks.runExclusive).toHaveBeenNthCalledWith(
+      2,
+      "dm-conv-1",
+      expect.any(Function),
+    )
+    expect(mocks.cacheDelete).toHaveBeenNthCalledWith(1, "comment-conv-1")
+    expect(mocks.cacheDelete).toHaveBeenNthCalledWith(2, "dm-conv-1")
+    expect(mocks.updateMarker).toHaveBeenNthCalledWith(1, {
+      workspaceId: "ws-1",
+      conversationId: "comment-conv-1",
+      messageId: "comment-last",
+    })
+    expect(mocks.updateMarker).toHaveBeenNthCalledWith(2, {
+      workspaceId: "ws-1",
+      conversationId: "dm-conv-1",
+      messageId: "dm-last",
+    })
   })
 
   test("returns the error route when marker mutation fails after deleting the cache", async () => {

--- a/apps/worker/src/integration/handlers/delete-message-history/index.ts
+++ b/apps/worker/src/integration/handlers/delete-message-history/index.ts
@@ -1,6 +1,7 @@
 import { aiContextStore } from "@chatbotx.io/ai/server"
 import { conversationService } from "@chatbotx.io/business"
 import { isMessageStorageError } from "@chatbotx.io/database/errors"
+import { channelTypes } from "@chatbotx.io/database/partials"
 import {
   createMessageRepository,
   getSafeSinceTime,
@@ -18,31 +19,34 @@ export async function handleAIDeleteMessageHistory({
   try {
     const repo = await createMessageRepository()
     await aiContextStore.runExclusive(conversation.id, async () => {
-      const narrowSinceTime =
-        getSafeSinceTime(contactInbox.lastMessageAt) ?? new Date(0)
-      let lastMessages = await repo.findLastByConversation(conversation.id, {
-        limit: 1,
-        requireCompleteResults: true,
-        sinceTime: narrowSinceTime,
+      await resetAIHistoryMarker({
+        conversationId: conversation.id,
         workspaceId: conversation.workspaceId,
+        lastMessageAt: contactInbox.lastMessageAt,
+        repo,
       })
 
-      if (lastMessages.length === 0 && contactInbox.lastMessageAt !== null) {
-        lastMessages = await repo.findLastByConversation(conversation.id, {
-          limit: 1,
-          requireCompleteResults: true,
-          sinceTime: new Date(0),
-          workspaceId: conversation.workspaceId,
-        })
+      if (conversation.sourceId === null) {
+        return
       }
 
-      const lastMessage = lastMessages[0] ?? null
-
-      await aiContextStore.delete(conversation.id)
-      await conversationService.updateAIContextLastMessageId({
+      const dmConversation = await conversationService.findDMByContact({
         workspaceId: conversation.workspaceId,
-        conversationId: conversation.id,
-        messageId: lastMessage?.id ?? null,
+        contactId: conversation.contactId,
+        channel: channelTypes.safeParse(contactInbox.channel).data,
+      })
+
+      if (!dmConversation || dmConversation.id === conversation.id) {
+        return
+      }
+
+      await aiContextStore.runExclusive(dmConversation.id, async () => {
+        await resetAIHistoryMarker({
+          conversationId: dmConversation.id,
+          workspaceId: dmConversation.workspaceId,
+          lastMessageAt: contactInbox.lastMessageAt,
+          repo,
+        })
       })
     })
 
@@ -63,4 +67,42 @@ export async function handleAIDeleteMessageHistory({
     }
     return { status: "error", errorMessage: error.message, result: null }
   }
+}
+
+async function resetAIHistoryMarker({
+  conversationId,
+  workspaceId,
+  lastMessageAt,
+  repo,
+}: {
+  conversationId: string
+  workspaceId: string
+  lastMessageAt: Date | null
+  repo: Awaited<ReturnType<typeof createMessageRepository>>
+}) {
+  const narrowSinceTime = getSafeSinceTime(lastMessageAt) ?? new Date(0)
+  let lastMessages = await repo.findLastByConversation(conversationId, {
+    limit: 1,
+    requireCompleteResults: true,
+    sinceTime: narrowSinceTime,
+    workspaceId,
+  })
+
+  if (lastMessages.length === 0 && lastMessageAt !== null) {
+    lastMessages = await repo.findLastByConversation(conversationId, {
+      limit: 1,
+      requireCompleteResults: true,
+      sinceTime: new Date(0),
+      workspaceId,
+    })
+  }
+
+  const lastMessage = lastMessages[0] ?? null
+
+  await aiContextStore.delete(conversationId)
+  await conversationService.updateAIContextLastMessageId({
+    workspaceId,
+    conversationId,
+    messageId: lastMessage?.id ?? null,
+  })
 }


### PR DESCRIPTION
Instagram comment automation runs private reply flows on the
comment/post conversation, while the default AI agent reads the DM
conversation. Reset the DM marker too so new enquiries start clean.