### PR TITLE
fix(variables): resolve user_id system field to the contact id

### DIFF
--- a/packages/variables/__tests__/system-fields.test.ts
+++ b/packages/variables/__tests__/system-fields.test.ts
@@ -688,6 +688,18 @@ describe("getSystemFieldValue", () => {
     ).resolves.toBeNull()
   })
 
+  test("user_id resolves to the contact id even without a contact inbox", async () => {
+    await expect(
+      getSystemFieldValue(createContext(), systemFieldTypes.enum.user_id),
+    ).resolves.toBe("contact-1")
+    await expect(
+      getSystemFieldValue(
+        createContext({ contactInbox: null }),
+        systemFieldTypes.enum.user_id,
+      ),
+    ).resolves.toBe("contact-1")
+  })
+
   test("contact inbox passthrough fields resolve from context", async () => {
     const passthroughInbox = {
       ...contactInbox,
@@ -695,12 +707,6 @@ describe("getSystemFieldValue", () => {
       lastErrorLog: "(#551) This person isn't available right now.",
     } as ContactInboxModel
 
-    await expect(
-      getSystemFieldValue(
-        createContext({ contactInbox: passthroughInbox }),
-        systemFieldTypes.enum.user_id,
-      ),
-    ).resolves.toBe("source-1")
     await expect(
       getSystemFieldValue(
         createContext({ contactInbox: passthroughInbox }),
@@ -723,7 +729,6 @@ describe("getSystemFieldValue", () => {
 
   test("contact inbox passthrough fields return null without a contact inbox", async () => {
     for (const key of [
-      systemFieldTypes.enum.user_id,
       systemFieldTypes.enum.user_external_id,
       systemFieldTypes.enum.webchat_parent_url,
       systemFieldTypes.enum.last_error_log,

--- a/packages/variables/src/utils.ts
+++ b/packages/variables/src/utils.ts
@@ -350,7 +350,7 @@ export const getSystemFieldValue = async (
         contactInbox?.language ?? languageFromLocale(contact.locale) ?? null
       )
     case systemFieldTypes.enum.user_id:
-      return contactInbox?.sourceId ?? null
+      return contact.id
     case systemFieldTypes.enum.subscribed_date:
       return formatDate(contactInbox?.createdAt, contactTimezone)
     case systemFieldTypes.enum.last_seen:


### PR DESCRIPTION
## Summary
- `{{user_id}}` now resolves to the internal contact id instead of the channel-specific inbox id, so it stays stable for a contact across channels and is available even when no contact inbox is attached.
- The channel-specific id remains available through the existing `{{user_external_id}}` system field, so no new field was introduced.

## Changes
- `packages/variables/src/utils.ts` — `user_id` returns `contact.id`
- `packages/variables/__tests__/system-fields.test.ts` — dedicated `user_id` test; `user_id` removed from the contact-inbox passthrough set

## Test plan
- [x] `pnpm --filter @chatbotx.io/variables test` — 174/174 passing
- [x] `pnpm lint` (ultracite) and `pnpm turbo check-types` — clean via pre-commit hooks
- [ ] Manual check: a flow message using `{{user_id}}` renders the contact id; `{{user_external_id}}` still renders the PSID / channel id