### PR TITLE
fix(telegram): populate image width/height on incoming photo attachments

### DIFF
--- a/integrations/telegram/__tests__/incoming-message.test.ts
+++ b/integrations/telegram/__tests__/incoming-message.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, test } from "vitest"
+import { afterEach, describe, expect, test, vi } from "vitest"
+import { getTelegramFileUrl } from "../src/apis/bot"
 import { receiveMessage } from "../src/handlers/message/incoming-message"
+
+vi.mock("../src/apis/bot", () => ({
+  getTelegramFileUrl: vi.fn(),
+}))
 
 const ctx = {
   auth: {
@@ -7,7 +12,61 @@ const ctx = {
   },
 } as never
 
+const photoMessagePayload = (
+  photo: Array<{
+    file_id: string
+    file_unique_id: string
+    width: number
+    height: number
+    file_size: number
+  }>,
+) => ({
+  update_id: 1,
+  message: {
+    message_id: 10,
+    from: {
+      id: 100,
+      is_bot: false,
+      first_name: "Ada",
+    },
+    chat: {
+      id: 100,
+      type: "private",
+    },
+    date: 1_765_440_000,
+    photo,
+  },
+})
+
+const samplePhoto = [
+  {
+    file_id: "small",
+    file_unique_id: "small-unique",
+    width: 90,
+    height: 90,
+    file_size: 2366,
+  },
+  {
+    file_id: "largest",
+    file_unique_id: "largest-unique",
+    width: 700,
+    height: 700,
+    file_size: 51_569,
+  },
+]
+
+const buildCtx = () => ({
+  auth: { secretText: "telegram-token" },
+  storagePrefix: "workspace-1",
+  uploader: { putObject: vi.fn().mockResolvedValue(undefined) },
+})
+
 describe("receiveMessage", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.mocked(getTelegramFileUrl).mockReset()
+  })
+
   test("stores locale from message sender language_code", async () => {
     const result = await receiveMessage({
       ctx,
@@ -86,5 +145,69 @@ describe("receiveMessage", () => {
     })
 
     expect(result.contact.locale).toBeUndefined()
+  })
+
+  test("attaches the largest photo with its width/height", async () => {
+    vi.mocked(getTelegramFileUrl).mockResolvedValue(
+      "https://api.telegram.org/file/bot-token/photo.jpg",
+    )
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: { "content-type": "image/jpeg" },
+        }),
+      ),
+    )
+
+    const testCtx = buildCtx()
+    const result = await receiveMessage({
+      ctx: testCtx as never,
+      data: {
+        integrationType: "telegram",
+        integrationIdentifier: "bot-1",
+        payload: photoMessagePayload(samplePhoto),
+      },
+    })
+
+    expect(result.message?.attachments).toEqual([
+      expect.objectContaining({
+        fileType: "image",
+        mimeType: "image/jpeg",
+        width: 700,
+        height: 700,
+      }),
+    ])
+    expect(testCtx.uploader.putObject).toHaveBeenCalledTimes(1)
+  })
+
+  test("rejects instead of silently dropping the attachment when the download fails", async () => {
+    vi.mocked(getTelegramFileUrl).mockResolvedValue(
+      "https://api.telegram.org/file/bot-token/photo.jpg",
+    )
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(null, {
+          status: 500,
+          statusText: "Internal Server Error",
+        }),
+      ),
+    )
+
+    const testCtx = buildCtx()
+
+    await expect(
+      receiveMessage({
+        ctx: testCtx as never,
+        data: {
+          integrationType: "telegram",
+          integrationIdentifier: "bot-1",
+          payload: photoMessagePayload(samplePhoto),
+        },
+      }),
+    ).rejects.toThrow()
+    expect(testCtx.uploader.putObject).not.toHaveBeenCalled()
   })
 })

--- a/integrations/telegram/src/handlers/message/incoming-message.ts
+++ b/integrations/telegram/src/handlers/message/incoming-message.ts
@@ -131,6 +131,7 @@ const getMessageAttachments = async (
         ctx,
         largestPhoto.file_id,
         "image/jpeg",
+        { width: largestPhoto.width, height: largestPhoto.height },
       )
       if (attachment) {
         attachments.push(attachment)
@@ -189,6 +190,7 @@ const downloadAndUploadFile = async (
   ctx: Context<TelegramAuthValue>,
   fileId: string,
   mimeType: string,
+  dimensions?: { width: number; height: number },
 ): Promise<IncomingAttachment | null> => {
   try {
     const fileUrl = await getTelegramFileUrl(ctx.auth, fileId)
@@ -198,7 +200,9 @@ const downloadAndUploadFile = async (
 
     const response = await fetch(fileUrl)
     if (!(response.ok && response.body)) {
-      return null
+      throw new TelegramException(
+        `Failed to download attachment (status ${response.status} ${response.statusText}): ${fileUrl}`,
+      )
     }
 
     const bytes = await response.arrayBuffer()
@@ -215,10 +219,14 @@ const downloadAndUploadFile = async (
       fileType: guessFileTypeFromMimeType(mimeType),
       mimeType,
       size: bytes.byteLength,
+      ...dimensions,
     }
   } catch (error) {
-    logger.error(error, "downloadAndUploadFile error")
-    return null
+    logger.error(
+      { err: error, fileId, mimeType },
+      "downloadAndUploadFile error",
+    )
+    throw error
   }
 }
 


### PR DESCRIPTION
## Summary
- Telegram incoming photo attachments never carried `width`/`height`, unlike every other channel (Messenger, Instagram) which compute them via `image-size`.
- The inbox image renderer falls back to a `fill`-based layout when `width`/`height` are missing, which collapses to a 0x0 box — so incoming Telegram photos loaded correctly (valid `src`) but were never visible.
- Telegram already includes `width`/`height` on each `photo` size in the webhook payload, so no extra download/computation is needed — just pass them through.
- Also stop silently swallowing download/upload failures in `downloadAndUploadFile`: it now logs with proper context (`err`, `fileId`, `mimeType`) and rethrows, matching Messenger's behavior, so a genuine failure surfaces via job retry/logs instead of producing an attachment-less message.

## Changes
- `integrations/telegram/src/handlers/message/incoming-message.ts`: pass `largestPhoto.width`/`height` into the attachment; `downloadAndUploadFile` accepts optional `dimensions` and rethrows instead of swallowing errors.
- `integrations/telegram/__tests__/incoming-message.test.ts`: added coverage for successful photo attachment (asserts `width`/`height`) and for the download-failure path now rejecting instead of silently dropping the attachment.

## Test plan
- [x] `pnpm --filter @chatbotx.io/integration-telegram test`
- [x] `pnpm --filter @chatbotx.io/integration-telegram check-types`
- [x] `pnpm lint` (pre-commit hook: ultracite fix + full monorepo check-types)
- [ ] Manual verification: send a real photo to a Telegram bot and confirm it renders in the inbox