### PR TITLE
feat(contacts): backfill missing contact profile names from channel profiles

### DIFF
--- a/apps/builder/__tests__/chat-store-update-contact.test.ts
+++ b/apps/builder/__tests__/chat-store-update-contact.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// chatStore.updateContact — a contact's `ContactInbox` (and its
+// `contactInboxes` in the conversation list) can be shared across multiple
+// conversations (e.g. a Messenger DM plus every comment-thread conversation
+// for the same page). A profile refresh must patch the contact snapshot on
+// ALL of the contact's conversations, immutably, leaving conversations for
+// other contacts untouched. See
+// .superpowers/sdd/2026-08-31-messenger-ctm-profile-backfill/task-3-brief.md
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/orpc/orpc", () => ({
+  client: { conversationsAPI: {} },
+}))
+
+vi.mock("ky", () => ({ default: { post: vi.fn() } }))
+
+const { createChatStore } = await import(
+  "../src/features/chat/store/chat-store"
+)
+
+type TestContact = {
+  id: string
+  firstName: string | null
+  lastName: string | null
+  avatar: string | null
+}
+type TestConversation = {
+  id: string
+  contactId: string
+  contact: TestContact | null
+}
+
+const makeConversation = (
+  id: string,
+  contactId: string,
+  contact: TestContact | null,
+): TestConversation => ({ id, contactId, contact })
+
+describe("chatStore.updateContact", () => {
+  test("patches every conversation belonging to the contact", () => {
+    const store = createChatStore()
+    const contact: TestContact = {
+      id: "contact-1",
+      firstName: null,
+      lastName: null,
+      avatar: null,
+    }
+    const dm = makeConversation("conv-dm", "contact-1", contact)
+    const comment = makeConversation("conv-comment", "contact-1", contact)
+    store.setState({ conversations: [dm, comment] as never })
+
+    store.getState().updateContact("contact-1", {
+      firstName: "Jane",
+      avatar: "avatars/contact-1.png",
+    })
+
+    const conversations = store.getState()
+      .conversations as never as TestConversation[]
+    expect(conversations[0]?.contact).toEqual({
+      ...contact,
+      firstName: "Jane",
+      avatar: "avatars/contact-1.png",
+    })
+    expect(conversations[1]?.contact).toEqual({
+      ...contact,
+      firstName: "Jane",
+      avatar: "avatars/contact-1.png",
+    })
+  })
+
+  test("leaves conversations belonging to other contacts untouched", () => {
+    const store = createChatStore()
+    const contactA: TestContact = {
+      id: "contact-a",
+      firstName: null,
+      lastName: null,
+      avatar: null,
+    }
+    const contactB: TestContact = {
+      id: "contact-b",
+      firstName: "Existing",
+      lastName: null,
+      avatar: null,
+    }
+    const convA = makeConversation("conv-a", "contact-a", contactA)
+    const convB = makeConversation("conv-b", "contact-b", contactB)
+    store.setState({ conversations: [convA, convB] as never })
+
+    store.getState().updateContact("contact-a", { firstName: "Jane" })
+
+    const conversations = store.getState()
+      .conversations as never as TestConversation[]
+    expect(conversations[0]?.contact).toEqual({
+      ...contactA,
+      firstName: "Jane",
+    })
+    // Untouched: same object reference, not just equal value.
+    expect(conversations[1]?.contact).toBe(contactB)
+  })
+
+  test("is a no-op when no conversation matches the contactId", () => {
+    const store = createChatStore()
+    const contact: TestContact = {
+      id: "contact-1",
+      firstName: null,
+      lastName: null,
+      avatar: null,
+    }
+    const conv = makeConversation("conv-1", "contact-1", contact)
+    store.setState({ conversations: [conv] as never })
+    const before = store.getState().conversations
+
+    store.getState().updateContact("contact-missing", { firstName: "Jane" })
+
+    expect(store.getState().conversations).toBe(before)
+  })
+})

--- a/apps/builder/__tests__/contact-inbox-panel.test.tsx
+++ b/apps/builder/__tests__/contact-inbox-panel.test.tsx
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// ContactInboxPanel — the "latest request wins" guard around
+// `getContactAuthenticatedAPI`. The panel fires an initial fetch on open AND
+// (via `useAutoRefreshContactProfile`'s `onProfileUpdated` callback) a
+// convergence re-fetch once the auto-refresh applies an update. Those two
+// requests can settle out of order (the initial one is often slower — it
+// races the Graph/Telegram round trip the refresh triggers) — whichever
+// request was issued LAST must win, never whichever RESOLVES last.
+// See docs/plans/2026-08-31-messenger-ctm-profile-backfill.md, fix wave 2
+// finding 3.
+// ---------------------------------------------------------------------------
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+const getContactMock = vi.fn()
+const listCouponsMock = vi.fn(async (_input: unknown) => [])
+const listAppointmentsMock = vi.fn(async (_input: unknown) => [])
+vi.mock("@/lib/orpc/orpc", () => ({
+  client: {
+    contactsAPIs: {
+      getContactAuthenticatedAPI: (input: unknown) => getContactMock(input),
+    },
+    couponsAPI: {
+      listContactCouponsAPI: (input: unknown) => listCouponsMock(input),
+    },
+    appointmentsAPI: {
+      listContactAppointmentsAPI: (input: unknown) =>
+        listAppointmentsMock(input),
+    },
+  },
+}))
+
+let latestConversations: unknown[] = []
+vi.mock("@/features/chat/store/chat-store-provider", () => ({
+  useChatStore: <T,>(
+    selector: (state: {
+      conversations: unknown[]
+      updateContact: () => void
+    }) => T,
+  ) => selector({ conversations: latestConversations, updateContact: vi.fn() }),
+}))
+
+// Captures the props `ContactInboxPanel` passes to the hook, including
+// `onProfileUpdated`, so the test can invoke it directly to simulate the
+// hook's own async `.then()` firing without re-driving the whole
+// refreshContactProfileAction plumbing (already covered in
+// use-auto-refresh-contact-profile.test.tsx).
+const hookCalls: Array<{ onProfileUpdated?: (contactId: string) => void }> = []
+vi.mock("@/features/contacts/hooks/use-auto-refresh-contact-profile", () => ({
+  useAutoRefreshContactProfile: (props: {
+    onProfileUpdated?: (contactId: string) => void
+  }) => {
+    hookCalls.push(props)
+  },
+}))
+
+vi.mock("@/features/contacts/contact-detail", () => ({
+  ContactDetail: ({
+    contact,
+  }: {
+    contact: { firstName?: string | null } | null
+  }) => (
+    <div data-testid="contact-detail">{contact?.firstName ?? "no-name"}</div>
+  ),
+}))
+
+vi.mock("@/features/contact-notes/contact-notes-manage", () => ({
+  ContactNotesManage: () => null,
+}))
+
+vi.mock("@/features/contacts/components/contact-appointments-list", () => ({
+  ContactAppointmentsList: () => null,
+}))
+
+vi.mock("@/features/contacts/components/update-contact-tag-field", () => ({
+  default: () => null,
+}))
+
+vi.mock("@/features/contact-sequences/update-contact-sequence-field", () => ({
+  default: () => null,
+}))
+
+vi.mock("@/features/sequences/provider/sequence-store-context", () => ({
+  SequenceStoreProvider: ({ children }: { children: React.ReactNode }) =>
+    children,
+}))
+
+vi.mock("@chatbotx.io/ui/components/ui/accordion", () => ({
+  Accordion: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AccordionItem: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AccordionTrigger: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AccordionContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}))
+
+const { ContactInboxPanel } = await import(
+  "@/features/contacts/contact-inbox-panel"
+)
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+const baseConversation = {
+  id: "conv-1",
+  contactId: "contact-1",
+  contact: { id: "contact-1", firstName: null, lastName: null },
+  contactInboxes: [],
+}
+
+describe("ContactInboxPanel", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+    container = document.createElement("div")
+    document.body.append(container)
+    root = createRoot(container)
+    getContactMock.mockReset()
+    listCouponsMock.mockClear()
+    listAppointmentsMock.mockClear()
+    hookCalls.length = 0
+    latestConversations = [baseConversation]
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+  })
+
+  function render() {
+    act(() => {
+      root.render(
+        <ContactInboxPanel activeConversationId="conv-1" workspaceId="ws-1" />,
+      )
+    })
+  }
+
+  test("normal open (no refresh in flight) applies the fetched contact", async () => {
+    const { promise, resolve } = deferred<{ firstName: string | null }>()
+    getContactMock.mockReturnValueOnce(promise)
+
+    render()
+
+    expect(getContactMock).toHaveBeenCalledTimes(1)
+    expect(getContactMock).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+    })
+
+    await act(async () => {
+      resolve({ firstName: "Jane" })
+      await Promise.resolve()
+    })
+
+    const detail = container.querySelector('[data-testid="contact-detail"]')
+    expect(detail?.textContent).toBe("Jane")
+  })
+
+  test("initial getContact resolves AFTER the refresh-triggered re-fetch → the panel keeps the refreshed data (latest request wins, not latest to resolve)", async () => {
+    const initialFetch = deferred<{ firstName: string | null }>()
+    const refreshFetch = deferred<{ firstName: string | null }>()
+    getContactMock
+      .mockReturnValueOnce(initialFetch.promise) // the panel's own initial fetch on open
+      .mockReturnValueOnce(refreshFetch.promise) // triggered by onProfileUpdated
+
+    render()
+    expect(getContactMock).toHaveBeenCalledTimes(1)
+
+    // Simulate the auto-refresh hook applying an update and calling back
+    // into the panel — this fires the SECOND (later-issued) fetch while the
+    // first is still in flight.
+    const onProfileUpdated = hookCalls.at(-1)?.onProfileUpdated
+    expect(onProfileUpdated).toBeTypeOf("function")
+    act(() => {
+      onProfileUpdated?.("contact-1")
+    })
+    expect(getContactMock).toHaveBeenCalledTimes(2)
+
+    // The later-issued (refresh) request resolves FIRST with the real name.
+    await act(async () => {
+      refreshFetch.resolve({ firstName: "Jane" })
+      await Promise.resolve()
+    })
+    let detail = container.querySelector('[data-testid="contact-detail"]')
+    expect(detail?.textContent).toBe("Jane")
+
+    // The earlier (initial) request resolves AFTER — stale data must be
+    // discarded, not applied over the refreshed name.
+    await act(async () => {
+      initialFetch.resolve({ firstName: null })
+      await Promise.resolve()
+    })
+    detail = container.querySelector('[data-testid="contact-detail"]')
+    expect(detail?.textContent).toBe("Jane")
+  })
+})

--- a/apps/builder/__tests__/contact-inbox-panel.test.tsx
+++ b/apps/builder/__tests__/contact-inbox-panel.test.tsx
@@ -53,11 +53,15 @@ vi.mock("@/features/chat/store/chat-store-provider", () => ({
 // hook's own async `.then()` firing without re-driving the whole
 // refreshContactProfileAction plumbing (already covered in
 // use-auto-refresh-contact-profile.test.tsx).
-const hookCalls: Array<{ onProfileUpdated?: (contactId: string) => void }> = []
+type CapturedHookProps = {
+  onProfileUpdated?: (contactId: string) => void
+  setContactData?: (
+    updater: (prev: { firstName: string | null } | null) => unknown,
+  ) => void
+}
+const hookCalls: CapturedHookProps[] = []
 vi.mock("@/features/contacts/hooks/use-auto-refresh-contact-profile", () => ({
-  useAutoRefreshContactProfile: (props: {
-    onProfileUpdated?: (contactId: string) => void
-  }) => {
+  useAutoRefreshContactProfile: (props: CapturedHookProps) => {
     hookCalls.push(props)
   },
 }))
@@ -114,10 +118,17 @@ const { ContactInboxPanel } = await import(
 
 function deferred<T>() {
   let resolve!: (value: T) => void
-  const promise = new Promise<T>((res) => {
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
     resolve = res
+    reject = rej
   })
-  return { promise, resolve }
+  // Attach a no-op catch handler so an intentionally-unresolved/rejected
+  // deferred never surfaces as an unhandled rejection warning in tests that
+  // never await this promise directly (the component under test consumes
+  // it via `.then()/.catch()`, which is what's actually under test).
+  promise.catch(() => undefined)
+  return { promise, resolve, reject }
 }
 
 const baseConversation = {
@@ -215,5 +226,65 @@ describe("ContactInboxPanel", () => {
     })
     detail = container.querySelector('[data-testid="contact-detail"]')
     expect(detail?.textContent).toBe("Jane")
+  })
+  test("refresh patch applied, then the convergence re-fetch REJECTS → the panel keeps the patched name (does not wipe to null)", async () => {
+    const initialFetch = deferred<{ firstName: string | null }>()
+    getContactMock.mockReturnValueOnce(initialFetch.promise) // the panel's own initial fetch on open
+
+    render()
+    expect(getContactMock).toHaveBeenCalledTimes(1)
+
+    // Initial fetch resolves with the (nameless) contact — this is what
+    // would have made the contact eligible for auto-refresh in real code.
+    await act(async () => {
+      initialFetch.resolve({ firstName: null })
+      await Promise.resolve()
+    })
+    let detail = container.querySelector('[data-testid="contact-detail"]')
+    expect(detail?.textContent).toBe("no-name")
+
+    const { setContactData, onProfileUpdated } = hookCalls.at(-1) ?? {}
+    expect(setContactData).toBeTypeOf("function")
+    expect(onProfileUpdated).toBeTypeOf("function")
+
+    const convergenceFetch = deferred<{ firstName: string | null }>()
+    getContactMock.mockReturnValueOnce(convergenceFetch.promise)
+
+    // Mirrors what the real (unmocked) hook does: patch `contactData`
+    // locally via `setContactData`, then call `onProfileUpdated` to kick
+    // off the convergence re-fetch.
+    act(() => {
+      setContactData?.((prev) => prev && { ...prev, firstName: "Jane" })
+      onProfileUpdated?.("contact-1")
+    })
+    expect(getContactMock).toHaveBeenCalledTimes(2)
+
+    detail = container.querySelector('[data-testid="contact-detail"]')
+    expect(detail?.textContent).toBe("Jane")
+
+    // The convergence re-fetch fails (network blip / RSC error) — the
+    // already-patched name must survive, not be wiped to null.
+    await act(async () => {
+      convergenceFetch.reject(new Error("network error"))
+      await Promise.resolve()
+    })
+    detail = container.querySelector('[data-testid="contact-detail"]')
+    expect(detail?.textContent).toBe("Jane")
+  })
+
+  test("initial fetch failure still clears the panel (pre-existing behaviour, unchanged)", async () => {
+    const initialFetch = deferred<{ firstName: string | null }>()
+    getContactMock.mockReturnValueOnce(initialFetch.promise)
+
+    render()
+    expect(getContactMock).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      initialFetch.reject(new Error("network error"))
+      await Promise.resolve()
+    })
+
+    const detail = container.querySelector('[data-testid="contact-detail"]')
+    expect(detail?.textContent).toBe("no-name")
   })
 })

--- a/apps/builder/__tests__/contact-inbox-resource.test.ts
+++ b/apps/builder/__tests__/contact-inbox-resource.test.ts
@@ -11,6 +11,7 @@ describe("contactInboxResource", () => {
       source: "inboundMessage",
       sourceId: "psid-1",
       language: "vi",
+      lastMessageAt: null,
       lastIncomingMessageAt: null,
       contactLastReadAt: null,
       inbox: { name: "Messenger Inbox" },

--- a/apps/builder/__tests__/contact-inbox-resource.test.ts
+++ b/apps/builder/__tests__/contact-inbox-resource.test.ts
@@ -11,7 +11,6 @@ describe("contactInboxResource", () => {
       source: "inboundMessage",
       sourceId: "psid-1",
       language: "vi",
-      lastMessageAt: null,
       lastIncomingMessageAt: null,
       contactLastReadAt: null,
       inbox: { name: "Messenger Inbox" },

--- a/apps/builder/__tests__/conversation-contact-inbox-resource.test.ts
+++ b/apps/builder/__tests__/conversation-contact-inbox-resource.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest"
+import { conversationContactInboxResource } from "@/features/conversations/schema/resource"
+
+// conversationContactInboxResource extends the shared contactInboxResource
+// with fields that must stay conversation-only (not leak into the public
+// workspace-token contact APIs that nest contactInboxResource directly).
+// lastMessageAt lives here — not on the shared resource — because it's only
+// needed by useAutoRefreshContactProfile's "newest capable inbox" selection.
+describe("conversationContactInboxResource", () => {
+  test("parses lastMessageAt as a Date", () => {
+    const parsed = conversationContactInboxResource.parse({
+      id: "contact-inbox-1",
+      contactId: "contact-1",
+      inboxId: "inbox-1",
+      channel: "messenger",
+      source: "inboundMessage",
+      sourceId: "psid-1",
+      language: "vi",
+      lastMessageAt: new Date("2026-06-10T00:00:00Z"),
+      lastIncomingMessageAt: null,
+      contactLastReadAt: null,
+      inbox: { name: "Messenger Inbox" },
+      adReferral: null,
+    })
+
+    expect(parsed.lastMessageAt).toEqual(new Date("2026-06-10T00:00:00Z"))
+  })
+
+  test("parses a null lastMessageAt", () => {
+    const parsed = conversationContactInboxResource.parse({
+      id: "contact-inbox-1",
+      contactId: "contact-1",
+      inboxId: "inbox-1",
+      channel: "messenger",
+      source: "inboundMessage",
+      sourceId: "psid-1",
+      language: "vi",
+      lastMessageAt: null,
+      lastIncomingMessageAt: null,
+      contactLastReadAt: null,
+      inbox: { name: "Messenger Inbox" },
+      adReferral: null,
+    })
+
+    expect(parsed.lastMessageAt).toBeNull()
+  })
+})

--- a/apps/builder/__tests__/refresh-contact-profile-action.test.ts
+++ b/apps/builder/__tests__/refresh-contact-profile-action.test.ts
@@ -205,6 +205,24 @@ describe("refreshContactProfileAction — channel capability gate", () => {
     expect(mocks.refresh).not.toHaveBeenCalled()
     noFactoryMocksCalled()
   })
+
+  test("unknown/legacy channel string returns skipped/channelNotCapable, never throws, factory uncalled", async () => {
+    mocks.findContactInboxByUncached.mockResolvedValueOnce({
+      id: "ci-1",
+      contactId: "contact-1",
+      channel: "legacy",
+      inboxId: "inbox-1",
+      sourceId: "source-1",
+    })
+
+    await expect(callAction({})).resolves.toEqual({
+      status: "skipped",
+      reason: "channelNotCapable",
+    })
+
+    expect(mocks.refresh).not.toHaveBeenCalled()
+    noFactoryMocksCalled()
+  })
 })
 
 describe("refreshContactProfileAction — per-channel factory table", () => {

--- a/apps/builder/__tests__/refresh-contact-profile-action.test.ts
+++ b/apps/builder/__tests__/refresh-contact-profile-action.test.ts
@@ -1,0 +1,411 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// refreshContactProfileAction — authorization gate (findByIdOrFail) runs
+// before any inbox/integration/Graph work; a non-capable channel short
+// circuits before the factory table; the per-channel factory table resolves
+// the right integration service + registry (including the instagram
+// facebook-vs-direct split); and failed/unavailable are RETURNED, never
+// thrown. See
+// .superpowers/sdd/2026-08-31-messenger-ctm-profile-backfill/task-3-brief.md
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  findByIdOrFail: vi.fn(),
+  findContactInboxByUncached: vi.fn(),
+  refresh: vi.fn(),
+  requireContactPermissionScope: vi.fn(),
+  messengerFindByInboxIdForWorkspace: vi.fn(),
+  instagramFindByInboxIdForWorkspace: vi.fn(),
+  zaloFindByInboxIdForWorkspace: vi.fn(),
+  telegramFindByInboxIdForWorkspace: vi.fn(),
+  buildContext: vi.fn(),
+  messengerRunChannelHandler: vi.fn(),
+  instagramRunChannelHandler: vi.fn(),
+  instagramFacebookRunChannelHandler: vi.fn(),
+  zaloRunChannelHandler: vi.fn(),
+  telegramRunChannelHandler: vi.fn(),
+}))
+
+const ON_DEMAND_CHANNELS = new Set([
+  "messenger",
+  "instagram",
+  "zalo",
+  "telegram",
+])
+
+vi.mock("@chatbotx.io/business", () => ({
+  contactService: { findByIdOrFail: mocks.findByIdOrFail },
+  contactInboxService: { findByUncached: mocks.findContactInboxByUncached },
+  contactProfileRefreshService: { refresh: mocks.refresh },
+  hasOnDemandProfileApi: (channel: string) => ON_DEMAND_CHANNELS.has(channel),
+  messengerIntegrationService: {
+    findByInboxIdForWorkspace: mocks.messengerFindByInboxIdForWorkspace,
+  },
+  instagramIntegrationService: {
+    findByInboxIdForWorkspace: mocks.instagramFindByInboxIdForWorkspace,
+  },
+  zaloIntegrationService: {
+    findByInboxIdForWorkspace: mocks.zaloFindByInboxIdForWorkspace,
+  },
+  telegramIntegrationService: {
+    findByInboxIdForWorkspace: mocks.telegramFindByInboxIdForWorkspace,
+  },
+  buildContext: mocks.buildContext,
+}))
+
+vi.mock("@chatbotx.io/business/errors", () => ({
+  notFoundException: (message: string) => new Error(message),
+}))
+
+vi.mock("@/integration", () => ({
+  integrations: {
+    messenger: { runChannelHandler: mocks.messengerRunChannelHandler },
+    instagram: { runChannelHandler: mocks.instagramRunChannelHandler },
+    instagramFacebook: {
+      runChannelHandler: mocks.instagramFacebookRunChannelHandler,
+    },
+    zalo: { runChannelHandler: mocks.zaloRunChannelHandler },
+    telegram: { runChannelHandler: mocks.telegramRunChannelHandler },
+  },
+}))
+
+vi.mock("@/lib/safe-action", () => ({
+  workspaceActionClient: {
+    bindArgsSchemas: () => ({
+      inputSchema: () => ({ action: (fn: unknown) => fn }),
+    }),
+  },
+}))
+
+vi.mock("@/features/contacts/permissions", () => ({
+  requireContactPermissionScope: mocks.requireContactPermissionScope,
+}))
+
+vi.mock("@/features/contacts/schema/action", () => ({
+  refreshContactProfileRequest: {},
+}))
+
+const { refreshContactProfileAction } = await import(
+  "../src/features/contacts/actions/refresh-contact-profile.action"
+)
+
+const ACCESS_SCOPE = { canViewEmailAndPhone: true }
+
+const callAction = (input: {
+  workspaceId?: string
+  contactId?: string
+  contactInboxId?: string
+}) =>
+  (
+    refreshContactProfileAction as unknown as (props: {
+      bindArgsParsedInputs: [string, string]
+      parsedInput: { contactInboxId: string }
+    }) => Promise<unknown>
+  )({
+    bindArgsParsedInputs: [
+      input.workspaceId ?? "ws-1",
+      input.contactId ?? "contact-1",
+    ],
+    parsedInput: { contactInboxId: input.contactInboxId ?? "ci-1" },
+  })
+
+const noFactoryMocksCalled = () => {
+  expect(mocks.messengerFindByInboxIdForWorkspace).not.toHaveBeenCalled()
+  expect(mocks.instagramFindByInboxIdForWorkspace).not.toHaveBeenCalled()
+  expect(mocks.zaloFindByInboxIdForWorkspace).not.toHaveBeenCalled()
+  expect(mocks.telegramFindByInboxIdForWorkspace).not.toHaveBeenCalled()
+  expect(mocks.buildContext).not.toHaveBeenCalled()
+  expect(mocks.messengerRunChannelHandler).not.toHaveBeenCalled()
+  expect(mocks.instagramRunChannelHandler).not.toHaveBeenCalled()
+  expect(mocks.instagramFacebookRunChannelHandler).not.toHaveBeenCalled()
+  expect(mocks.zaloRunChannelHandler).not.toHaveBeenCalled()
+  expect(mocks.telegramRunChannelHandler).not.toHaveBeenCalled()
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.requireContactPermissionScope.mockResolvedValue(ACCESS_SCOPE)
+  mocks.findByIdOrFail.mockResolvedValue({ id: "contact-1" })
+  mocks.buildContext.mockImplementation(
+    async ({ integrationType, integration }) => ({
+      integrationType,
+      auth: integration.auth,
+    }),
+  )
+  // Simulates the essential part of the real
+  // contactProfileRefreshService.refresh pipeline: call fetchProfile and
+  // never let it throw out of the action — a rejection becomes "failed".
+  mocks.refresh.mockImplementation(async (input) => {
+    try {
+      const profile = await input.fetchProfile()
+      return profile
+        ? { status: "updated", contact: { id: input.contactId, ...profile } }
+        : { status: "unavailable" }
+    } catch {
+      return { status: "failed" }
+    }
+  })
+})
+
+describe("refreshContactProfileAction — authorization gate", () => {
+  test("a permission-scope rejection propagates before any inbox/integration/Graph work", async () => {
+    mocks.requireContactPermissionScope.mockRejectedValueOnce(
+      new Error("not authorized"),
+    )
+
+    await expect(callAction({})).rejects.toThrow("not authorized")
+
+    expect(mocks.findByIdOrFail).not.toHaveBeenCalled()
+    expect(mocks.findContactInboxByUncached).not.toHaveBeenCalled()
+    noFactoryMocksCalled()
+  })
+
+  test("a contact outside the accessScope/workspace rejects at findByIdOrFail before findByUncached, the adapter, buildContext or Graph", async () => {
+    mocks.findByIdOrFail.mockRejectedValueOnce(new Error("contact not found"))
+
+    await expect(callAction({})).rejects.toThrow("contact not found")
+
+    expect(mocks.findByIdOrFail).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      id: "contact-1",
+      accessScope: ACCESS_SCOPE,
+    })
+    expect(mocks.findContactInboxByUncached).not.toHaveBeenCalled()
+    noFactoryMocksCalled()
+  })
+
+  test("a contactInboxId not belonging to contactId throws a not-found exception, factory uncalled", async () => {
+    mocks.findContactInboxByUncached.mockResolvedValueOnce(undefined)
+
+    await expect(callAction({})).rejects.toThrow("Contact inbox not found")
+
+    expect(mocks.findContactInboxByUncached).toHaveBeenCalledWith({
+      where: { id: "ci-1", contactId: "contact-1" },
+    })
+    noFactoryMocksCalled()
+  })
+})
+
+describe("refreshContactProfileAction — channel capability gate", () => {
+  test("onDemand:false channel (whatsapp) returns skipped/channelNotCapable, factory uncalled", async () => {
+    mocks.findContactInboxByUncached.mockResolvedValueOnce({
+      id: "ci-1",
+      contactId: "contact-1",
+      channel: "whatsapp",
+      inboxId: "inbox-1",
+      sourceId: "source-1",
+    })
+
+    await expect(callAction({})).resolves.toEqual({
+      status: "skipped",
+      reason: "channelNotCapable",
+    })
+
+    expect(mocks.refresh).not.toHaveBeenCalled()
+    noFactoryMocksCalled()
+  })
+})
+
+describe("refreshContactProfileAction — per-channel factory table", () => {
+  test("findByInboxIdForWorkspace throwing (disconnected integration) returns failed, never thrown", async () => {
+    mocks.findContactInboxByUncached.mockResolvedValueOnce({
+      id: "ci-1",
+      contactId: "contact-1",
+      channel: "messenger",
+      inboxId: "inbox-1",
+      sourceId: "source-1",
+    })
+    mocks.messengerFindByInboxIdForWorkspace.mockRejectedValueOnce(
+      new Error("integration disconnected"),
+    )
+
+    await expect(callAction({})).resolves.toEqual({ status: "failed" })
+
+    expect(mocks.buildContext).not.toHaveBeenCalled()
+    expect(mocks.messengerRunChannelHandler).not.toHaveBeenCalled()
+  })
+
+  test("instagram row with type:'facebook' dispatches through integrations.instagramFacebook", async () => {
+    mocks.findContactInboxByUncached.mockResolvedValueOnce({
+      id: "ci-1",
+      contactId: "contact-1",
+      channel: "instagram",
+      inboxId: "inbox-1",
+      sourceId: "source-1",
+    })
+    mocks.instagramFindByInboxIdForWorkspace.mockResolvedValueOnce({
+      id: "ig-1",
+      type: "facebook",
+      auth: { accessToken: "tok" },
+    })
+    mocks.instagramFacebookRunChannelHandler.mockResolvedValueOnce({
+      firstName: "Jane",
+    })
+
+    await expect(callAction({})).resolves.toEqual({
+      status: "updated",
+      contact: { id: "contact-1", firstName: "Jane" },
+    })
+
+    expect(mocks.instagramFacebookRunChannelHandler).toHaveBeenCalledWith(
+      "contact",
+      "getProfile",
+      expect.objectContaining({ data: { sourceId: "source-1" } }),
+    )
+    expect(mocks.instagramRunChannelHandler).not.toHaveBeenCalled()
+  })
+
+  test("instagram row with type:'instagram' dispatches through integrations.instagram", async () => {
+    mocks.findContactInboxByUncached.mockResolvedValueOnce({
+      id: "ci-1",
+      contactId: "contact-1",
+      channel: "instagram",
+      inboxId: "inbox-1",
+      sourceId: "source-1",
+    })
+    mocks.instagramFindByInboxIdForWorkspace.mockResolvedValueOnce({
+      id: "ig-1",
+      type: "instagram",
+      auth: { accessToken: "tok" },
+    })
+    mocks.instagramRunChannelHandler.mockResolvedValueOnce({
+      firstName: "Jane",
+    })
+
+    await expect(callAction({})).resolves.toEqual({
+      status: "updated",
+      contact: { id: "contact-1", firstName: "Jane" },
+    })
+
+    expect(mocks.instagramRunChannelHandler).toHaveBeenCalledWith(
+      "contact",
+      "getProfile",
+      expect.objectContaining({ data: { sourceId: "source-1" } }),
+    )
+    expect(mocks.instagramFacebookRunChannelHandler).not.toHaveBeenCalled()
+  })
+
+  test("zalo factory resolves through zaloIntegrationService.findByInboxIdForWorkspace", async () => {
+    mocks.findContactInboxByUncached.mockResolvedValueOnce({
+      id: "ci-1",
+      contactId: "contact-1",
+      channel: "zalo",
+      inboxId: "inbox-1",
+      sourceId: "source-1",
+    })
+    mocks.zaloFindByInboxIdForWorkspace.mockResolvedValueOnce({
+      id: "zalo-1",
+      auth: { accessToken: "tok" },
+    })
+    mocks.zaloRunChannelHandler.mockResolvedValueOnce({ firstName: "Jane" })
+
+    await expect(callAction({})).resolves.toEqual({
+      status: "updated",
+      contact: { id: "contact-1", firstName: "Jane" },
+    })
+
+    expect(mocks.zaloFindByInboxIdForWorkspace).toHaveBeenCalledWith({
+      inboxId: "inbox-1",
+      workspaceId: "ws-1",
+    })
+    expect(mocks.zaloRunChannelHandler).toHaveBeenCalledWith(
+      "contact",
+      "getProfile",
+      expect.objectContaining({ data: { sourceId: "source-1" } }),
+    )
+  })
+
+  test("telegram factory resolves through telegramIntegrationService.findByInboxIdForWorkspace", async () => {
+    mocks.findContactInboxByUncached.mockResolvedValueOnce({
+      id: "ci-1",
+      contactId: "contact-1",
+      channel: "telegram",
+      inboxId: "inbox-1",
+      sourceId: "source-1",
+    })
+    mocks.telegramFindByInboxIdForWorkspace.mockResolvedValueOnce({
+      id: "telegram-1",
+      auth: { secretText: "tok" },
+    })
+    mocks.telegramRunChannelHandler.mockResolvedValueOnce({
+      firstName: "Jane",
+    })
+
+    await expect(callAction({})).resolves.toEqual({
+      status: "updated",
+      contact: { id: "contact-1", firstName: "Jane" },
+    })
+
+    expect(mocks.telegramFindByInboxIdForWorkspace).toHaveBeenCalledWith({
+      inboxId: "inbox-1",
+      workspaceId: "ws-1",
+    })
+    expect(mocks.telegramRunChannelHandler).toHaveBeenCalledWith(
+      "contact",
+      "getProfile",
+      expect.objectContaining({ data: { sourceId: "source-1" } }),
+    )
+  })
+})
+
+describe("refreshContactProfileAction — service outcomes are returned, never thrown", () => {
+  test("failed is returned, not thrown", async () => {
+    mocks.findContactInboxByUncached.mockResolvedValueOnce({
+      id: "ci-1",
+      contactId: "contact-1",
+      channel: "messenger",
+      inboxId: "inbox-1",
+      sourceId: "source-1",
+    })
+    mocks.messengerFindByInboxIdForWorkspace.mockResolvedValueOnce({
+      id: "messenger-1",
+      auth: { accessToken: "tok" },
+    })
+    mocks.messengerRunChannelHandler.mockRejectedValueOnce(
+      new Error("graph error"),
+    )
+
+    await expect(callAction({})).resolves.toEqual({ status: "failed" })
+  })
+
+  test("unavailable is returned, not thrown", async () => {
+    mocks.findContactInboxByUncached.mockResolvedValueOnce({
+      id: "ci-1",
+      contactId: "contact-1",
+      channel: "messenger",
+      inboxId: "inbox-1",
+      sourceId: "source-1",
+    })
+    mocks.messengerFindByInboxIdForWorkspace.mockResolvedValueOnce({
+      id: "messenger-1",
+      auth: { accessToken: "tok" },
+    })
+    mocks.messengerRunChannelHandler.mockResolvedValueOnce(null)
+
+    await expect(callAction({})).resolves.toEqual({ status: "unavailable" })
+  })
+
+  test("happy path returns status:'updated' with a ContactResource-shaped contact", async () => {
+    mocks.findContactInboxByUncached.mockResolvedValueOnce({
+      id: "ci-1",
+      contactId: "contact-1",
+      channel: "messenger",
+      inboxId: "inbox-1",
+      sourceId: "source-1",
+    })
+    mocks.messengerFindByInboxIdForWorkspace.mockResolvedValueOnce({
+      id: "messenger-1",
+      auth: { accessToken: "tok" },
+    })
+    mocks.messengerRunChannelHandler.mockResolvedValueOnce({
+      firstName: "Jane",
+      lastName: "Doe",
+    })
+
+    await expect(callAction({})).resolves.toEqual({
+      status: "updated",
+      contact: { id: "contact-1", firstName: "Jane", lastName: "Doe" },
+    })
+  })
+})

--- a/apps/builder/__tests__/use-auto-refresh-contact-profile.test.tsx
+++ b/apps/builder/__tests__/use-auto-refresh-contact-profile.test.tsx
@@ -1,0 +1,342 @@
+// @vitest-environment jsdom
+
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import type { SetContactData } from "@/features/contacts/hooks/use-auto-refresh-contact-profile"
+
+// ---------------------------------------------------------------------------
+// useAutoRefreshContactProfile — selects the newest on-demand-capable inbox
+// for a nameless contact, fires refreshContactProfileAction at most once per
+// contactId per mount, and patches the store + panel contactData only on a
+// status:"updated" result. See
+// .superpowers/sdd/2026-08-31-messenger-ctm-profile-backfill/task-3-brief.md
+// ---------------------------------------------------------------------------
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+const toastMocks = { error: vi.fn(), success: vi.fn() }
+vi.mock("sonner", () => ({ toast: toastMocks }))
+
+const executeMock = vi.fn()
+let latestOnSuccess: ((args: { data: unknown }) => void) | undefined
+
+vi.mock("next-safe-action/hooks", () => ({
+  useAction: (
+    _action: unknown,
+    options?: { onSuccess?: (args: { data: unknown }) => void },
+  ) => {
+    latestOnSuccess = options?.onSuccess
+    return { execute: executeMock, isPending: false }
+  },
+}))
+
+vi.mock("@/features/contacts/actions/refresh-contact-profile.action", () => ({
+  refreshContactProfileAction: { bind: () => "bound-refresh-action" },
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  hasEmptyProfileName: (contact: {
+    firstName?: string | null
+    lastName?: string | null
+  }) => !(contact.firstName?.trim() || contact.lastName?.trim()),
+  hasOnDemandProfileApi: (channel: string) =>
+    channel === "messenger" ||
+    channel === "instagram" ||
+    channel === "zalo" ||
+    channel === "telegram",
+}))
+
+const updateContactMock = vi.fn()
+vi.mock("@/features/chat/store/chat-store-provider", () => ({
+  useChatStore: <T,>(
+    selector: (state: { updateContact: typeof updateContactMock }) => T,
+  ) => selector({ updateContact: updateContactMock }),
+}))
+
+const { useAutoRefreshContactProfile } = await import(
+  "@/features/contacts/hooks/use-auto-refresh-contact-profile"
+)
+
+type TestContact = {
+  id: string
+  avatar?: string | null
+  firstName: string | null
+  lastName: string | null
+}
+type TestContactInbox = {
+  id: string
+  channel: string
+  lastMessageAt: string | null
+}
+type TestConversation = {
+  id: string
+  contactId: string
+  contact: TestContact | null
+  contactInboxes: TestContactInbox[]
+}
+
+const namelessContact = (id: string): TestContact => ({
+  id,
+  avatar: null,
+  firstName: null,
+  lastName: null,
+})
+
+const conversation = (
+  overrides: Partial<TestConversation> & { contactId: string },
+): TestConversation => ({
+  id: `conv-${overrides.contactId}`,
+  contact: namelessContact(overrides.contactId),
+  contactInboxes: [],
+  ...overrides,
+})
+
+function HookHost({
+  workspaceId,
+  conv,
+  setContactData,
+}: {
+  workspaceId: string
+  conv: TestConversation | null
+  setContactData: SetContactData
+}) {
+  useAutoRefreshContactProfile({
+    workspaceId,
+    // The hook only reads `contact`/`contactId`/`contactInboxes`, so this
+    // narrow fixture shape stands in for the full ListConversationItemResource.
+    conversation: conv as unknown as Parameters<
+      typeof useAutoRefreshContactProfile
+    >[0]["conversation"],
+    setContactData,
+  })
+  return null
+}
+
+describe("useAutoRefreshContactProfile", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+    container = document.createElement("div")
+    document.body.append(container)
+    root = createRoot(container)
+    executeMock.mockClear()
+    updateContactMock.mockClear()
+    toastMocks.error.mockClear()
+    toastMocks.success.mockClear()
+    latestOnSuccess = undefined
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+  })
+
+  function render(conv: TestConversation | null, setContactData = vi.fn()) {
+    act(() => {
+      root.render(
+        <HookHost
+          conv={conv}
+          setContactData={setContactData}
+          workspaceId="ws-1"
+        />,
+      )
+    })
+    return setContactData
+  }
+
+  test("fires once for a nameless messenger contact", () => {
+    render(
+      conversation({
+        contactId: "contact-1",
+        contactInboxes: [
+          { id: "ci-1", channel: "messenger", lastMessageAt: null },
+        ],
+      }),
+    )
+
+    expect(executeMock).toHaveBeenCalledTimes(1)
+    expect(executeMock).toHaveBeenCalledWith({ contactInboxId: "ci-1" })
+  })
+
+  test("does not fire for a contact with either name present", () => {
+    render(
+      conversation({
+        contactId: "contact-2",
+        contact: { id: "contact-2", firstName: "Jane", lastName: null },
+        contactInboxes: [
+          { id: "ci-2", channel: "messenger", lastMessageAt: null },
+        ],
+      }),
+    )
+
+    expect(executeMock).not.toHaveBeenCalled()
+  })
+
+  test("does not fire for a non-capable channel", () => {
+    render(
+      conversation({
+        contactId: "contact-3",
+        contactInboxes: [
+          { id: "ci-3", channel: "whatsapp", lastMessageAt: null },
+        ],
+      }),
+    )
+
+    expect(executeMock).not.toHaveBeenCalled()
+  })
+
+  test("with two messenger inboxes, picks the most recent lastMessageAt and does not fall back when the action returns failed", () => {
+    render(
+      conversation({
+        contactId: "contact-4",
+        contactInboxes: [
+          {
+            id: "ci-older",
+            channel: "messenger",
+            lastMessageAt: "2026-01-01T00:00:00Z",
+          },
+          {
+            id: "ci-newer",
+            channel: "messenger",
+            lastMessageAt: "2026-06-01T00:00:00Z",
+          },
+        ],
+      }),
+    )
+
+    expect(executeMock).toHaveBeenCalledTimes(1)
+    expect(executeMock).toHaveBeenCalledWith({ contactInboxId: "ci-newer" })
+
+    act(() => {
+      latestOnSuccess?.({ data: { status: "failed" } })
+    })
+
+    // No retry against the older inbox — a failed attempt is never retried
+    // on a different inbox.
+    expect(executeMock).toHaveBeenCalledTimes(1)
+    expect(updateContactMock).not.toHaveBeenCalled()
+  })
+
+  test("does not re-fire on re-render or on returning to the same conversation while mounted", () => {
+    const conv1 = conversation({
+      contactId: "contact-5",
+      contactInboxes: [
+        { id: "ci-5", channel: "messenger", lastMessageAt: null },
+      ],
+    })
+    const conv2 = conversation({
+      contactId: "contact-6",
+      contact: { id: "contact-6", firstName: "Bob", lastName: null },
+      contactInboxes: [
+        { id: "ci-6", channel: "messenger", lastMessageAt: null },
+      ],
+    })
+
+    render(conv1)
+    expect(executeMock).toHaveBeenCalledTimes(1)
+
+    // Re-render with the same conversation (new object reference).
+    render({ ...conv1 })
+    expect(executeMock).toHaveBeenCalledTimes(1)
+
+    // Switch to a different (non-eligible) conversation, then back.
+    render(conv2)
+    expect(executeMock).toHaveBeenCalledTimes(1)
+    render({ ...conv1 })
+    expect(executeMock).toHaveBeenCalledTimes(1)
+  })
+
+  test("re-fires after a remount", () => {
+    const conv = conversation({
+      contactId: "contact-7",
+      contactInboxes: [
+        { id: "ci-7", channel: "messenger", lastMessageAt: null },
+      ],
+    })
+
+    render(conv)
+    expect(executeMock).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+    container = document.createElement("div")
+    document.body.append(container)
+    root = createRoot(container)
+    executeMock.mockClear()
+
+    render(conv)
+    expect(executeMock).toHaveBeenCalledTimes(1)
+  })
+
+  test("on updated, patches both the store conversation(s) and the panel contactData", () => {
+    const setContactData = render(
+      conversation({
+        contactId: "contact-8",
+        contactInboxes: [
+          { id: "ci-8", channel: "messenger", lastMessageAt: null },
+        ],
+      }),
+    )
+
+    const updatedContact = {
+      id: "contact-8",
+      avatar: "avatars/contact-8.png",
+      firstName: "Jane",
+      lastName: "Doe",
+    }
+
+    act(() => {
+      latestOnSuccess?.({
+        data: { status: "updated", contact: updatedContact },
+      })
+    })
+
+    expect(updateContactMock).toHaveBeenCalledWith("contact-8", updatedContact)
+    expect(setContactData).toHaveBeenCalledTimes(1)
+    const updater = setContactData.mock.calls[0]?.[0] as (
+      prev: unknown,
+    ) => unknown
+    const prev = { id: "contact-8", avatar: null, tags: [] }
+    expect(updater(prev)).toEqual({ ...prev, ...updatedContact })
+    expect(toastMocks.error).not.toHaveBeenCalled()
+    expect(toastMocks.success).not.toHaveBeenCalled()
+  })
+
+  test.each([
+    "skipped",
+    "unavailable",
+    "failed",
+  ] as const)("on %s, nothing changes and no toast", (status) => {
+    const setContactData = render(
+      conversation({
+        contactId: `contact-status-${status}`,
+        contactInboxes: [
+          { id: `ci-${status}`, channel: "messenger", lastMessageAt: null },
+        ],
+      }),
+    )
+
+    act(() => {
+      latestOnSuccess?.({
+        data:
+          status === "skipped"
+            ? { status, reason: "profileComplete" }
+            : { status },
+      })
+    })
+
+    expect(updateContactMock).not.toHaveBeenCalled()
+    expect(setContactData).not.toHaveBeenCalled()
+    expect(toastMocks.error).not.toHaveBeenCalled()
+    expect(toastMocks.success).not.toHaveBeenCalled()
+  })
+})

--- a/apps/builder/__tests__/use-auto-refresh-contact-profile.test.tsx
+++ b/apps/builder/__tests__/use-auto-refresh-contact-profile.test.tsx
@@ -101,10 +101,12 @@ function HookHost({
   workspaceId,
   conv,
   setContactData,
+  onProfileUpdated,
 }: {
   workspaceId: string
   conv: TestConversation | null
   setContactData: SetContactData
+  onProfileUpdated?: (contactId: string) => void
 }) {
   useAutoRefreshContactProfile({
     workspaceId,
@@ -114,6 +116,7 @@ function HookHost({
       typeof useAutoRefreshContactProfile
     >[0]["conversation"],
     setContactData,
+    onProfileUpdated,
   })
   return null
 }
@@ -150,6 +153,24 @@ describe("useAutoRefreshContactProfile", () => {
       root.render(
         <HookHost
           conv={conv}
+          setContactData={setContactData}
+          workspaceId="ws-1"
+        />,
+      )
+    })
+    return setContactData
+  }
+
+  function renderWithOnUpdated(
+    conv: TestConversation | null,
+    onProfileUpdated: (contactId: string) => void,
+    setContactData = vi.fn(),
+  ) {
+    act(() => {
+      root.render(
+        <HookHost
+          conv={conv}
+          onProfileUpdated={onProfileUpdated}
           setContactData={setContactData}
           workspaceId="ws-1"
         />,
@@ -220,6 +241,19 @@ describe("useAutoRefreshContactProfile", () => {
         contactId: "contact-3",
         contactInboxes: [
           { id: "ci-3", channel: "whatsapp", lastMessageAt: null },
+        ],
+      }),
+    )
+
+    expect(refreshContactProfileActionMock).not.toHaveBeenCalled()
+  })
+
+  test("does not fire and does not throw for an unknown/legacy channel string", () => {
+    render(
+      conversation({
+        contactId: "contact-legacy",
+        contactInboxes: [
+          { id: "ci-legacy", channel: "legacy", lastMessageAt: null },
         ],
       }),
     )
@@ -359,6 +393,68 @@ describe("useAutoRefreshContactProfile", () => {
     expect(updater(prev)).toEqual({ ...prev, ...updatedContact })
     expect(toastMocks.error).not.toHaveBeenCalled()
     expect(toastMocks.success).not.toHaveBeenCalled()
+  })
+
+  test("on updated while still the active contact, calls onProfileUpdated with the contactId (convergence re-fetch trigger)", async () => {
+    const { promise, resolve } = deferred<{
+      data: { status: string; contact?: unknown }
+    }>()
+    refreshContactProfileActionMock.mockReturnValueOnce(promise)
+    const onProfileUpdated = vi.fn()
+
+    renderWithOnUpdated(
+      conversation({
+        contactId: "contact-9",
+        contactInboxes: [
+          { id: "ci-9", channel: "messenger", lastMessageAt: null },
+        ],
+      }),
+      onProfileUpdated,
+    )
+
+    await act(async () => {
+      resolve({
+        data: { status: "updated", contact: { id: "contact-9" } },
+      })
+      await Promise.resolve()
+    })
+
+    expect(onProfileUpdated).toHaveBeenCalledTimes(1)
+    expect(onProfileUpdated).toHaveBeenCalledWith("contact-9")
+  })
+
+  test("on updated after the panel switched to another contact, does NOT call onProfileUpdated (stale attempt)", async () => {
+    const { promise, resolve } = deferred<{
+      data: { status: string; contact?: unknown }
+    }>()
+    refreshContactProfileActionMock.mockReturnValueOnce(promise)
+    const onProfileUpdated = vi.fn()
+
+    const convA = conversation({
+      contactId: "contact-a3",
+      contactInboxes: [
+        { id: "ci-a3", channel: "messenger", lastMessageAt: null },
+      ],
+    })
+    const convB = conversation({
+      contactId: "contact-b3",
+      contact: { id: "contact-b3", firstName: "Present", lastName: null },
+      contactInboxes: [
+        { id: "ci-b3", channel: "messenger", lastMessageAt: null },
+      ],
+    })
+
+    renderWithOnUpdated(convA, onProfileUpdated)
+    renderWithOnUpdated(convB, onProfileUpdated)
+
+    await act(async () => {
+      resolve({
+        data: { status: "updated", contact: { id: "contact-a3" } },
+      })
+      await Promise.resolve()
+    })
+
+    expect(onProfileUpdated).not.toHaveBeenCalled()
   })
 
   test.each([

--- a/apps/builder/__tests__/use-auto-refresh-contact-profile.test.tsx
+++ b/apps/builder/__tests__/use-auto-refresh-contact-profile.test.tsx
@@ -7,9 +7,13 @@ import type { SetContactData } from "@/features/contacts/hooks/use-auto-refresh-
 
 // ---------------------------------------------------------------------------
 // useAutoRefreshContactProfile — selects the newest on-demand-capable inbox
-// for a nameless contact, fires refreshContactProfileAction at most once per
-// contactId per mount, and patches the store + panel contactData only on a
-// status:"updated" result. See
+// for a nameless contact, fires refreshContactProfileAction directly (not
+// via useAction — see the hook's own doc comment for why: a single
+// useAction instance reused across contacts as `conversation` changes would
+// let next-safe-action's newer-request-wins tracking silently drop an
+// earlier in-flight attempt's result) at most once per contactId per mount,
+// and patches the store + panel contactData only on a status:"updated"
+// result — independent of any other attempt's order or in-flight state. See
 // .superpowers/sdd/2026-08-31-messenger-ctm-profile-backfill/task-3-brief.md
 // ---------------------------------------------------------------------------
 
@@ -20,21 +24,10 @@ vi.mock("next-intl", () => ({
 const toastMocks = { error: vi.fn(), success: vi.fn() }
 vi.mock("sonner", () => ({ toast: toastMocks }))
 
-const executeMock = vi.fn()
-let latestOnSuccess: ((args: { data: unknown }) => void) | undefined
-
-vi.mock("next-safe-action/hooks", () => ({
-  useAction: (
-    _action: unknown,
-    options?: { onSuccess?: (args: { data: unknown }) => void },
-  ) => {
-    latestOnSuccess = options?.onSuccess
-    return { execute: executeMock, isPending: false }
-  },
-}))
-
+const refreshContactProfileActionMock = vi.fn()
 vi.mock("@/features/contacts/actions/refresh-contact-profile.action", () => ({
-  refreshContactProfileAction: { bind: () => "bound-refresh-action" },
+  refreshContactProfileAction: (...args: unknown[]) =>
+    refreshContactProfileActionMock(...args),
 }))
 
 vi.mock("@chatbotx.io/business", () => ({
@@ -94,6 +87,16 @@ const conversation = (
   ...overrides,
 })
 
+// A promise the test controls the settlement of, to simulate an in-flight
+// server action call.
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
 function HookHost({
   workspaceId,
   conv,
@@ -124,11 +127,15 @@ describe("useAutoRefreshContactProfile", () => {
     container = document.createElement("div")
     document.body.append(container)
     root = createRoot(container)
-    executeMock.mockClear()
+    refreshContactProfileActionMock.mockReset()
+    // Default: a never-resolving promise, so tests that don't care about the
+    // result don't need to handle settlement.
+    refreshContactProfileActionMock.mockReturnValue(
+      new Promise(() => undefined),
+    )
     updateContactMock.mockClear()
     toastMocks.error.mockClear()
     toastMocks.success.mockClear()
-    latestOnSuccess = undefined
   })
 
   afterEach(() => {
@@ -161,8 +168,12 @@ describe("useAutoRefreshContactProfile", () => {
       }),
     )
 
-    expect(executeMock).toHaveBeenCalledTimes(1)
-    expect(executeMock).toHaveBeenCalledWith({ contactInboxId: "ci-1" })
+    expect(refreshContactProfileActionMock).toHaveBeenCalledTimes(1)
+    expect(refreshContactProfileActionMock).toHaveBeenCalledWith(
+      "ws-1",
+      "contact-1",
+      { contactInboxId: "ci-1" },
+    )
   })
 
   test("does not fire for a contact with either name present", () => {
@@ -176,7 +187,7 @@ describe("useAutoRefreshContactProfile", () => {
       }),
     )
 
-    expect(executeMock).not.toHaveBeenCalled()
+    expect(refreshContactProfileActionMock).not.toHaveBeenCalled()
   })
 
   test("does not fire for a non-capable channel", () => {
@@ -189,10 +200,13 @@ describe("useAutoRefreshContactProfile", () => {
       }),
     )
 
-    expect(executeMock).not.toHaveBeenCalled()
+    expect(refreshContactProfileActionMock).not.toHaveBeenCalled()
   })
 
-  test("with two messenger inboxes, picks the most recent lastMessageAt and does not fall back when the action returns failed", () => {
+  test("with two messenger inboxes, picks the most recent lastMessageAt and does not fall back when the action returns failed", async () => {
+    const { promise, resolve } = deferred<{ data: { status: string } }>()
+    refreshContactProfileActionMock.mockReturnValueOnce(promise)
+
     render(
       conversation({
         contactId: "contact-4",
@@ -211,16 +225,21 @@ describe("useAutoRefreshContactProfile", () => {
       }),
     )
 
-    expect(executeMock).toHaveBeenCalledTimes(1)
-    expect(executeMock).toHaveBeenCalledWith({ contactInboxId: "ci-newer" })
+    expect(refreshContactProfileActionMock).toHaveBeenCalledTimes(1)
+    expect(refreshContactProfileActionMock).toHaveBeenCalledWith(
+      "ws-1",
+      "contact-4",
+      { contactInboxId: "ci-newer" },
+    )
 
-    act(() => {
-      latestOnSuccess?.({ data: { status: "failed" } })
+    await act(async () => {
+      resolve({ data: { status: "failed" } })
+      await Promise.resolve()
     })
 
     // No retry against the older inbox — a failed attempt is never retried
     // on a different inbox.
-    expect(executeMock).toHaveBeenCalledTimes(1)
+    expect(refreshContactProfileActionMock).toHaveBeenCalledTimes(1)
     expect(updateContactMock).not.toHaveBeenCalled()
   })
 
@@ -240,17 +259,17 @@ describe("useAutoRefreshContactProfile", () => {
     })
 
     render(conv1)
-    expect(executeMock).toHaveBeenCalledTimes(1)
+    expect(refreshContactProfileActionMock).toHaveBeenCalledTimes(1)
 
     // Re-render with the same conversation (new object reference).
     render({ ...conv1 })
-    expect(executeMock).toHaveBeenCalledTimes(1)
+    expect(refreshContactProfileActionMock).toHaveBeenCalledTimes(1)
 
     // Switch to a different (non-eligible) conversation, then back.
     render(conv2)
-    expect(executeMock).toHaveBeenCalledTimes(1)
+    expect(refreshContactProfileActionMock).toHaveBeenCalledTimes(1)
     render({ ...conv1 })
-    expect(executeMock).toHaveBeenCalledTimes(1)
+    expect(refreshContactProfileActionMock).toHaveBeenCalledTimes(1)
   })
 
   test("re-fires after a remount", () => {
@@ -262,7 +281,7 @@ describe("useAutoRefreshContactProfile", () => {
     })
 
     render(conv)
-    expect(executeMock).toHaveBeenCalledTimes(1)
+    expect(refreshContactProfileActionMock).toHaveBeenCalledTimes(1)
 
     act(() => {
       root.unmount()
@@ -271,13 +290,21 @@ describe("useAutoRefreshContactProfile", () => {
     container = document.createElement("div")
     document.body.append(container)
     root = createRoot(container)
-    executeMock.mockClear()
+    refreshContactProfileActionMock.mockClear()
+    refreshContactProfileActionMock.mockReturnValue(
+      new Promise(() => undefined),
+    )
 
     render(conv)
-    expect(executeMock).toHaveBeenCalledTimes(1)
+    expect(refreshContactProfileActionMock).toHaveBeenCalledTimes(1)
   })
 
-  test("on updated, patches both the store conversation(s) and the panel contactData", () => {
+  test("on updated, patches both the store conversation(s) and the panel contactData", async () => {
+    const { promise, resolve } = deferred<{
+      data: { status: string; contact?: unknown }
+    }>()
+    refreshContactProfileActionMock.mockReturnValueOnce(promise)
+
     const setContactData = render(
       conversation({
         contactId: "contact-8",
@@ -294,10 +321,9 @@ describe("useAutoRefreshContactProfile", () => {
       lastName: "Doe",
     }
 
-    act(() => {
-      latestOnSuccess?.({
-        data: { status: "updated", contact: updatedContact },
-      })
+    await act(async () => {
+      resolve({ data: { status: "updated", contact: updatedContact } })
+      await Promise.resolve()
     })
 
     expect(updateContactMock).toHaveBeenCalledWith("contact-8", updatedContact)
@@ -315,7 +341,12 @@ describe("useAutoRefreshContactProfile", () => {
     "skipped",
     "unavailable",
     "failed",
-  ] as const)("on %s, nothing changes and no toast", (status) => {
+  ] as const)("on %s, nothing changes and no toast", async (status) => {
+    const { promise, resolve } = deferred<{
+      data: { status: string; reason?: string }
+    }>()
+    refreshContactProfileActionMock.mockReturnValueOnce(promise)
+
     const setContactData = render(
       conversation({
         contactId: `contact-status-${status}`,
@@ -325,18 +356,105 @@ describe("useAutoRefreshContactProfile", () => {
       }),
     )
 
-    act(() => {
-      latestOnSuccess?.({
-        data:
-          status === "skipped"
-            ? { status, reason: "profileComplete" }
-            : { status },
-      })
+    await act(async () => {
+      resolve(
+        status === "skipped"
+          ? { data: { status, reason: "profileComplete" } }
+          : { data: { status } },
+      )
+      await Promise.resolve()
     })
 
     expect(updateContactMock).not.toHaveBeenCalled()
     expect(setContactData).not.toHaveBeenCalled()
     expect(toastMocks.error).not.toHaveBeenCalled()
     expect(toastMocks.success).not.toHaveBeenCalled()
+  })
+
+  test("two overlapping attempts (A then B before A resolves) each apply their own result independently", async () => {
+    const deferredA = deferred<{
+      data: { status: string; contact?: unknown }
+    }>()
+    const deferredB = deferred<{
+      data: { status: string; contact?: unknown }
+    }>()
+    refreshContactProfileActionMock
+      .mockReturnValueOnce(deferredA.promise)
+      .mockReturnValueOnce(deferredB.promise)
+
+    const setContactData = vi.fn()
+    const convA = conversation({
+      contactId: "contact-a",
+      contactInboxes: [
+        { id: "ci-a", channel: "messenger", lastMessageAt: null },
+      ],
+    })
+    const convB = conversation({
+      contactId: "contact-b",
+      contactInboxes: [
+        { id: "ci-b", channel: "messenger", lastMessageAt: null },
+      ],
+    })
+
+    // Open contact A — its refresh starts and stays in flight.
+    render(convA, setContactData)
+    expect(refreshContactProfileActionMock).toHaveBeenCalledTimes(1)
+
+    // Switch to contact B before A resolves — B's refresh starts too.
+    render(convB, setContactData)
+    expect(refreshContactProfileActionMock).toHaveBeenCalledTimes(2)
+
+    const contactA = { id: "contact-a", firstName: "Alice", lastName: null }
+    const contactB = { id: "contact-b", firstName: "Bob", lastName: null }
+
+    // B resolves first (a real Graph/Telegram round trip has no fixed
+    // ordering), then A resolves — both must still be applied.
+    await act(async () => {
+      deferredB.resolve({ data: { status: "updated", contact: contactB } })
+      await Promise.resolve()
+    })
+    expect(updateContactMock).toHaveBeenCalledWith("contact-b", contactB)
+
+    await act(async () => {
+      deferredA.resolve({ data: { status: "updated", contact: contactA } })
+      await Promise.resolve()
+    })
+    expect(updateContactMock).toHaveBeenCalledWith("contact-a", contactA)
+
+    expect(updateContactMock).toHaveBeenCalledTimes(2)
+    expect(setContactData).toHaveBeenCalledTimes(2)
+  })
+
+  test("does not update state after the owning component has unmounted", async () => {
+    const { promise, resolve } = deferred<{
+      data: { status: string; contact?: unknown }
+    }>()
+    refreshContactProfileActionMock.mockReturnValueOnce(promise)
+
+    render(
+      conversation({
+        contactId: "contact-unmount",
+        contactInboxes: [
+          { id: "ci-unmount", channel: "messenger", lastMessageAt: null },
+        ],
+      }),
+    )
+    expect(refreshContactProfileActionMock).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      root.unmount()
+    })
+
+    await act(async () => {
+      resolve({
+        data: {
+          status: "updated",
+          contact: { id: "contact-unmount", firstName: "Late" },
+        },
+      })
+      await Promise.resolve()
+    })
+
+    expect(updateContactMock).not.toHaveBeenCalled()
   })
 })

--- a/apps/builder/__tests__/use-auto-refresh-contact-profile.test.tsx
+++ b/apps/builder/__tests__/use-auto-refresh-contact-profile.test.tsx
@@ -395,7 +395,50 @@ describe("useAutoRefreshContactProfile", () => {
     expect(toastMocks.success).not.toHaveBeenCalled()
   })
 
-  test("two overlapping attempts (A then B before A resolves) each apply their own result independently", async () => {
+  test("transport failure (rejected promise) is swallowed silently — no state update, no unhandled rejection", async () => {
+    const unhandledRejections: unknown[] = []
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason)
+    }
+    process.on("unhandledRejection", onUnhandledRejection)
+
+    let rejectAction!: (reason: unknown) => void
+    const promise = new Promise((_resolve, reject) => {
+      rejectAction = reject
+    })
+    refreshContactProfileActionMock.mockReturnValueOnce(promise)
+
+    const setContactData = render(
+      conversation({
+        contactId: "contact-transport-fail",
+        contactInboxes: [
+          {
+            id: "ci-transport-fail",
+            channel: "messenger",
+            lastMessageAt: null,
+          },
+        ],
+      }),
+    )
+
+    try {
+      await act(async () => {
+        rejectAction(new Error("network error"))
+        // Flush the microtask queue so `.catch()` runs — an unhandled
+        // rejection (if the fix regresses) would surface on this same tick.
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection)
+    }
+
+    expect(updateContactMock).not.toHaveBeenCalled()
+    expect(setContactData).not.toHaveBeenCalled()
+    expect(unhandledRejections).toHaveLength(0)
+  })
+
+  test("two overlapping attempts (A then B before A resolves): the store is patched for both, but the panel (now showing B) is only patched for B — A's result is stale for the panel", async () => {
     const deferredA = deferred<{
       data: { status: string; contact?: unknown }
     }>()
@@ -424,7 +467,8 @@ describe("useAutoRefreshContactProfile", () => {
     render(convA, setContactData)
     expect(refreshContactProfileActionMock).toHaveBeenCalledTimes(1)
 
-    // Switch to contact B before A resolves — B's refresh starts too.
+    // Switch to contact B before A resolves — B's refresh starts too. The
+    // panel now shows B, so `activeContactIdRef` moves off A.
     render(convB, setContactData)
     expect(refreshContactProfileActionMock).toHaveBeenCalledTimes(2)
 
@@ -432,13 +476,17 @@ describe("useAutoRefreshContactProfile", () => {
     const contactB = { id: "contact-b", firstName: "Bob", lastName: null }
 
     // B resolves first (a real Graph/Telegram round trip has no fixed
-    // ordering), then A resolves — both must still be applied.
+    // ordering) — panel is still showing B, so both store and panel are
+    // patched.
     await act(async () => {
       deferredB.resolve({ data: { status: "updated", contact: contactB } })
       await Promise.resolve()
     })
     expect(updateContactMock).toHaveBeenCalledWith("contact-b", contactB)
 
+    // A resolves AFTER the switch — the store is still patched (it's keyed
+    // by contactId, independent of the panel), but the panel must NOT be
+    // overwritten with A's data since it has already moved on to B.
     await act(async () => {
       deferredA.resolve({ data: { status: "updated", contact: contactA } })
       await Promise.resolve()
@@ -446,7 +494,60 @@ describe("useAutoRefreshContactProfile", () => {
     expect(updateContactMock).toHaveBeenCalledWith("contact-a", contactA)
 
     expect(updateContactMock).toHaveBeenCalledTimes(2)
-    expect(setContactData).toHaveBeenCalledTimes(2)
+    // Only B's result reaches the panel-local patch.
+    expect(setContactData).toHaveBeenCalledTimes(1)
+    const updater = setContactData.mock.calls[0]?.[0] as (
+      prev: unknown,
+    ) => unknown
+    const prev = { id: "contact-b", avatar: null, tags: [] }
+    expect(updater(prev)).toEqual({ ...prev, ...contactB })
+  })
+
+  test("two overlapping attempts (A then B), A resolves BEFORE the switch: the panel is patched for A while it is still showing A", async () => {
+    const deferredA = deferred<{
+      data: { status: string; contact?: unknown }
+    }>()
+    refreshContactProfileActionMock.mockReturnValueOnce(deferredA.promise)
+
+    const setContactData = vi.fn()
+    const convA = conversation({
+      contactId: "contact-a2",
+      contactInboxes: [
+        { id: "ci-a2", channel: "messenger", lastMessageAt: null },
+      ],
+    })
+    const convB = conversation({
+      contactId: "contact-b2",
+      contact: { id: "contact-b2", firstName: "Present", lastName: null },
+      contactInboxes: [
+        { id: "ci-b2", channel: "messenger", lastMessageAt: null },
+      ],
+    })
+
+    // Open contact A — its refresh starts and stays in flight.
+    render(convA, setContactData)
+    expect(refreshContactProfileActionMock).toHaveBeenCalledTimes(1)
+
+    const contactA = { id: "contact-a2", firstName: "Alice", lastName: null }
+
+    // A resolves while the panel is STILL showing A.
+    await act(async () => {
+      deferredA.resolve({ data: { status: "updated", contact: contactA } })
+      await Promise.resolve()
+    })
+    expect(updateContactMock).toHaveBeenCalledWith("contact-a2", contactA)
+    expect(setContactData).toHaveBeenCalledTimes(1)
+    const updater = setContactData.mock.calls[0]?.[0] as (
+      prev: unknown,
+    ) => unknown
+    const prev = { id: "contact-a2", avatar: null, tags: [] }
+    expect(updater(prev)).toEqual({ ...prev, ...contactA })
+
+    // Switch to B (already named — not eligible for a new attempt) — no
+    // further patches should occur.
+    render(convB, setContactData)
+    expect(refreshContactProfileActionMock).toHaveBeenCalledTimes(1)
+    expect(setContactData).toHaveBeenCalledTimes(1)
   })
 
   test("does not update state after the owning component has unmounted", async () => {

--- a/apps/builder/__tests__/use-auto-refresh-contact-profile.test.tsx
+++ b/apps/builder/__tests__/use-auto-refresh-contact-profile.test.tsx
@@ -30,7 +30,7 @@ vi.mock("@/features/contacts/actions/refresh-contact-profile.action", () => ({
     refreshContactProfileActionMock(...args),
 }))
 
-vi.mock("@chatbotx.io/business", () => ({
+vi.mock("@chatbotx.io/business/contact-profile-rules", () => ({
   hasEmptyProfileName: (contact: {
     firstName?: string | null
     lastName?: string | null

--- a/apps/builder/__tests__/use-auto-refresh-contact-profile.test.tsx
+++ b/apps/builder/__tests__/use-auto-refresh-contact-profile.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act } from "react"
+import { act, StrictMode } from "react"
 import { createRoot, type Root } from "react-dom/client"
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 import type { SetContactData } from "@/features/contacts/hooks/use-auto-refresh-contact-profile"
@@ -153,6 +153,30 @@ describe("useAutoRefreshContactProfile", () => {
           setContactData={setContactData}
           workspaceId="ws-1"
         />,
+      )
+    })
+    return setContactData
+  }
+
+  // React (with reactStrictMode: true, apps/builder/next.config.ts)
+  // double-invokes effects on initial mount in dev — setup, cleanup, setup —
+  // which the plain `render()` helper above never exercises (a bare
+  // createRoot().render() only single-invokes). Wrapping in <StrictMode>
+  // reproduces that double-invocation so a regression like a cleanup-only
+  // isMountedRef (never re-armed on the second setup) shows up here.
+  function renderStrict(
+    conv: TestConversation | null,
+    setContactData = vi.fn(),
+  ) {
+    act(() => {
+      root.render(
+        <StrictMode>
+          <HookHost
+            conv={conv}
+            setContactData={setContactData}
+            workspaceId="ws-1"
+          />
+        </StrictMode>,
       )
     })
     return setContactData
@@ -456,5 +480,62 @@ describe("useAutoRefreshContactProfile", () => {
     })
 
     expect(updateContactMock).not.toHaveBeenCalled()
+  })
+
+  test("under StrictMode, still applies a refresh that resolves after the double-invoked mount effects", async () => {
+    const { promise, resolve } = deferred<{
+      data: { status: string; contact?: unknown }
+    }>()
+    refreshContactProfileActionMock.mockReturnValueOnce(promise)
+
+    const setContactData = renderStrict(
+      conversation({
+        contactId: "contact-strict",
+        contactInboxes: [
+          { id: "ci-strict", channel: "messenger", lastMessageAt: null },
+        ],
+      }),
+    )
+
+    const updatedContact = {
+      id: "contact-strict",
+      firstName: "Jane",
+      lastName: "Doe",
+    }
+
+    await act(async () => {
+      resolve({ data: { status: "updated", contact: updatedContact } })
+      await Promise.resolve()
+    })
+
+    // Regression guard: a cleanup-only `isMountedRef` (set to false on the
+    // StrictMode double-invoke's first cleanup and never re-armed) would
+    // silently drop this result for the rest of the mount's lifetime.
+    expect(updateContactMock).toHaveBeenCalledWith(
+      "contact-strict",
+      updatedContact,
+    )
+    expect(setContactData).toHaveBeenCalledTimes(1)
+  })
+
+  test("under StrictMode, fires the action exactly once per contact despite the double-invoked mount effect", () => {
+    renderStrict(
+      conversation({
+        contactId: "contact-strict-once",
+        contactInboxes: [
+          {
+            id: "ci-strict-once",
+            channel: "messenger",
+            lastMessageAt: null,
+          },
+        ],
+      }),
+    )
+
+    // attemptedContactIds.current.add(contactId) runs synchronously, before
+    // the async action call, in the FIRST of the two synchronous
+    // setup-cleanup-setup invocations — so the second setup's `.has()` check
+    // already sees it and bails, and the action fires only once.
+    expect(refreshContactProfileActionMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/builder/src/features/chat/store/chat-store.ts
+++ b/apps/builder/src/features/chat/store/chat-store.ts
@@ -775,20 +775,21 @@ export const createChatStore = () => {
 
     updateContact: (contactId: string, data: Partial<ContactResource>) => {
       const { conversations } = get()
-      const conversationIndex = conversations.findIndex(
-        (c) => c.contactId === contactId,
-      )
-      if (conversationIndex > -1) {
-        const updatedConversations = [...conversations]
-        if (updatedConversations[conversationIndex].contact) {
-          updatedConversations[conversationIndex].contact = {
-            ...updatedConversations[conversationIndex].contact,
-            ...data,
-          }
-        }
-
-        set({ conversations: updatedConversations })
+      const hasMatch = conversations.some((c) => c.contactId === contactId)
+      if (!hasMatch) {
+        return
       }
+
+      set({
+        conversations: conversations.map((conversation) =>
+          conversation.contactId === contactId && conversation.contact
+            ? {
+                ...conversation,
+                contact: { ...conversation.contact, ...data },
+              }
+            : conversation,
+        ),
+      })
     },
   }))
 }

--- a/apps/builder/src/features/contact-inboxes/schema/resource.ts
+++ b/apps/builder/src/features/contact-inboxes/schema/resource.ts
@@ -25,7 +25,6 @@ export const contactInboxResource = createSelectSchema(contactInboxModel, {
     sourceUserId: true,
     sourceUsername: true,
     language: true,
-    lastMessageAt: true,
     lastIncomingMessageAt: true,
     contactLastReadAt: true,
   })

--- a/apps/builder/src/features/contact-inboxes/schema/resource.ts
+++ b/apps/builder/src/features/contact-inboxes/schema/resource.ts
@@ -25,6 +25,7 @@ export const contactInboxResource = createSelectSchema(contactInboxModel, {
     sourceUserId: true,
     sourceUsername: true,
     language: true,
+    lastMessageAt: true,
     lastIncomingMessageAt: true,
     contactLastReadAt: true,
   })

--- a/apps/builder/src/features/contacts/actions/refresh-contact-profile.action.ts
+++ b/apps/builder/src/features/contacts/actions/refresh-contact-profile.action.ts
@@ -1,0 +1,92 @@
+"use server"
+
+import {
+  type ContactProfileRefreshResult,
+  contactInboxService,
+  contactProfileRefreshService,
+  contactService,
+  hasOnDemandProfileApi,
+} from "@chatbotx.io/business"
+import { notFoundException } from "@chatbotx.io/business/errors"
+import type { ChannelType } from "@chatbotx.io/database/partials"
+import { zodBigintAsString } from "@chatbotx.io/utils"
+import { workspaceActionClient } from "@/lib/safe-action"
+import { profileFetcherFactories } from "../lib/profile-fetcher-factories"
+import { requireContactPermissionScope } from "../permissions"
+import {
+  type RefreshContactProfileResult,
+  refreshContactProfileRequest,
+} from "../schema/action"
+import type { ContactResource } from "../schema/resource"
+
+// Maps the channel-agnostic service result onto the builder's client
+// contract. `channelNotCapable` is a builder-level reason — the service
+// itself never inspects the channel name, so it never produces it.
+const toClientResult = (
+  result: ContactProfileRefreshResult,
+): RefreshContactProfileResult => {
+  switch (result.status) {
+    case "updated":
+      return { status: "updated", contact: result.contact as ContactResource }
+    case "skipped":
+      return { status: "skipped", reason: result.reason }
+    case "unavailable":
+      return { status: "unavailable" }
+    case "failed":
+      return { status: "failed" }
+    default: {
+      const exhaustive: never = result
+      return exhaustive
+    }
+  }
+}
+
+export const refreshContactProfileAction = workspaceActionClient
+  .bindArgsSchemas([zodBigintAsString(), zodBigintAsString()])
+  .inputSchema(refreshContactProfileRequest)
+  .action(
+    async ({
+      bindArgsParsedInputs: [workspaceId, contactId],
+      parsedInput,
+    }): Promise<RefreshContactProfileResult> => {
+      const accessScope = await requireContactPermissionScope(workspaceId)
+
+      // Authorization is the gate — a contact outside the workspace/scope
+      // fails here and nothing else (inbox lookup, integration resolution,
+      // Graph call) runs.
+      await contactService.findByIdOrFail({
+        workspaceId,
+        id: contactId,
+        accessScope,
+      })
+
+      const contactInbox = await contactInboxService.findByUncached({
+        where: { id: parsedInput.contactInboxId, contactId },
+      })
+      if (!contactInbox) {
+        throw notFoundException("Contact inbox not found")
+      }
+
+      const channel = contactInbox.channel as ChannelType
+      if (!hasOnDemandProfileApi(channel)) {
+        return { status: "skipped", reason: "channelNotCapable" }
+      }
+
+      const fetchProfile = profileFetcherFactories[channel]({
+        workspaceId,
+        inboxId: contactInbox.inboxId,
+        sourceId: contactInbox.sourceId,
+      })
+
+      const result = await contactProfileRefreshService.refresh({
+        workspaceId,
+        contactId,
+        contactInbox: { id: contactInbox.id, channel },
+        source: "channelApi",
+        accessScope,
+        fetchProfile,
+      })
+
+      return toClientResult(result)
+    },
+  )

--- a/apps/builder/src/features/contacts/contact-inbox-panel.tsx
+++ b/apps/builder/src/features/contacts/contact-inbox-panel.tsx
@@ -57,7 +57,7 @@ export const ContactInboxPanel = ({
   const requestSeqRef = useRef(0)
 
   const fetchContactData = useCallback(
-    (contactId: string) => {
+    (contactId: string, options?: { preserveOnError?: boolean }) => {
       const seq = ++requestSeqRef.current
       client.contactsAPIs
         .getContactAuthenticatedAPI({ workspaceId, contactId })
@@ -67,7 +67,13 @@ export const ContactInboxPanel = ({
           }
         })
         .catch(() => {
-          if (requestSeqRef.current === seq) {
+          // On the INITIAL open fetch, a failure must clear stale data from
+          // the previous contact. On the auto-refresh convergence re-fetch
+          // (`preserveOnError: true`), the hook has already patched
+          // `contactData` with the fresh name/avatar — a transport blip on
+          // this re-fetch must not wipe that out; keeping the patched state
+          // is strictly better than showing nothing.
+          if (requestSeqRef.current === seq && !options?.preserveOnError) {
             setContactData(null)
           }
         })
@@ -82,7 +88,8 @@ export const ContactInboxPanel = ({
     // Re-fetch the canonical contact once the auto-refresh applies an
     // update, so `contactData` converges even if the initial fetch below is
     // still in flight and resolves afterwards.
-    onProfileUpdated: fetchContactData,
+    onProfileUpdated: (contactId) =>
+      fetchContactData(contactId, { preserveOnError: true }),
   })
   const [coupons, setCoupons] = useState<
     Array<{ id: string; topicName: string; code: string; usedAt: Date | null }>

--- a/apps/builder/src/features/contacts/contact-inbox-panel.tsx
+++ b/apps/builder/src/features/contacts/contact-inbox-panel.tsx
@@ -7,7 +7,7 @@ import {
   AccordionTrigger,
 } from "@chatbotx.io/ui/components/ui/accordion"
 import { useTranslations } from "next-intl"
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { client } from "@/lib/orpc/orpc"
 import type { ContactAppointmentResource } from "../appointments/schema/resource"
 import { useChatStore } from "../chat/store/chat-store-provider"
@@ -48,10 +48,41 @@ export const ContactInboxPanel = ({
     null,
   )
 
+  // Guards `getContactAuthenticatedAPI` against out-of-order resolution:
+  // the initial fetch (below) and the auto-refresh convergence re-fetch
+  // (`onProfileUpdated`) can both be in flight for the same contact, and
+  // whichever request was issued LAST must win regardless of which settles
+  // first — otherwise a slow initial fetch resolving after the refresh
+  // patch would silently overwrite the just-applied name/avatar.
+  const requestSeqRef = useRef(0)
+
+  const fetchContactData = useCallback(
+    (contactId: string) => {
+      const seq = ++requestSeqRef.current
+      client.contactsAPIs
+        .getContactAuthenticatedAPI({ workspaceId, contactId })
+        .then((data) => {
+          if (requestSeqRef.current === seq) {
+            setContactData(data)
+          }
+        })
+        .catch(() => {
+          if (requestSeqRef.current === seq) {
+            setContactData(null)
+          }
+        })
+    },
+    [workspaceId],
+  )
+
   useAutoRefreshContactProfile({
     workspaceId,
     conversation: activeConversation,
     setContactData,
+    // Re-fetch the canonical contact once the auto-refresh applies an
+    // update, so `contactData` converges even if the initial fetch below is
+    // still in flight and resolves afterwards.
+    onProfileUpdated: fetchContactData,
   })
   const [coupons, setCoupons] = useState<
     Array<{ id: string; topicName: string; code: string; usedAt: Date | null }>
@@ -64,6 +95,7 @@ export const ContactInboxPanel = ({
     const contactId = storeContact?.id
 
     if (!activeConversationId) {
+      requestSeqRef.current += 1
       setContactData(null)
       setCoupons([])
       setAppointments([])
@@ -71,20 +103,14 @@ export const ContactInboxPanel = ({
     }
 
     if (!contactId) {
+      requestSeqRef.current += 1
       setContactData(null)
       setCoupons([])
       setAppointments([])
       return
     }
 
-    client.contactsAPIs
-      .getContactAuthenticatedAPI({ workspaceId, contactId })
-      .then((data) => {
-        setContactData(data)
-      })
-      .catch(() => {
-        setContactData(null)
-      })
+    fetchContactData(contactId)
 
     client.couponsAPI
       .listContactCouponsAPI({ workspaceId, contactId })
@@ -95,7 +121,7 @@ export const ContactInboxPanel = ({
       .listContactAppointmentsAPI({ workspaceId, contactId })
       .then(setAppointments)
       .catch(() => setAppointments([]))
-  }, [activeConversationId, storeContact?.id, workspaceId])
+  }, [activeConversationId, storeContact?.id, workspaceId, fetchContactData])
 
   const accordionModules: AccordionModule[] = useMemo(() => {
     if (!contactData) {

--- a/apps/builder/src/features/contacts/contact-inbox-panel.tsx
+++ b/apps/builder/src/features/contacts/contact-inbox-panel.tsx
@@ -57,7 +57,7 @@ export const ContactInboxPanel = ({
   const requestSeqRef = useRef(0)
 
   const fetchContactData = useCallback(
-    (contactId: string, options?: { preserveOnError?: boolean }) => {
+    (contactId: string, preserveOnError = false) => {
       const seq = ++requestSeqRef.current
       client.contactsAPIs
         .getContactAuthenticatedAPI({ workspaceId, contactId })
@@ -73,7 +73,7 @@ export const ContactInboxPanel = ({
           // `contactData` with the fresh name/avatar — a transport blip on
           // this re-fetch must not wipe that out; keeping the patched state
           // is strictly better than showing nothing.
-          if (requestSeqRef.current === seq && !options?.preserveOnError) {
+          if (requestSeqRef.current === seq && !preserveOnError) {
             setContactData(null)
           }
         })
@@ -81,15 +81,19 @@ export const ContactInboxPanel = ({
     [workspaceId],
   )
 
+  // Re-fetch the canonical contact once the auto-refresh applies an update,
+  // so `contactData` converges even if the initial fetch below is still in
+  // flight and resolves afterwards.
+  const onProfileUpdated = useCallback(
+    (contactId: string) => fetchContactData(contactId, true),
+    [fetchContactData],
+  )
+
   useAutoRefreshContactProfile({
     workspaceId,
     conversation: activeConversation,
     setContactData,
-    // Re-fetch the canonical contact once the auto-refresh applies an
-    // update, so `contactData` converges even if the initial fetch below is
-    // still in flight and resolves afterwards.
-    onProfileUpdated: (contactId) =>
-      fetchContactData(contactId, { preserveOnError: true }),
+    onProfileUpdated,
   })
   const [coupons, setCoupons] = useState<
     Array<{ id: string; topicName: string; code: string; usedAt: Date | null }>
@@ -101,15 +105,7 @@ export const ContactInboxPanel = ({
   useEffect(() => {
     const contactId = storeContact?.id
 
-    if (!activeConversationId) {
-      requestSeqRef.current += 1
-      setContactData(null)
-      setCoupons([])
-      setAppointments([])
-      return
-    }
-
-    if (!contactId) {
+    if (!(activeConversationId && contactId)) {
       requestSeqRef.current += 1
       setContactData(null)
       setCoupons([])

--- a/apps/builder/src/features/contacts/contact-inbox-panel.tsx
+++ b/apps/builder/src/features/contacts/contact-inbox-panel.tsx
@@ -19,6 +19,7 @@ import type { TagResource } from "../tags/schema/resource"
 import { ContactAppointmentsList } from "./components/contact-appointments-list"
 import UpdateContactTagField from "./components/update-contact-tag-field"
 import { ContactDetail } from "./contact-detail"
+import { useAutoRefreshContactProfile } from "./hooks/use-auto-refresh-contact-profile"
 import type { GetContactResponse } from "./schema/query"
 
 type AccordionModule = {
@@ -37,15 +38,21 @@ export const ContactInboxPanel = ({
 
   const { conversations } = useChatStore((state) => state)
 
-  const storeContact = useMemo(
-    () =>
-      conversations.find((c) => c.id === activeConversationId)?.contact ?? null,
+  const activeConversation = useMemo(
+    () => conversations.find((c) => c.id === activeConversationId) ?? null,
     [conversations, activeConversationId],
   )
+  const storeContact = activeConversation?.contact ?? null
 
   const [contactData, setContactData] = useState<GetContactResponse | null>(
     null,
   )
+
+  useAutoRefreshContactProfile({
+    workspaceId,
+    conversation: activeConversation,
+    setContactData,
+  })
   const [coupons, setCoupons] = useState<
     Array<{ id: string; topicName: string; code: string; usedAt: Date | null }>
   >([])

--- a/apps/builder/src/features/contacts/hooks/use-auto-refresh-contact-profile.ts
+++ b/apps/builder/src/features/contacts/hooks/use-auto-refresh-contact-profile.ts
@@ -75,12 +75,19 @@ export function useAutoRefreshContactProfile(
   const updateContact = useChatStore((state) => state.updateContact)
   const isMountedRef = useRef(true)
 
-  useEffect(
-    () => () => {
+  // Re-arm on setup, not just clean up on teardown: React (with
+  // reactStrictMode, apps/builder/next.config.ts) double-invokes effects in
+  // dev — setup, cleanup, setup — on initial mount. A cleanup-only effect
+  // would set this to `false` on the first cleanup and never set it back to
+  // `true`, silently disabling every `.then()` below for the component's
+  // entire lifetime in `next dev` (production is single-invoke and
+  // unaffected, but this must not ship either way).
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
       isMountedRef.current = false
-    },
-    [],
-  )
+    }
+  }, [])
 
   useEffect(() => {
     if (!(conversation?.contact && conversation.contactId)) {

--- a/apps/builder/src/features/contacts/hooks/use-auto-refresh-contact-profile.ts
+++ b/apps/builder/src/features/contacts/hooks/use-auto-refresh-contact-profile.ts
@@ -1,0 +1,103 @@
+"use client"
+
+import {
+  hasEmptyProfileName,
+  hasOnDemandProfileApi,
+} from "@chatbotx.io/business"
+import type { ChannelType } from "@chatbotx.io/database/partials"
+import { useAction } from "next-safe-action/hooks"
+import { useEffect, useRef } from "react"
+import type {
+  ConversationContactInboxResource,
+  ListConversationItemResource,
+} from "@/features/conversations/schema/resource"
+import { useChatStore } from "../../chat/store/chat-store-provider"
+import { refreshContactProfileAction } from "../actions/refresh-contact-profile.action"
+import type { GetContactResponse } from "../schema/query"
+
+export type SetContactData = (
+  updater: (prev: GetContactResponse | null) => GetContactResponse | null,
+) => void
+
+export type UseAutoRefreshContactProfileProps = {
+  workspaceId: string
+  conversation: ListConversationItemResource | null | undefined
+  setContactData: SetContactData
+}
+
+/**
+ * Among the contact's on-demand-capable inboxes (the channels
+ * `hasOnDemandProfileApi` says the builder can fetch a profile from), the
+ * one with the most recent `lastMessageAt` — the "newest capable inbox" half
+ * of the worker's `resolveMessengerUserContext`
+ * (apps/worker/src/integration/handlers/messenger-context.ts). No fallback:
+ * only this inbox is ever attempted.
+ */
+const selectOnDemandInbox = (
+  contactInboxes: readonly ConversationContactInboxResource[],
+): ConversationContactInboxResource | undefined =>
+  contactInboxes
+    .filter((contactInbox) =>
+      hasOnDemandProfileApi(contactInbox.channel as ChannelType),
+    )
+    .toSorted(
+      (a, b) =>
+        new Date(b.lastMessageAt ?? 0).getTime() -
+        new Date(a.lastMessageAt ?? 0).getTime(),
+    )[0]
+
+/**
+ * Fires `refreshContactProfileAction` at most once per `contactId` per mount
+ * of the owning component (`ContactInboxPanel`) for a nameless contact whose
+ * conversation has an on-demand-capable inbox. Silent — no toast on any
+ * outcome; a `failed`/`unavailable` result never triggers a retry on another
+ * inbox, and switching back to an already-attempted conversation while
+ * mounted does not re-fire (only a remount resets the attempted set).
+ */
+export function useAutoRefreshContactProfile(
+  props: UseAutoRefreshContactProfileProps,
+): void {
+  const { workspaceId, conversation, setContactData } = props
+  const attemptedContactIds = useRef<Set<string>>(new Set())
+  const updateContact = useChatStore((state) => state.updateContact)
+
+  const contactId = conversation?.contactId ?? ""
+
+  const { execute } = useAction(
+    refreshContactProfileAction.bind(null, workspaceId, contactId),
+    {
+      onSuccess: ({ data }) => {
+        if (data?.status !== "updated") {
+          return
+        }
+        updateContact(contactId, data.contact)
+        setContactData((prev) => prev && { ...prev, ...data.contact })
+      },
+    },
+  )
+
+  // `execute` is rebuilt every render from the current workspaceId/contactId
+  // — depending on it would refire this effect on every render. The
+  // `attemptedContactIds` guard below is what actually prevents duplicate
+  // attempts, independent of the effect's own re-run cadence.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: execute intentionally excluded, see comment above
+  useEffect(() => {
+    if (!(conversation?.contact && conversation.contactId)) {
+      return
+    }
+    if (attemptedContactIds.current.has(conversation.contactId)) {
+      return
+    }
+    if (!hasEmptyProfileName(conversation.contact)) {
+      return
+    }
+
+    const contactInbox = selectOnDemandInbox(conversation.contactInboxes)
+    if (!contactInbox) {
+      return
+    }
+
+    attemptedContactIds.current.add(conversation.contactId)
+    execute({ contactInboxId: contactInbox.id })
+  }, [conversation])
+}

--- a/apps/builder/src/features/contacts/hooks/use-auto-refresh-contact-profile.ts
+++ b/apps/builder/src/features/contacts/hooks/use-auto-refresh-contact-profile.ts
@@ -22,6 +22,16 @@ export type UseAutoRefreshContactProfileProps = {
   workspaceId: string
   conversation: ListConversationItemResource | null | undefined
   setContactData: SetContactData
+  /**
+   * Called right after the panel-local patch, with the contactId that was
+   * updated — lets the panel re-fetch the canonical contact from the server
+   * so its `contactData` converges even if an earlier `getContact` request
+   * (fired when the panel first opened) resolves AFTER this patch and would
+   * otherwise overwrite it with stale data. The immediate `setContactData`
+   * patch above is kept for instant UI feedback; this is a convergence
+   * guarantee, not a replacement for it.
+   */
+  onProfileUpdated?: (contactId: string) => void
 }
 
 /**
@@ -79,7 +89,7 @@ const selectOnDemandInbox = (
 export function useAutoRefreshContactProfile(
   props: UseAutoRefreshContactProfileProps,
 ): void {
-  const { workspaceId, conversation, setContactData } = props
+  const { workspaceId, conversation, setContactData, onProfileUpdated } = props
   const attemptedContactIds = useRef<Set<string>>(new Set())
   const updateContact = useChatStore((state) => state.updateContact)
   const isMountedRef = useRef(true)
@@ -142,8 +152,15 @@ export function useAutoRefreshContactProfile(
         // resolved (see the hook's doc comment on `activeContactIdRef`).
         if (activeContactIdRef.current === contactId) {
           setContactData((prev) => prev && { ...prev, ...updatedContact })
+          onProfileUpdated?.(contactId)
         }
       })
       .catch(() => undefined) // transport failure (network/RSC) — silent, no state update, no retry
-  }, [conversation, workspaceId, updateContact, setContactData])
+  }, [
+    conversation,
+    workspaceId,
+    updateContact,
+    setContactData,
+    onProfileUpdated,
+  ])
 }

--- a/apps/builder/src/features/contacts/hooks/use-auto-refresh-contact-profile.ts
+++ b/apps/builder/src/features/contacts/hooks/use-auto-refresh-contact-profile.ts
@@ -66,6 +66,15 @@ const selectOnDemandInbox = (
  * whenever IT resolves, independent of any other attempt's order or
  * in-flight state. `isMountedRef` guards against applying a result that
  * resolves after the owning component has unmounted.
+ *
+ * `activeContactIdRef` guards the PANEL-local patch specifically: the store
+ * patch (`updateContact`) is safe to apply for any resolved contactId (it's
+ * keyed by id), but `setContactData` writes into the single contact the
+ * panel currently renders. Without the guard, contact A's refresh resolving
+ * AFTER the operator has already switched the panel to contact B would
+ * overwrite B's visible name/avatar with A's data. The ref is updated for
+ * every conversation change (not just eligible ones) so it always reflects
+ * whichever contact is currently on screen.
  */
 export function useAutoRefreshContactProfile(
   props: UseAutoRefreshContactProfileProps,
@@ -74,6 +83,7 @@ export function useAutoRefreshContactProfile(
   const attemptedContactIds = useRef<Set<string>>(new Set())
   const updateContact = useChatStore((state) => state.updateContact)
   const isMountedRef = useRef(true)
+  const activeContactIdRef = useRef<string | null>(null)
 
   // Re-arm on setup, not just clean up on teardown: React (with
   // reactStrictMode, apps/builder/next.config.ts) double-invokes effects in
@@ -90,6 +100,11 @@ export function useAutoRefreshContactProfile(
   }, [])
 
   useEffect(() => {
+    // Track which contact the panel is currently showing regardless of
+    // eligibility — a later-resolving attempt for a PREVIOUS contact must
+    // never patch `setContactData` once the panel has moved on.
+    activeContactIdRef.current = conversation?.contactId ?? null
+
     if (!(conversation?.contact && conversation.contactId)) {
       return
     }
@@ -110,16 +125,25 @@ export function useAutoRefreshContactProfile(
 
     refreshContactProfileAction(workspaceId, contactId, {
       contactInboxId: contactInbox.id,
-    }).then((result) => {
-      if (!isMountedRef.current) {
-        return
-      }
-      if (result?.data?.status !== "updated") {
-        return
-      }
-      const { contact: updatedContact } = result.data
-      updateContact(contactId, updatedContact)
-      setContactData((prev) => prev && { ...prev, ...updatedContact })
     })
+      .then((result) => {
+        if (!isMountedRef.current) {
+          return
+        }
+        if (result?.data?.status !== "updated") {
+          return
+        }
+        const { contact: updatedContact } = result.data
+        // Store patch: safe for any resolved contactId — the store is keyed
+        // by id, independent of what the panel currently shows.
+        updateContact(contactId, updatedContact)
+        // Panel-local patch: only if the panel is STILL showing this
+        // contact — an operator may have switched away before this attempt
+        // resolved (see the hook's doc comment on `activeContactIdRef`).
+        if (activeContactIdRef.current === contactId) {
+          setContactData((prev) => prev && { ...prev, ...updatedContact })
+        }
+      })
+      .catch(() => undefined) // transport failure (network/RSC) — silent, no state update, no retry
   }, [conversation, workspaceId, updateContact, setContactData])
 }

--- a/apps/builder/src/features/contacts/hooks/use-auto-refresh-contact-profile.ts
+++ b/apps/builder/src/features/contacts/hooks/use-auto-refresh-contact-profile.ts
@@ -5,7 +5,7 @@ import {
   hasOnDemandProfileApi,
 } from "@chatbotx.io/business"
 import type { ChannelType } from "@chatbotx.io/database/partials"
-import { useEffect, useRef } from "react"
+import { type RefObject, useEffect, useRef } from "react"
 import type {
   ConversationContactInboxResource,
   ListConversationItemResource,
@@ -13,6 +13,7 @@ import type {
 import { useChatStore } from "../../chat/store/chat-store-provider"
 import { refreshContactProfileAction } from "../actions/refresh-contact-profile.action"
 import type { GetContactResponse } from "../schema/query"
+import type { ContactResource } from "../schema/resource"
 
 export type SetContactData = (
   updater: (prev: GetContactResponse | null) => GetContactResponse | null,
@@ -54,6 +55,75 @@ const selectOnDemandInbox = (
         new Date(b.lastMessageAt ?? 0).getTime() -
         new Date(a.lastMessageAt ?? 0).getTime(),
     )[0]
+
+type RefreshTarget = {
+  contactId: string
+  contactInboxId: string
+}
+
+/**
+ * Whether `conversation` is eligible for an auto-refresh attempt: a nameless
+ * contact with an on-demand-capable inbox, and if so, which inbox
+ * (`selectOnDemandInbox`'s newest-capable-inbox pick). Pure — does not
+ * consult `attemptedContactIds`; the effect still gates on that itself.
+ */
+const selectRefreshTarget = (
+  conversation: ListConversationItemResource | null | undefined,
+): RefreshTarget | null => {
+  if (!(conversation?.contact && conversation.contactId)) {
+    return null
+  }
+  if (!hasEmptyProfileName(conversation.contact)) {
+    return null
+  }
+  const contactInbox = selectOnDemandInbox(conversation.contactInboxes)
+  if (!contactInbox) {
+    return null
+  }
+  return { contactId: conversation.contactId, contactInboxId: contactInbox.id }
+}
+
+type ApplyRefreshResultDeps = {
+  isMountedRef: RefObject<boolean>
+  activeContactIdRef: RefObject<string | null>
+  updateContact: (contactId: string, data: Partial<ContactResource>) => void
+  setContactData: SetContactData
+  onProfileUpdated?: (contactId: string) => void
+}
+
+/**
+ * Applies a settled `refreshContactProfileAction` result: the store patch
+ * runs for any resolved contactId (the store is keyed by id, independent of
+ * what the panel currently shows); the panel-local patch and convergence
+ * callback only run while the panel is STILL showing this contact — an
+ * operator may have switched away before this attempt resolved. `isMounted`
+ * and `activeContactId` are read from the refs at call time, never captured,
+ * so they reflect state as of when the promise actually settles.
+ */
+const applyRefreshResult = (
+  contactId: string,
+  result: Awaited<ReturnType<typeof refreshContactProfileAction>>,
+  {
+    isMountedRef,
+    activeContactIdRef,
+    updateContact,
+    setContactData,
+    onProfileUpdated,
+  }: ApplyRefreshResultDeps,
+) => {
+  if (!isMountedRef.current) {
+    return
+  }
+  if (result?.data?.status !== "updated") {
+    return
+  }
+  const { contact: updatedContact } = result.data
+  updateContact(contactId, updatedContact)
+  if (activeContactIdRef.current === contactId) {
+    setContactData((prev) => prev && { ...prev, ...updatedContact })
+    onProfileUpdated?.(contactId)
+  }
+}
 
 /**
  * Fires `refreshContactProfileAction` at most once per `contactId` per mount
@@ -98,46 +168,26 @@ export function useAutoRefreshContactProfile(
     // never patch `setContactData` once the panel has moved on.
     activeContactIdRef.current = conversation?.contactId ?? null
 
-    if (!(conversation?.contact && conversation.contactId)) {
+    const target = selectRefreshTarget(conversation)
+    if (!target) {
       return
     }
-    const { contactId, contact } = conversation
+    const { contactId, contactInboxId } = target
     if (attemptedContactIds.current.has(contactId)) {
       return
     }
-    if (!hasEmptyProfileName(contact)) {
-      return
-    }
-
-    const contactInbox = selectOnDemandInbox(conversation.contactInboxes)
-    if (!contactInbox) {
-      return
-    }
-
     attemptedContactIds.current.add(contactId)
 
-    refreshContactProfileAction(workspaceId, contactId, {
-      contactInboxId: contactInbox.id,
-    })
-      .then((result) => {
-        if (!isMountedRef.current) {
-          return
-        }
-        if (result?.data?.status !== "updated") {
-          return
-        }
-        const { contact: updatedContact } = result.data
-        // Store patch: safe for any resolved contactId — the store is keyed
-        // by id, independent of what the panel currently shows.
-        updateContact(contactId, updatedContact)
-        // Panel-local patch: only if the panel is STILL showing this
-        // contact — an operator may have switched away before this attempt
-        // resolved (see the hook's doc comment on `activeContactIdRef`).
-        if (activeContactIdRef.current === contactId) {
-          setContactData((prev) => prev && { ...prev, ...updatedContact })
-          onProfileUpdated?.(contactId)
-        }
-      })
+    refreshContactProfileAction(workspaceId, contactId, { contactInboxId })
+      .then((result) =>
+        applyRefreshResult(contactId, result, {
+          isMountedRef,
+          activeContactIdRef,
+          updateContact,
+          setContactData,
+          onProfileUpdated,
+        }),
+      )
       .catch(() => undefined) // transport failure (network/RSC) — silent, no state update, no retry
   }, [
     conversation,

--- a/apps/builder/src/features/contacts/hooks/use-auto-refresh-contact-profile.ts
+++ b/apps/builder/src/features/contacts/hooks/use-auto-refresh-contact-profile.ts
@@ -3,7 +3,7 @@
 import {
   hasEmptyProfileName,
   hasOnDemandProfileApi,
-} from "@chatbotx.io/business"
+} from "@chatbotx.io/business/contact-profile-rules"
 import type { ChannelType } from "@chatbotx.io/database/partials"
 import { type RefObject, useEffect, useRef } from "react"
 import type {

--- a/apps/builder/src/features/contacts/hooks/use-auto-refresh-contact-profile.ts
+++ b/apps/builder/src/features/contacts/hooks/use-auto-refresh-contact-profile.ts
@@ -5,7 +5,6 @@ import {
   hasOnDemandProfileApi,
 } from "@chatbotx.io/business"
 import type { ChannelType } from "@chatbotx.io/database/partials"
-import { useAction } from "next-safe-action/hooks"
 import { useEffect, useRef } from "react"
 import type {
   ConversationContactInboxResource,
@@ -53,6 +52,20 @@ const selectOnDemandInbox = (
  * outcome; a `failed`/`unavailable` result never triggers a retry on another
  * inbox, and switching back to an already-attempted conversation while
  * mounted does not re-fire (only a remount resets the attempted set).
+ *
+ * The action is called directly (`refreshContactProfileAction(workspaceId,
+ * contactId, input)`) rather than through `useAction` — a single `useAction`
+ * instance is scoped to ONE bound action, so reusing it as `contactId`
+ * changes within a mount would let next-safe-action's own
+ * newer-request-wins tracking silently drop an EARLIER attempt's result once
+ * a LATER attempt starts (e.g. contact A's refresh is still in flight when
+ * the operator switches to contact B — A's `updated` result, already
+ * persisted server-side, would never reach the UI). Calling the action
+ * directly gives each attempt its own promise and its own closure over
+ * `contactId`/`setContactData`, so every attempt's result is applied
+ * whenever IT resolves, independent of any other attempt's order or
+ * in-flight state. `isMountedRef` guards against applying a result that
+ * resolves after the owning component has unmounted.
  */
 export function useAutoRefreshContactProfile(
   props: UseAutoRefreshContactProfileProps,
@@ -60,35 +73,24 @@ export function useAutoRefreshContactProfile(
   const { workspaceId, conversation, setContactData } = props
   const attemptedContactIds = useRef<Set<string>>(new Set())
   const updateContact = useChatStore((state) => state.updateContact)
+  const isMountedRef = useRef(true)
 
-  const contactId = conversation?.contactId ?? ""
-
-  const { execute } = useAction(
-    refreshContactProfileAction.bind(null, workspaceId, contactId),
-    {
-      onSuccess: ({ data }) => {
-        if (data?.status !== "updated") {
-          return
-        }
-        updateContact(contactId, data.contact)
-        setContactData((prev) => prev && { ...prev, ...data.contact })
-      },
+  useEffect(
+    () => () => {
+      isMountedRef.current = false
     },
+    [],
   )
 
-  // `execute` is rebuilt every render from the current workspaceId/contactId
-  // — depending on it would refire this effect on every render. The
-  // `attemptedContactIds` guard below is what actually prevents duplicate
-  // attempts, independent of the effect's own re-run cadence.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: execute intentionally excluded, see comment above
   useEffect(() => {
     if (!(conversation?.contact && conversation.contactId)) {
       return
     }
-    if (attemptedContactIds.current.has(conversation.contactId)) {
+    const { contactId, contact } = conversation
+    if (attemptedContactIds.current.has(contactId)) {
       return
     }
-    if (!hasEmptyProfileName(conversation.contact)) {
+    if (!hasEmptyProfileName(contact)) {
       return
     }
 
@@ -97,7 +99,20 @@ export function useAutoRefreshContactProfile(
       return
     }
 
-    attemptedContactIds.current.add(conversation.contactId)
-    execute({ contactInboxId: contactInbox.id })
-  }, [conversation])
+    attemptedContactIds.current.add(contactId)
+
+    refreshContactProfileAction(workspaceId, contactId, {
+      contactInboxId: contactInbox.id,
+    }).then((result) => {
+      if (!isMountedRef.current) {
+        return
+      }
+      if (result?.data?.status !== "updated") {
+        return
+      }
+      const { contact: updatedContact } = result.data
+      updateContact(contactId, updatedContact)
+      setContactData((prev) => prev && { ...prev, ...updatedContact })
+    })
+  }, [conversation, workspaceId, updateContact, setContactData])
 }

--- a/apps/builder/src/features/contacts/hooks/use-auto-refresh-contact-profile.ts
+++ b/apps/builder/src/features/contacts/hooks/use-auto-refresh-contact-profile.ts
@@ -57,34 +57,17 @@ const selectOnDemandInbox = (
 
 /**
  * Fires `refreshContactProfileAction` at most once per `contactId` per mount
- * of the owning component (`ContactInboxPanel`) for a nameless contact whose
- * conversation has an on-demand-capable inbox. Silent — no toast on any
- * outcome; a `failed`/`unavailable` result never triggers a retry on another
- * inbox, and switching back to an already-attempted conversation while
- * mounted does not re-fire (only a remount resets the attempted set).
+ * for a nameless contact whose conversation has an on-demand-capable inbox.
+ * Silent — no toast, no retry on another inbox, no re-fire on switching back
+ * to an already-attempted conversation (only a remount resets that).
  *
- * The action is called directly (`refreshContactProfileAction(workspaceId,
- * contactId, input)`) rather than through `useAction` — a single `useAction`
- * instance is scoped to ONE bound action, so reusing it as `contactId`
- * changes within a mount would let next-safe-action's own
- * newer-request-wins tracking silently drop an EARLIER attempt's result once
- * a LATER attempt starts (e.g. contact A's refresh is still in flight when
- * the operator switches to contact B — A's `updated` result, already
- * persisted server-side, would never reach the UI). Calling the action
- * directly gives each attempt its own promise and its own closure over
- * `contactId`/`setContactData`, so every attempt's result is applied
- * whenever IT resolves, independent of any other attempt's order or
- * in-flight state. `isMountedRef` guards against applying a result that
- * resolves after the owning component has unmounted.
- *
- * `activeContactIdRef` guards the PANEL-local patch specifically: the store
- * patch (`updateContact`) is safe to apply for any resolved contactId (it's
- * keyed by id), but `setContactData` writes into the single contact the
- * panel currently renders. Without the guard, contact A's refresh resolving
- * AFTER the operator has already switched the panel to contact B would
- * overwrite B's visible name/avatar with A's data. The ref is updated for
- * every conversation change (not just eligible ones) so it always reflects
- * whichever contact is currently on screen.
+ * The action is called directly rather than through `useAction`, so each
+ * attempt gets its own promise/closure and applies its result independent of
+ * any other attempt's order — `useAction` is scoped to one bound action and
+ * would let a later attempt silently drop an earlier one's result.
+ * `isMountedRef` guards against applying a result after unmount;
+ * `activeContactIdRef` guards the panel-local patch against a stale contact
+ * resolving after the panel has switched to another one.
  */
 export function useAutoRefreshContactProfile(
   props: UseAutoRefreshContactProfileProps,

--- a/apps/builder/src/features/contacts/lib/profile-fetcher-factories.ts
+++ b/apps/builder/src/features/contacts/lib/profile-fetcher-factories.ts
@@ -1,6 +1,8 @@
 import {
+  type BuildContextIntegrationRow,
   buildContext,
   type ContactProfileFetcher,
+  type IntegrationContext,
   instagramIntegrationService,
   messengerIntegrationService,
   type OnDemandProfileChannel,
@@ -11,6 +13,7 @@ import type { InstagramAuthValue } from "@chatbotx.io/integration-instagram/sche
 import type { MessengerAuthValue } from "@chatbotx.io/integration-messenger/schema"
 import type { TelegramAuthValue } from "@chatbotx.io/integration-telegram"
 import type { ZaloAuthValue } from "@chatbotx.io/integration-zalo/schema"
+import type { AuthValue } from "@chatbotx.io/sdk"
 import { integrations } from "@/integration"
 
 export type ProfileFetcherFactoryInput = {
@@ -22,6 +25,44 @@ export type ProfileFetcherFactory = (
   input: ProfileFetcherFactoryInput,
 ) => ContactProfileFetcher
 
+type ChannelProfileRunner<TAuth extends AuthValue> = (
+  group: "contact",
+  name: "getProfile",
+  props: { ctx: IntegrationContext<TAuth>; data: { sourceId: string } },
+) => ReturnType<ContactProfileFetcher>
+
+/**
+ * Shared core behind every `profileFetcherFactories` entry: `buildContext`
+ * from the already-fetched integration row, then dispatch
+ * `contact.getProfile` through the caller's (already-bound)
+ * `runChannelHandler`. Per-channel closures below keep their own literal
+ * `integrationType`, auth cast, and registry lookup (instagram's
+ * facebook-vs-direct split) so `runChannelHandler` stays typed per channel.
+ */
+const fetchChannelProfile = async <TAuth extends AuthValue>({
+  workspaceId,
+  sourceId,
+  integrationType,
+  row,
+  runChannelHandler,
+}: {
+  workspaceId: string
+  sourceId: string
+  integrationType: OnDemandProfileChannel
+  row: BuildContextIntegrationRow<TAuth>
+  runChannelHandler: ChannelProfileRunner<TAuth>
+}): ReturnType<ContactProfileFetcher> => {
+  const ctx = await buildContext<TAuth>({
+    workspaceId,
+    integrationType,
+    integration: row,
+  })
+  return runChannelHandler("contact", "getProfile", {
+    ctx,
+    data: { sourceId },
+  })
+}
+
 /**
  * One lazy `ContactProfileFetcher` factory per on-demand-capable channel,
  * exhaustive over `OnDemandProfileChannel`. Each entry does ALL channel
@@ -29,8 +70,7 @@ export type ProfileFetcherFactory = (
  * inside the returned callback — a missing/disconnected integration
  * (`findByInboxIdForWorkspace` throws) surfaces inside
  * `contactProfileRefreshService.refresh` as `failed` + cooldown instead of an
- * action rejection. Every entry is written against its own literal registry
- * key so `runChannelHandler` stays typed per channel (no union widening).
+ * action rejection.
  */
 export const profileFetcherFactories: Record<
   OnDemandProfileChannel,
@@ -43,14 +83,13 @@ export const profileFetcherFactories: Record<
         inboxId,
         workspaceId,
       })
-      const ctx = await buildContext({
+      return fetchChannelProfile<MessengerAuthValue>({
         workspaceId,
+        sourceId,
         integrationType: "messenger",
-        integration: { ...row, auth: row.auth as MessengerAuthValue },
-      })
-      return integrations.messenger.runChannelHandler("contact", "getProfile", {
-        ctx,
-        data: { sourceId },
+        row: { ...row, auth: row.auth as MessengerAuthValue },
+        runChannelHandler: (group, name, props) =>
+          integrations.messenger.runChannelHandler(group, name, props),
       })
     },
   instagram:
@@ -60,19 +99,18 @@ export const profileFetcherFactories: Record<
         inboxId,
         workspaceId,
       })
-      const ctx = await buildContext({
-        workspaceId,
-        integrationType: "instagram",
-        integration: { ...row, auth: row.auth as InstagramAuthValue },
-      })
       // Mirrors apps/worker/src/services/integrations.ts (isInstagramViaFacebook).
       const registry =
         row.type === "facebook"
           ? integrations.instagramFacebook
           : integrations.instagram
-      return registry.runChannelHandler("contact", "getProfile", {
-        ctx,
-        data: { sourceId },
+      return fetchChannelProfile<InstagramAuthValue>({
+        workspaceId,
+        sourceId,
+        integrationType: "instagram",
+        row: { ...row, auth: row.auth as InstagramAuthValue },
+        runChannelHandler: (group, name, props) =>
+          registry.runChannelHandler(group, name, props),
       })
     },
   zalo:
@@ -82,14 +120,13 @@ export const profileFetcherFactories: Record<
         inboxId,
         workspaceId,
       })
-      const ctx = await buildContext({
+      return fetchChannelProfile<ZaloAuthValue>({
         workspaceId,
+        sourceId,
         integrationType: "zalo",
-        integration: { ...row, auth: row.auth as ZaloAuthValue },
-      })
-      return integrations.zalo.runChannelHandler("contact", "getProfile", {
-        ctx,
-        data: { sourceId },
+        row: { ...row, auth: row.auth as ZaloAuthValue },
+        runChannelHandler: (group, name, props) =>
+          integrations.zalo.runChannelHandler(group, name, props),
       })
     },
   telegram:
@@ -99,14 +136,13 @@ export const profileFetcherFactories: Record<
         inboxId,
         workspaceId,
       })
-      const ctx = await buildContext({
+      return fetchChannelProfile<TelegramAuthValue>({
         workspaceId,
+        sourceId,
         integrationType: "telegram",
-        integration: { ...row, auth: row.auth as TelegramAuthValue },
-      })
-      return integrations.telegram.runChannelHandler("contact", "getProfile", {
-        ctx,
-        data: { sourceId },
+        row: { ...row, auth: row.auth as TelegramAuthValue },
+        runChannelHandler: (group, name, props) =>
+          integrations.telegram.runChannelHandler(group, name, props),
       })
     },
 }

--- a/apps/builder/src/features/contacts/lib/profile-fetcher-factories.ts
+++ b/apps/builder/src/features/contacts/lib/profile-fetcher-factories.ts
@@ -1,0 +1,112 @@
+import {
+  buildContext,
+  type ContactProfileFetcher,
+  instagramIntegrationService,
+  messengerIntegrationService,
+  type OnDemandProfileChannel,
+  telegramIntegrationService,
+  zaloIntegrationService,
+} from "@chatbotx.io/business"
+import type { InstagramAuthValue } from "@chatbotx.io/integration-instagram/schemas"
+import type { MessengerAuthValue } from "@chatbotx.io/integration-messenger/schema"
+import type { TelegramAuthValue } from "@chatbotx.io/integration-telegram"
+import type { ZaloAuthValue } from "@chatbotx.io/integration-zalo/schema"
+import { integrations } from "@/integration"
+
+export type ProfileFetcherFactoryInput = {
+  workspaceId: string
+  inboxId: string
+  sourceId: string
+}
+export type ProfileFetcherFactory = (
+  input: ProfileFetcherFactoryInput,
+) => ContactProfileFetcher
+
+/**
+ * One lazy `ContactProfileFetcher` factory per on-demand-capable channel,
+ * exhaustive over `OnDemandProfileChannel`. Each entry does ALL channel
+ * resolution (integration row, `buildContext`, registry lookup, Graph call)
+ * inside the returned callback — a missing/disconnected integration
+ * (`findByInboxIdForWorkspace` throws) surfaces inside
+ * `contactProfileRefreshService.refresh` as `failed` + cooldown instead of an
+ * action rejection. Every entry is written against its own literal registry
+ * key so `runChannelHandler` stays typed per channel (no union widening).
+ */
+export const profileFetcherFactories: Record<
+  OnDemandProfileChannel,
+  ProfileFetcherFactory
+> = {
+  messenger:
+    ({ workspaceId, inboxId, sourceId }) =>
+    async () => {
+      const row = await messengerIntegrationService.findByInboxIdForWorkspace({
+        inboxId,
+        workspaceId,
+      })
+      const ctx = await buildContext({
+        workspaceId,
+        integrationType: "messenger",
+        integration: { ...row, auth: row.auth as MessengerAuthValue },
+      })
+      return integrations.messenger.runChannelHandler("contact", "getProfile", {
+        ctx,
+        data: { sourceId },
+      })
+    },
+  instagram:
+    ({ workspaceId, inboxId, sourceId }) =>
+    async () => {
+      const row = await instagramIntegrationService.findByInboxIdForWorkspace({
+        inboxId,
+        workspaceId,
+      })
+      const ctx = await buildContext({
+        workspaceId,
+        integrationType: "instagram",
+        integration: { ...row, auth: row.auth as InstagramAuthValue },
+      })
+      // Mirrors apps/worker/src/services/integrations.ts (isInstagramViaFacebook).
+      const registry =
+        row.type === "facebook"
+          ? integrations.instagramFacebook
+          : integrations.instagram
+      return registry.runChannelHandler("contact", "getProfile", {
+        ctx,
+        data: { sourceId },
+      })
+    },
+  zalo:
+    ({ workspaceId, inboxId, sourceId }) =>
+    async () => {
+      const row = await zaloIntegrationService.findByInboxIdForWorkspace({
+        inboxId,
+        workspaceId,
+      })
+      const ctx = await buildContext({
+        workspaceId,
+        integrationType: "zalo",
+        integration: { ...row, auth: row.auth as ZaloAuthValue },
+      })
+      return integrations.zalo.runChannelHandler("contact", "getProfile", {
+        ctx,
+        data: { sourceId },
+      })
+    },
+  telegram:
+    ({ workspaceId, inboxId, sourceId }) =>
+    async () => {
+      const row = await telegramIntegrationService.findByInboxIdForWorkspace({
+        inboxId,
+        workspaceId,
+      })
+      const ctx = await buildContext({
+        workspaceId,
+        integrationType: "telegram",
+        integration: { ...row, auth: row.auth as TelegramAuthValue },
+      })
+      return integrations.telegram.runChannelHandler("contact", "getProfile", {
+        ctx,
+        data: { sourceId },
+      })
+    },
+}

--- a/apps/builder/src/features/contacts/schema/action.ts
+++ b/apps/builder/src/features/contacts/schema/action.ts
@@ -2,6 +2,7 @@ import { channelTypes, genderTypes } from "@chatbotx.io/database/partials"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { z } from "zod"
 import { contactFilterCriteriaSchema } from "@/features/contact-filter/schema"
+import type { ContactResource } from "./resource"
 
 export const contactPrefix = "sys"
 export const contactFieldPrefix = "cus"
@@ -109,3 +110,31 @@ export const getExportFileResponse = z.object({
   totalRecords: z.number().nullable(),
 })
 export type GetExportFileResponse = z.infer<typeof getExportFileResponse>
+
+export const refreshContactProfileRequest = z.object({
+  contactInboxId: zodBigintAsString(),
+})
+export type RefreshContactProfileRequest = z.infer<
+  typeof refreshContactProfileRequest
+>
+
+// Builder-level reasons a refresh produced no update. Mirrors
+// `ContactProfileRefreshResult["reason"]`
+// (`packages/business/src/contact/profile-refresh/service.ts`) plus
+// `channelNotCapable` — the one outcome the business service never produces
+// since `refresh()` never inspects the channel name.
+export const refreshContactProfileSkippedReasons = [
+  "profileComplete",
+  "coolingDown",
+  "channelNotCapable",
+] as const
+export type RefreshContactProfileSkippedReason =
+  (typeof refreshContactProfileSkippedReasons)[number]
+
+/** Client contract for `refreshContactProfileAction` — `failed` and
+ * `unavailable` are returned, never thrown. */
+export type RefreshContactProfileResult =
+  | { status: "updated"; contact: ContactResource }
+  | { status: "skipped"; reason: RefreshContactProfileSkippedReason }
+  | { status: "unavailable" }
+  | { status: "failed" }

--- a/apps/builder/src/features/contacts/schema/action.ts
+++ b/apps/builder/src/features/contacts/schema/action.ts
@@ -123,13 +123,10 @@ export type RefreshContactProfileRequest = z.infer<
 // (`packages/business/src/contact/profile-refresh/service.ts`) plus
 // `channelNotCapable` — the one outcome the business service never produces
 // since `refresh()` never inspects the channel name.
-export const refreshContactProfileSkippedReasons = [
-  "profileComplete",
-  "coolingDown",
-  "channelNotCapable",
-] as const
 export type RefreshContactProfileSkippedReason =
-  (typeof refreshContactProfileSkippedReasons)[number]
+  | "profileComplete"
+  | "coolingDown"
+  | "channelNotCapable"
 
 /** Client contract for `refreshContactProfileAction` — `failed` and
  * `unavailable` are returned, never thrown. */

--- a/apps/builder/src/features/conversations/schema/resource.ts
+++ b/apps/builder/src/features/conversations/schema/resource.ts
@@ -35,8 +35,17 @@ export const adReferralResource = z.object({
 // routes that nest `contactInboxResource`) are unaffected. Both conversation
 // query paths (`listConversations` and `findConversation`) must map to this
 // exact shape or oRPC output validation fails.
+//
+// `lastMessageAt` is conversation-only for the same reason: the auto-refresh
+// profile hook (`useAutoRefreshContactProfile`) picks the most recently
+// active on-demand-capable inbox among a contact's `contactInboxes`, mirroring
+// the worker's `resolveMessengerUserContext`
+// (apps/worker/src/integration/handlers/messenger-context.ts) — but that
+// selection has no reason to leak into the public/workspace-token contact
+// APIs that nest the shared `contactInboxResource`.
 export const conversationContactInboxResource = contactInboxResource.extend({
   adReferral: adReferralResource.nullable(),
+  lastMessageAt: z.date().nullable(),
 })
 export type ConversationContactInboxResource = z.infer<
   typeof conversationContactInboxResource

--- a/apps/worker/__tests__/contact-profile-refresh-real-service.test.ts
+++ b/apps/worker/__tests__/contact-profile-refresh-real-service.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// Worker-level coverage for `refreshExistingContactProfile` running against
+// the REAL `contactProfileRefreshService.refresh`
+// (packages/business/src/contact/profile-refresh/service.ts +
+// cooldown.ts) — unlike `contact-profile-refresh.test.ts` (which fakes
+// `contactProfileRefreshService.refresh` wholesale to isolate the worker's
+// own wiring), this file only fakes the service's leaf dependencies
+// (`distributedStore`, `contactService`, `logProviderErrorForChannel`,
+// `uploader`) so the cooldown/skip/failed-recording rules run for real,
+// end-to-end, from the worker's handler. Added per final-review item 5 of
+// .superpowers/sdd/2026-08-31-messenger-ctm-profile-backfill/final-fix-report.md.
+// ---------------------------------------------------------------------------
+
+const existsMock = vi.fn(async () => false)
+const setNumberMock = vi.fn(async () => undefined)
+// `importOriginal`, not a full replacement: the real `@chatbotx.io/business`
+// barrel (imported below) reaches other `@chatbotx.io/redis` exports (e.g.
+// `bloomFilter`, via packages/analytics) that a plain-object mock would leave
+// undefined.
+vi.mock("@chatbotx.io/redis", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@chatbotx.io/redis")>()
+  return {
+    ...actual,
+    distributedStore: { exists: existsMock, setNumber: setNumberMock },
+  }
+})
+
+const deleteObjectMock = vi.fn(async () => undefined)
+vi.mock("@chatbotx.io/filesystem", () => ({
+  uploader: { deleteObject: deleteObjectMock },
+}))
+
+// Mocked by their resolved file path, not the `@chatbotx.io/business`
+// package specifier: `contactProfileRefreshService.refresh` imports these
+// two via relative paths internal to the business package
+// (`../service` / `../../error-log/service` from
+// `packages/business/src/contact/profile-refresh/service.ts`), so a mock
+// keyed on the `@chatbotx.io/business` barrel specifier would never
+// intercept them.
+const findByIdOrFailMock = vi.fn()
+const findByIdMock = vi.fn()
+const updateMock = vi.fn()
+vi.mock("../../../packages/business/src/contact/service", () => ({
+  contactService: {
+    findByIdOrFail: findByIdOrFailMock,
+    findById: findByIdMock,
+    update: updateMock,
+  },
+}))
+
+const logProviderErrorForChannelMock = vi.fn(async () => undefined)
+vi.mock("../../../packages/business/src/error-log/service", () => ({
+  logProviderErrorForChannel: logProviderErrorForChannelMock,
+}))
+
+const mockResolveIntegrationContextFromContactInbox = vi.fn()
+vi.mock("../src/services/integrations", () => ({
+  resolveIntegrationContextFromContactInbox:
+    mockResolveIntegrationContextFromContactInbox,
+}))
+
+const mockLoggerWarn = vi.fn()
+const mockLoggerDebug = vi.fn()
+vi.mock("../src/lib/logger", () => ({
+  logger: {
+    warn: mockLoggerWarn,
+    debug: mockLoggerDebug,
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const { refreshExistingContactProfile } = await import(
+  "../src/integration/handlers/contact-profile-refresh"
+)
+const { PROFILE_REFRESH_COOLDOWN_SECONDS } = await import(
+  "@chatbotx.io/business"
+)
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const namelessContact = { firstName: null, lastName: null }
+
+const fakeInbox = {
+  id: "inbox-1",
+  workspaceId: "ws-1",
+  channel: "messenger",
+} as unknown as import("@chatbotx.io/database/types").InboxModel
+
+const fakeContactInbox = {
+  id: "ci-1",
+  contactId: "contact-1",
+  inboxId: "inbox-1",
+  sourceId: "psid-123",
+  channel: "messenger",
+} as unknown as import("@chatbotx.io/database/types").ContactInboxModel
+
+const fakeIncomingContact = { sourceId: "psid-123", firstName: "Jane" }
+
+const cooldownKey = `contact-profile-refresh:cooldown:${fakeContactInbox.id}`
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  existsMock.mockResolvedValue(false)
+  setNumberMock.mockResolvedValue(undefined)
+  deleteObjectMock.mockResolvedValue(undefined)
+  logProviderErrorForChannelMock.mockResolvedValue(undefined)
+  findByIdOrFailMock.mockResolvedValue({ ...namelessContact })
+  findByIdMock.mockResolvedValue(undefined)
+  updateMock.mockImplementation(async (ctx, data) => ({
+    id: ctx.id,
+    workspaceId: ctx.workspaceId,
+    ...data,
+  }))
+})
+
+describe("refreshExistingContactProfile against the real contactProfileRefreshService", () => {
+  test("channelApi getProfile throws → failed + cooldown started; a second attempt while cooling down skips without calling getProfile; a third attempt after cooldown clears calls getProfile again", async () => {
+    const runChannelHandler = vi
+      .fn()
+      .mockRejectedValue(new Error("Graph API unavailable"))
+    mockResolveIntegrationContextFromContactInbox.mockResolvedValue({
+      integration: { runChannelHandler },
+      ctx: { workspaceId: "ws-1" },
+    })
+
+    // --- Attempt 1: the channel-API fetch throws ---------------------------
+    await refreshExistingContactProfile({
+      inbox: fakeInbox,
+      contactInbox: fakeContactInbox,
+      incomingContact: fakeIncomingContact,
+      contactId: "contact-1",
+    })
+
+    expect(runChannelHandler).toHaveBeenCalledTimes(1)
+    expect(logProviderErrorForChannelMock).toHaveBeenCalledWith(
+      "messenger",
+      expect.objectContaining({
+        workspaceId: "ws-1",
+        contactId: "contact-1",
+      }),
+    )
+    expect(setNumberMock).toHaveBeenCalledWith(
+      cooldownKey,
+      expect.any(Number),
+      PROFILE_REFRESH_COOLDOWN_SECONDS,
+    )
+    expect(PROFILE_REFRESH_COOLDOWN_SECONDS).toBe(300)
+    expect(mockLoggerDebug).toHaveBeenCalledWith(
+      expect.objectContaining({ result: { status: "failed" } }),
+      expect.any(String),
+    )
+
+    // --- Attempt 2: still cooling down --------------------------------------
+    existsMock.mockResolvedValueOnce(true)
+    runChannelHandler.mockClear()
+    setNumberMock.mockClear()
+
+    await refreshExistingContactProfile({
+      inbox: fakeInbox,
+      contactInbox: fakeContactInbox,
+      incomingContact: fakeIncomingContact,
+      contactId: "contact-1",
+    })
+
+    expect(runChannelHandler).not.toHaveBeenCalled()
+    expect(setNumberMock).not.toHaveBeenCalled()
+    expect(mockLoggerDebug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        result: { status: "skipped", reason: "coolingDown" },
+      }),
+      expect.any(String),
+    )
+
+    // --- Attempt 3: cooldown has cleared -------------------------------------
+    existsMock.mockResolvedValueOnce(false)
+    runChannelHandler.mockResolvedValueOnce({
+      firstName: "Jane",
+      lastName: null,
+    })
+
+    await refreshExistingContactProfile({
+      inbox: fakeInbox,
+      contactInbox: fakeContactInbox,
+      incomingContact: fakeIncomingContact,
+      contactId: "contact-1",
+    })
+
+    expect(runChannelHandler).toHaveBeenCalledTimes(1)
+    expect(mockLoggerDebug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        result: expect.objectContaining({ status: "updated" }),
+      }),
+      expect.any(String),
+    )
+  })
+
+  test("resolveIntegrationContextFromContactInbox throws (missing/disconnected integration) → failed, cooldown started, never throws", async () => {
+    mockResolveIntegrationContextFromContactInbox.mockRejectedValue(
+      new Error("integration not found"),
+    )
+
+    await expect(
+      refreshExistingContactProfile({
+        inbox: fakeInbox,
+        contactInbox: fakeContactInbox,
+        incomingContact: fakeIncomingContact,
+        contactId: "contact-1",
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(logProviderErrorForChannelMock).toHaveBeenCalledWith(
+      "messenger",
+      expect.objectContaining({
+        workspaceId: "ws-1",
+        contactId: "contact-1",
+      }),
+    )
+    expect(setNumberMock).toHaveBeenCalledWith(
+      cooldownKey,
+      expect.any(Number),
+      PROFILE_REFRESH_COOLDOWN_SECONDS,
+    )
+    expect(mockLoggerDebug).toHaveBeenCalledWith(
+      expect.objectContaining({ result: { status: "failed" } }),
+      expect.any(String),
+    )
+  })
+})

--- a/apps/worker/__tests__/contact-profile-refresh-real-service.test.ts
+++ b/apps/worker/__tests__/contact-profile-refresh-real-service.test.ts
@@ -140,6 +140,7 @@ describe("refreshExistingContactProfile against the real contactProfileRefreshSe
 
     // --- Attempt 1: the channel-API fetch throws ---------------------------
     await refreshExistingContactProfile({
+      source: "channelApi",
       inbox: fakeInbox,
       contactInbox: fakeContactInbox,
       incomingContact: fakeIncomingContact,
@@ -171,6 +172,7 @@ describe("refreshExistingContactProfile against the real contactProfileRefreshSe
     setNumberMock.mockClear()
 
     await refreshExistingContactProfile({
+      source: "channelApi",
       inbox: fakeInbox,
       contactInbox: fakeContactInbox,
       incomingContact: fakeIncomingContact,
@@ -194,6 +196,7 @@ describe("refreshExistingContactProfile against the real contactProfileRefreshSe
     })
 
     await refreshExistingContactProfile({
+      source: "channelApi",
       inbox: fakeInbox,
       contactInbox: fakeContactInbox,
       incomingContact: fakeIncomingContact,
@@ -216,6 +219,7 @@ describe("refreshExistingContactProfile against the real contactProfileRefreshSe
 
     await expect(
       refreshExistingContactProfile({
+        source: "channelApi",
         inbox: fakeInbox,
         contactInbox: fakeContactInbox,
         incomingContact: fakeIncomingContact,

--- a/apps/worker/__tests__/contact-profile-refresh-real-service.test.ts
+++ b/apps/worker/__tests__/contact-profile-refresh-real-service.test.ts
@@ -42,11 +42,13 @@ vi.mock("@chatbotx.io/filesystem", () => ({
 const findByIdOrFailMock = vi.fn()
 const findByIdMock = vi.fn()
 const updateMock = vi.fn()
+const updateIfProfileNameEmptyMock = vi.fn()
 vi.mock("../../../packages/business/src/contact/service", () => ({
   contactService: {
     findByIdOrFail: findByIdOrFailMock,
     findById: findByIdMock,
     update: updateMock,
+    updateIfProfileNameEmpty: updateIfProfileNameEmptyMock,
   },
 }))
 
@@ -112,6 +114,14 @@ beforeEach(() => {
   findByIdOrFailMock.mockResolvedValue({ ...namelessContact })
   findByIdMock.mockResolvedValue(undefined)
   updateMock.mockImplementation(async (ctx, data) => ({
+    id: ctx.id,
+    workspaceId: ctx.workspaceId,
+    ...data,
+  }))
+  // `contactProfileRefreshService.refresh` writes through the atomic
+  // conditional method (`applyContactProfile({ onlyIfProfileNameEmpty: true
+  // })`), not the plain `update` above — see fix wave 3, item 2.
+  updateIfProfileNameEmptyMock.mockImplementation(async (ctx, data) => ({
     id: ctx.id,
     workspaceId: ctx.workspaceId,
     ...data,

--- a/apps/worker/__tests__/contact-profile-refresh.test.ts
+++ b/apps/worker/__tests__/contact-profile-refresh.test.ts
@@ -1,0 +1,335 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// apps/worker/src/integration/handlers/contact-profile-refresh.ts — the
+// eligibility predicate, the fetcher strategy table, and the best-effort
+// executor that runs right after an inbound message is persisted (Task 2 of
+// .superpowers/sdd/2026-08-31-messenger-ctm-profile-backfill).
+//
+// The business rules (capability table, cooldown, apply+avatar compensation)
+// live in `@chatbotx.io/business/contact/profile-refresh` and are already
+// unit-tested in `packages/business/__tests__/contact-profile-refresh.test.ts`
+// (Task 1). This file only tests the WORKER's own wiring: rule composition,
+// fetcher selection per source, and the never-throws contract around
+// `contactProfileRefreshService.refresh`.
+// ---------------------------------------------------------------------------
+
+const mockContactProfileRefresh = vi.fn()
+const mockResolveIntegrationContextFromContactInbox = vi.fn()
+const mockLoggerWarn = vi.fn()
+const mockLoggerDebug = vi.fn()
+
+// Mirror of the real capability table
+// (packages/business/src/contact/profile-refresh/rules.ts) — this module
+// only depends on the two lookup functions built from it, not its shape.
+const CAPABILITIES: Record<
+  string,
+  { inbound: "payload" | "channelApi" | null; onDemand: boolean }
+> = {
+  messenger: { inbound: "channelApi", onDemand: true },
+  instagram: { inbound: "channelApi", onDemand: true },
+  zalo: { inbound: "channelApi", onDemand: true },
+  telegram: { inbound: "channelApi", onDemand: true },
+  whatsapp: { inbound: "payload", onDemand: false },
+  tiktok: { inbound: null, onDemand: false },
+  api: { inbound: "payload", onDemand: false },
+  webchat: { inbound: null, onDemand: false },
+  smtp: { inbound: null, onDemand: false },
+  omnichannel: { inbound: null, onDemand: false },
+}
+
+vi.mock("@chatbotx.io/business", () => ({
+  contactProfileRefreshService: { refresh: mockContactProfileRefresh },
+  resolveInboundProfileNameSource: (channel: string) =>
+    CAPABILITIES[channel]?.inbound ?? null,
+  // Mirror of the real one-liner: empty only when BOTH names are blank.
+  hasEmptyProfileName: (contact: {
+    firstName?: string | null
+    lastName?: string | null
+  }) => !(contact.firstName?.trim() || contact.lastName?.trim()),
+}))
+
+vi.mock("../src/services/integrations", () => ({
+  resolveIntegrationContextFromContactInbox:
+    mockResolveIntegrationContextFromContactInbox,
+}))
+
+// `isInboundConversationMessage` is extracted from received-message.ts and
+// reused here; mirrored rather than imported for real so this file stays
+// isolated from received-message.ts's much heavier import graph.
+vi.mock("../src/integration/handlers/received-message", () => ({
+  isInboundConversationMessage: (message: {
+    messageType?: string
+    type?: string
+  }) =>
+    message.messageType !== "outgoing" &&
+    (message.type ?? "message") === "message",
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: {
+    warn: mockLoggerWarn,
+    debug: mockLoggerDebug,
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const { shouldRefreshContactProfile, refreshExistingContactProfile } =
+  await import("../src/integration/handlers/contact-profile-refresh")
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const namelessContact = { firstName: null, lastName: null }
+
+const inboundTextMessage = {
+  sourceId: "msg-1",
+  messageType: "incoming" as const,
+  text: "hi",
+  contentType: "text" as const,
+}
+
+const fakeInbox = {
+  id: "inbox-1",
+  workspaceId: "ws-1",
+  channel: "messenger",
+} as unknown as import("@chatbotx.io/database/types").InboxModel
+
+const fakeContactInbox = {
+  id: "ci-1",
+  contactId: "contact-1",
+  inboxId: "inbox-1",
+  sourceId: "psid-123",
+  channel: "messenger",
+} as unknown as import("@chatbotx.io/database/types").ContactInboxModel
+
+const fakeIncomingContact = { sourceId: "psid-123", firstName: "Jane" }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Default: mirror `contactProfileRefreshService.refresh`'s fetch step
+  // closely enough to exercise the worker's fetcher wiring (which source
+  // was selected, what args it was called with) without re-testing Task 1's
+  // owned cooldown/skip business rules.
+  mockContactProfileRefresh.mockImplementation(async (input) => {
+    try {
+      const profile = await input.fetchProfile()
+      return profile
+        ? { status: "updated", contact: { id: input.contactId } }
+        : { status: "unavailable" }
+    } catch {
+      return { status: "failed" }
+    }
+  })
+  mockResolveIntegrationContextFromContactInbox.mockResolvedValue({
+    integration: {
+      runChannelHandler: vi.fn().mockResolvedValue(fakeIncomingContact),
+    },
+    ctx: { workspaceId: "ws-1" },
+  })
+})
+
+// ---------------------------------------------------------------------------
+// shouldRefreshContactProfile — per-rule coverage
+// ---------------------------------------------------------------------------
+
+describe("shouldRefreshContactProfile", () => {
+  test("all three rules pass → true", () => {
+    expect(
+      shouldRefreshContactProfile({
+        channel: "messenger",
+        incomingMessage: inboundTextMessage,
+        contact: namelessContact,
+      }),
+    ).toBe(true)
+  })
+
+  test("rule 1 (capability): channel with inbound: null → false", () => {
+    expect(
+      shouldRefreshContactProfile({
+        channel: "webchat",
+        incomingMessage: inboundTextMessage,
+        contact: namelessContact,
+      }),
+    ).toBe(false)
+  })
+
+  test("rule 2 (inbound-only): outgoing echo → false", () => {
+    expect(
+      shouldRefreshContactProfile({
+        channel: "messenger",
+        incomingMessage: { ...inboundTextMessage, messageType: "outgoing" },
+        contact: namelessContact,
+      }),
+    ).toBe(false)
+  })
+
+  test("rule 2 (inbound-only): activity-typed message (e.g. a reaction) → false", () => {
+    expect(
+      shouldRefreshContactProfile({
+        channel: "messenger",
+        incomingMessage: { ...inboundTextMessage, type: "activity" },
+        contact: namelessContact,
+      }),
+    ).toBe(false)
+  })
+
+  test("rule 3 (name presence): firstName-only contact → false", () => {
+    expect(
+      shouldRefreshContactProfile({
+        channel: "messenger",
+        incomingMessage: inboundTextMessage,
+        contact: { firstName: "Jane", lastName: null },
+      }),
+    ).toBe(false)
+  })
+
+  test("rule 3 (name presence): lastName-only contact → false", () => {
+    expect(
+      shouldRefreshContactProfile({
+        channel: "messenger",
+        incomingMessage: inboundTextMessage,
+        contact: { firstName: null, lastName: "Doe" },
+      }),
+    ).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// refreshExistingContactProfile
+// ---------------------------------------------------------------------------
+
+describe("refreshExistingContactProfile", () => {
+  test("channelApi source: lazily resolves the integration and calls getProfile with the contactInbox's sourceId", async () => {
+    await refreshExistingContactProfile({
+      inbox: fakeInbox,
+      contactInbox: fakeContactInbox,
+      incomingContact: fakeIncomingContact,
+      contactId: "contact-1",
+    })
+
+    expect(mockResolveIntegrationContextFromContactInbox).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      contactInbox: fakeContactInbox,
+    })
+    const { integration } =
+      await mockResolveIntegrationContextFromContactInbox.mock.results[0].value
+    expect(integration.runChannelHandler).toHaveBeenCalledWith(
+      "contact",
+      "getProfile",
+      {
+        ctx: { workspaceId: "ws-1" },
+        data: { sourceId: "psid-123" },
+      },
+    )
+    expect(mockContactProfileRefresh).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "ws-1",
+        contactId: "contact-1",
+        contactInbox: fakeContactInbox,
+        source: "channelApi",
+        fetchProfile: expect.any(Function),
+      }),
+    )
+  })
+
+  test("payload source: applies the already-parsed IncomingContact directly, no integration resolution and no Graph call", async () => {
+    const whatsappInbox = { ...fakeInbox, channel: "whatsapp" }
+    const whatsappContactInbox = { ...fakeContactInbox, channel: "whatsapp" }
+
+    await refreshExistingContactProfile({
+      inbox: whatsappInbox as typeof fakeInbox,
+      contactInbox: whatsappContactInbox as typeof fakeContactInbox,
+      incomingContact: fakeIncomingContact,
+      contactId: "contact-1",
+    })
+
+    expect(mockResolveIntegrationContextFromContactInbox).not.toHaveBeenCalled()
+    expect(mockContactProfileRefresh).toHaveBeenCalledWith(
+      expect.objectContaining({ source: "payload" }),
+    )
+    const call = mockContactProfileRefresh.mock.calls[0]?.[0] as {
+      fetchProfile: () => Promise<unknown>
+    }
+    await expect(call.fetchProfile()).resolves.toBe(fakeIncomingContact)
+  })
+
+  test("channel with no inbound source (e.g. webchat) → the service is never called", async () => {
+    const webchatInbox = { ...fakeInbox, channel: "webchat" }
+
+    await refreshExistingContactProfile({
+      inbox: webchatInbox as typeof fakeInbox,
+      contactInbox: {
+        ...fakeContactInbox,
+        channel: "webchat",
+      } as typeof fakeContactInbox,
+      incomingContact: fakeIncomingContact,
+      contactId: "contact-1",
+    })
+
+    expect(mockContactProfileRefresh).not.toHaveBeenCalled()
+    expect(mockResolveIntegrationContextFromContactInbox).not.toHaveBeenCalled()
+  })
+
+  test("resolveIntegrationContextFromContactInbox throws (missing/disconnected integration) → never throws, logged at debug", async () => {
+    mockResolveIntegrationContextFromContactInbox.mockRejectedValue(
+      new Error("integration not found"),
+    )
+
+    await expect(
+      refreshExistingContactProfile({
+        inbox: fakeInbox,
+        contactInbox: fakeContactInbox,
+        incomingContact: fakeIncomingContact,
+        contactId: "contact-1",
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(mockLoggerDebug).toHaveBeenCalledWith(
+      expect.objectContaining({ result: { status: "failed" } }),
+      expect.any(String),
+    )
+  })
+
+  test("contactProfileRefreshService.refresh throws unexpectedly → never throws, logger.warn called", async () => {
+    mockContactProfileRefresh.mockRejectedValue(new Error("boom"))
+
+    await expect(
+      refreshExistingContactProfile({
+        inbox: fakeInbox,
+        contactInbox: fakeContactInbox,
+        incomingContact: fakeIncomingContact,
+        contactId: "contact-1",
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.any(Error),
+        contactId: "contact-1",
+        channel: "messenger",
+      }),
+      expect.any(String),
+    )
+  })
+
+  test("successful refresh is logged at debug with the service result", async () => {
+    await refreshExistingContactProfile({
+      inbox: fakeInbox,
+      contactInbox: fakeContactInbox,
+      incomingContact: fakeIncomingContact,
+      contactId: "contact-1",
+    })
+
+    expect(mockLoggerDebug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        result: { status: "updated", contact: { id: "contact-1" } },
+        contactId: "contact-1",
+        channel: "messenger",
+      }),
+      expect.any(String),
+    )
+  })
+})

--- a/apps/worker/__tests__/contact-profile-refresh.test.ts
+++ b/apps/worker/__tests__/contact-profile-refresh.test.ts
@@ -19,51 +19,21 @@ const mockResolveIntegrationContextFromContactInbox = vi.fn()
 const mockLoggerWarn = vi.fn()
 const mockLoggerDebug = vi.fn()
 
-// Mirror of the real capability table
-// (packages/business/src/contact/profile-refresh/rules.ts) — this module
-// only depends on the two lookup functions built from it, not its shape.
-const CAPABILITIES: Record<
-  string,
-  { inbound: "payload" | "channelApi" | null; onDemand: boolean }
-> = {
-  messenger: { inbound: "channelApi", onDemand: true },
-  instagram: { inbound: "channelApi", onDemand: true },
-  zalo: { inbound: "channelApi", onDemand: true },
-  telegram: { inbound: "channelApi", onDemand: true },
-  whatsapp: { inbound: "payload", onDemand: false },
-  tiktok: { inbound: null, onDemand: false },
-  api: { inbound: "payload", onDemand: false },
-  webchat: { inbound: null, onDemand: false },
-  smtp: { inbound: null, onDemand: false },
-  omnichannel: { inbound: null, onDemand: false },
-}
-
-vi.mock("@chatbotx.io/business", () => ({
-  contactProfileRefreshService: { refresh: mockContactProfileRefresh },
-  resolveInboundProfileNameSource: (channel: string) =>
-    CAPABILITIES[channel]?.inbound ?? null,
-  // Mirror of the real one-liner: empty only when BOTH names are blank.
-  hasEmptyProfileName: (contact: {
-    firstName?: string | null
-    lastName?: string | null
-  }) => !(contact.firstName?.trim() || contact.lastName?.trim()),
-}))
+// Real capability table + predicates (packages/business/src/contact/profile-refresh/rules.ts)
+// — only `contactProfileRefreshService.refresh` (the redis/db-touching part,
+// covered on its own in packages/business/__tests__/contact-profile-refresh.test.ts)
+// is mocked here, so this file can't drift from the real capability table.
+vi.mock("@chatbotx.io/business", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@chatbotx.io/business")>()
+  return {
+    ...actual,
+    contactProfileRefreshService: { refresh: mockContactProfileRefresh },
+  }
+})
 
 vi.mock("../src/services/integrations", () => ({
   resolveIntegrationContextFromContactInbox:
     mockResolveIntegrationContextFromContactInbox,
-}))
-
-// `isInboundConversationMessage` is extracted from received-message.ts and
-// reused here; mirrored rather than imported for real so this file stays
-// isolated from received-message.ts's much heavier import graph.
-vi.mock("../src/integration/handlers/received-message", () => ({
-  isInboundConversationMessage: (message: {
-    messageType?: string
-    type?: string
-  }) =>
-    message.messageType !== "outgoing" &&
-    (message.type ?? "message") === "message",
 }))
 
 vi.mock("../src/lib/logger", () => ({

--- a/apps/worker/__tests__/contact-profile-refresh.test.ts
+++ b/apps/worker/__tests__/contact-profile-refresh.test.ts
@@ -165,6 +165,26 @@ describe("shouldRefreshContactProfile", () => {
       }),
     ).toBe(false)
   })
+
+  // `vi.mock("@chatbotx.io/business", async (importOriginal) => ...)` above
+  // is the REAL rules.ts, so this exercises the actual capability-table
+  // null-safety fix, not a mirror.
+  test("rule 1 (capability): unknown/legacy channel string → false, never throws", () => {
+    expect(() =>
+      shouldRefreshContactProfile({
+        channel: "legacy" as never,
+        incomingMessage: inboundTextMessage,
+        contact: namelessContact,
+      }),
+    ).not.toThrow()
+    expect(
+      shouldRefreshContactProfile({
+        channel: "legacy" as never,
+        incomingMessage: inboundTextMessage,
+        contact: namelessContact,
+      }),
+    ).toBe(false)
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -223,7 +243,44 @@ describe("refreshExistingContactProfile", () => {
     const call = mockContactProfileRefresh.mock.calls[0]?.[0] as {
       fetchProfile: () => Promise<unknown>
     }
-    await expect(call.fetchProfile()).resolves.toBe(fakeIncomingContact)
+    // Picked to a new object (name-related fields only) — not the same
+    // reference as `fakeIncomingContact` — but equal in value here since
+    // this fixture only carries name-related fields to begin with.
+    await expect(call.fetchProfile()).resolves.toEqual(fakeIncomingContact)
+  })
+
+  test("payload source: strips locale/timezone/gender from the fetched profile, keeps name and avatar", async () => {
+    const apiInbox = { ...fakeInbox, channel: "api" }
+    const apiContactInbox = { ...fakeContactInbox, channel: "api" }
+    const rawIncomingContact = {
+      sourceId: "psid-123",
+      firstName: "Jane",
+      lastName: "Doe",
+      avatar: "public/space/ws-1/avatars/new",
+      // Carried on the webhook payload but must never overwrite the
+      // normalized values `finalizeContactProfile` already wrote at
+      // contact-creation time.
+      locale: "en_US",
+      timezone: "+07:00",
+      gender: "female",
+    }
+
+    await refreshExistingContactProfile({
+      inbox: apiInbox as typeof fakeInbox,
+      contactInbox: apiContactInbox as typeof fakeContactInbox,
+      incomingContact: rawIncomingContact,
+      contactId: "contact-1",
+    })
+
+    const call = mockContactProfileRefresh.mock.calls[0]?.[0] as {
+      fetchProfile: () => Promise<unknown>
+    }
+    await expect(call.fetchProfile()).resolves.toEqual({
+      sourceId: "psid-123",
+      firstName: "Jane",
+      lastName: "Doe",
+      avatar: "public/space/ws-1/avatars/new",
+    })
   })
 
   test("channel with no inbound source (e.g. webchat) → the service is never called", async () => {

--- a/apps/worker/__tests__/contact-profile-refresh.test.ts
+++ b/apps/worker/__tests__/contact-profile-refresh.test.ts
@@ -45,8 +45,9 @@ vi.mock("../src/lib/logger", () => ({
   },
 }))
 
-const { shouldRefreshContactProfile, refreshExistingContactProfile } =
-  await import("../src/integration/handlers/contact-profile-refresh")
+const { getProfileRefreshSource, refreshExistingContactProfile } = await import(
+  "../src/integration/handlers/contact-profile-refresh"
+)
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -102,88 +103,88 @@ beforeEach(() => {
 })
 
 // ---------------------------------------------------------------------------
-// shouldRefreshContactProfile — per-rule coverage
+// getProfileRefreshSource — per-rule coverage
 // ---------------------------------------------------------------------------
 
-describe("shouldRefreshContactProfile", () => {
-  test("all three rules pass → true", () => {
+describe("getProfileRefreshSource", () => {
+  test("all three rules pass → the resolved source", () => {
     expect(
-      shouldRefreshContactProfile({
+      getProfileRefreshSource({
         channel: "messenger",
         incomingMessage: inboundTextMessage,
         contact: namelessContact,
       }),
-    ).toBe(true)
+    ).toBe("channelApi")
   })
 
-  test("rule 1 (capability): channel with inbound: null → false", () => {
+  test("rule 1 (capability): channel with inbound: null → null", () => {
     expect(
-      shouldRefreshContactProfile({
+      getProfileRefreshSource({
         channel: "webchat",
         incomingMessage: inboundTextMessage,
         contact: namelessContact,
       }),
-    ).toBe(false)
+    ).toBeNull()
   })
 
-  test("rule 2 (inbound-only): outgoing echo → false", () => {
+  test("rule 2 (inbound-only): outgoing echo → null", () => {
     expect(
-      shouldRefreshContactProfile({
+      getProfileRefreshSource({
         channel: "messenger",
         incomingMessage: { ...inboundTextMessage, messageType: "outgoing" },
         contact: namelessContact,
       }),
-    ).toBe(false)
+    ).toBeNull()
   })
 
-  test("rule 2 (inbound-only): activity-typed message (e.g. a reaction) → false", () => {
+  test("rule 2 (inbound-only): activity-typed message (e.g. a reaction) → null", () => {
     expect(
-      shouldRefreshContactProfile({
+      getProfileRefreshSource({
         channel: "messenger",
         incomingMessage: { ...inboundTextMessage, type: "activity" },
         contact: namelessContact,
       }),
-    ).toBe(false)
+    ).toBeNull()
   })
 
-  test("rule 3 (name presence): firstName-only contact → false", () => {
+  test("rule 3 (name presence): firstName-only contact → null", () => {
     expect(
-      shouldRefreshContactProfile({
+      getProfileRefreshSource({
         channel: "messenger",
         incomingMessage: inboundTextMessage,
         contact: { firstName: "Jane", lastName: null },
       }),
-    ).toBe(false)
+    ).toBeNull()
   })
 
-  test("rule 3 (name presence): lastName-only contact → false", () => {
+  test("rule 3 (name presence): lastName-only contact → null", () => {
     expect(
-      shouldRefreshContactProfile({
+      getProfileRefreshSource({
         channel: "messenger",
         incomingMessage: inboundTextMessage,
         contact: { firstName: null, lastName: "Doe" },
       }),
-    ).toBe(false)
+    ).toBeNull()
   })
 
   // `vi.mock("@chatbotx.io/business", async (importOriginal) => ...)` above
   // is the REAL rules.ts, so this exercises the actual capability-table
   // null-safety fix, not a mirror.
-  test("rule 1 (capability): unknown/legacy channel string → false, never throws", () => {
+  test("rule 1 (capability): unknown/legacy channel string → null, never throws", () => {
     expect(() =>
-      shouldRefreshContactProfile({
+      getProfileRefreshSource({
         channel: "legacy" as never,
         incomingMessage: inboundTextMessage,
         contact: namelessContact,
       }),
     ).not.toThrow()
     expect(
-      shouldRefreshContactProfile({
+      getProfileRefreshSource({
         channel: "legacy" as never,
         incomingMessage: inboundTextMessage,
         contact: namelessContact,
       }),
-    ).toBe(false)
+    ).toBeNull()
   })
 })
 
@@ -194,6 +195,7 @@ describe("shouldRefreshContactProfile", () => {
 describe("refreshExistingContactProfile", () => {
   test("channelApi source: lazily resolves the integration and calls getProfile with the contactInbox's sourceId", async () => {
     await refreshExistingContactProfile({
+      source: "channelApi",
       inbox: fakeInbox,
       contactInbox: fakeContactInbox,
       incomingContact: fakeIncomingContact,
@@ -230,6 +232,7 @@ describe("refreshExistingContactProfile", () => {
     const whatsappContactInbox = { ...fakeContactInbox, channel: "whatsapp" }
 
     await refreshExistingContactProfile({
+      source: "payload",
       inbox: whatsappInbox as typeof fakeInbox,
       contactInbox: whatsappContactInbox as typeof fakeContactInbox,
       incomingContact: fakeIncomingContact,
@@ -266,6 +269,7 @@ describe("refreshExistingContactProfile", () => {
     }
 
     await refreshExistingContactProfile({
+      source: "payload",
       inbox: apiInbox as typeof fakeInbox,
       contactInbox: apiContactInbox as typeof fakeContactInbox,
       incomingContact: rawIncomingContact,
@@ -283,23 +287,6 @@ describe("refreshExistingContactProfile", () => {
     })
   })
 
-  test("channel with no inbound source (e.g. webchat) → the service is never called", async () => {
-    const webchatInbox = { ...fakeInbox, channel: "webchat" }
-
-    await refreshExistingContactProfile({
-      inbox: webchatInbox as typeof fakeInbox,
-      contactInbox: {
-        ...fakeContactInbox,
-        channel: "webchat",
-      } as typeof fakeContactInbox,
-      incomingContact: fakeIncomingContact,
-      contactId: "contact-1",
-    })
-
-    expect(mockContactProfileRefresh).not.toHaveBeenCalled()
-    expect(mockResolveIntegrationContextFromContactInbox).not.toHaveBeenCalled()
-  })
-
   test("resolveIntegrationContextFromContactInbox throws (missing/disconnected integration) → never throws, logged at debug", async () => {
     mockResolveIntegrationContextFromContactInbox.mockRejectedValue(
       new Error("integration not found"),
@@ -307,6 +294,7 @@ describe("refreshExistingContactProfile", () => {
 
     await expect(
       refreshExistingContactProfile({
+        source: "channelApi",
         inbox: fakeInbox,
         contactInbox: fakeContactInbox,
         incomingContact: fakeIncomingContact,
@@ -325,6 +313,7 @@ describe("refreshExistingContactProfile", () => {
 
     await expect(
       refreshExistingContactProfile({
+        source: "channelApi",
         inbox: fakeInbox,
         contactInbox: fakeContactInbox,
         incomingContact: fakeIncomingContact,
@@ -344,6 +333,7 @@ describe("refreshExistingContactProfile", () => {
 
   test("successful refresh is logged at debug with the service result", async () => {
     await refreshExistingContactProfile({
+      source: "channelApi",
       inbox: fakeInbox,
       contactInbox: fakeContactInbox,
       incomingContact: fakeIncomingContact,

--- a/apps/worker/__tests__/integration-worker-incoming-message.test.ts
+++ b/apps/worker/__tests__/integration-worker-incoming-message.test.ts
@@ -1,0 +1,640 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// Job-level ordering proof for the `incomingMessage` case in
+// `src/integration/worker.ts` (fix round 1 of Task 2 of
+// .superpowers/sdd/2026-08-31-messenger-ctm-profile-backfill): the
+// receiveMessage-level assertion in received-message.test.ts is a fine
+// proxy, but the brief's actual bullet asks for the refresh's resolution to
+// be proven ordered before the automated-response dispatch AT THE JOB
+// LEVEL, i.e. through the real `worker.ts` processor. Unlike
+// integration-worker-boot.test.ts, this file does NOT mock
+// `./handlers/received-message` — it boots the REAL `receiveMessage`
+// pipeline (mocking only its DB/Redis/channel-registry dependencies, same
+// convention as received-message.test.ts) so the real post-save
+// `refreshExistingContactProfile` call runs, while `resolveIncomingTextRouting`
+// and `automatedResponseService.enqueue` (the dispatch this bullet cares
+// about) stay mocked and observable.
+// ---------------------------------------------------------------------------
+
+type CapturedWorker = {
+  queueName: unknown
+  processor: (job: { data: unknown }) => Promise<unknown>
+}
+
+const {
+  mockCreateOrUpdate,
+  mockCreateMessageRepository,
+  mockDbUpdate,
+  mockFindContactInbox,
+  mockRunChannelHandler,
+  mockBuildContext,
+  mockresolveTenantSettings,
+  mockUpdateContactFromMessage,
+  mockContactUnblockIfBlocked,
+  mockContactUpdate,
+  mockDbTransaction,
+  mockDbCount,
+  mockWorkspaceIsActiveNow,
+  mockSyncScopedIdentity,
+  mockIsUniqueViolationError,
+  mockContactProfileRefresh,
+  mockResolveIntegrationContextFromContactInbox,
+  mockResolveIncomingTextRouting,
+  mockAutomatedResponseEnqueue,
+  mockConversationFindOrCreate,
+  workerState,
+} = vi.hoisted(() => {
+  const mockDbSet = vi.fn()
+  const updateChain = { set: mockDbSet, where: vi.fn() }
+  updateChain.set.mockReturnValue(updateChain)
+  updateChain.where.mockResolvedValue(undefined)
+  const mockDbUpdate = vi.fn().mockReturnValue(updateChain)
+  const mockDbTransaction = vi
+    .fn()
+    .mockImplementation((fn: (tx: unknown) => unknown) =>
+      fn({ update: mockDbUpdate }),
+    )
+  const mockDbCount = vi.fn().mockResolvedValue(1)
+  const mockFindContactInbox = vi.fn()
+  const mockRunChannelHandler = vi.fn()
+  const mockCreateOrUpdate = vi.fn()
+  const mockCreateMessageRepository = vi.fn().mockResolvedValue({
+    createOrUpdate: mockCreateOrUpdate,
+    createOrUpdateWithAttachments: vi.fn(),
+  })
+
+  return {
+    mockCreateOrUpdate,
+    mockCreateMessageRepository,
+    mockDbUpdate,
+    mockFindContactInbox,
+    mockRunChannelHandler,
+    mockBuildContext: vi.fn().mockResolvedValue({ workspaceId: "ws-1" }),
+    mockresolveTenantSettings: vi
+      .fn()
+      .mockResolvedValue({ storageUrl: "https://files.example.test" }),
+    mockUpdateContactFromMessage: vi.fn().mockResolvedValue(undefined),
+    mockContactUnblockIfBlocked: vi.fn().mockResolvedValue(null),
+    mockContactUpdate: vi.fn().mockResolvedValue({}),
+    mockDbTransaction,
+    mockDbCount,
+    mockWorkspaceIsActiveNow: vi.fn().mockReturnValue(true),
+    // Pass-through by default: returns the matched contactInbox unchanged.
+    mockSyncScopedIdentity: vi.fn(
+      async ({ contactInbox }: { contactInbox: unknown }) => ({
+        contactInbox,
+        learnedPrimaryIdentity: undefined,
+      }),
+    ),
+    mockIsUniqueViolationError: vi.fn().mockReturnValue(false),
+    mockContactProfileRefresh: vi.fn(),
+    mockResolveIntegrationContextFromContactInbox: vi.fn(),
+    mockResolveIncomingTextRouting: vi.fn(),
+    mockAutomatedResponseEnqueue: vi.fn().mockResolvedValue(undefined),
+    mockConversationFindOrCreate: vi.fn(),
+    workerState: { capturedWorkers: [] as CapturedWorker[] },
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Worker-boot infra (mirrors integration-worker-boot.test.ts)
+// ---------------------------------------------------------------------------
+
+vi.mock("bullmq", () => {
+  class WorkerMock {
+    close = vi.fn()
+    on = vi.fn()
+    constructor(queueName: unknown, processor: CapturedWorker["processor"]) {
+      workerState.capturedWorkers.push({ queueName, processor })
+    }
+  }
+  return { Worker: WorkerMock, UnrecoverableError: class extends Error {} }
+})
+
+vi.mock("../src/env", () => ({
+  env: { INTEGRATION_WORKER_CONCURRENCY: 10 },
+}))
+
+vi.mock("../src/lib/bootstrap", () => ({
+  ensureBootstrapped: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock("../src/lib/is-blocked-workspace", () => ({
+  isBlockedWorkspace: vi.fn().mockResolvedValue(false),
+}))
+
+vi.mock("../src/lib/resolve-workspace-id", () => ({
+  resolveWorkspaceId: vi.fn().mockResolvedValue("ws-1"),
+}))
+
+vi.mock("../src/integration/job-context", () => ({
+  runIntegrationJobWithWebhookContext: (
+    _job: unknown,
+    callback: () => Promise<unknown>,
+  ) => callback(),
+}))
+
+vi.mock("../src/integration/routing", () => ({
+  resolveIncomingTextRouting: mockResolveIncomingTextRouting,
+}))
+
+vi.mock("../src/integration/utils/message", () => ({
+  closeChatQueueEvents: vi.fn().mockResolvedValue(undefined),
+}))
+
+// Every OTHER handler module worker.ts wires into its switch — none of them
+// are exercised by the `incomingMessage` case, stubbed only so the module
+// graph resolves.
+vi.mock("../src/integration/handlers/ads-automatic-event", () => ({
+  handleAdsAutomaticEvent: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/ads-conversion/registry", () => ({
+  dispatchAdsConversionJob: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/automated-response", () => ({
+  processAutomatedResponse: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/challenge", () => ({
+  runChallenge: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/coexist/attachment-download", () => ({
+  coexistAttachmentDownload: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/coexist/instagram-sync", () => ({
+  coexistInstagramSync: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/coexist/messenger-sync", () => ({
+  coexistMessengerSync: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/coexist/whatsapp-buffer", () => ({
+  coexistWhatsappBuffer: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/coexist/whatsapp-flush", () => ({
+  coexistWhatsappFlush: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/comment-automation", () => ({
+  processCommentAutomation: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/comment-automation/ai-reply", () => ({
+  processCommentAIReply: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/contact/update-avatar", () => ({
+  updateContactAvatar: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/conversation", () => ({
+  agentMarkAsRead: vi.fn(),
+  contactMarkAsRead: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/flow", () => ({
+  runFlowNode: vi.fn(),
+  runFlowPostback: vi.fn(),
+  runFlowQuickReply: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/follow-up", () => ({
+  runFollowUpResume: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/inbox_labels", () => ({
+  handleChannelLabelWebhook: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/lead-ads", () => ({
+  processLeadgen: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/message-status", () => ({
+  handleMessageStatus: vi.fn(),
+}))
+vi.mock(
+  "../src/integration/handlers/meta-conversions/send-meta-capi-event",
+  () => ({ handleSendMetaCapiEvent: vi.fn() }),
+)
+vi.mock("../src/integration/handlers/ref", () => ({
+  runRef: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/sequence-flow", () => ({
+  handleSendSequenceFlow: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/story-reply-automation", () => ({
+  processStoryReplyAutomation: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/template-flow-response", () => ({
+  captureTemplateFlowResponse: vi.fn(),
+}))
+vi.mock("../src/integration/handlers/wait-resume", () => ({
+  runWaitResume: vi.fn(),
+}))
+
+// ---------------------------------------------------------------------------
+// receiveMessage's own dependencies — deliberately NOT mocking
+// `../src/integration/handlers/received-message` itself (that is the module
+// under test here), mirroring `received-message.test.ts`'s mock surface so
+// the real pipeline — including the new post-save profile refresh call —
+// runs for real.
+// ---------------------------------------------------------------------------
+
+vi.mock("@chatbotx.io/database/repositories", () => ({
+  createMessageRepository: mockCreateMessageRepository,
+}))
+
+vi.mock("@chatbotx.io/automated-response", () => ({
+  automatedResponseService: {
+    enqueue: mockAutomatedResponseEnqueue,
+    enqueueFlowAction: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    update: mockDbUpdate,
+    query: { contactInboxModel: { findFirst: mockFindContactInbox } },
+    $count: mockDbCount,
+    transaction: mockDbTransaction,
+  },
+  eq: vi.fn((col: unknown, val: unknown) => ({ __eq: [col, val] })),
+  findOrFail: vi.fn(),
+  isUniqueViolationError: mockIsUniqueViolationError,
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  CONTACT_INBOX_SOURCE_ID_KEY: "ContactInbox_inboxId_sourceId_key",
+  CONTACT_INBOX_SOURCE_USER_ID_KEY: "ContactInbox_inboxId_sourceUserId_key",
+  contactInboxModel: {
+    id: "id",
+    lastMessageAt: "lastMessageAt",
+    lastIncomingMessageAt: "lastIncomingMessageAt",
+  },
+  contactModel: { id: "id" },
+  conversationModel: {
+    id: "id",
+    lastActivityAt: "lastActivityAt",
+    sourceId: "sourceId",
+    workspaceId: "workspaceId",
+  },
+}))
+
+// Mirror of the real capability table
+// (packages/business/src/contact/profile-refresh/rules.ts), matching the
+// convention already used in received-message.test.ts.
+const CONTACT_PROFILE_NAME_CAPABILITIES: Record<
+  string,
+  { inbound: "payload" | "channelApi" | null; onDemand: boolean }
+> = {
+  messenger: { inbound: "channelApi", onDemand: true },
+  instagram: { inbound: "channelApi", onDemand: true },
+  zalo: { inbound: "channelApi", onDemand: true },
+  telegram: { inbound: "channelApi", onDemand: true },
+  whatsapp: { inbound: "payload", onDemand: false },
+  tiktok: { inbound: null, onDemand: false },
+  api: { inbound: "payload", onDemand: false },
+  webchat: { inbound: null, onDemand: false },
+  smtp: { inbound: null, onDemand: false },
+  omnichannel: { inbound: null, onDemand: false },
+}
+
+vi.mock("@chatbotx.io/business", () => ({
+  appointmentService: { cancelAppointmentByToken: vi.fn() },
+  broadcastToWorkspaceParty: vi.fn(),
+  buildContext: mockBuildContext,
+  resolveTenantSettings: mockresolveTenantSettings,
+  updateContactFromMessage: mockUpdateContactFromMessage,
+  hasOnDemandProfileApi: (channel: string) =>
+    CONTACT_PROFILE_NAME_CAPABILITIES[channel]?.onDemand ?? false,
+  resolveInboundProfileNameSource: (channel: string) =>
+    CONTACT_PROFILE_NAME_CAPABILITIES[channel]?.inbound ?? null,
+  hasEmptyProfileName: (contact: {
+    firstName?: string | null
+    lastName?: string | null
+  }) => !(contact.firstName?.trim() || contact.lastName?.trim()),
+  contactProfileRefreshService: { refresh: mockContactProfileRefresh },
+  recordProfileRefreshFailure: vi.fn().mockResolvedValue(undefined),
+  contactInboxService: {
+    updateTracking: vi
+      .fn()
+      .mockResolvedValue({ cacheTags: ["contacts:contact-1:contact-inboxes"] }),
+    invalidateTracking: vi.fn().mockResolvedValue(undefined),
+    syncScopedIdentity: mockSyncScopedIdentity,
+  },
+  contactService: {
+    unblockIfBlocked: mockContactUnblockIfBlocked,
+    update: mockContactUpdate,
+  },
+  conversationService: {
+    findOrCreate: mockConversationFindOrCreate,
+    ensureActive: vi.fn().mockResolvedValue(true),
+  },
+  workspaceService: {
+    find: vi.fn(),
+    findById: vi.fn().mockResolvedValue({
+      isActive: true,
+      startTime: null,
+      endTime: null,
+      timezone: "UTC",
+    }),
+    isActiveNow: mockWorkspaceIsActiveNow,
+  },
+  quotaEnforcementService: {
+    increment: vi.fn().mockResolvedValue(undefined),
+    createNewContactWithMac: vi.fn(),
+  },
+  userQuotaService: {
+    isLimitReached: vi.fn().mockResolvedValue(false),
+    increment: vi.fn().mockResolvedValue(undefined),
+  },
+  messageCleanupService: {
+    cancelByInboxSource: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
+vi.mock("@chatbotx.io/event-bus", () => ({
+  emit: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock("@chatbotx.io/events", () => ({
+  emitContactCreated: vi.fn().mockResolvedValue(undefined),
+  setWebhookExecutionContext: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/partysocket-config", () => ({
+  RealtimeEventType: { messageCreated: "messageCreated" },
+}))
+
+vi.mock("@chatbotx.io/sdk", () => ({
+  contentTypes: { enum: { text: "text", location: "location" } },
+  resolveWithSourceUserIdFallback: async <T>(
+    identity: { sourceId: string; sourceUserId?: string | null },
+    lookup: (
+      where: { sourceId: string } | { sourceUserId: string },
+    ) => Promise<T | undefined>,
+  ): Promise<T | undefined> => {
+    const bySourceId = await lookup({ sourceId: identity.sourceId })
+    if (bySourceId || !identity.sourceUserId) {
+      return bySourceId
+    }
+    return await lookup({ sourceUserId: identity.sourceUserId })
+  },
+  messageTypes: { enum: { incoming: "incoming", outgoing: "outgoing" } },
+  SdkException: class SdkException extends Error {},
+  isSourceUserIdKeyedIdentity: (identity: {
+    sourceId: string
+    sourceUserId?: string | null
+  }) =>
+    Boolean(identity.sourceUserId) &&
+    identity.sourceId === identity.sourceUserId,
+  getStoryReply: () => undefined,
+}))
+
+vi.mock("@chatbotx.io/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@chatbotx.io/utils")>()
+  return { ...actual, createId: vi.fn(() => "test-id") }
+})
+
+vi.mock("@chatbotx.io/flow-config", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@chatbotx.io/flow-config")>()
+  return { ...actual }
+})
+
+vi.mock("@chatbotx.io/encryption", () => ({
+  parseAppointmentCancelPostback: vi.fn().mockReturnValue(null),
+  verifyAppointmentCancelPostback: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/worker-config", () => ({
+  isNoRedisEnv: () => true,
+  defaultWorkerOptions: {
+    concurrency: 5,
+    removeOnComplete: { count: 1000 },
+    removeOnFail: { count: 5000 },
+  },
+  getRedisConnection: () => ({}),
+  closeIntegrationQueueEvents: vi.fn().mockResolvedValue(undefined),
+  queueNames: { enum: { integration: "integration" } },
+  ChatJobAction: { sendChatMessage: "sendChatMessage" },
+  chatQueue: { add: vi.fn().mockResolvedValue(undefined) },
+  IntegrationJobAction: {
+    incomingMessage: "incomingMessage",
+    runFlowPostback: "runFlowPostback",
+    runFlowQuickReply: "runFlowQuickReply",
+    runRef: "runRef",
+  },
+  integrationQueue: {
+    add: vi.fn().mockResolvedValue(undefined),
+    getJob: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
+vi.mock("../src/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock("../src/lib/db", () => ({
+  detectFlowVersion: vi.fn(),
+}))
+
+vi.mock("../src/services/integrations", () => ({
+  allIntegrations: {
+    messenger: { runChannelHandler: mockRunChannelHandler },
+  },
+  integrationService: {
+    identifyInboxAndIntegrationAuthFromIdentifier: vi.fn(),
+  },
+  isInstagramViaFacebook: (row: { type?: string }) => row.type === "facebook",
+  resolveIntegrationContextFromContactInbox:
+    mockResolveIntegrationContextFromContactInbox,
+}))
+
+// ---------------------------------------------------------------------------
+// Boot the real worker (side effect of importing worker.ts) and fixtures
+// ---------------------------------------------------------------------------
+
+await import("../src/integration/worker")
+await vi.waitFor(() => {
+  expect(workerState.capturedWorkers).toHaveLength(1)
+})
+const { integrationService } = await import("../src/services/integrations")
+
+const fakeInbox = {
+  id: "inbox-1",
+  workspaceId: "ws-1",
+  channel: "messenger",
+} as unknown as import("@chatbotx.io/database/types").InboxModel
+
+const fakeIntegrationRow = {
+  id: "integration-1",
+  auth: {},
+  inboxId: "inbox-1",
+} as unknown as { id: string; auth: unknown; inboxId: string }
+
+const fakeContactInbox = {
+  id: "ci-1",
+  contactId: "contact-1",
+  inboxId: "inbox-1",
+  sourceId: "psid-123",
+  channel: "messenger",
+  source: "messenger",
+} as unknown as import("@chatbotx.io/database/types").ContactInboxModel
+
+// Nameless — eligible for the post-save refresh (`hasEmptyProfileName`).
+const fakeContact = {
+  id: "contact-1",
+  workspaceId: "ws-1",
+  firstName: null,
+  lastName: null,
+  blockedAt: null,
+} as unknown as import("@chatbotx.io/database/types").ContactModel
+
+const fakeConversation = {
+  id: "conv-1",
+  workspaceId: "ws-1",
+  contactId: "contact-1",
+} as unknown as import("@chatbotx.io/database/types").ConversationModel
+
+const fakeCreatedMessage = {
+  id: "msg-created",
+  sourceId: "msg-src-1",
+  conversationId: "conv-1",
+  contactInboxId: "ci-1",
+  workspaceId: "ws-1",
+  messageType: "incoming",
+  contentType: "text",
+  senderType: "contact",
+  text: "hello",
+  contentAttributes: {},
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("integration worker — incomingMessage case: profile refresh vs. automated-response dispatch ordering", () => {
+  beforeEach(() => {
+    mockCreateOrUpdate.mockReset()
+    mockRunChannelHandler.mockReset()
+    mockFindContactInbox.mockReset()
+    mockContactProfileRefresh.mockReset()
+    mockResolveIntegrationContextFromContactInbox.mockReset()
+    mockResolveIncomingTextRouting.mockReset()
+    mockAutomatedResponseEnqueue.mockClear()
+    mockDbTransaction.mockClear()
+    mockContactUpdate.mockClear()
+    mockConversationFindOrCreate.mockReset()
+
+    vi.mocked(
+      integrationService.identifyInboxAndIntegrationAuthFromIdentifier,
+    ).mockResolvedValue({
+      inbox: fakeInbox,
+      integrationRow: fakeIntegrationRow,
+    } as never)
+    mockFindContactInbox.mockResolvedValue({
+      ...fakeContactInbox,
+      contact: fakeContact,
+    })
+    mockConversationFindOrCreate.mockResolvedValue(fakeConversation)
+    mockCreateMessageRepository.mockResolvedValue({
+      createOrUpdate: mockCreateOrUpdate,
+      createOrUpdateWithAttachments: vi.fn(),
+    })
+    mockCreateOrUpdate.mockResolvedValue({
+      message: fakeCreatedMessage,
+      isNew: true,
+    })
+    // The channel already parsed a plain inbound text message, no
+    // postback/quickReply/ref/referral — the simplest path into
+    // `resolveIncomingTextRouting`.
+    mockRunChannelHandler.mockImplementation(
+      (_domain: string, action: string) => {
+        if (action === "getProfile") {
+          return Promise.resolve({ firstName: "Jane", lastName: "Doe" })
+        }
+        return Promise.resolve({
+          message: {
+            sourceId: "msg-src-1",
+            messageType: "incoming",
+            text: "hello",
+            contentType: "text",
+            contentAttributes: {},
+            attachments: [],
+          },
+          contact: { sourceId: "psid-123" },
+          postbackAction: null,
+          quickReplyAction: null,
+          ref: null,
+        })
+      },
+    )
+    mockResolveIntegrationContextFromContactInbox.mockResolvedValue({
+      integration: { runChannelHandler: mockRunChannelHandler },
+      ctx: { workspaceId: "ws-1" },
+    })
+    // The real `contactProfileRefreshService.refresh` — mocked here, as
+    // received-message.test.ts does — resolves `contactService.update`
+    // (the marker this bullet cares about) as part of a successful
+    // channelApi fetch, matching Task 1's real "updated" outcome.
+    mockContactProfileRefresh.mockImplementation(async (input) => {
+      await input.fetchProfile()
+      await mockContactUpdate({ id: input.contactId }, {})
+      return { status: "updated", contact: { id: input.contactId } }
+    })
+    mockResolveIncomingTextRouting.mockResolvedValue({
+      type: "automatedResponse",
+      conversation: fakeConversation,
+    })
+  })
+
+  test("the refresh's contactService.update resolves before automatedResponseService.enqueue is invoked", async () => {
+    const [integrationWorker] = workerState.capturedWorkers
+
+    await integrationWorker?.processor({
+      data: {
+        type: "incomingMessage",
+        data: {
+          integrationType: "messenger",
+          integrationIdentifier: "inbox-1",
+          payload: {},
+        },
+      },
+    })
+
+    expect(mockContactProfileRefresh).toHaveBeenCalledWith(
+      expect.objectContaining({ contactId: "contact-1", source: "channelApi" }),
+    )
+    expect(mockAutomatedResponseEnqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ contactInboxId: "ci-1" }),
+    )
+    // The refresh (and the `contactService.update` write inside it) is
+    // awaited to completion inside `receiveMessage`, strictly before
+    // `worker.ts`'s `incomingMessage` case goes on to call
+    // `resolveIncomingTextRouting` and `automatedResponseService.enqueue` —
+    // both invocation order AND resolution order are proven by these two
+    // independent mocks only ever being called in this sequence.
+    expect(mockContactUpdate.mock.invocationCallOrder[0]).toBeLessThan(
+      mockAutomatedResponseEnqueue.mock.invocationCallOrder[0],
+    )
+    expect(mockContactProfileRefresh.mock.invocationCallOrder[0]).toBeLessThan(
+      mockResolveIncomingTextRouting.mock.invocationCallOrder[0],
+    )
+  })
+
+  test("a named contact skips the refresh entirely but automated-response dispatch still runs", async () => {
+    mockFindContactInbox.mockResolvedValue({
+      ...fakeContactInbox,
+      contact: { ...fakeContact, firstName: "Already Named" },
+    })
+    const [integrationWorker] = workerState.capturedWorkers
+
+    await integrationWorker?.processor({
+      data: {
+        type: "incomingMessage",
+        data: {
+          integrationType: "messenger",
+          integrationIdentifier: "inbox-1",
+          payload: {},
+        },
+      },
+    })
+
+    expect(mockContactProfileRefresh).not.toHaveBeenCalled()
+    expect(mockAutomatedResponseEnqueue).toHaveBeenCalled()
+  })
+})

--- a/apps/worker/__tests__/messenger-contact-data.test.ts
+++ b/apps/worker/__tests__/messenger-contact-data.test.ts
@@ -37,11 +37,82 @@ vi.mock("../src/integration/handlers/messenger-context", () => ({
 
 const update = vi.fn(async () => undefined)
 const findById = vi.fn(async () => state.currentContact)
+const deleteObject = vi.fn(async () => undefined)
+
+// `applyContactProfile` and `buildContactProfileUpdate` are the shared
+// helpers this handler now delegates to (see
+// packages/business/src/contact/profile-refresh) — unit-tested exhaustively
+// there. Here they are reproduced against this file's own `update`/
+// `findById`/`deleteObject` mocks so the assertions below (which target
+// those mocks directly) keep verifying the same observable behaviour.
+const EXTERNAL_URL_PATTERN = /^https?:\/\//
+function isManagedAvatarObject(avatar: string): boolean {
+  return !EXTERNAL_URL_PATTERN.test(avatar) && avatar.includes("/avatars/")
+}
+
+const PROFILE_FIELDS = [
+  "firstName",
+  "lastName",
+  "avatar",
+  "locale",
+  "timezone",
+  "gender",
+] as const
+
+const buildContactProfileUpdate = vi.fn((profile: Profile) => {
+  const update: Profile = {}
+  for (const field of PROFILE_FIELDS) {
+    if (profile[field] !== undefined) {
+      update[field] = profile[field]
+    }
+  }
+  return update
+})
+
+const loggerWarn = vi.fn()
+
+const applyContactProfile = vi.fn(
+  async (input: {
+    workspaceId: string
+    contactId: string
+    update: Profile
+  }) => {
+    const previousAvatar =
+      input.update.avatar === undefined
+        ? undefined
+        : (
+            await findById({
+              workspaceId: input.workspaceId,
+              id: input.contactId,
+            })
+          )?.avatar
+
+    const updated = await update(
+      { workspaceId: input.workspaceId, id: input.contactId },
+      input.update,
+    )
+
+    if (
+      previousAvatar &&
+      previousAvatar !== input.update.avatar &&
+      isManagedAvatarObject(previousAvatar)
+    ) {
+      try {
+        await deleteObject(previousAvatar)
+      } catch (error) {
+        loggerWarn(error)
+      }
+    }
+
+    return updated
+  },
+)
+
 vi.mock("@chatbotx.io/business", () => ({
-  contactService: { update, findById },
+  applyContactProfile,
+  buildContactProfileUpdate,
 }))
 
-const deleteObject = vi.fn(async () => undefined)
 vi.mock("@chatbotx.io/filesystem", () => ({
   uploader: { deleteObject },
 }))

--- a/apps/worker/__tests__/received-message.test.ts
+++ b/apps/worker/__tests__/received-message.test.ts
@@ -1922,6 +1922,44 @@ describe("receiveMessage — existing contact profile refresh (post-save)", () =
     expect(mockResolveIntegrationContextFromContactInbox).not.toHaveBeenCalled()
   })
 
+  test("unknown/legacy channel string on the inbox row → message still persists, refresh not called, receiveMessage never throws", async () => {
+    // Simulates a legacy/unknown `Inbox.channel` value (a plain text()
+    // column) reaching the capability table — regression guard for
+    // resolveInboundProfileNameSource/hasOnDemandProfileApi throwing a
+    // TypeError on an unrecognized channel and rejecting the whole receive
+    // job (which BullMQ would then retry, replaying postback/quickReply/
+    // runRef enqueue for an already-saved message).
+    const legacyInbox = { ...fakeInbox, channel: "legacy" }
+    vi.mocked(
+      integrationService.identifyInboxAndIntegrationAuthFromIdentifier,
+    ).mockResolvedValue({
+      inbox: legacyInbox,
+      integrationRow: fakeIntegrationRow,
+    } as never)
+    mockFindContactInbox.mockResolvedValue({
+      ...fakeContactInbox,
+      channel: "legacy",
+      contact: fakeContact,
+    })
+    mockRunChannelHandler.mockResolvedValue({
+      message: { ...baseIncomingMessage, attachments: [] },
+      contact: { sourceId: "psid-123" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+
+    // `integrationType` (webhook dispatch key) stays a registered value —
+    // only `Inbox.channel` (the capability-table lookup key) is the
+    // legacy/unknown string, matching how a real corrupted/legacy row would
+    // reach `shouldRefreshContactProfile` independent of webhook routing.
+    await receiveMessage(baseProps)
+
+    expect(mockCreateOrUpdate).toHaveBeenCalled()
+    expect(mockContactProfileRefresh).not.toHaveBeenCalled()
+    expect(mockResolveIntegrationContextFromContactInbox).not.toHaveBeenCalled()
+  })
+
   test("tiktok nameless existing contact → refresh not called (inbound: null); a sourceId is never treated as a name", async () => {
     const tiktokInbox = { ...fakeInbox, channel: "tiktok" }
     vi.mocked(

--- a/apps/worker/__tests__/received-message.test.ts
+++ b/apps/worker/__tests__/received-message.test.ts
@@ -182,6 +182,16 @@ vi.mock("@chatbotx.io/database/schema", () => ({
 // re-implemented here rather than partially importing the real (heavy)
 // `@chatbotx.io/business` barrel, matching this file's existing convention
 // for `@chatbotx.io/sdk`'s pure helpers above.
+//
+// Tried switching to `vi.mock("@chatbotx.io/business", async (importOriginal)
+// => ...)` (as done in contact-profile-refresh.test.ts, which has no
+// `@chatbotx.io/database/schema` mock to conflict with) — it breaks here: the
+// real barrel's module graph reaches `ads-conversion/schema.ts`, which calls
+// `createSelectSchema` from `@chatbotx.io/database/schema` at import time,
+// and this file's `@chatbotx.io/database/schema` mock above is deliberately
+// minimal (a handful of table shapes) and has no such export. Keeping the
+// mirror here rather than widening that mock (and whatever else the real
+// barrel transitively touches) to stay a small, scoped fix.
 const CONTACT_PROFILE_NAME_CAPABILITIES: Record<
   string,
   { inbound: "payload" | "channelApi" | null; onDemand: boolean }
@@ -2507,6 +2517,65 @@ describe("receiveMessage — existing contact profile refresh (post-save)", () =
       "contact",
       "getProfile",
       expect.objectContaining({ data: { sourceId: "zalo-psid-1" } }),
+    )
+  })
+
+  test("telegram: a new contact creation still fetches getProfile at creation time via hasOnDemandProfileApi", async () => {
+    mockFindContactInbox.mockResolvedValue(undefined)
+    mockWorkspaceFind.mockResolvedValue({ ownerId: "owner-1" })
+    const telegramInbox = { ...fakeInbox, channel: "telegram" }
+    vi.mocked(
+      integrationService.identifyInboxAndIntegrationAuthFromIdentifier,
+    ).mockResolvedValue({
+      inbox: telegramInbox,
+      integrationRow: fakeIntegrationRow,
+    } as never)
+    mockRunChannelHandler.mockImplementation(
+      (_domain: string, action: string) => {
+        if (action === "getProfile") {
+          return Promise.resolve({ firstName: "Telegram Contact" })
+        }
+        return Promise.resolve({
+          message: { ...baseIncomingMessage, attachments: [] },
+          contact: { sourceId: "telegram-chat-1" },
+          postbackAction: null,
+          quickReplyAction: null,
+          ref: null,
+        })
+      },
+    )
+    mockCreateNewContactWithMac.mockResolvedValue({
+      ok: true,
+      value: {
+        newContact: {
+          id: "contact-telegram-new",
+          workspaceId: "ws-1",
+          firstName: "Telegram Contact",
+          phoneNumber: null,
+          email: null,
+          blockedAt: null,
+          createdAt: new Date("2026-06-21T00:00:00Z"),
+        },
+        contactInbox: {
+          ...fakeContactInbox,
+          id: "ci-telegram-new",
+          contactId: "contact-telegram-new",
+          channel: "telegram",
+        },
+        conversation: fakeConversation,
+      },
+    })
+    mockCreateOrUpdate.mockResolvedValue({
+      message: { ...fakeCreatedMessage, contactInboxId: "ci-telegram-new" },
+      isNew: true,
+    })
+
+    await receiveMessage({ ...baseProps, integrationType: "telegram" })
+
+    expect(mockRunChannelHandler).toHaveBeenCalledWith(
+      "contact",
+      "getProfile",
+      expect.objectContaining({ data: { sourceId: "telegram-chat-1" } }),
     )
   })
 

--- a/apps/worker/__tests__/received-message.test.ts
+++ b/apps/worker/__tests__/received-message.test.ts
@@ -39,6 +39,9 @@ const {
   mockSyncScopedIdentity,
   mockIsUniqueViolationError,
   mockDetectFlowVersion,
+  mockContactProfileRefresh,
+  mockRecordProfileRefreshFailure,
+  mockResolveIntegrationContextFromContactInbox,
 } = vi.hoisted(() => {
   const mockDbSet = vi.fn()
   const updateChain = { set: mockDbSet, where: vi.fn() }
@@ -113,6 +116,19 @@ const {
     ),
     mockIsUniqueViolationError: vi.fn().mockReturnValue(false),
     mockDetectFlowVersion: vi.fn(),
+    // Default: a safe no-op result that never invokes `fetchProfile`, so
+    // unrelated tests (most of which now have a nameless `fakeContact` and
+    // therefore ARE eligible per `shouldRefreshContactProfile`) never
+    // trigger a Graph call or touch `resolveIntegrationContextFromContactInbox`
+    // unless a test explicitly overrides this mock to exercise the wiring.
+    mockContactProfileRefresh: vi
+      .fn()
+      .mockResolvedValue({ status: "skipped", reason: "profileComplete" }),
+    mockRecordProfileRefreshFailure: vi.fn().mockResolvedValue(undefined),
+    mockResolveIntegrationContextFromContactInbox: vi.fn().mockResolvedValue({
+      integration: { runChannelHandler: mockRunChannelHandler },
+      ctx: { workspaceId: "ws-1" },
+    }),
   }
 })
 
@@ -161,6 +177,27 @@ vi.mock("@chatbotx.io/database/schema", () => ({
   },
 }))
 
+// Mirror of the real capability table
+// (packages/business/src/contact/profile-refresh/rules.ts) — pure, so
+// re-implemented here rather than partially importing the real (heavy)
+// `@chatbotx.io/business` barrel, matching this file's existing convention
+// for `@chatbotx.io/sdk`'s pure helpers above.
+const CONTACT_PROFILE_NAME_CAPABILITIES: Record<
+  string,
+  { inbound: "payload" | "channelApi" | null; onDemand: boolean }
+> = {
+  messenger: { inbound: "channelApi", onDemand: true },
+  instagram: { inbound: "channelApi", onDemand: true },
+  zalo: { inbound: "channelApi", onDemand: true },
+  telegram: { inbound: "channelApi", onDemand: true },
+  whatsapp: { inbound: "payload", onDemand: false },
+  tiktok: { inbound: null, onDemand: false },
+  api: { inbound: "payload", onDemand: false },
+  webchat: { inbound: null, onDemand: false },
+  smtp: { inbound: null, onDemand: false },
+  omnichannel: { inbound: null, onDemand: false },
+}
+
 vi.mock("@chatbotx.io/business", () => ({
   appointmentService: {
     cancelAppointmentByToken: mockAppointmentCancelByToken,
@@ -169,6 +206,16 @@ vi.mock("@chatbotx.io/business", () => ({
   buildContext: mockBuildContext,
   resolveTenantSettings: mockresolveTenantSettings,
   updateContactFromMessage: mockUpdateContactFromMessage,
+  hasOnDemandProfileApi: (channel: string) =>
+    CONTACT_PROFILE_NAME_CAPABILITIES[channel]?.onDemand ?? false,
+  resolveInboundProfileNameSource: (channel: string) =>
+    CONTACT_PROFILE_NAME_CAPABILITIES[channel]?.inbound ?? null,
+  hasEmptyProfileName: (contact: {
+    firstName?: string | null
+    lastName?: string | null
+  }) => !(contact.firstName?.trim() || contact.lastName?.trim()),
+  contactProfileRefreshService: { refresh: mockContactProfileRefresh },
+  recordProfileRefreshFailure: mockRecordProfileRefreshFailure,
   contactInboxService: {
     updateTracking: mockUpdateTracking,
     invalidateTracking: mockInvalidateTracking,
@@ -313,10 +360,29 @@ vi.mock("../src/services/integrations", () => ({
     zalo: {
       runChannelHandler: mockRunChannelHandler,
     },
+    instagram: {
+      runChannelHandler: mockRunChannelHandler,
+    },
+    instagramFacebook: {
+      runChannelHandler: mockRunChannelHandler,
+    },
+    tiktok: {
+      runChannelHandler: mockRunChannelHandler,
+    },
+    webchat: {
+      runChannelHandler: mockRunChannelHandler,
+    },
+    api: {
+      runChannelHandler: mockRunChannelHandler,
+    },
   },
   integrationService: {
     identifyInboxAndIntegrationAuthFromIdentifier: vi.fn(),
   },
+  // Mirror of the real one-liner (apps/worker/src/services/integrations.ts).
+  isInstagramViaFacebook: (row: { type?: string }) => row.type === "facebook",
+  resolveIntegrationContextFromContactInbox:
+    mockResolveIntegrationContextFromContactInbox,
 }))
 
 // ---------------------------------------------------------------------------
@@ -1732,6 +1798,850 @@ describe("receiveMessage — referral-only events", () => {
         type: "runRef",
         data: expect.objectContaining({ ref: "ad-ref" }),
       }),
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Existing-contact profile refresh — post-save, all channels (Task 2 of
+// .superpowers/sdd/2026-08-31-messenger-ctm-profile-backfill). The business
+// rules (capability table, cooldown) are Task 1's, tested in
+// packages/business/__tests__/contact-profile-refresh.test.ts; this suite
+// only exercises the WORKER's wiring through the real `receiveMessage`
+// pipeline: eligibility, fetcher selection per channel, and the never-throws
+// guarantee.
+// ---------------------------------------------------------------------------
+
+describe("receiveMessage — existing contact profile refresh (post-save)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockFindContactInbox.mockResolvedValue({
+      ...fakeContactInbox,
+      contact: fakeContact,
+    })
+    mockFindOrFail.mockResolvedValue(fakeConversation)
+    mockConversationFindOrCreate.mockResolvedValue(fakeConversation)
+
+    vi.mocked(
+      integrationService.identifyInboxAndIntegrationAuthFromIdentifier,
+    ).mockResolvedValue({
+      inbox: fakeInbox,
+      integrationRow: fakeIntegrationRow,
+    } as never)
+
+    mockBuildContext.mockResolvedValue({ workspaceId: "ws-1" })
+    mockresolveTenantSettings.mockResolvedValue({
+      storageUrl: "https://files.example.test",
+    })
+    mockCreateMessageRepository.mockResolvedValue({
+      createOrUpdate: mockCreateOrUpdate,
+      createOrUpdateWithAttachments: mockCreateOrUpdateWithAttachments,
+    })
+    mockCreateOrUpdate.mockResolvedValue({
+      message: fakeCreatedMessage,
+      isNew: true,
+    })
+    mockWorkspaceIsActiveNow.mockReturnValue(true)
+    mockResolveIntegrationContextFromContactInbox.mockResolvedValue({
+      integration: { runChannelHandler: mockRunChannelHandler },
+      ctx: { workspaceId: "ws-1" },
+    })
+  })
+
+  test("named contact (has a name already) → refresh not called", async () => {
+    mockFindContactInbox.mockResolvedValue({
+      ...fakeContactInbox,
+      contact: { ...fakeContact, firstName: "Jane" },
+    })
+    mockRunChannelHandler.mockResolvedValue({
+      message: { ...baseIncomingMessage, attachments: [] },
+      contact: { sourceId: "psid-123" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+
+    await receiveMessage(baseProps)
+
+    expect(mockContactProfileRefresh).not.toHaveBeenCalled()
+  })
+
+  test("outgoing echo on an existing nameless contact → refresh not called", async () => {
+    mockRunChannelHandler.mockResolvedValue({
+      message: {
+        ...baseIncomingMessage,
+        messageType: "outgoing",
+        attachments: [],
+      },
+      contact: { sourceId: "psid-123" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+
+    await receiveMessage(baseProps)
+
+    expect(mockContactProfileRefresh).not.toHaveBeenCalled()
+  })
+
+  test("channel with inbound: null (webchat) → refresh not called even for a nameless existing contact", async () => {
+    const webchatInbox = { ...fakeInbox, channel: "webchat" }
+    vi.mocked(
+      integrationService.identifyInboxAndIntegrationAuthFromIdentifier,
+    ).mockResolvedValue({
+      inbox: webchatInbox,
+      integrationRow: fakeIntegrationRow,
+    } as never)
+    mockFindContactInbox.mockResolvedValue({
+      ...fakeContactInbox,
+      channel: "webchat",
+      contact: fakeContact,
+    })
+    mockRunChannelHandler.mockResolvedValue({
+      message: { ...baseIncomingMessage, attachments: [] },
+      contact: { sourceId: "psid-123" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+
+    await receiveMessage({ ...baseProps, integrationType: "webchat" })
+
+    expect(mockContactProfileRefresh).not.toHaveBeenCalled()
+    expect(mockResolveIntegrationContextFromContactInbox).not.toHaveBeenCalled()
+  })
+
+  test("tiktok nameless existing contact → refresh not called (inbound: null); a sourceId is never treated as a name", async () => {
+    const tiktokInbox = { ...fakeInbox, channel: "tiktok" }
+    vi.mocked(
+      integrationService.identifyInboxAndIntegrationAuthFromIdentifier,
+    ).mockResolvedValue({
+      inbox: tiktokInbox,
+      integrationRow: fakeIntegrationRow,
+    } as never)
+    mockFindContactInbox.mockResolvedValue({
+      ...fakeContactInbox,
+      channel: "tiktok",
+      contact: fakeContact,
+    })
+    mockRunChannelHandler.mockResolvedValue({
+      message: { ...baseIncomingMessage, attachments: [] },
+      contact: { sourceId: "tiktok-openid-1" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+
+    await receiveMessage({ ...baseProps, integrationType: "tiktok" })
+
+    expect(mockContactProfileRefresh).not.toHaveBeenCalled()
+  })
+
+  test("whatsapp payload with contacts[0].profile.name → applies it directly, no integration resolution and no Graph call", async () => {
+    const whatsappInbox = { ...fakeInbox, channel: "whatsapp" }
+    vi.mocked(
+      integrationService.identifyInboxAndIntegrationAuthFromIdentifier,
+    ).mockResolvedValue({
+      inbox: whatsappInbox,
+      integrationRow: fakeIntegrationRow,
+    } as never)
+    mockFindContactInbox.mockResolvedValue({
+      ...fakeContactInbox,
+      channel: "whatsapp",
+      contact: fakeContact,
+    })
+    mockRunChannelHandler.mockResolvedValue({
+      message: { ...baseIncomingMessage, attachments: [] },
+      // The channel already parsed contacts[0].profile.name into the SDK
+      // IncomingContact — this is the payload the fetcher must apply as-is.
+      contact: { sourceId: "psid-123", firstName: "Maria" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+    mockContactProfileRefresh.mockImplementation(async (input) => {
+      const profile = await input.fetchProfile()
+      return profile?.firstName
+        ? { status: "updated", contact: {} }
+        : { status: "unavailable" }
+    })
+
+    await receiveMessage({ ...baseProps, integrationType: "whatsapp" })
+
+    expect(mockContactProfileRefresh).toHaveBeenCalledWith(
+      expect.objectContaining({ source: "payload" }),
+    )
+    expect(mockResolveIntegrationContextFromContactInbox).not.toHaveBeenCalled()
+    expect(mockRunChannelHandler).not.toHaveBeenCalledWith(
+      "contact",
+      "getProfile",
+      expect.anything(),
+    )
+  })
+
+  test("whatsapp payload without a name → unavailable, no local cooldown gate; a later message tries again", async () => {
+    const whatsappInbox = { ...fakeInbox, channel: "whatsapp" }
+    vi.mocked(
+      integrationService.identifyInboxAndIntegrationAuthFromIdentifier,
+    ).mockResolvedValue({
+      inbox: whatsappInbox,
+      integrationRow: fakeIntegrationRow,
+    } as never)
+    mockFindContactInbox.mockResolvedValue({
+      ...fakeContactInbox,
+      channel: "whatsapp",
+      contact: fakeContact,
+    })
+    mockRunChannelHandler.mockResolvedValue({
+      message: { ...baseIncomingMessage, attachments: [] },
+      contact: { sourceId: "psid-123" }, // no name in the payload
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+    mockContactProfileRefresh.mockResolvedValue({ status: "unavailable" })
+
+    await receiveMessage({ ...baseProps, integrationType: "whatsapp" })
+    expect(mockContactProfileRefresh).toHaveBeenCalledTimes(1)
+
+    // The worker adds no gate of its own — a later message is still a
+    // candidate; the service (Task 1, tested there) owns the cooldown.
+    await receiveMessage({ ...baseProps, integrationType: "whatsapp" })
+    expect(mockContactProfileRefresh).toHaveBeenCalledTimes(2)
+  })
+
+  test("api channel: payload source, same as whatsapp", async () => {
+    const apiInbox = { ...fakeInbox, channel: "api" }
+    vi.mocked(
+      integrationService.identifyInboxAndIntegrationAuthFromIdentifier,
+    ).mockResolvedValue({
+      inbox: apiInbox,
+      integrationRow: fakeIntegrationRow,
+    } as never)
+    mockFindContactInbox.mockResolvedValue({
+      ...fakeContactInbox,
+      channel: "api",
+      contact: fakeContact,
+    })
+    mockRunChannelHandler.mockResolvedValue({
+      message: { ...baseIncomingMessage, attachments: [] },
+      contact: { sourceId: "psid-123", firstName: "API Contact" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+
+    await receiveMessage({ ...baseProps, integrationType: "api" })
+
+    expect(mockContactProfileRefresh).toHaveBeenCalledWith(
+      expect.objectContaining({ source: "payload" }),
+    )
+    expect(mockResolveIntegrationContextFromContactInbox).not.toHaveBeenCalled()
+  })
+
+  test("telegram nameless existing contact → getProfile (getChat) called with the contactInbox's own sourceId, ignoring any name on the payload", async () => {
+    const telegramInbox = { ...fakeInbox, channel: "telegram" }
+    const telegramContactInbox = {
+      ...fakeContactInbox,
+      channel: "telegram",
+      sourceId: "tg-chat-1",
+    }
+    vi.mocked(
+      integrationService.identifyInboxAndIntegrationAuthFromIdentifier,
+    ).mockResolvedValue({
+      inbox: telegramInbox,
+      integrationRow: fakeIntegrationRow,
+    } as never)
+    mockFindContactInbox.mockResolvedValue({
+      ...telegramContactInbox,
+      contact: fakeContact,
+    })
+    mockRunChannelHandler.mockImplementation(
+      (_domain: string, action: string) => {
+        if (action === "getProfile") {
+          return Promise.resolve({ firstName: "Alex" })
+        }
+        return Promise.resolve({
+          message: { ...baseIncomingMessage, attachments: [] },
+          // A group-chat callback query names the clicking user here, not
+          // the chat's own identity — the payload source must never be
+          // used for telegram (capability table: inbound = "channelApi").
+          contact: { sourceId: "tg-chat-1", firstName: "Whoever Clicked" },
+          postbackAction: null,
+          quickReplyAction: null,
+          ref: null,
+        })
+      },
+    )
+    mockContactProfileRefresh.mockImplementation(async (input) => {
+      await input.fetchProfile()
+      return { status: "updated", contact: {} }
+    })
+
+    await receiveMessage({ ...baseProps, integrationType: "telegram" })
+
+    expect(mockContactProfileRefresh).toHaveBeenCalledWith(
+      expect.objectContaining({ source: "channelApi" }),
+    )
+    expect(mockResolveIntegrationContextFromContactInbox).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      contactInbox: expect.objectContaining({ sourceId: "tg-chat-1" }),
+    })
+    expect(mockRunChannelHandler).toHaveBeenCalledWith(
+      "contact",
+      "getProfile",
+      {
+        ctx: { workspaceId: "ws-1" },
+        data: { sourceId: "tg-chat-1" },
+      },
+    )
+  })
+
+  test("instagram: the channelApi fetcher delegates registry dispatch to resolveIntegrationContextFromContactInbox (direct vs via-Facebook is invisible here)", async () => {
+    const instagramInbox = { ...fakeInbox, channel: "instagram" }
+    vi.mocked(
+      integrationService.identifyInboxAndIntegrationAuthFromIdentifier,
+    ).mockResolvedValue({
+      inbox: instagramInbox,
+      integrationRow: fakeIntegrationRow,
+    } as never)
+    mockFindContactInbox.mockResolvedValue({
+      ...fakeContactInbox,
+      channel: "instagram",
+      contact: fakeContact,
+    })
+    mockRunChannelHandler.mockResolvedValue({
+      message: { ...baseIncomingMessage, attachments: [] },
+      contact: { sourceId: "psid-123" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+    // Standing in for `resolveIntegrationContextFromContactInbox` picking
+    // the `instagramFacebook` registry (its own existing, unit-tested
+    // behaviour) — this test only proves our fetcher uses whatever it
+    // resolves rather than re-implementing the dispatch itself.
+    const instagramFacebookRunChannelHandler = vi
+      .fn()
+      .mockResolvedValue({ firstName: "Via FB" })
+    mockResolveIntegrationContextFromContactInbox.mockResolvedValue({
+      integration: { runChannelHandler: instagramFacebookRunChannelHandler },
+      ctx: { workspaceId: "ws-1" },
+    })
+    mockContactProfileRefresh.mockImplementation(async (input) => {
+      await input.fetchProfile()
+      return { status: "updated", contact: {} }
+    })
+
+    await receiveMessage({ ...baseProps, integrationType: "instagram" })
+
+    expect(mockResolveIntegrationContextFromContactInbox).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      contactInbox: expect.objectContaining({ channel: "instagram" }),
+    })
+    expect(instagramFacebookRunChannelHandler).toHaveBeenCalledWith(
+      "contact",
+      "getProfile",
+      expect.objectContaining({ data: { sourceId: "psid-123" } }),
+    )
+  })
+
+  test("zalo nameless existing contact → getProfile called, display_name applied", async () => {
+    const zaloInbox = { ...fakeInbox, channel: "zalo" }
+    vi.mocked(
+      integrationService.identifyInboxAndIntegrationAuthFromIdentifier,
+    ).mockResolvedValue({
+      inbox: zaloInbox,
+      integrationRow: fakeIntegrationRow,
+    } as never)
+    mockFindContactInbox.mockResolvedValue({
+      ...fakeContactInbox,
+      channel: "zalo",
+      contact: fakeContact,
+    })
+    mockRunChannelHandler.mockImplementation(
+      (_domain: string, action: string) => {
+        if (action === "getProfile") {
+          // The zalo integration maps `display_name` onto `firstName`.
+          return Promise.resolve({ firstName: "Nguyen Van A" })
+        }
+        return Promise.resolve({
+          message: { ...baseIncomingMessage, attachments: [] },
+          contact: { sourceId: "psid-123" },
+          postbackAction: null,
+          quickReplyAction: null,
+          ref: null,
+        })
+      },
+    )
+    mockContactProfileRefresh.mockImplementation(async (input) => {
+      const profile = await input.fetchProfile()
+      return profile?.firstName
+        ? { status: "updated", contact: {} }
+        : { status: "unavailable" }
+    })
+
+    await receiveMessage({ ...baseProps, integrationType: "zalo" })
+
+    expect(mockContactProfileRefresh).toHaveBeenCalledWith(
+      expect.objectContaining({ source: "channelApi" }),
+    )
+    expect(mockRunChannelHandler).toHaveBeenCalledWith(
+      "contact",
+      "getProfile",
+      {
+        ctx: { workspaceId: "ws-1" },
+        data: { sourceId: "psid-123" },
+      },
+    )
+  })
+
+  test("zalo display_name blank → unavailable (cooldown remains the service's responsibility)", async () => {
+    const zaloInbox = { ...fakeInbox, channel: "zalo" }
+    vi.mocked(
+      integrationService.identifyInboxAndIntegrationAuthFromIdentifier,
+    ).mockResolvedValue({
+      inbox: zaloInbox,
+      integrationRow: fakeIntegrationRow,
+    } as never)
+    mockFindContactInbox.mockResolvedValue({
+      ...fakeContactInbox,
+      channel: "zalo",
+      contact: fakeContact,
+    })
+    mockRunChannelHandler.mockResolvedValue({
+      message: { ...baseIncomingMessage, attachments: [] },
+      contact: { sourceId: "psid-123" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+    mockContactProfileRefresh.mockResolvedValue({ status: "unavailable" })
+
+    await receiveMessage({ ...baseProps, integrationType: "zalo" })
+
+    expect(mockContactProfileRefresh).toHaveBeenCalledWith(
+      expect.objectContaining({ source: "channelApi" }),
+    )
+  })
+
+  test("duplicate webhook (isNewMessage === false) → the service is still called (owner decision)", async () => {
+    mockCreateOrUpdate.mockResolvedValue({
+      message: fakeCreatedMessage,
+      isNew: false,
+    })
+    mockRunChannelHandler.mockResolvedValue({
+      message: { ...baseIncomingMessage, attachments: [] },
+      contact: { sourceId: "psid-123" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+
+    await receiveMessage(baseProps)
+
+    expect(mockContactProfileRefresh).toHaveBeenCalled()
+  })
+
+  test("a new contact created by a text message whose creation-path getProfile failed still gets a refresh attempt in the same job (owner decision)", async () => {
+    mockFindContactInbox.mockResolvedValue(undefined)
+    mockWorkspaceFind.mockResolvedValue({ ownerId: "owner-1" })
+    mockRunChannelHandler.mockImplementation(
+      (_domain: string, action: string) => {
+        if (action === "getProfile") {
+          return Promise.reject(new Error("consent required"))
+        }
+        return Promise.resolve({
+          message: { ...baseIncomingMessage, attachments: [] },
+          contact: { sourceId: "psid-123" },
+          postbackAction: null,
+          quickReplyAction: null,
+          ref: null,
+        })
+      },
+    )
+    mockCreateNewContactWithMac.mockResolvedValue({
+      ok: true,
+      value: {
+        newContact: {
+          id: "contact-new",
+          workspaceId: "ws-1",
+          firstName: null,
+          lastName: null,
+          phoneNumber: null,
+          email: null,
+          blockedAt: null,
+          createdAt: new Date("2026-06-21T00:00:00Z"),
+        },
+        contactInbox: {
+          ...fakeContactInbox,
+          id: "ci-new",
+          contactId: "contact-new",
+        },
+        conversation: fakeConversation,
+      },
+    })
+    mockCreateOrUpdate.mockResolvedValue({
+      message: { ...fakeCreatedMessage, contactInboxId: "ci-new" },
+      isNew: true,
+    })
+
+    await receiveMessage(baseProps)
+
+    expect(mockRecordProfileRefreshFailure).toHaveBeenCalled()
+    expect(mockContactProfileRefresh).toHaveBeenCalledWith(
+      expect.objectContaining({ contactId: "contact-new" }),
+    )
+  })
+
+  test("creation path: if recordProfileRefreshFailure itself rejects, the contact is still created", async () => {
+    mockFindContactInbox.mockResolvedValue(undefined)
+    mockWorkspaceFind.mockResolvedValue({ ownerId: "owner-1" })
+    mockRunChannelHandler.mockImplementation(
+      (_domain: string, action: string) => {
+        if (action === "getProfile") {
+          return Promise.reject(new Error("consent required"))
+        }
+        return Promise.resolve({
+          message: { ...baseIncomingMessage, attachments: [] },
+          contact: { sourceId: "psid-123" },
+          postbackAction: null,
+          quickReplyAction: null,
+          ref: null,
+        })
+      },
+    )
+    mockRecordProfileRefreshFailure.mockRejectedValueOnce(
+      new Error("error-log stream down"),
+    )
+    mockCreateNewContactWithMac.mockResolvedValue({
+      ok: true,
+      value: {
+        newContact: {
+          id: "contact-new",
+          workspaceId: "ws-1",
+          firstName: null,
+          lastName: null,
+          phoneNumber: null,
+          email: null,
+          blockedAt: null,
+          createdAt: new Date("2026-06-21T00:00:00Z"),
+        },
+        contactInbox: {
+          ...fakeContactInbox,
+          id: "ci-new",
+          contactId: "contact-new",
+        },
+        conversation: fakeConversation,
+      },
+    })
+
+    await expect(receiveMessage(baseProps)).resolves.toBeDefined()
+    expect(mockCreateMessageRepository).toHaveBeenCalled()
+  })
+
+  test("if the profile-refresh service throws unexpectedly, receiveMessage still resolves and a warning is logged", async () => {
+    mockContactProfileRefresh.mockRejectedValue(new Error("boom"))
+    mockRunChannelHandler.mockResolvedValue({
+      message: { ...baseIncomingMessage, attachments: [] },
+      contact: { sourceId: "psid-123" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+
+    await expect(receiveMessage(baseProps)).resolves.toBeDefined()
+    expect(logger.warn).toHaveBeenCalled()
+  })
+
+  test("two concurrent inbound messages from the same nameless contact → both persist, refresh runs for both (no lock)", async () => {
+    mockRunChannelHandler.mockResolvedValue({
+      message: { ...baseIncomingMessage, attachments: [] },
+      contact: { sourceId: "psid-123" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+    mockContactProfileRefresh.mockImplementation(async (input) => {
+      await input.fetchProfile()
+      return { status: "updated", contact: {} }
+    })
+
+    await Promise.all([receiveMessage(baseProps), receiveMessage(baseProps)])
+
+    expect(mockCreateOrUpdate).toHaveBeenCalledTimes(2)
+    expect(mockContactProfileRefresh).toHaveBeenCalledTimes(2)
+  })
+
+  test("no worker-side cooldown gate: the service is called on every eligible message, even immediately after a failed/cooling-down attempt", async () => {
+    mockRunChannelHandler.mockResolvedValue({
+      message: { ...baseIncomingMessage, attachments: [] },
+      contact: { sourceId: "psid-123" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+    mockContactProfileRefresh
+      .mockResolvedValueOnce({ status: "failed" })
+      .mockResolvedValueOnce({ status: "skipped", reason: "coolingDown" })
+      .mockResolvedValueOnce({ status: "updated", contact: {} })
+
+    await receiveMessage(baseProps)
+    await receiveMessage(baseProps)
+    await receiveMessage(baseProps)
+
+    expect(mockContactProfileRefresh).toHaveBeenCalledTimes(3)
+  })
+
+  test("instagram: a referral-only event still fetches getProfile at creation time via hasOnDemandProfileApi (replaces canGetUserProfileIfNeeded)", async () => {
+    const instagramInbox = { ...fakeInbox, channel: "instagram" }
+    vi.mocked(
+      integrationService.identifyInboxAndIntegrationAuthFromIdentifier,
+    ).mockResolvedValue({
+      inbox: instagramInbox,
+      integrationRow: fakeIntegrationRow,
+    } as never)
+    mockFindContactInbox.mockResolvedValue(undefined)
+    mockWorkspaceFind.mockResolvedValue({ ownerId: "owner-1" })
+    mockRunChannelHandler.mockImplementation(
+      (_domain: string, action: string) => {
+        if (action === "getProfile") {
+          return Promise.resolve({ firstName: "IG Contact" })
+        }
+        return Promise.resolve({
+          message: null,
+          contact: { sourceId: "ig-psid-1" },
+          postbackAction: null,
+          quickReplyAction: null,
+          ref: "ad-ref",
+          referralSource: "ADS",
+          referral: { ref: "ad-ref", source: "ADS", type: "OPEN_THREAD" },
+        })
+      },
+    )
+    mockCreateNewContactWithMac.mockResolvedValue({
+      ok: true,
+      value: {
+        newContact: {
+          id: "contact-ig-new",
+          workspaceId: "ws-1",
+          firstName: "IG Contact",
+          phoneNumber: null,
+          email: null,
+          blockedAt: null,
+          createdAt: new Date("2026-06-21T00:00:00Z"),
+        },
+        contactInbox: {
+          ...fakeContactInbox,
+          id: "ci-ig-new",
+          contactId: "contact-ig-new",
+          channel: "instagram",
+        },
+        conversation: fakeConversation,
+      },
+    })
+
+    await receiveMessage({ ...baseProps, integrationType: "instagram" })
+
+    expect(mockRunChannelHandler).toHaveBeenCalledWith(
+      "contact",
+      "getProfile",
+      expect.objectContaining({ data: { sourceId: "ig-psid-1" } }),
+    )
+  })
+
+  test("zalo: a new contact creation still fetches getProfile at creation time via hasOnDemandProfileApi", async () => {
+    mockFindContactInbox.mockResolvedValue(undefined)
+    mockWorkspaceFind.mockResolvedValue({ ownerId: "owner-1" })
+    const zaloInbox = { ...fakeInbox, channel: "zalo" }
+    vi.mocked(
+      integrationService.identifyInboxAndIntegrationAuthFromIdentifier,
+    ).mockResolvedValue({
+      inbox: zaloInbox,
+      integrationRow: fakeIntegrationRow,
+    } as never)
+    mockRunChannelHandler.mockImplementation(
+      (_domain: string, action: string) => {
+        if (action === "getProfile") {
+          return Promise.resolve({ firstName: "Zalo Contact" })
+        }
+        return Promise.resolve({
+          message: { ...baseIncomingMessage, attachments: [] },
+          contact: { sourceId: "zalo-psid-1" },
+          postbackAction: null,
+          quickReplyAction: null,
+          ref: null,
+        })
+      },
+    )
+    mockCreateNewContactWithMac.mockResolvedValue({
+      ok: true,
+      value: {
+        newContact: {
+          id: "contact-zalo-new",
+          workspaceId: "ws-1",
+          firstName: "Zalo Contact",
+          phoneNumber: null,
+          email: null,
+          blockedAt: null,
+          createdAt: new Date("2026-06-21T00:00:00Z"),
+        },
+        contactInbox: {
+          ...fakeContactInbox,
+          id: "ci-zalo-new",
+          contactId: "contact-zalo-new",
+          channel: "zalo",
+        },
+        conversation: fakeConversation,
+      },
+    })
+    mockCreateOrUpdate.mockResolvedValue({
+      message: { ...fakeCreatedMessage, contactInboxId: "ci-zalo-new" },
+      isNew: true,
+    })
+
+    await receiveMessage({ ...baseProps, integrationType: "zalo" })
+
+    expect(mockRunChannelHandler).toHaveBeenCalledWith(
+      "contact",
+      "getProfile",
+      expect.objectContaining({ data: { sourceId: "zalo-psid-1" } }),
+    )
+  })
+
+  test("CTM sequence: a referral-only creation whose getProfile fetch failed, then a text message from the same PSID triggers the refresh after the message is persisted", async () => {
+    // --- Call 1: referral-only event, brand-new contact -------------------
+    mockFindContactInbox.mockResolvedValueOnce(undefined)
+    mockWorkspaceFind.mockResolvedValue({ ownerId: "owner-1" })
+    mockRunChannelHandler.mockImplementation(
+      (_domain: string, action: string) => {
+        if (action === "getProfile") {
+          return Promise.reject({
+            code: 2_018_218,
+            message: "consent required",
+          })
+        }
+        return Promise.resolve({
+          message: null,
+          contact: { sourceId: "psid-ctm" },
+          postbackAction: null,
+          quickReplyAction: null,
+          ref: "ad-ref",
+          referralSource: "ADS",
+          referral: {
+            ref: "ad-ref",
+            source: "ADS",
+            type: "OPEN_THREAD",
+            adId: "ad-1",
+          },
+        })
+      },
+    )
+    mockCreateNewContactWithMac.mockResolvedValue({
+      ok: true,
+      value: {
+        newContact: {
+          id: "contact-ctm",
+          workspaceId: "ws-1",
+          firstName: null,
+          lastName: null,
+          phoneNumber: null,
+          email: null,
+          blockedAt: null,
+          createdAt: new Date("2026-06-21T00:00:00Z"),
+        },
+        contactInbox: {
+          ...fakeContactInbox,
+          id: "ci-ctm",
+          contactId: "contact-ctm",
+          sourceId: "psid-ctm",
+        },
+        conversation: fakeConversation,
+      },
+    })
+
+    await receiveMessage(baseProps)
+
+    // No message on a referral-only event → the `if (incomingMessage)`
+    // block (where the refresh call lives) never runs; only the
+    // creation-path failure is recorded, with no cooldown possible from
+    // this path (the service, and therefore the cooldown, is never called).
+    expect(mockContactProfileRefresh).not.toHaveBeenCalled()
+    expect(mockRecordProfileRefreshFailure).toHaveBeenCalled()
+
+    // --- Call 2: a real text message from the same PSID --------------------
+    mockFindContactInbox.mockResolvedValue({
+      ...fakeContactInbox,
+      id: "ci-ctm",
+      contactId: "contact-ctm",
+      sourceId: "psid-ctm",
+      contact: {
+        id: "contact-ctm",
+        workspaceId: "ws-1",
+        firstName: null,
+        lastName: null,
+      },
+    })
+    mockRunChannelHandler.mockImplementation(
+      (_domain: string, action: string) => {
+        if (action === "getProfile") {
+          return Promise.resolve({ firstName: "Jane", lastName: "Doe" })
+        }
+        return Promise.resolve({
+          message: {
+            ...baseIncomingMessage,
+            sourceId: "msg-ctm-2",
+            attachments: [],
+          },
+          contact: { sourceId: "psid-ctm" },
+          postbackAction: null,
+          quickReplyAction: null,
+          ref: null,
+        })
+      },
+    )
+    mockCreateOrUpdate.mockResolvedValue({
+      message: {
+        ...fakeCreatedMessage,
+        id: "msg-ctm-2",
+        contactInboxId: "ci-ctm",
+      },
+      isNew: true,
+    })
+    mockContactProfileRefresh.mockImplementation(async (input) => {
+      await input.fetchProfile()
+      return {
+        status: "updated",
+        contact: { id: "contact-ctm", firstName: "Jane", lastName: "Doe" },
+      }
+    })
+
+    await receiveMessage(baseProps)
+
+    expect(mockContactProfileRefresh).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contactId: "contact-ctm",
+        source: "channelApi",
+      }),
+    )
+    expect(mockRunChannelHandler).toHaveBeenCalledWith(
+      "contact",
+      "getProfile",
+      {
+        ctx: { workspaceId: "ws-1" },
+        data: { sourceId: "psid-ctm" },
+      },
+    )
+    // The message row is persisted before the refresh runs — both happen
+    // inside the same `receiveMessage` call, and the refresh is awaited
+    // before it returns, so `receiveMessage` resolving already proves the
+    // refresh (and therefore the mocked `contactService.update` inside it)
+    // completed before anything `worker.ts`'s `incomingMessage` case does
+    // afterwards (e.g. enqueueing `processAutomatedResponse`) — see
+    // apps/worker/src/integration/worker.ts:82-160.
+    expect(mockCreateOrUpdate.mock.invocationCallOrder[0]).toBeLessThan(
+      mockContactProfileRefresh.mock.invocationCallOrder[0],
     )
   })
 })

--- a/apps/worker/__tests__/received-message.test.ts
+++ b/apps/worker/__tests__/received-message.test.ts
@@ -2343,52 +2343,6 @@ describe("receiveMessage — existing contact profile refresh (post-save)", () =
     )
   })
 
-  test("creation path: if recordProfileRefreshFailure itself rejects, the contact is still created", async () => {
-    mockFindContactInbox.mockResolvedValue(undefined)
-    mockWorkspaceFind.mockResolvedValue({ ownerId: "owner-1" })
-    mockRunChannelHandler.mockImplementation(
-      (_domain: string, action: string) => {
-        if (action === "getProfile") {
-          return Promise.reject(new Error("consent required"))
-        }
-        return Promise.resolve({
-          message: { ...baseIncomingMessage, attachments: [] },
-          contact: { sourceId: "psid-123" },
-          postbackAction: null,
-          quickReplyAction: null,
-          ref: null,
-        })
-      },
-    )
-    mockRecordProfileRefreshFailure.mockRejectedValueOnce(
-      new Error("error-log stream down"),
-    )
-    mockCreateNewContactWithMac.mockResolvedValue({
-      ok: true,
-      value: {
-        newContact: {
-          id: "contact-new",
-          workspaceId: "ws-1",
-          firstName: null,
-          lastName: null,
-          phoneNumber: null,
-          email: null,
-          blockedAt: null,
-          createdAt: new Date("2026-06-21T00:00:00Z"),
-        },
-        contactInbox: {
-          ...fakeContactInbox,
-          id: "ci-new",
-          contactId: "contact-new",
-        },
-        conversation: fakeConversation,
-      },
-    })
-
-    await expect(receiveMessage(baseProps)).resolves.toBeDefined()
-    expect(mockCreateMessageRepository).toHaveBeenCalled()
-  })
-
   test("if the profile-refresh service throws unexpectedly, receiveMessage still resolves and a warning is logged", async () => {
     mockContactProfileRefresh.mockRejectedValue(new Error("boom"))
     mockRunChannelHandler.mockResolvedValue({

--- a/apps/worker/src/integration/handlers/contact-profile-refresh.ts
+++ b/apps/worker/src/integration/handlers/contact-profile-refresh.ts
@@ -55,6 +55,31 @@ type InboundFetcherDeps = {
   incomingContact: IncomingContact
 }
 
+// Name-related fields only. `locale`/`timezone`/`gender` are deliberately
+// NOT forwarded here even when the webhook payload carries them: those
+// columns are only trustworthy once `finalizeContactProfile` has normalized
+// them at contact-creation time (locale normalization, phone-derived
+// timezone), and a later inbound message must never clobber that finalized
+// value with the raw, unnormalized payload value.
+const PAYLOAD_NAME_FIELDS = [
+  "firstName",
+  "lastName",
+  "avatar",
+] as const satisfies readonly (keyof IncomingContact)[]
+
+const pickPayloadNameFields = (
+  incomingContact: IncomingContact,
+): IncomingContact => {
+  const picked: IncomingContact = { sourceId: incomingContact.sourceId }
+  for (const field of PAYLOAD_NAME_FIELDS) {
+    const value = incomingContact[field]
+    if (value !== undefined) {
+      picked[field] = value
+    }
+  }
+  return picked
+}
+
 // Strategy table keyed by `ContactProfileNameSource` — exhaustive via
 // `Record`, so adding a source is one row, never a branch.
 const inboundProfileFetchers: Record<
@@ -62,10 +87,11 @@ const inboundProfileFetchers: Record<
   (deps: InboundFetcherDeps) => ContactProfileFetcher
 > = {
   // What the channel already parsed from the webhook — no network call.
+  // Filtered to name-related fields only; see `pickPayloadNameFields`.
   payload:
     ({ incomingContact }) =>
     () =>
-      Promise.resolve(incomingContact),
+      Promise.resolve(pickPayloadNameFields(incomingContact)),
   // Lazy: integration resolution (and the Graph call itself) only happens
   // when this callback runs, so a missing/disconnected integration surfaces
   // inside `contactProfileRefreshService.refresh` as `failed` + cooldown

--- a/apps/worker/src/integration/handlers/contact-profile-refresh.ts
+++ b/apps/worker/src/integration/handlers/contact-profile-refresh.ts
@@ -11,13 +11,26 @@ import type { ContactInboxModel, InboxModel } from "@chatbotx.io/database/types"
 import type { IncomingContact, IncomingMessage } from "@chatbotx.io/sdk"
 import { logger } from "../../lib/logger"
 import { resolveIntegrationContextFromContactInbox } from "../../services/integrations"
-import { isInboundConversationMessage } from "./received-message"
 
 export type ProfileRefreshCandidate = {
   channel: ChannelType
   incomingMessage: IncomingMessage
   contact: ContactProfileName
 }
+
+// "Real inbound" = not an echo/outgoing send, and not a non-message row
+// (e.g. an `activity` reaction row) — owned here (not received-message.ts)
+// so this module's eligibility rule table below doesn't have to import from
+// received-message.ts, which itself imports this module's
+// `refreshExistingContactProfile`/`shouldRefreshContactProfile` (that cycle
+// used to only work because the binding was resolved lazily at call time).
+// received-message.ts imports this back for its own
+// `getMessageActivityTracking` so "inbound" means the same thing everywhere.
+export const isInboundConversationMessage = (
+  incomingMessage: IncomingMessage,
+): boolean =>
+  incomingMessage.messageType !== "outgoing" &&
+  (incomingMessage.type ?? "message") === "message"
 
 // Declarative rule table — every branch is a single-purpose predicate over
 // values already in scope; adding/removing a rule never touches call sites.

--- a/apps/worker/src/integration/handlers/contact-profile-refresh.ts
+++ b/apps/worker/src/integration/handlers/contact-profile-refresh.ts
@@ -1,0 +1,124 @@
+import {
+  type ContactProfileFetcher,
+  type ContactProfileName,
+  type ContactProfileNameSource,
+  contactProfileRefreshService,
+  hasEmptyProfileName,
+  resolveInboundProfileNameSource,
+} from "@chatbotx.io/business"
+import type { ChannelType } from "@chatbotx.io/database/partials"
+import type { ContactInboxModel, InboxModel } from "@chatbotx.io/database/types"
+import type { IncomingContact, IncomingMessage } from "@chatbotx.io/sdk"
+import { logger } from "../../lib/logger"
+import { resolveIntegrationContextFromContactInbox } from "../../services/integrations"
+import { isInboundConversationMessage } from "./received-message"
+
+export type ProfileRefreshCandidate = {
+  channel: ChannelType
+  incomingMessage: IncomingMessage
+  contact: ContactProfileName
+}
+
+// Declarative rule table — every branch is a single-purpose predicate over
+// values already in scope; adding/removing a rule never touches call sites.
+const profileRefreshRules: ReadonlyArray<
+  (candidate: ProfileRefreshCandidate) => boolean
+> = [
+  // The capability table says this channel can source a name at all.
+  (candidate) => resolveInboundProfileNameSource(candidate.channel) !== null,
+  // A real inbound message — not an echo/outgoing send, not an activity row.
+  (candidate) => isInboundConversationMessage(candidate.incomingMessage),
+  // Both firstName and lastName are blank.
+  (candidate) => hasEmptyProfileName(candidate.contact),
+]
+
+export const shouldRefreshContactProfile = (
+  candidate: ProfileRefreshCandidate,
+): boolean => profileRefreshRules.every((rule) => rule(candidate))
+
+type InboundFetcherDeps = {
+  inbox: InboxModel
+  contactInbox: ContactInboxModel
+  incomingContact: IncomingContact
+}
+
+// Strategy table keyed by `ContactProfileNameSource` — exhaustive via
+// `Record`, so adding a source is one row, never a branch.
+const inboundProfileFetchers: Record<
+  ContactProfileNameSource,
+  (deps: InboundFetcherDeps) => ContactProfileFetcher
+> = {
+  // What the channel already parsed from the webhook — no network call.
+  payload:
+    ({ incomingContact }) =>
+    () =>
+      Promise.resolve(incomingContact),
+  // Lazy: integration resolution (and the Graph call itself) only happens
+  // when this callback runs, so a missing/disconnected integration surfaces
+  // inside `contactProfileRefreshService.refresh` as `failed` + cooldown
+  // instead of throwing before the service can decide anything.
+  channelApi:
+    ({ inbox, contactInbox }) =>
+    async () => {
+      const { integration, ctx } =
+        await resolveIntegrationContextFromContactInbox({
+          workspaceId: inbox.workspaceId,
+          contactInbox,
+        })
+      return integration.runChannelHandler("contact", "getProfile", {
+        ctx,
+        data: { sourceId: contactInbox.sourceId },
+      })
+    },
+}
+
+export type RefreshExistingContactProfileInput = {
+  inbox: InboxModel
+  contactInbox: ContactInboxModel
+  incomingContact: IncomingContact
+  contactId: string
+}
+
+/**
+ * Best-effort refresh of a nameless existing contact's profile after an
+ * inbound message has been persisted. Never throws — every failure path
+ * (including an unexpected one from the service itself) is caught and
+ * logged so the receive job can never be rejected by profile work (owner
+ * mandate). The outcome is logged at `debug`.
+ */
+export const refreshExistingContactProfile = async (
+  input: RefreshExistingContactProfileInput,
+): Promise<void> => {
+  const { inbox, contactInbox, incomingContact, contactId } = input
+  const source = resolveInboundProfileNameSource(inbox.channel as ChannelType)
+  // Unreachable when the caller gates on `shouldRefreshContactProfile`
+  // first (it checks the same table row) — kept for type safety and as a
+  // last line of defence against a direct call.
+  if (!source) {
+    return
+  }
+
+  try {
+    const fetchProfile = inboundProfileFetchers[source]({
+      inbox,
+      contactInbox,
+      incomingContact,
+    })
+    const result = await contactProfileRefreshService.refresh({
+      workspaceId: inbox.workspaceId,
+      contactId,
+      contactInbox,
+      source,
+      fetchProfile,
+    })
+    logger.debug(
+      { result, contactId, channel: inbox.channel },
+      "refreshExistingContactProfile: result",
+    )
+  } catch (error) {
+    logger.warn(
+      { error, contactId, channel: inbox.channel },
+      "refreshExistingContactProfile: unexpected error",
+    )
+  }
+}

--- a/apps/worker/src/integration/handlers/contact-profile-refresh.ts
+++ b/apps/worker/src/integration/handlers/contact-profile-refresh.ts
@@ -19,35 +19,35 @@ export type ProfileRefreshCandidate = {
 }
 
 // "Real inbound" = not an echo/outgoing send, and not a non-message row
-// (e.g. an `activity` reaction row) — owned here (not received-message.ts)
-// so this module's eligibility rule table below doesn't have to import from
-// received-message.ts, which itself imports this module's
-// `refreshExistingContactProfile`/`shouldRefreshContactProfile` (that cycle
-// used to only work because the binding was resolved lazily at call time).
-// received-message.ts imports this back for its own
-// `getMessageActivityTracking` so "inbound" means the same thing everywhere.
+// (e.g. an `activity` reaction row) — owned here so received-message.ts's
+// `getMessageActivityTracking` can import it back and mean the same thing.
 export const isInboundConversationMessage = (
   incomingMessage: IncomingMessage,
 ): boolean =>
   incomingMessage.messageType !== "outgoing" &&
   (incomingMessage.type ?? "message") === "message"
 
-// Declarative rule table — every branch is a single-purpose predicate over
-// values already in scope; adding/removing a rule never touches call sites.
-const profileRefreshRules: ReadonlyArray<
-  (candidate: ProfileRefreshCandidate) => boolean
-> = [
-  // The capability table says this channel can source a name at all.
-  (candidate) => resolveInboundProfileNameSource(candidate.channel) !== null,
-  // A real inbound message — not an echo/outgoing send, not an activity row.
-  (candidate) => isInboundConversationMessage(candidate.incomingMessage),
-  // Both firstName and lastName are blank.
-  (candidate) => hasEmptyProfileName(candidate.contact),
-]
-
-export const shouldRefreshContactProfile = (
+/**
+ * The channel/message/contact eligibility gate, collapsed to the source the
+ * caller needs: `null` when any check fails, otherwise the source to fetch
+ * with. Order matches the old rule table — capability, then real-inbound,
+ * then name-empty.
+ */
+export const getProfileRefreshSource = (
   candidate: ProfileRefreshCandidate,
-): boolean => profileRefreshRules.every((rule) => rule(candidate))
+): ContactProfileNameSource | null => {
+  const source = resolveInboundProfileNameSource(candidate.channel)
+  if (
+    !(
+      source &&
+      isInboundConversationMessage(candidate.incomingMessage) &&
+      hasEmptyProfileName(candidate.contact)
+    )
+  ) {
+    return null
+  }
+  return source
+}
 
 type InboundFetcherDeps = {
   inbox: InboxModel
@@ -112,6 +112,7 @@ const inboundProfileFetchers: Record<
 }
 
 export type RefreshExistingContactProfileInput = {
+  source: ContactProfileNameSource
   inbox: InboxModel
   contactInbox: ContactInboxModel
   incomingContact: IncomingContact
@@ -128,14 +129,7 @@ export type RefreshExistingContactProfileInput = {
 export const refreshExistingContactProfile = async (
   input: RefreshExistingContactProfileInput,
 ): Promise<void> => {
-  const { inbox, contactInbox, incomingContact, contactId } = input
-  const source = resolveInboundProfileNameSource(inbox.channel as ChannelType)
-  // Unreachable when the caller gates on `shouldRefreshContactProfile`
-  // first (it checks the same table row) — kept for type safety and as a
-  // last line of defence against a direct call.
-  if (!source) {
-    return
-  }
+  const { source, inbox, contactInbox, incomingContact, contactId } = input
 
   try {
     const fetchProfile = inboundProfileFetchers[source]({

--- a/apps/worker/src/integration/handlers/messenger-contact-data.ts
+++ b/apps/worker/src/integration/handlers/messenger-contact-data.ts
@@ -1,69 +1,24 @@
-import { contactService } from "@chatbotx.io/business"
-import type { GenderType } from "@chatbotx.io/database/partials"
-import type { ContactModel } from "@chatbotx.io/database/types"
-import { uploader } from "@chatbotx.io/filesystem"
+import {
+  applyContactProfile,
+  buildContactProfileUpdate,
+} from "@chatbotx.io/business"
 import type { UpdateMessengerContactDataStepSchema } from "@chatbotx.io/flow-config"
 import type { IncomingContact } from "@chatbotx.io/sdk"
 import { logger } from "../../lib/logger"
 import type { ExecuteStepProps } from "./flow-utils"
 import { resolveMessengerUserContext } from "./messenger-context"
 
-// Contact columns this action can write from the Facebook profile. `fullName` is
-// a generated column (derived from first/last name) and must never be set.
-type UpdatableContactData = Partial<
-  Pick<
-    ContactModel,
-    "firstName" | "lastName" | "avatar" | "locale" | "timezone" | "gender"
-  >
->
-
-/**
- * Build the set of fields to write from the fetched profile, keeping only the
- * values Facebook actually returned. `locale`/`timezone`/`gender` require extra
- * page permissions and are frequently absent, so an undefined value must never
- * clobber existing contact data.
- */
-function buildCandidate(profile: IncomingContact): UpdatableContactData {
-  const candidate: UpdatableContactData = {}
-  if (profile.firstName !== undefined) {
-    candidate.firstName = profile.firstName
-  }
-  if (profile.lastName !== undefined) {
-    candidate.lastName = profile.lastName
-  }
-  if (profile.avatar !== undefined) {
-    candidate.avatar = profile.avatar
-  }
-  if (profile.locale !== undefined) {
-    candidate.locale = profile.locale
-  }
-  if (profile.timezone !== undefined) {
-    candidate.timezone = profile.timezone
-  }
-  // `getUserProfile` normalizes gender to the DB enum ("male"/"female"/
-  // "unknown") or undefined, so the cast is safe.
-  if (profile.gender !== undefined) {
-    candidate.gender = profile.gender as GenderType
-  }
-  return candidate
-}
-
-const EXTERNAL_URL_PATTERN = /^https?:\/\//
-
-/**
- * True when `avatar` is an object we uploaded to our own storage (an
- * `.../avatars/<id>` key), so it is safe to delete when superseded. External
- * URLs (http/https) and non-avatar paths are left untouched.
- */
-function isManagedAvatarObject(avatar: string): boolean {
-  return !EXTERNAL_URL_PATTERN.test(avatar) && avatar.includes("/avatars/")
-}
-
 /**
  * Re-sync a Messenger contact's profile (name, avatar, locale, timezone,
  * gender) from Facebook, overwriting the contact's current values. Best-effort
  * and fire-and-forget: a contact with no Messenger inbox, an expired page
  * token, or a Graph error is a silent no-op so the flow always continues.
+ *
+ * Field mapping (`buildContactProfileUpdate`) and the write + managed-avatar
+ * compensation (`applyContactProfile`) are shared with
+ * `packages/business/src/contact/profile-refresh` — this step keeps its own
+ * "overwrite even when a name already exists" semantics and does not go
+ * through `contactProfileRefreshService.refresh`.
  */
 export async function updateMessengerContactData(
   props: ExecuteStepProps<UpdateMessengerContactDataStepSchema>,
@@ -86,43 +41,16 @@ export async function updateMessengerContactData(
       return
     }
 
-    const data = buildCandidate(profile)
-    if (Object.keys(data).length === 0) {
+    const update = buildContactProfileUpdate(profile)
+    if (Object.keys(update).length === 0) {
       return
     }
 
-    // `getProfile` uploads the fetched picture to a fresh `avatars/<id>` object
-    // on every run, so capture the current avatar first and delete it once the
-    // new one is persisted — otherwise repeated syncs orphan storage objects.
-    const previousAvatar =
-      data.avatar === undefined
-        ? undefined
-        : (
-            await contactService.findById({
-              workspaceId: conversation.workspaceId,
-              id: conversation.contactId,
-            })
-          )?.avatar
-
-    await contactService.update(
-      { workspaceId: conversation.workspaceId, id: conversation.contactId },
-      data,
-    )
-
-    if (
-      previousAvatar &&
-      previousAvatar !== data.avatar &&
-      isManagedAvatarObject(previousAvatar)
-    ) {
-      try {
-        await uploader.deleteObject(previousAvatar)
-      } catch (error) {
-        logger.warn(
-          { error, path: previousAvatar },
-          "updateMessengerContactData: failed to delete superseded avatar",
-        )
-      }
-    }
+    await applyContactProfile({
+      workspaceId: conversation.workspaceId,
+      contactId: conversation.contactId,
+      update,
+    })
   } catch (error) {
     logger.error(error, "updateMessengerContactData failed")
   }

--- a/apps/worker/src/integration/handlers/received-message.ts
+++ b/apps/worker/src/integration/handlers/received-message.ts
@@ -93,9 +93,9 @@ import {
   isInstagramViaFacebook,
 } from "../../services/integrations"
 import {
+  getProfileRefreshSource,
   isInboundConversationMessage,
   refreshExistingContactProfile,
-  shouldRefreshContactProfile,
 } from "./contact-profile-refresh"
 import { resolvePostbackButtonLabel, sanitizeFlowAction } from "./flow-action"
 
@@ -345,20 +345,17 @@ export const receiveMessage = async (
         ...systemFieldUpdates,
       })
 
-    // Best-effort backfill of a nameless existing contact's profile, for
-    // every channel. No `isNewMessage`/`isNewContact` gate (owner decision):
-    // every inbound message from a nameless contact is a candidate, and a
-    // duplicate webhook still gets a chance to fill in the name. Awaited
-    // here (before postback/quickReply/runRef enqueue below) so the first
-    // automated reply already sees `{{first_name}}`.
-    if (
-      shouldRefreshContactProfile({
-        channel: inbox.channel as ChannelType,
-        incomingMessage,
-        contact,
-      })
-    ) {
+    // Best-effort backfill of a nameless existing contact's profile. No
+    // isNewMessage/isNewContact gate; awaited before the flow-action enqueue
+    // below so the first automated reply already sees `{{first_name}}`.
+    const profileRefreshSource = getProfileRefreshSource({
+      channel: inbox.channel as ChannelType,
+      incomingMessage,
+      contact,
+    })
+    if (profileRefreshSource) {
       await refreshExistingContactProfile({
+        source: profileRefreshSource,
         inbox,
         contactInbox,
         incomingContact,
@@ -1455,22 +1452,12 @@ const createNewContactAndContactInbox = async (props: {
           "detectContactAndConversation: getProfile failed, creating contact without profile data",
         )
         // No `contactId` — the contact does not exist yet at this point.
-        // `recordProfileRefreshFailure` never throws by contract; the extra
-        // guard here matches this file's established best-effort pattern
-        // (§1.3: profile work can never reject the job) in case that
-        // contract is ever violated.
-        try {
-          await recordProfileRefreshFailure({
-            channel: inbox.channel,
-            workspaceId: inbox.workspaceId,
-            error,
-          })
-        } catch (recordError) {
-          logger.warn(
-            { error: recordError, channel: inbox.channel },
-            "detectContactAndConversation: recordProfileRefreshFailure failed",
-          )
-        }
+        // `recordProfileRefreshFailure` never throws by contract.
+        await recordProfileRefreshFailure({
+          channel: inbox.channel,
+          workspaceId: inbox.workspaceId,
+          error,
+        })
       }
     }
   }

--- a/apps/worker/src/integration/handlers/received-message.ts
+++ b/apps/worker/src/integration/handlers/received-message.ts
@@ -7,8 +7,10 @@ import {
   contactInboxService,
   contactService,
   conversationService,
+  hasOnDemandProfileApi,
   messageCleanupService,
   quotaEnforcementService,
+  recordProfileRefreshFailure,
   resolveTenantSettings,
   updateContactFromMessage,
   workspaceService,
@@ -18,9 +20,9 @@ import {
   finalizeContactProfile,
   normalizeLanguage,
 } from "@chatbotx.io/business/contact-locale"
-import { logProviderErrorForChannel } from "@chatbotx.io/business/error-log"
 import { db, eq, isUniqueViolationError } from "@chatbotx.io/database/client"
 import {
+  type ChannelType,
   type ContactSource,
   contactSources,
   type IntegrationType,
@@ -90,6 +92,10 @@ import {
   integrationService,
   isInstagramViaFacebook,
 } from "../../services/integrations"
+import {
+  refreshExistingContactProfile,
+  shouldRefreshContactProfile,
+} from "./contact-profile-refresh"
 import { resolvePostbackButtonLabel, sanitizeFlowAction } from "./flow-action"
 
 type ContactInboxTracking = ContactInboxTrackingData
@@ -337,6 +343,27 @@ export const receiveMessage = async (
         storageUrl,
         ...systemFieldUpdates,
       })
+
+    // Best-effort backfill of a nameless existing contact's profile, for
+    // every channel. No `isNewMessage`/`isNewContact` gate (owner decision):
+    // every inbound message from a nameless contact is a candidate, and a
+    // duplicate webhook still gets a chance to fill in the name. Awaited
+    // here (before postback/quickReply/runRef enqueue below) so the first
+    // automated reply already sees `{{first_name}}`.
+    if (
+      shouldRefreshContactProfile({
+        channel: inbox.channel as ChannelType,
+        incomingMessage,
+        contact,
+      })
+    ) {
+      await refreshExistingContactProfile({
+        inbox,
+        contactInbox,
+        incomingContact,
+        contactId: contact.id,
+      })
+    }
 
     if (isNewMessage) {
       createdMessage = newMessage
@@ -794,6 +821,16 @@ const persistNewMessageSideEffects = async (props: {
   }
 }
 
+// "Real inbound" = not an echo/outgoing send, and not a non-message row
+// (e.g. an `activity` reaction row) — reused by the profile-refresh
+// eligibility table (`contact-profile-refresh.ts`) so "inbound" means the
+// same thing everywhere.
+export const isInboundConversationMessage = (
+  incomingMessage: IncomingMessage,
+): boolean =>
+  incomingMessage.messageType !== "outgoing" &&
+  (incomingMessage.type ?? "message") === "message"
+
 const getMessageActivityTracking = (props: {
   incomingMessage: IncomingMessage
   message: MessageModel
@@ -810,10 +847,7 @@ const getMessageActivityTracking = (props: {
     tracking.lastCommentMessageAt = message.createdAt
   }
 
-  if (
-    incomingMessage.messageType !== "outgoing" &&
-    (incomingMessage.type ?? "message") === "message"
-  ) {
+  if (isInboundConversationMessage(incomingMessage)) {
     tracking.lastIncomingMessageAt = message.createdAt
     Object.assign(
       tracking,
@@ -1399,7 +1433,7 @@ const createNewContactAndContactInbox = async (props: {
     ...incomingContact,
     workspaceId: inbox.workspaceId,
   }
-  if (canGetUserProfileIfNeeded(inbox.channel)) {
+  if (hasOnDemandProfileApi(inbox.channel as ChannelType)) {
     const integrationType =
       inbox.channel === "instagram" && isInstagramViaFacebook(integrationRow)
         ? "instagramFacebook"
@@ -1430,10 +1464,22 @@ const createNewContactAndContactInbox = async (props: {
           "detectContactAndConversation: getProfile failed, creating contact without profile data",
         )
         // No `contactId` — the contact does not exist yet at this point.
-        await logProviderErrorForChannel(inbox.channel, {
-          workspaceId: inbox.workspaceId,
-          error,
-        })
+        // `recordProfileRefreshFailure` never throws by contract; the extra
+        // guard here matches this file's established best-effort pattern
+        // (§1.3: profile work can never reject the job) in case that
+        // contract is ever violated.
+        try {
+          await recordProfileRefreshFailure({
+            channel: inbox.channel,
+            workspaceId: inbox.workspaceId,
+            error,
+          })
+        } catch (recordError) {
+          logger.warn(
+            { error: recordError, channel: inbox.channel },
+            "detectContactAndConversation: recordProfileRefreshFailure failed",
+          )
+        }
       }
     }
   }
@@ -1588,9 +1634,3 @@ const createNewContactAndContactInbox = async (props: {
 
   return { contactInbox, contact: newContact, conversation, isNewContact: true }
 }
-
-const canGetUserProfileIfNeeded = (integrationType: string) =>
-  integrationType === "messenger" ||
-  integrationType === "instagram" ||
-  integrationType === "zalo" ||
-  integrationType === "telegram"

--- a/apps/worker/src/integration/handlers/received-message.ts
+++ b/apps/worker/src/integration/handlers/received-message.ts
@@ -93,6 +93,7 @@ import {
   isInstagramViaFacebook,
 } from "../../services/integrations"
 import {
+  isInboundConversationMessage,
   refreshExistingContactProfile,
   shouldRefreshContactProfile,
 } from "./contact-profile-refresh"
@@ -820,16 +821,6 @@ const persistNewMessageSideEffects = async (props: {
     await contactInboxService.invalidateTracking(trackingInvalidation)
   }
 }
-
-// "Real inbound" = not an echo/outgoing send, and not a non-message row
-// (e.g. an `activity` reaction row) — reused by the profile-refresh
-// eligibility table (`contact-profile-refresh.ts`) so "inbound" means the
-// same thing everywhere.
-export const isInboundConversationMessage = (
-  incomingMessage: IncomingMessage,
-): boolean =>
-  incomingMessage.messageType !== "outgoing" &&
-  (incomingMessage.type ?? "message") === "message"
 
 const getMessageActivityTracking = (props: {
   incomingMessage: IncomingMessage

--- a/packages/business/__tests__/contact-profile-refresh.test.ts
+++ b/packages/business/__tests__/contact-profile-refresh.test.ts
@@ -24,11 +24,13 @@ vi.mock("@chatbotx.io/redis", () => ({
 const findByIdOrFailMock = vi.fn()
 const findByIdMock = vi.fn()
 const updateMock = vi.fn()
+const updateIfProfileNameEmptyMock = vi.fn()
 vi.mock("../src/contact/service", () => ({
   contactService: {
     findByIdOrFail: findByIdOrFailMock,
     findById: findByIdMock,
     update: updateMock,
+    updateIfProfileNameEmpty: updateIfProfileNameEmptyMock,
   },
 }))
 
@@ -80,6 +82,11 @@ beforeEach(() => {
   findByIdOrFailMock.mockResolvedValue({ ...NAMELESS_CONTACT })
   findByIdMock.mockResolvedValue(undefined)
   updateMock.mockImplementation(async (ctx, data) => ({
+    id: ctx.id,
+    workspaceId: ctx.workspaceId,
+    ...data,
+  }))
+  updateIfProfileNameEmptyMock.mockImplementation(async (ctx, data) => ({
     id: ctx.id,
     workspaceId: ctx.workspaceId,
     ...data,
@@ -410,7 +417,7 @@ describe("contactProfileRefreshService.refresh", () => {
       expect.any(Number),
       300,
     )
-    expect(updateMock).not.toHaveBeenCalled()
+    expect(updateIfProfileNameEmptyMock).not.toHaveBeenCalled()
   })
 
   test("fetch returns null → unavailable, cooldown started, no write", async () => {
@@ -422,7 +429,7 @@ describe("contactProfileRefreshService.refresh", () => {
 
     expect(result).toEqual({ status: "unavailable" })
     expect(setNumberMock).toHaveBeenCalled()
-    expect(updateMock).not.toHaveBeenCalled()
+    expect(updateIfProfileNameEmptyMock).not.toHaveBeenCalled()
   })
 
   test("fetch returns undefined → unavailable, cooldown started, no write", async () => {
@@ -434,7 +441,7 @@ describe("contactProfileRefreshService.refresh", () => {
 
     expect(result).toEqual({ status: "unavailable" })
     expect(setNumberMock).toHaveBeenCalled()
-    expect(updateMock).not.toHaveBeenCalled()
+    expect(updateIfProfileNameEmptyMock).not.toHaveBeenCalled()
   })
 
   test("applyContactProfile throws → failed, cooldown started, new upload deleted (best-effort)", async () => {
@@ -442,7 +449,7 @@ describe("contactProfileRefreshService.refresh", () => {
       firstName: "Jane",
       avatar: "public/space/ws-1/avatars/new",
     }))
-    updateMock.mockRejectedValueOnce(new Error("db down"))
+    updateIfProfileNameEmptyMock.mockRejectedValueOnce(new Error("db down"))
 
     const result = await contactProfileRefreshService.refresh(
       refreshInput({ fetchProfile }),
@@ -461,7 +468,7 @@ describe("contactProfileRefreshService.refresh", () => {
       firstName: "Jane",
       avatar: "public/space/ws-1/avatars/new",
     }))
-    updateMock.mockRejectedValueOnce(new Error("db down"))
+    updateIfProfileNameEmptyMock.mockRejectedValueOnce(new Error("db down"))
     deleteObjectMock.mockRejectedValueOnce(new Error("s3 down"))
 
     const result = await contactProfileRefreshService.refresh(
@@ -495,7 +502,7 @@ describe("contactProfileRefreshService.refresh", () => {
     )
 
     expect(result).toEqual({ status: "unavailable" })
-    expect(updateMock).not.toHaveBeenCalled()
+    expect(updateIfProfileNameEmptyMock).not.toHaveBeenCalled()
     expect(deleteObjectMock).toHaveBeenCalledWith(
       "public/space/ws-1/avatars/orphan",
     )
@@ -526,7 +533,7 @@ describe("contactProfileRefreshService.refresh", () => {
     expect(deleteObjectMock).not.toHaveBeenCalled()
   })
 
-  test("happy path → updated, contactService.update called once with mapped data, no cooldown started", async () => {
+  test("happy path → updated, contactService.updateIfProfileNameEmpty called once with mapped data, no cooldown started", async () => {
     const fetchProfile = vi.fn(async () => ({
       firstName: "Jane",
       lastName: "Doe",
@@ -537,8 +544,8 @@ describe("contactProfileRefreshService.refresh", () => {
     )
 
     expect(result.status).toBe("updated")
-    expect(updateMock).toHaveBeenCalledTimes(1)
-    expect(updateMock).toHaveBeenCalledWith(
+    expect(updateIfProfileNameEmptyMock).toHaveBeenCalledTimes(1)
+    expect(updateIfProfileNameEmptyMock).toHaveBeenCalledWith(
       { workspaceId: "ws-1", id: "contact-1", accessScope: undefined },
       { firstName: "Jane", lastName: "Doe" },
     )
@@ -556,14 +563,16 @@ describe("contactProfileRefreshService.refresh", () => {
   })
 
   test("name filled between fetch and write → skipped/profileComplete, no update, uploaded avatar discarded, no cooldown", async () => {
-    // findByIdOrFailMock (top-of-function read) still sees the nameless
-    // contact from `beforeEach`; the re-check `findById` right before the
-    // write sees a name that landed WHILE `fetchProfile` was in flight (an
-    // operator edit, or a concurrent refresh).
-    findByIdMock.mockResolvedValueOnce({
-      firstName: "Jane",
-      lastName: "Doe",
-    })
+    // findByIdOrFailMock (top-of-function eligibility read) still sees the
+    // nameless contact from `beforeEach`. The ATOMIC conditional write
+    // (`contactService.updateIfProfileNameEmpty`) is what actually closes
+    // this race in production — simulated here by making it match zero
+    // rows, exactly as the real UPDATE would if a name landed WHILE
+    // `fetchProfile` was in flight (an operator edit, or a concurrent
+    // refresh): the WHERE clause's name-empty predicate simply no longer
+    // matches, so no row updates and `updateIfProfileNameEmpty` resolves
+    // `undefined`.
+    updateIfProfileNameEmptyMock.mockResolvedValueOnce(undefined)
     const fetchProfile = vi.fn(async () => ({
       firstName: "Jane",
       avatar: "public/space/ws-1/avatars/new",
@@ -574,7 +583,7 @@ describe("contactProfileRefreshService.refresh", () => {
     )
 
     expect(result).toEqual({ status: "skipped", reason: "profileComplete" })
-    expect(updateMock).not.toHaveBeenCalled()
+    expect(updateIfProfileNameEmptyMock).toHaveBeenCalledTimes(1)
     expect(deleteObjectMock).toHaveBeenCalledWith(
       "public/space/ws-1/avatars/new",
     )
@@ -689,5 +698,47 @@ describe("applyContactProfile", () => {
       expect.objectContaining({ accessScope }),
       expect.anything(),
     )
+  })
+
+  test("returns { applied: true, contact } on a successful unconditional write", async () => {
+    const result = await applyContactProfile({
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+      update: { firstName: "Jane" },
+    })
+
+    expect(result).toEqual({
+      applied: true,
+      contact: { id: "contact-1", workspaceId: "ws-1", firstName: "Jane" },
+    })
+  })
+
+  test("onlyIfProfileNameEmpty: true routes through contactService.updateIfProfileNameEmpty, not update", async () => {
+    await applyContactProfile({
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+      update: { firstName: "Jane" },
+      onlyIfProfileNameEmpty: true,
+    })
+
+    expect(updateIfProfileNameEmptyMock).toHaveBeenCalledTimes(1)
+    expect(updateMock).not.toHaveBeenCalled()
+  })
+
+  test("onlyIfProfileNameEmpty: true and zero rows matched → { applied: false }, no avatar cleanup (nothing was superseded)", async () => {
+    updateIfProfileNameEmptyMock.mockResolvedValueOnce(undefined)
+    findByIdMock.mockResolvedValueOnce({
+      avatar: "public/space/ws-1/avatars/old",
+    })
+
+    const result = await applyContactProfile({
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+      update: { avatar: "public/space/ws-1/avatars/new" },
+      onlyIfProfileNameEmpty: true,
+    })
+
+    expect(result).toEqual({ applied: false })
+    expect(deleteObjectMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/business/__tests__/contact-profile-refresh.test.ts
+++ b/packages/business/__tests__/contact-profile-refresh.test.ts
@@ -229,6 +229,21 @@ describe("capability table", () => {
       expect(contactProfileNameCapabilities[channel]).toBeDefined()
     }
   })
+
+  // `Inbox`/`ContactInbox`.`channel` is a plain `text()` column — callers
+  // cast `as ChannelType`, so a legacy/unknown row must resolve to "no
+  // source" instead of throwing on the missing table row.
+  test("resolveInboundProfileNameSource returns null for an unknown channel string, never throws", () => {
+    expect(() =>
+      resolveInboundProfileNameSource("legacy" as never),
+    ).not.toThrow()
+    expect(resolveInboundProfileNameSource("legacy" as never)).toBeNull()
+  })
+
+  test("hasOnDemandProfileApi returns false for an unknown channel string, never throws", () => {
+    expect(() => hasOnDemandProfileApi("legacy" as never)).not.toThrow()
+    expect(hasOnDemandProfileApi("legacy" as never)).toBe(false)
+  })
 })
 
 describe("COOLDOWN_BY_PROFILE_SOURCE", () => {
@@ -538,6 +553,32 @@ describe("contactProfileRefreshService.refresh", () => {
     expect(findByIdOrFailMock).toHaveBeenCalledWith(
       expect.objectContaining({ accessScope }),
     )
+  })
+
+  test("name filled between fetch and write → skipped/profileComplete, no update, uploaded avatar discarded, no cooldown", async () => {
+    // findByIdOrFailMock (top-of-function read) still sees the nameless
+    // contact from `beforeEach`; the re-check `findById` right before the
+    // write sees a name that landed WHILE `fetchProfile` was in flight (an
+    // operator edit, or a concurrent refresh).
+    findByIdMock.mockResolvedValueOnce({
+      firstName: "Jane",
+      lastName: "Doe",
+    })
+    const fetchProfile = vi.fn(async () => ({
+      firstName: "Jane",
+      avatar: "public/space/ws-1/avatars/new",
+    }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result).toEqual({ status: "skipped", reason: "profileComplete" })
+    expect(updateMock).not.toHaveBeenCalled()
+    expect(deleteObjectMock).toHaveBeenCalledWith(
+      "public/space/ws-1/avatars/new",
+    )
+    expect(setNumberMock).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/business/__tests__/contact-profile-refresh.test.ts
+++ b/packages/business/__tests__/contact-profile-refresh.test.ts
@@ -1,0 +1,652 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// packages/business/src/contact/profile-refresh — channel-agnostic module
+// that decides whether a contact's profile name is missing, whether a
+// channel may supply one, maps a fetched profile onto contact columns, rate
+// limits channel-API attempts, applies the write with avatar compensation,
+// and records non-fatal errors. See
+// .superpowers/sdd/2026-08-31-messenger-ctm-profile-backfill/task-1-brief.md
+// ---------------------------------------------------------------------------
+
+const warnMock = vi.fn()
+const errorMock = vi.fn()
+vi.mock("../src/logger", () => ({
+  logger: { warn: warnMock, error: errorMock, info: vi.fn(), debug: vi.fn() },
+}))
+
+const existsMock = vi.fn(async () => false)
+const setNumberMock = vi.fn(async () => undefined)
+vi.mock("@chatbotx.io/redis", () => ({
+  distributedStore: { exists: existsMock, setNumber: setNumberMock },
+}))
+
+const findByIdOrFailMock = vi.fn()
+const findByIdMock = vi.fn()
+const updateMock = vi.fn()
+vi.mock("../src/contact/service", () => ({
+  contactService: {
+    findByIdOrFail: findByIdOrFailMock,
+    findById: findByIdMock,
+    update: updateMock,
+  },
+}))
+
+const logProviderErrorForChannelMock = vi.fn(async () => undefined)
+vi.mock("../src/error-log/service", () => ({
+  logProviderErrorForChannel: logProviderErrorForChannelMock,
+}))
+
+const deleteObjectMock = vi.fn(async () => undefined)
+vi.mock("@chatbotx.io/filesystem", () => ({
+  uploader: { deleteObject: deleteObjectMock },
+}))
+
+const {
+  applyContactProfile,
+  buildContactProfileUpdate,
+  contactProfileNameCapabilities,
+  contactProfileRefreshService,
+  COOLDOWN_BY_PROFILE_SOURCE,
+  hasEmptyProfileName,
+  hasOnDemandProfileApi,
+  hasProfileName,
+  isContactProfileRefreshCoolingDown,
+  PROFILE_REFRESH_COOLDOWN_SECONDS,
+  resolveInboundProfileNameSource,
+  startContactProfileRefreshCooldown,
+} = await import("../src/contact/profile-refresh")
+
+const { channelTypes } = await import("@chatbotx.io/database/partials")
+
+const NAMELESS_CONTACT = { firstName: null, lastName: null }
+const CONTACT_INBOX = { id: "inbox-1", channel: "messenger" }
+
+function refreshInput(overrides: Record<string, unknown> = {}) {
+  return {
+    workspaceId: "ws-1",
+    contactId: "contact-1",
+    contactInbox: CONTACT_INBOX,
+    source: "channelApi" as const,
+    fetchProfile: vi.fn(async () => ({ firstName: "Jane" })),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  existsMock.mockResolvedValue(false)
+  setNumberMock.mockResolvedValue(undefined)
+  findByIdOrFailMock.mockResolvedValue({ ...NAMELESS_CONTACT })
+  findByIdMock.mockResolvedValue(undefined)
+  updateMock.mockImplementation(async (ctx, data) => ({
+    id: ctx.id,
+    workspaceId: ctx.workspaceId,
+    ...data,
+  }))
+  logProviderErrorForChannelMock.mockResolvedValue(undefined)
+  deleteObjectMock.mockResolvedValue(undefined)
+})
+
+// ─── rules.ts ────────────────────────────────────────────────────────────
+
+describe("hasEmptyProfileName", () => {
+  test("both blank → true", () => {
+    expect(hasEmptyProfileName({ firstName: null, lastName: null })).toBe(true)
+  })
+
+  test("both whitespace-only → true", () => {
+    expect(hasEmptyProfileName({ firstName: "   ", lastName: "  " })).toBe(true)
+  })
+
+  test("firstName only → false", () => {
+    expect(hasEmptyProfileName({ firstName: "Jane", lastName: null })).toBe(
+      false,
+    )
+  })
+
+  test("lastName only → false", () => {
+    expect(hasEmptyProfileName({ firstName: null, lastName: "Doe" })).toBe(
+      false,
+    )
+  })
+})
+
+describe("hasProfileName", () => {
+  test("both blank → false", () => {
+    expect(hasProfileName({})).toBe(false)
+  })
+
+  test("both whitespace-only → false", () => {
+    expect(hasProfileName({ firstName: "   ", lastName: "  " })).toBe(false)
+  })
+
+  test("firstName only → true", () => {
+    expect(hasProfileName({ firstName: "Jane" })).toBe(true)
+  })
+
+  test("lastName only → true", () => {
+    expect(hasProfileName({ lastName: "Doe" })).toBe(true)
+  })
+})
+
+describe("buildContactProfileUpdate", () => {
+  test("drops undefined fields", () => {
+    const update = buildContactProfileUpdate({
+      sourceId: "psid-1",
+      firstName: "Jane",
+    })
+
+    expect(update).toEqual({ firstName: "Jane" })
+  })
+
+  test("keeps every field the profile returned", () => {
+    const update = buildContactProfileUpdate({
+      sourceId: "psid-1",
+      firstName: "Jane",
+      lastName: "Doe",
+      avatar: "public/space/ws-1/avatars/abc",
+      locale: "en_US",
+      timezone: "+07:00",
+      gender: "female",
+    })
+
+    expect(update).toEqual({
+      firstName: "Jane",
+      lastName: "Doe",
+      avatar: "public/space/ws-1/avatars/abc",
+      locale: "en_US",
+      timezone: "+07:00",
+      gender: "female",
+    })
+  })
+
+  test("invalid gender string is dropped", () => {
+    const update = buildContactProfileUpdate({
+      sourceId: "psid-1",
+      firstName: "Jane",
+      gender: "not-a-real-gender",
+    })
+
+    expect(update).toEqual({ firstName: "Jane" })
+    expect(update.gender).toBeUndefined()
+  })
+
+  test("never emits fullName (generated column)", () => {
+    const update = buildContactProfileUpdate({
+      sourceId: "psid-1",
+      firstName: "Jane",
+      lastName: "Doe",
+    })
+
+    const allowedKeys = [
+      "firstName",
+      "lastName",
+      "avatar",
+      "locale",
+      "timezone",
+      "gender",
+    ]
+    expect(Object.keys(update).every((key) => allowedKeys.includes(key))).toBe(
+      true,
+    )
+    expect("fullName" in update).toBe(false)
+  })
+})
+
+describe("capability table", () => {
+  test("resolveInboundProfileNameSource per channel", () => {
+    const expected: Record<string, "channelApi" | "payload" | null> = {
+      messenger: "channelApi",
+      instagram: "channelApi",
+      zalo: "channelApi",
+      telegram: "channelApi",
+      whatsapp: "payload",
+      api: "payload",
+      tiktok: null,
+      webchat: null,
+      smtp: null,
+      omnichannel: null,
+    }
+
+    for (const [channel, source] of Object.entries(expected)) {
+      expect(resolveInboundProfileNameSource(channel as never)).toBe(source)
+    }
+  })
+
+  test("hasOnDemandProfileApi is true for exactly messenger/instagram/zalo/telegram", () => {
+    const onDemandChannels = ["messenger", "instagram", "zalo", "telegram"]
+
+    for (const channel of channelTypes.options) {
+      expect(hasOnDemandProfileApi(channel)).toBe(
+        onDemandChannels.includes(channel),
+      )
+    }
+  })
+
+  test("every channelTypes.options value has a capability row", () => {
+    for (const channel of channelTypes.options) {
+      expect(contactProfileNameCapabilities[channel]).toBeDefined()
+    }
+  })
+})
+
+describe("COOLDOWN_BY_PROFILE_SOURCE", () => {
+  test("payload is not rate-limited, channelApi is", () => {
+    expect(COOLDOWN_BY_PROFILE_SOURCE).toEqual({
+      payload: false,
+      channelApi: true,
+    })
+  })
+})
+
+// ─── cooldown.ts ─────────────────────────────────────────────────────────
+
+describe("isContactProfileRefreshCoolingDown", () => {
+  test("true while the key exists", async () => {
+    existsMock.mockResolvedValueOnce(true)
+
+    await expect(isContactProfileRefreshCoolingDown("inbox-1")).resolves.toBe(
+      true,
+    )
+    expect(existsMock).toHaveBeenCalledWith(
+      "contact-profile-refresh:cooldown:inbox-1",
+    )
+  })
+
+  test("false while the key is absent", async () => {
+    existsMock.mockResolvedValueOnce(false)
+
+    await expect(isContactProfileRefreshCoolingDown("inbox-1")).resolves.toBe(
+      false,
+    )
+  })
+
+  test("a Redis error is logged at warn and treated as not cooling down", async () => {
+    existsMock.mockRejectedValueOnce(new Error("redis down"))
+
+    await expect(isContactProfileRefreshCoolingDown("inbox-1")).resolves.toBe(
+      false,
+    )
+    expect(warnMock).toHaveBeenCalled()
+  })
+})
+
+describe("startContactProfileRefreshCooldown", () => {
+  test("writes the key with a 300s TTL", async () => {
+    await startContactProfileRefreshCooldown("inbox-1")
+
+    expect(setNumberMock).toHaveBeenCalledWith(
+      "contact-profile-refresh:cooldown:inbox-1",
+      expect.any(Number),
+      300,
+    )
+    expect(PROFILE_REFRESH_COOLDOWN_SECONDS).toBe(300)
+  })
+
+  test("a Redis write error is logged at warn and swallowed", async () => {
+    setNumberMock.mockRejectedValueOnce(new Error("redis down"))
+
+    await expect(
+      startContactProfileRefreshCooldown("inbox-1"),
+    ).resolves.toBeUndefined()
+    expect(warnMock).toHaveBeenCalled()
+  })
+})
+
+// ─── service.ts: contactProfileRefreshService.refresh ──────────────────
+
+describe("contactProfileRefreshService.refresh", () => {
+  test("name present → skipped/profileComplete, no cooldown check, no fetch", async () => {
+    findByIdOrFailMock.mockResolvedValueOnce({
+      firstName: "Jane",
+      lastName: null,
+    })
+    const fetchProfile = vi.fn()
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result).toEqual({ status: "skipped", reason: "profileComplete" })
+    expect(existsMock).not.toHaveBeenCalled()
+    expect(fetchProfile).not.toHaveBeenCalled()
+  })
+
+  test("payload source: cooldown never checked nor started (unavailable outcome)", async () => {
+    const fetchProfile = vi.fn(async () => null)
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ source: "payload", fetchProfile }),
+    )
+
+    expect(result).toEqual({ status: "unavailable" })
+    expect(existsMock).not.toHaveBeenCalled()
+    expect(setNumberMock).not.toHaveBeenCalled()
+  })
+
+  test("payload source: cooldown never checked nor started (failed outcome)", async () => {
+    const fetchProfile = vi.fn(() =>
+      Promise.reject(new Error("resolution failed")),
+    )
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ source: "payload", fetchProfile }),
+    )
+
+    expect(result).toEqual({ status: "failed" })
+    expect(existsMock).not.toHaveBeenCalled()
+    expect(setNumberMock).not.toHaveBeenCalled()
+  })
+
+  test("cooling down → skipped/coolingDown, no fetch", async () => {
+    existsMock.mockResolvedValueOnce(true)
+    const fetchProfile = vi.fn()
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result).toEqual({ status: "skipped", reason: "coolingDown" })
+    expect(fetchProfile).not.toHaveBeenCalled()
+  })
+
+  test("cooldown check throws → warn, fetch still runs", async () => {
+    existsMock.mockRejectedValueOnce(new Error("redis down"))
+    const fetchProfile = vi.fn(async () => ({ firstName: "Jane" }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(warnMock).toHaveBeenCalled()
+    expect(fetchProfile).toHaveBeenCalled()
+    expect(result.status).toBe("updated")
+  })
+
+  test("cooldown write throws → warn, result unchanged", async () => {
+    setNumberMock.mockRejectedValueOnce(new Error("redis down"))
+    const fetchProfile = vi.fn(async () => null)
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result).toEqual({ status: "unavailable" })
+    expect(warnMock).toHaveBeenCalled()
+  })
+
+  test("fetch throws → failed, error recorded, cooldown started, contact untouched", async () => {
+    const error = new Error("graph error")
+    const fetchProfile = vi.fn(() => Promise.reject(error))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result).toEqual({ status: "failed" })
+    expect(logProviderErrorForChannelMock).toHaveBeenCalledWith("messenger", {
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+      error,
+    })
+    expect(setNumberMock).toHaveBeenCalledWith(
+      "contact-profile-refresh:cooldown:inbox-1",
+      expect.any(Number),
+      300,
+    )
+    expect(updateMock).not.toHaveBeenCalled()
+  })
+
+  test("fetch returns null → unavailable, cooldown started, no write", async () => {
+    const fetchProfile = vi.fn(async () => null)
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result).toEqual({ status: "unavailable" })
+    expect(setNumberMock).toHaveBeenCalled()
+    expect(updateMock).not.toHaveBeenCalled()
+  })
+
+  test("fetch returns undefined → unavailable, cooldown started, no write", async () => {
+    const fetchProfile = vi.fn(async () => undefined)
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result).toEqual({ status: "unavailable" })
+    expect(setNumberMock).toHaveBeenCalled()
+    expect(updateMock).not.toHaveBeenCalled()
+  })
+
+  test("applyContactProfile throws → failed, cooldown started, new upload deleted (best-effort)", async () => {
+    const fetchProfile = vi.fn(async () => ({
+      firstName: "Jane",
+      avatar: "public/space/ws-1/avatars/new",
+    }))
+    updateMock.mockRejectedValueOnce(new Error("db down"))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result).toEqual({ status: "failed" })
+    expect(deleteObjectMock).toHaveBeenCalledWith(
+      "public/space/ws-1/avatars/new",
+    )
+    expect(setNumberMock).toHaveBeenCalled()
+    expect(logProviderErrorForChannelMock).toHaveBeenCalled()
+  })
+
+  test("uploader.deleteObject throws after a write failure → logged, result unchanged", async () => {
+    const fetchProfile = vi.fn(async () => ({
+      firstName: "Jane",
+      avatar: "public/space/ws-1/avatars/new",
+    }))
+    updateMock.mockRejectedValueOnce(new Error("db down"))
+    deleteObjectMock.mockRejectedValueOnce(new Error("s3 down"))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result).toEqual({ status: "failed" })
+    expect(warnMock).toHaveBeenCalled()
+  })
+
+  test("Error-Log write throws after a channel error → still failed, no rejection", async () => {
+    const fetchProfile = vi.fn(() => Promise.reject(new Error("graph error")))
+    logProviderErrorForChannelMock.mockRejectedValueOnce(
+      new Error("error-log down"),
+    )
+
+    await expect(
+      contactProfileRefreshService.refresh(refreshInput({ fetchProfile })),
+    ).resolves.toEqual({ status: "failed" })
+    expect(warnMock).toHaveBeenCalled()
+  })
+
+  test("fetch returns avatar/locale but no name → unavailable, no update, managed avatar deleted, cooldown started", async () => {
+    const fetchProfile = vi.fn(async () => ({
+      avatar: "public/space/ws-1/avatars/orphan",
+      locale: "en_US",
+    }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result).toEqual({ status: "unavailable" })
+    expect(updateMock).not.toHaveBeenCalled()
+    expect(deleteObjectMock).toHaveBeenCalledWith(
+      "public/space/ws-1/avatars/orphan",
+    )
+    expect(setNumberMock).toHaveBeenCalled()
+  })
+
+  test("no usable name and an external (unmanaged) avatar → left untouched", async () => {
+    const fetchProfile = vi.fn(async () => ({
+      avatar: "https://cdn.example.com/pic.jpg",
+    }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result).toEqual({ status: "unavailable" })
+    expect(deleteObjectMock).not.toHaveBeenCalled()
+  })
+
+  test("no usable name and no avatar at all → nothing to delete", async () => {
+    const fetchProfile = vi.fn(async () => ({ locale: "en_US" }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result).toEqual({ status: "unavailable" })
+    expect(deleteObjectMock).not.toHaveBeenCalled()
+  })
+
+  test("happy path → updated, contactService.update called once with mapped data, no cooldown started", async () => {
+    const fetchProfile = vi.fn(async () => ({
+      firstName: "Jane",
+      lastName: "Doe",
+    }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result.status).toBe("updated")
+    expect(updateMock).toHaveBeenCalledTimes(1)
+    expect(updateMock).toHaveBeenCalledWith(
+      { workspaceId: "ws-1", id: "contact-1", accessScope: undefined },
+      { firstName: "Jane", lastName: "Doe" },
+    )
+    expect(setNumberMock).not.toHaveBeenCalled()
+  })
+
+  test("accessScope is forwarded to findByIdOrFail", async () => {
+    const accessScope = { restrictToAssignedUserId: "user-1" }
+
+    await contactProfileRefreshService.refresh(refreshInput({ accessScope }))
+
+    expect(findByIdOrFailMock).toHaveBeenCalledWith(
+      expect.objectContaining({ accessScope }),
+    )
+  })
+})
+
+// ─── service.ts: applyContactProfile ────────────────────────────────────
+
+describe("applyContactProfile", () => {
+  test("deletes the superseded managed avatar after the write", async () => {
+    findByIdMock.mockResolvedValueOnce({
+      avatar: "public/space/ws-1/avatars/old",
+    })
+
+    await applyContactProfile({
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+      update: { avatar: "public/space/ws-1/avatars/new" },
+    })
+
+    expect(updateMock).toHaveBeenCalledTimes(1)
+    expect(deleteObjectMock).toHaveBeenCalledWith(
+      "public/space/ws-1/avatars/old",
+    )
+  })
+
+  test("leaves an external (unmanaged) avatar untouched", async () => {
+    findByIdMock.mockResolvedValueOnce({
+      avatar: "https://cdn.example.com/pic.jpg",
+    })
+
+    await applyContactProfile({
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+      update: { avatar: "public/space/ws-1/avatars/new" },
+    })
+
+    expect(deleteObjectMock).not.toHaveBeenCalled()
+  })
+
+  test("no avatar in the update → previous avatar is never looked up or deleted", async () => {
+    await applyContactProfile({
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+      update: { firstName: "Jane" },
+    })
+
+    expect(findByIdMock).not.toHaveBeenCalled()
+    expect(deleteObjectMock).not.toHaveBeenCalled()
+  })
+
+  test("unchanged avatar path → not deleted", async () => {
+    findByIdMock.mockResolvedValueOnce({
+      avatar: "public/space/ws-1/avatars/same",
+    })
+
+    await applyContactProfile({
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+      update: { avatar: "public/space/ws-1/avatars/same" },
+    })
+
+    expect(deleteObjectMock).not.toHaveBeenCalled()
+  })
+
+  test("no previous avatar → nothing to delete", async () => {
+    findByIdMock.mockResolvedValueOnce(undefined)
+
+    await applyContactProfile({
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+      update: { avatar: "public/space/ws-1/avatars/new" },
+    })
+
+    expect(deleteObjectMock).not.toHaveBeenCalled()
+  })
+
+  test("uploader.deleteObject failure is swallowed and does not throw", async () => {
+    findByIdMock.mockResolvedValueOnce({
+      avatar: "public/space/ws-1/avatars/old",
+    })
+    deleteObjectMock.mockRejectedValueOnce(new Error("s3 down"))
+
+    await expect(
+      applyContactProfile({
+        workspaceId: "ws-1",
+        contactId: "contact-1",
+        update: { avatar: "public/space/ws-1/avatars/new" },
+      }),
+    ).resolves.toBeDefined()
+    expect(warnMock).toHaveBeenCalled()
+  })
+
+  test("forwards accessScope to findById and update", async () => {
+    const accessScope = { restrictToAssignedUserId: "user-1" }
+    findByIdMock.mockResolvedValueOnce({
+      avatar: "public/space/ws-1/avatars/old",
+    })
+
+    await applyContactProfile({
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+      accessScope,
+      update: { avatar: "public/space/ws-1/avatars/new" },
+    })
+
+    expect(findByIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({ accessScope }),
+    )
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ accessScope }),
+      expect.anything(),
+    )
+  })
+})

--- a/packages/business/__tests__/contact-profile-refresh.test.ts
+++ b/packages/business/__tests__/contact-profile-refresh.test.ts
@@ -46,6 +46,7 @@ vi.mock("@chatbotx.io/filesystem", () => ({
 
 const {
   applyContactProfile,
+  applyContactProfileIfNameEmpty,
   buildContactProfileUpdate,
   contactProfileNameCapabilities,
   contactProfileRefreshService,
@@ -743,7 +744,7 @@ describe("applyContactProfile", () => {
     )
   })
 
-  test("returns { applied: true, contact } on a successful unconditional write", async () => {
+  test("returns the updated contact on a successful unconditional write", async () => {
     const result = await applyContactProfile({
       workspaceId: "ws-1",
       contactId: "contact-1",
@@ -751,37 +752,40 @@ describe("applyContactProfile", () => {
     })
 
     expect(result).toEqual({
-      applied: true,
-      contact: { id: "contact-1", workspaceId: "ws-1", firstName: "Jane" },
+      id: "contact-1",
+      workspaceId: "ws-1",
+      firstName: "Jane",
     })
   })
+})
 
-  test("onlyIfProfileNameEmpty: true routes through contactService.updateIfProfileNameEmpty, not update", async () => {
-    await applyContactProfile({
+// ─── service.ts: applyContactProfileIfNameEmpty ─────────────────────────
+
+describe("applyContactProfileIfNameEmpty", () => {
+  test("routes through contactService.updateIfProfileNameEmpty, not update", async () => {
+    await applyContactProfileIfNameEmpty({
       workspaceId: "ws-1",
       contactId: "contact-1",
       update: { firstName: "Jane" },
-      onlyIfProfileNameEmpty: true,
     })
 
     expect(updateIfProfileNameEmptyMock).toHaveBeenCalledTimes(1)
     expect(updateMock).not.toHaveBeenCalled()
   })
 
-  test("onlyIfProfileNameEmpty: true and zero rows matched → { applied: false }, no avatar cleanup (nothing was superseded)", async () => {
+  test("zero rows matched → undefined, no avatar cleanup (nothing was superseded)", async () => {
     updateIfProfileNameEmptyMock.mockResolvedValueOnce(undefined)
     findByIdMock.mockResolvedValueOnce({
       avatar: "public/space/ws-1/avatars/old",
     })
 
-    const result = await applyContactProfile({
+    const result = await applyContactProfileIfNameEmpty({
       workspaceId: "ws-1",
       contactId: "contact-1",
       update: { avatar: "public/space/ws-1/avatars/new" },
-      onlyIfProfileNameEmpty: true,
     })
 
-    expect(result).toEqual({ applied: false })
+    expect(result).toBeUndefined()
     expect(deleteObjectMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/business/__tests__/contact-profile-refresh.test.ts
+++ b/packages/business/__tests__/contact-profile-refresh.test.ts
@@ -54,6 +54,7 @@ const {
   hasOnDemandProfileApi,
   hasProfileName,
   isContactProfileRefreshCoolingDown,
+  PROFILE_NAME_BLANK_CHARACTERS,
   PROFILE_REFRESH_COOLDOWN_SECONDS,
   resolveInboundProfileNameSource,
   startContactProfileRefreshCooldown,
@@ -97,6 +98,34 @@ beforeEach(() => {
 
 // ─── rules.ts ────────────────────────────────────────────────────────────
 
+describe("PROFILE_NAME_BLANK_CHARACTERS", () => {
+  // The single source of truth ContactService.updateIfProfileNameEmpty
+  // binds into Postgres' btrim(text, characters) so the SQL predicate can
+  // never drift from what hasEmptyProfileName/hasProfileName (below) treat
+  // as blank via JS's own String.prototype.trim().
+  test("every character in the set is blank per String.prototype.trim() — agrees with hasEmptyProfileName's definition of blank", () => {
+    expect(PROFILE_NAME_BLANK_CHARACTERS.length).toBeGreaterThan(0)
+    for (const ch of PROFILE_NAME_BLANK_CHARACTERS) {
+      expect(ch.trim()).toBe("")
+      expect(`x${ch}`.trim()).toBe("x")
+    }
+  })
+
+  test("a non-whitespace character is not blank and is not in the set", () => {
+    expect("x".trim()).toBe("x")
+    expect(PROFILE_NAME_BLANK_CHARACTERS.includes("x")).toBe(false)
+  })
+
+  test("contains the ECMAScript WhiteSpace + LineTerminator code points the finding named (tab, newline, NBSP, ideographic space, BOM)", () => {
+    expect(PROFILE_NAME_BLANK_CHARACTERS.length).toBe(25)
+    expect(PROFILE_NAME_BLANK_CHARACTERS).toContain("\t")
+    expect(PROFILE_NAME_BLANK_CHARACTERS).toContain("\n")
+    expect(PROFILE_NAME_BLANK_CHARACTERS).toContain("\u00A0") // NBSP
+    expect(PROFILE_NAME_BLANK_CHARACTERS).toContain("\u3000") // ideographic space (U+3000)
+    expect(PROFILE_NAME_BLANK_CHARACTERS).toContain("\uFEFF") // BOM / ZWNBSP
+  })
+})
+
 describe("hasEmptyProfileName", () => {
   test("both blank → true", () => {
     expect(hasEmptyProfileName({ firstName: null, lastName: null })).toBe(true)
@@ -104,6 +133,16 @@ describe("hasEmptyProfileName", () => {
 
   test("both whitespace-only → true", () => {
     expect(hasEmptyProfileName({ firstName: "   ", lastName: "  " })).toBe(true)
+  })
+
+  test("tab-only firstName, newline-only lastName → true", () => {
+    expect(hasEmptyProfileName({ firstName: "\t", lastName: "\n" })).toBe(true)
+  })
+
+  test("NBSP-only firstName, ideographic-space-only lastName → true", () => {
+    expect(
+      hasEmptyProfileName({ firstName: "\u00A0", lastName: "\u3000" }),
+    ).toBe(true)
   })
 
   test("firstName only → false", () => {
@@ -126,6 +165,10 @@ describe("hasProfileName", () => {
 
   test("both whitespace-only → false", () => {
     expect(hasProfileName({ firstName: "   ", lastName: "  " })).toBe(false)
+  })
+
+  test("tab-only firstName and NBSP-only lastName → false", () => {
+    expect(hasProfileName({ firstName: "\t", lastName: "\u00A0" })).toBe(false)
   })
 
   test("firstName only → true", () => {

--- a/packages/business/__tests__/contact-service-update-if-profile-name-empty.test.ts
+++ b/packages/business/__tests__/contact-service-update-if-profile-name-empty.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// ContactService.updateIfProfileNameEmpty — the atomic conditional write
+// (packages/business/src/contact/service.ts) that folds "both firstName and
+// lastName are still empty" into the UPDATE's own WHERE clause — matching
+// `hasEmptyProfileName`'s null-or-whitespace-only semantics — instead of a
+// separate read-then-write. Closes the TOCTOU race
+// `contactProfileRefreshService.refresh` used to have: a name written
+// between an eligibility check and an unconditional `update()` used to get
+// silently clobbered.
+//
+// The DB layer is mocked (mirrors contact-service-update-events.test.ts's
+// existing pattern for `contactService.update`), so these tests verify:
+// (a) the WHERE clause is built with the id/workspaceId/name-empty
+// predicate the finding specified, and (b) the method's own branching on
+// what the (real) DB would have matched — a row (name was still empty) vs
+// zero rows (a name was already set by write time). The btrim/coalesce SQL
+// itself is PostgreSQL-specific and is not re-evaluated by this mock.
+// ---------------------------------------------------------------------------
+
+const { mockDbUpdate, mockEmitContactInfoUpdated } = vi.hoisted(() => ({
+  mockDbUpdate: vi.fn(),
+  mockEmitContactInfoUpdated: vi.fn(),
+}))
+
+const sqlCalls: Array<{ strings: readonly string[]; values: unknown[] }> = []
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  and: vi.fn((...args: unknown[]) => ({ __and: args })),
+  db: { update: mockDbUpdate },
+  eq: vi.fn((left: unknown, right: unknown) => ({ __eq: [left, right] })),
+  findOrFail: vi.fn(),
+  inArray: vi.fn(),
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const entry = { strings: [...strings], values }
+    sqlCalls.push(entry)
+    return { __sql: entry }
+  },
+}))
+
+vi.mock("@chatbotx.io/database/schema", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@chatbotx.io/database/schema")>()
+  return actual
+})
+
+vi.mock("@chatbotx.io/event-bus", () => ({
+  emit: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/events", () => ({
+  emitContactCreated: vi.fn(),
+  emitContactInfoUpdated: mockEmitContactInfoUpdated,
+}))
+
+vi.mock("@chatbotx.io/filesystem", () => ({
+  uploadFileFromUrl: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/redis", () => ({
+  invalidateCacheByTags: vi.fn(),
+  withCache: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/analytics", () => ({
+  macAnalyticsService: {},
+}))
+
+vi.mock("../src/quota-enforcement/service", () => ({
+  quotaEnforcementService: {},
+}))
+
+vi.mock("../src/user-quota/service", () => ({
+  userQuotaService: {},
+}))
+
+vi.mock("../src/workspace/service", () => ({
+  workspaceService: {},
+}))
+
+const { contactService } = await import("../src/contact/service")
+const { and: andMock, eq: eqMock } = await import(
+  "@chatbotx.io/database/client"
+)
+
+const buildUpdateClient = (returningResult: unknown[]) => {
+  const returning = vi.fn().mockResolvedValue(returningResult)
+  const where = vi.fn(() => ({ returning }))
+  const set = vi.fn(() => ({ where }))
+  const update = vi.fn(() => ({ set }))
+  return { returning, set, update, where }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  sqlCalls.length = 0
+})
+
+describe("contactService.updateIfProfileNameEmpty", () => {
+  test("WHERE scopes by id AND workspaceId — never touches another workspace's row", async () => {
+    const dbUpdateClient = buildUpdateClient([
+      { id: "contact-1", workspaceId: "ws-1", firstName: "Jane" },
+    ])
+    mockDbUpdate.mockImplementation(dbUpdateClient.update)
+    vi.spyOn(contactService, "findByIdOrFail").mockResolvedValue({
+      id: "contact-1",
+      workspaceId: "ws-1",
+      firstName: null,
+      lastName: null,
+    } as never)
+    vi.spyOn(contactService, "invalidate").mockResolvedValue(undefined)
+
+    await contactService.updateIfProfileNameEmpty(
+      { workspaceId: "ws-1", id: "contact-1" },
+      { firstName: "Jane" },
+    )
+
+    expect(eqMock).toHaveBeenCalledWith(expect.anything(), "contact-1")
+    expect(eqMock).toHaveBeenCalledWith(expect.anything(), "ws-1")
+    expect(andMock).toHaveBeenCalledTimes(1)
+    // id, workspaceId, firstName-empty, lastName-empty
+    expect(andMock.mock.calls[0]).toHaveLength(4)
+  })
+
+  test("the name-empty predicate matches hasEmptyProfileName semantics (NULL-or-blank via btrim/coalesce) for both firstName and lastName", async () => {
+    const dbUpdateClient = buildUpdateClient([{ id: "contact-1" }])
+    mockDbUpdate.mockImplementation(dbUpdateClient.update)
+    vi.spyOn(contactService, "findByIdOrFail").mockResolvedValue({} as never)
+    vi.spyOn(contactService, "invalidate").mockResolvedValue(undefined)
+
+    await contactService.updateIfProfileNameEmpty(
+      { workspaceId: "ws-1", id: "contact-1" },
+      { firstName: "Jane" },
+    )
+
+    expect(sqlCalls).toHaveLength(2)
+    for (const call of sqlCalls) {
+      const text = call.strings.join("?")
+      expect(text).toContain("btrim")
+      expect(text).toContain("coalesce")
+      expect(text).toContain("''")
+    }
+  })
+
+  test("row updated (name still empty when the UPDATE ran) → returns the updated contact and invalidates the cache", async () => {
+    const existing = {
+      id: "contact-1",
+      workspaceId: "ws-1",
+      phoneNumber: null,
+      email: null,
+    }
+    const updated = { ...existing, firstName: "Jane" }
+    const dbUpdateClient = buildUpdateClient([updated])
+    mockDbUpdate.mockImplementation(dbUpdateClient.update)
+    vi.spyOn(contactService, "findByIdOrFail").mockResolvedValue(
+      existing as never,
+    )
+    const invalidateSpy = vi
+      .spyOn(contactService, "invalidate")
+      .mockResolvedValue(undefined)
+
+    const result = await contactService.updateIfProfileNameEmpty(
+      { workspaceId: "ws-1", id: "contact-1" },
+      { firstName: "Jane" },
+    )
+
+    expect(result).toEqual(updated)
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      ids: ["contact-1"],
+    })
+  })
+
+  test("zero rows matched (a name was set concurrently before the UPDATE ran) → returns undefined, no cache invalidation, no events", async () => {
+    const dbUpdateClient = buildUpdateClient([]) // simulates the WHERE predicate no longer matching
+    mockDbUpdate.mockImplementation(dbUpdateClient.update)
+    vi.spyOn(contactService, "findByIdOrFail").mockResolvedValue({
+      id: "contact-1",
+      workspaceId: "ws-1",
+      firstName: null,
+      lastName: null,
+    } as never)
+    const invalidateSpy = vi
+      .spyOn(contactService, "invalidate")
+      .mockResolvedValue(undefined)
+
+    const result = await contactService.updateIfProfileNameEmpty(
+      { workspaceId: "ws-1", id: "contact-1" },
+      { firstName: "Jane" },
+    )
+
+    expect(result).toBeUndefined()
+    expect(invalidateSpy).not.toHaveBeenCalled()
+    expect(mockEmitContactInfoUpdated).not.toHaveBeenCalled()
+  })
+
+  test("does not emit before a caller-owned transaction commits (mirrors update())", async () => {
+    const existing = { id: "contact-1", workspaceId: "ws-1" }
+    const updated = { ...existing, firstName: "Jane" }
+    const txUpdateClient = buildUpdateClient([updated])
+    const tx = { update: txUpdateClient.update }
+    vi.spyOn(contactService, "findByIdOrFail").mockResolvedValue(
+      existing as never,
+    )
+    vi.spyOn(contactService, "invalidate").mockResolvedValue(undefined)
+
+    await contactService.updateIfProfileNameEmpty(
+      { workspaceId: "ws-1", id: "contact-1" },
+      { firstName: "Jane" },
+      tx as never,
+    )
+
+    expect(mockEmitContactInfoUpdated).not.toHaveBeenCalled()
+  })
+})

--- a/packages/business/__tests__/contact-service-update-if-profile-name-empty.test.ts
+++ b/packages/business/__tests__/contact-service-update-if-profile-name-empty.test.ts
@@ -83,6 +83,9 @@ const { contactService } = await import("../src/contact/service")
 const { and: andMock, eq: eqMock } = await import(
   "@chatbotx.io/database/client"
 )
+const { PROFILE_NAME_BLANK_CHARACTERS } = await import(
+  "../src/contact/profile-refresh/rules"
+)
 
 const buildUpdateClient = (returningResult: unknown[]) => {
   const returning = vi.fn().mockResolvedValue(returningResult)
@@ -123,7 +126,7 @@ describe("contactService.updateIfProfileNameEmpty", () => {
     expect(andMock.mock.calls[0]).toHaveLength(4)
   })
 
-  test("the name-empty predicate matches hasEmptyProfileName semantics (NULL-or-blank via btrim/coalesce) for both firstName and lastName", async () => {
+  test("the name-empty predicate matches hasEmptyProfileName semantics (NULL-or-blank via btrim(text, characters)/coalesce) for both firstName and lastName, bound to the shared PROFILE_NAME_BLANK_CHARACTERS constant", async () => {
     const dbUpdateClient = buildUpdateClient([{ id: "contact-1" }])
     mockDbUpdate.mockImplementation(dbUpdateClient.update)
     vi.spyOn(contactService, "findByIdOrFail").mockResolvedValue({} as never)
@@ -140,6 +143,14 @@ describe("contactService.updateIfProfileNameEmpty", () => {
       expect(text).toContain("btrim")
       expect(text).toContain("coalesce")
       expect(text).toContain("''")
+      // Two-argument btrim(text, characters) — Postgres' single-argument
+      // btrim only strips ASCII space, which would desync from JS's
+      // .trim() (tab/NBSP/ideographic-space/etc. — see
+      // PROFILE_NAME_BLANK_CHARACTERS in profile-refresh/rules.ts). The
+      // character set is a BOUND parameter (call.values), never
+      // interpolated into the SQL text itself.
+      expect(call.values).toHaveLength(2)
+      expect(call.values[1]).toBe(PROFILE_NAME_BLANK_CHARACTERS)
     }
   })
 

--- a/packages/business/__tests__/integration-inbox-lookup.test.ts
+++ b/packages/business/__tests__/integration-inbox-lookup.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// zaloIntegrationService.findByInboxIdForWorkspace /
+// telegramIntegrationService.findByInboxIdForWorkspace — both new lookups
+// added for the builder's on-demand contact-profile refresh (Task 3). They
+// mirror messengerIntegrationService/instagramIntegrationService.
+// findByInboxIdForWorkspace: scope by BOTH inboxId and workspaceId, throw
+// when no row matches. See
+// .superpowers/sdd/2026-08-31-messenger-ctm-profile-backfill/task-3-brief.md
+// ---------------------------------------------------------------------------
+
+const findOrFailMock = vi.fn()
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  findOrFail: findOrFailMock,
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  integrationZaloModel: { __table: "IntegrationZalo" },
+  integrationTelegramModel: { __table: "IntegrationTelegram" },
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("zaloIntegrationService.findByInboxIdForWorkspace", () => {
+  test("scopes the lookup by both inboxId and workspaceId", async () => {
+    const { zaloIntegrationService } = await import(
+      "../src/integration-zalo/service"
+    )
+    const row = { id: "zalo-1", inboxId: "inbox-1", workspaceId: "ws-1" }
+    findOrFailMock.mockResolvedValueOnce(row)
+
+    await expect(
+      zaloIntegrationService.findByInboxIdForWorkspace({
+        inboxId: "inbox-1",
+        workspaceId: "ws-1",
+      }),
+    ).resolves.toBe(row)
+
+    expect(findOrFailMock).toHaveBeenCalledWith({
+      table: { __table: "IntegrationZalo" },
+      where: { inboxId: "inbox-1", workspaceId: "ws-1" },
+    })
+  })
+
+  test("throws when no row matches the scope", async () => {
+    const { zaloIntegrationService } = await import(
+      "../src/integration-zalo/service"
+    )
+    findOrFailMock.mockRejectedValueOnce(new Error("Record not found"))
+
+    await expect(
+      zaloIntegrationService.findByInboxIdForWorkspace({
+        inboxId: "inbox-missing",
+        workspaceId: "ws-1",
+      }),
+    ).rejects.toThrow("Record not found")
+  })
+})
+
+describe("telegramIntegrationService.findByInboxIdForWorkspace", () => {
+  test("scopes the lookup by both inboxId and workspaceId", async () => {
+    const { telegramIntegrationService } = await import(
+      "../src/integration-telegram/service"
+    )
+    const row = { id: "telegram-1", inboxId: "inbox-2", workspaceId: "ws-2" }
+    findOrFailMock.mockResolvedValueOnce(row)
+
+    await expect(
+      telegramIntegrationService.findByInboxIdForWorkspace({
+        inboxId: "inbox-2",
+        workspaceId: "ws-2",
+      }),
+    ).resolves.toBe(row)
+
+    expect(findOrFailMock).toHaveBeenCalledWith({
+      table: { __table: "IntegrationTelegram" },
+      where: { inboxId: "inbox-2", workspaceId: "ws-2" },
+    })
+  })
+
+  test("throws when no row matches the scope", async () => {
+    const { telegramIntegrationService } = await import(
+      "../src/integration-telegram/service"
+    )
+    findOrFailMock.mockRejectedValueOnce(new Error("Record not found"))
+
+    await expect(
+      telegramIntegrationService.findByInboxIdForWorkspace({
+        inboxId: "inbox-missing",
+        workspaceId: "ws-2",
+      }),
+    ).rejects.toThrow("Record not found")
+  })
+})

--- a/packages/business/package.json
+++ b/packages/business/package.json
@@ -11,6 +11,7 @@
     "./contact-custom-field-value": "./src/contact-custom-field/value-service.ts",
     "./contact-inbox": "./src/contact-inbox/index.ts",
     "./contact-locale": "./src/contact-locale/index.ts",
+    "./contact-profile-rules": "./src/contact/profile-refresh/rules.ts",
     "./contact-sequence": "./src/contact-sequence/index.ts",
     "./coupon": "./src/coupon/index.ts",
     "./dynamic-image": "./src/dynamic-image/index.ts",

--- a/packages/business/src/contact/index.ts
+++ b/packages/business/src/contact/index.ts
@@ -1,5 +1,6 @@
 export * from "./contact-info-changes"
 export * from "./extract-contact"
+export * from "./profile-refresh"
 export * from "./service"
 export * from "./update-from-message"
 export * from "./utils"

--- a/packages/business/src/contact/profile-refresh/cooldown.ts
+++ b/packages/business/src/contact/profile-refresh/cooldown.ts
@@ -1,0 +1,46 @@
+import { distributedStore } from "@chatbotx.io/redis" // packages/redis/src/index.ts:15
+import { logger } from "../../logger"
+
+export const PROFILE_REFRESH_COOLDOWN_SECONDS = 5 * 60 // owner decision
+
+const cooldownKey = (contactInboxId: string) =>
+  `contact-profile-refresh:cooldown:${contactInboxId}`
+
+/**
+ * Best-effort: a Redis error is logged at `warn` and treated as "not cooling
+ * down" so a transient Redis outage never blocks a legitimate profile fetch.
+ */
+export const isContactProfileRefreshCoolingDown = async (
+  contactInboxId: string,
+): Promise<boolean> => {
+  try {
+    return await distributedStore.exists(cooldownKey(contactInboxId)) // distributed-store.ts:60
+  } catch (error) {
+    logger.warn(
+      { error, contactInboxId },
+      "isContactProfileRefreshCoolingDown: Redis check failed, treating as not cooling down",
+    )
+    return false
+  }
+}
+
+/**
+ * Best-effort: a Redis error is logged at `warn` and ignored — the caller's
+ * outcome does not change because the cooldown marker failed to write.
+ */
+export const startContactProfileRefreshCooldown = async (
+  contactInboxId: string,
+): Promise<void> => {
+  try {
+    await distributedStore.setNumber(
+      cooldownKey(contactInboxId),
+      Date.now(),
+      PROFILE_REFRESH_COOLDOWN_SECONDS,
+    ) // distributed-store.ts:310
+  } catch (error) {
+    logger.warn(
+      { error, contactInboxId },
+      "startContactProfileRefreshCooldown: Redis write failed",
+    )
+  }
+}

--- a/packages/business/src/contact/profile-refresh/index.ts
+++ b/packages/business/src/contact/profile-refresh/index.ts
@@ -1,0 +1,3 @@
+export * from "./cooldown"
+export * from "./rules"
+export * from "./service"

--- a/packages/business/src/contact/profile-refresh/rules.ts
+++ b/packages/business/src/contact/profile-refresh/rules.ts
@@ -1,0 +1,120 @@
+import { type ChannelType, genderTypes } from "@chatbotx.io/database/partials"
+import type { ContactModel } from "@chatbotx.io/database/types"
+import type { IncomingContact } from "@chatbotx.io/sdk"
+
+/**
+ * Where a contact's profile name can come from, per channel. Exhaustive over
+ * `ChannelType` (invariant #3: adding a channel is a compile error here until
+ * a row is added — the row is the whole decision, callers never branch on
+ * the channel name).
+ *
+ * - `inbound`: how the worker refreshes a nameless existing contact on a real
+ *   inbound message. `"channelApi"` reuses the channel's `contact.getProfile`
+ *   handler; `"payload"` applies the `IncomingContact` the channel already
+ *   parsed from the webhook (no network); `null` = nothing to do.
+ * - `onDemand`: the channel has a `contact.getProfile` handler that returns a
+ *   name, so the builder can refresh on request and the worker fetches at
+ *   creation time (replaces `canGetUserProfileIfNeeded`).
+ */
+export const CONTACT_PROFILE_NAME_SOURCES = ["payload", "channelApi"] as const
+export type ContactProfileNameSource =
+  (typeof CONTACT_PROFILE_NAME_SOURCES)[number]
+
+export type ContactProfileNameCapability = {
+  inbound: ContactProfileNameSource | null
+  onDemand: boolean
+}
+
+export const contactProfileNameCapabilities = {
+  messenger: { inbound: "channelApi", onDemand: true },
+  instagram: { inbound: "channelApi", onDemand: true }, // direct and via-Facebook; registry dispatch is the app's concern
+  zalo: { inbound: "channelApi", onDemand: true },
+  telegram: { inbound: "channelApi", onDemand: true }, // getChat keyed by the contact's chat id — identity-safe (payload names a clicking user, not the chat)
+  whatsapp: { inbound: "payload", onDemand: false }, // contacts[0].profile.name; no user-profile API
+  tiktok: { inbound: null, onDemand: false }, // webhook carries ids only, no profile API
+  api: { inbound: "payload", onDemand: false },
+  webchat: { inbound: null, onDemand: false },
+  smtp: { inbound: null, onDemand: false },
+  omnichannel: { inbound: null, onDemand: false },
+} as const satisfies Record<ChannelType, ContactProfileNameCapability>
+
+export type OnDemandProfileChannel = {
+  [K in ChannelType]: (typeof contactProfileNameCapabilities)[K]["onDemand"] extends true
+    ? K
+    : never
+}[ChannelType] // "messenger" | "instagram" | "zalo" | "telegram"
+
+export const resolveInboundProfileNameSource = (
+  channel: ChannelType,
+): ContactProfileNameSource | null =>
+  contactProfileNameCapabilities[channel].inbound
+
+export const hasOnDemandProfileApi = (
+  channel: ChannelType,
+): channel is OnDemandProfileChannel =>
+  contactProfileNameCapabilities[channel].onDemand
+
+/** Only channel-API attempts are rate-limited; payload attempts are free. */
+export const COOLDOWN_BY_PROFILE_SOURCE = {
+  payload: false,
+  channelApi: true,
+} as const satisfies Record<ContactProfileNameSource, boolean>
+
+export type ContactProfileName = Pick<ContactModel, "firstName" | "lastName">
+/** Empty only when BOTH names are blank — either one present means "has a name". */
+export const hasEmptyProfileName = (contact: ContactProfileName): boolean =>
+  !(contact.firstName?.trim() || contact.lastName?.trim())
+
+/** Contact columns a channel profile may write. `fullName` is generated — never written. */
+export type ContactProfileUpdate = Partial<
+  Pick<
+    ContactModel,
+    "firstName" | "lastName" | "avatar" | "locale" | "timezone" | "gender"
+  >
+>
+
+/**
+ * Per-column mapper table. `gender` is validated with the DB enum, not cast.
+ * `undefined` values are dropped so a channel lacking `pages_user_locale` /
+ * `timezone` / `gender` never clobbers existing data. Replaces `buildCandidate`
+ * in `apps/worker/src/integration/handlers/messenger-contact-data.ts:26-49`.
+ */
+const profileColumnMappers = {
+  firstName: (p) => p.firstName,
+  lastName: (p) => p.lastName,
+  avatar: (p) => p.avatar,
+  locale: (p) => p.locale,
+  timezone: (p) => p.timezone,
+  gender: (p) => genderTypes.safeParse(p.gender).data,
+} as const satisfies {
+  [K in keyof ContactProfileUpdate]-?: (
+    profile: IncomingContact,
+  ) => ContactProfileUpdate[K] | undefined
+}
+
+type ProfileColumn = keyof typeof profileColumnMappers
+const PROFILE_COLUMNS = Object.keys(
+  profileColumnMappers,
+) as readonly ProfileColumn[] // literal-union narrowing, not `any`
+
+/**
+ * Typed accumulation over `PROFILE_COLUMNS` — no `Object.fromEntries` index
+ * signature, and no per-iteration object-spread (avoids the O(n²) pattern on
+ * an accumulator): the local `update` object is built once and returned.
+ */
+export const buildContactProfileUpdate = (
+  profile: IncomingContact,
+): ContactProfileUpdate => {
+  const update: ContactProfileUpdate = {}
+  for (const column of PROFILE_COLUMNS) {
+    const value = profileColumnMappers[column](profile)
+    if (value !== undefined) {
+      update[column] = value
+    }
+  }
+  return update
+}
+
+/** A refresh only counts when the channel returned a usable name. */
+export const hasProfileName = (update: ContactProfileUpdate): boolean =>
+  Boolean(update.firstName?.trim() || update.lastName?.trim())

--- a/packages/business/src/contact/profile-refresh/rules.ts
+++ b/packages/business/src/contact/profile-refresh/rules.ts
@@ -44,15 +44,22 @@ export type OnDemandProfileChannel = {
     : never
 }[ChannelType] // "messenger" | "instagram" | "zalo" | "telegram"
 
+/**
+ * Null-safe against a runtime `channel` value outside `ChannelType` — `Inbox`
+ * / `ContactInbox`.`channel` is a plain `text()` column (callers cast `as
+ * ChannelType`), so a legacy/unknown row must resolve to "no source" instead
+ * of throwing a `TypeError` on the missing table row (matches the pre-table
+ * `canGetUserProfileIfNeeded`, which returned `false` for anything unknown).
+ */
 export const resolveInboundProfileNameSource = (
   channel: ChannelType,
 ): ContactProfileNameSource | null =>
-  contactProfileNameCapabilities[channel].inbound
+  contactProfileNameCapabilities[channel]?.inbound ?? null
 
 export const hasOnDemandProfileApi = (
   channel: ChannelType,
 ): channel is OnDemandProfileChannel =>
-  contactProfileNameCapabilities[channel].onDemand
+  contactProfileNameCapabilities[channel]?.onDemand ?? false
 
 /** Only channel-API attempts are rate-limited; payload attempts are free. */
 export const COOLDOWN_BY_PROFILE_SOURCE = {

--- a/packages/business/src/contact/profile-refresh/rules.ts
+++ b/packages/business/src/contact/profile-refresh/rules.ts
@@ -69,22 +69,14 @@ export const COOLDOWN_BY_PROFILE_SOURCE = {
 
 /**
  * The exact set of ECMAScript `WhiteSpace` + `LineTerminator` code points
- * `String.prototype.trim()` strips (ECMA-262 `TrimString`) — the same set
- * `hasEmptyProfileName`/`hasProfileName` below rely on via `.trim()`. Kept
- * as one exported source of truth so `ContactService.updateIfProfileNameEmpty`
- * (`packages/business/src/contact/service.ts`) can bind the identical
- * character set into Postgres' `btrim(text, characters)` instead of
- * drifting from JS's definition of "blank" — plain `btrim(text)` (no
- * second argument) only strips ASCII space, which would let a
- * tab-only/NBSP-only name (blank per `.trim()`) desync the SQL predicate
- * from `hasEmptyProfileName` and silently stop backfilling forever.
- *
- * Written as explicit `\u` escapes (never literal characters) so the exact
- * code points are auditable in source and immune to editor/encoding
- * mangling: TAB, LF, VT, FF, CR, SPACE, NBSP, OGHAM SPACE MARK, EN QUAD..
- * HAIR SPACE (U+2000-U+200A), LINE SEPARATOR, PARAGRAPH SEPARATOR, NARROW
- * NO-BREAK SPACE, MEDIUM MATHEMATICAL SPACE, IDEOGRAPHIC SPACE, ZERO WIDTH
- * NO-BREAK SPACE (BOM).
+ * `String.prototype.trim()` strips — the same set `hasEmptyProfileName` /
+ * `hasProfileName` rely on. Exported as one source of truth so
+ * `ContactService.updateIfProfileNameEmpty` can bind it into Postgres'
+ * `btrim(text, characters)` instead of drifting from JS's "blank" (plain
+ * `btrim(text)` only strips ASCII space). Explicit `\u` escapes, not literal
+ * characters, so the code points stay auditable: TAB, LF, VT, FF, CR, SPACE,
+ * NBSP, OGHAM SPACE MARK, EN QUAD..HAIR SPACE (U+2000-U+200A), LINE/PARAGRAPH
+ * SEPARATOR, NARROW/MEDIUM MATH SPACE, IDEOGRAPHIC SPACE, BOM.
  */
 export const PROFILE_NAME_BLANK_CHARACTERS =
   "\u0009\u000A\u000B\u000C\u000D\u0020\u00A0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF"
@@ -103,45 +95,23 @@ export type ContactProfileUpdate = Partial<
 >
 
 /**
- * Per-column mapper table. `gender` is validated with the DB enum, not cast.
- * `undefined` values are dropped so a channel lacking `pages_user_locale` /
- * `timezone` / `gender` never clobbers existing data. Replaces `buildCandidate`
- * in `apps/worker/src/integration/handlers/messenger-contact-data.ts:26-49`.
- */
-const profileColumnMappers = {
-  firstName: (p) => p.firstName,
-  lastName: (p) => p.lastName,
-  avatar: (p) => p.avatar,
-  locale: (p) => p.locale,
-  timezone: (p) => p.timezone,
-  gender: (p) => genderTypes.safeParse(p.gender).data,
-} as const satisfies {
-  [K in keyof ContactProfileUpdate]-?: (
-    profile: IncomingContact,
-  ) => ContactProfileUpdate[K] | undefined
-}
-
-type ProfileColumn = keyof typeof profileColumnMappers
-const PROFILE_COLUMNS = Object.keys(
-  profileColumnMappers,
-) as readonly ProfileColumn[] // literal-union narrowing, not `any`
-
-/**
- * Typed accumulation over `PROFILE_COLUMNS` — no `Object.fromEntries` index
- * signature, and no per-iteration object-spread (avoids the O(n²) pattern on
- * an accumulator): the local `update` object is built once and returned.
+ * Six fixed columns, so a direct literal beats a mapper table + loop.
+ * `undefined` values are dropped (conditional spread) so a channel lacking
+ * `pages_user_locale`/`timezone`/`gender` never clobbers existing data.
+ * `gender` is validated with the DB enum, not cast.
  */
 export const buildContactProfileUpdate = (
   profile: IncomingContact,
 ): ContactProfileUpdate => {
-  const update: ContactProfileUpdate = {}
-  for (const column of PROFILE_COLUMNS) {
-    const value = profileColumnMappers[column](profile)
-    if (value !== undefined) {
-      update[column] = value
-    }
+  const gender = genderTypes.safeParse(profile.gender).data
+  return {
+    ...(profile.firstName !== undefined && { firstName: profile.firstName }),
+    ...(profile.lastName !== undefined && { lastName: profile.lastName }),
+    ...(profile.avatar !== undefined && { avatar: profile.avatar }),
+    ...(profile.locale !== undefined && { locale: profile.locale }),
+    ...(profile.timezone !== undefined && { timezone: profile.timezone }),
+    ...(gender !== undefined && { gender }),
   }
-  return update
 }
 
 /** A refresh only counts when the channel returned a usable name. */

--- a/packages/business/src/contact/profile-refresh/rules.ts
+++ b/packages/business/src/contact/profile-refresh/rules.ts
@@ -67,6 +67,28 @@ export const COOLDOWN_BY_PROFILE_SOURCE = {
   channelApi: true,
 } as const satisfies Record<ContactProfileNameSource, boolean>
 
+/**
+ * The exact set of ECMAScript `WhiteSpace` + `LineTerminator` code points
+ * `String.prototype.trim()` strips (ECMA-262 `TrimString`) — the same set
+ * `hasEmptyProfileName`/`hasProfileName` below rely on via `.trim()`. Kept
+ * as one exported source of truth so `ContactService.updateIfProfileNameEmpty`
+ * (`packages/business/src/contact/service.ts`) can bind the identical
+ * character set into Postgres' `btrim(text, characters)` instead of
+ * drifting from JS's definition of "blank" — plain `btrim(text)` (no
+ * second argument) only strips ASCII space, which would let a
+ * tab-only/NBSP-only name (blank per `.trim()`) desync the SQL predicate
+ * from `hasEmptyProfileName` and silently stop backfilling forever.
+ *
+ * Written as explicit `\u` escapes (never literal characters) so the exact
+ * code points are auditable in source and immune to editor/encoding
+ * mangling: TAB, LF, VT, FF, CR, SPACE, NBSP, OGHAM SPACE MARK, EN QUAD..
+ * HAIR SPACE (U+2000-U+200A), LINE SEPARATOR, PARAGRAPH SEPARATOR, NARROW
+ * NO-BREAK SPACE, MEDIUM MATHEMATICAL SPACE, IDEOGRAPHIC SPACE, ZERO WIDTH
+ * NO-BREAK SPACE (BOM).
+ */
+export const PROFILE_NAME_BLANK_CHARACTERS =
+  "\u0009\u000A\u000B\u000C\u000D\u0020\u00A0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF"
+
 export type ContactProfileName = Pick<ContactModel, "firstName" | "lastName">
 /** Empty only when BOTH names are blank — either one present means "has a name". */
 export const hasEmptyProfileName = (contact: ContactProfileName): boolean =>

--- a/packages/business/src/contact/profile-refresh/service.ts
+++ b/packages/business/src/contact/profile-refresh/service.ts
@@ -89,12 +89,15 @@ const startCooldownIfApplicable = async (
 /**
  * Wraps `logProviderErrorForChannel` in its own `try/catch` + `logger.warn`
  * so an Error-Log write failure can never surface — every caller here is
- * already inside a `failed` branch.
+ * already inside a `failed` branch. Exported for the worker's creation-path
+ * fetch (`received-message.ts`), which has no `contactId` yet at the point
+ * of failure — the contact row does not exist until after `getProfile`
+ * would have populated it.
  */
-const recordProfileRefreshFailure = async (input: {
+export const recordProfileRefreshFailure = async (input: {
   channel: string
   workspaceId: string
-  contactId: string
+  contactId?: string
   error: unknown
 }): Promise<void> => {
   try {

--- a/packages/business/src/contact/profile-refresh/service.ts
+++ b/packages/business/src/contact/profile-refresh/service.ts
@@ -1,0 +1,254 @@
+import type {
+  ContactInboxModel,
+  ContactModel,
+} from "@chatbotx.io/database/types"
+import { uploader } from "@chatbotx.io/filesystem"
+import type { IncomingContact } from "@chatbotx.io/sdk"
+import { logProviderErrorForChannel } from "../../error-log/service"
+import { logger } from "../../logger"
+import type { ContactAccessScope } from "../service"
+import { contactService } from "../service"
+import {
+  isContactProfileRefreshCoolingDown,
+  startContactProfileRefreshCooldown,
+} from "./cooldown"
+import {
+  buildContactProfileUpdate,
+  COOLDOWN_BY_PROFILE_SOURCE,
+  type ContactProfileNameSource,
+  type ContactProfileUpdate,
+  hasEmptyProfileName,
+  hasProfileName,
+} from "./rules"
+
+/**
+ * Strategy supplied by the app. It must do ALL channel resolution lazily
+ * (integration row, `buildContext`, registry lookup, Graph call) so that any
+ * failure along the way surfaces inside `refresh()` as `failed` + cooldown —
+ * nothing channel-related happens before the service decides to fetch.
+ */
+export type ContactProfileFetcher = () => Promise<
+  IncomingContact | null | undefined
+>
+
+export type ContactProfileRefreshResult =
+  | { status: "updated"; contact: ContactModel }
+  | { status: "skipped"; reason: "profileComplete" | "coolingDown" }
+  | { status: "unavailable" } // fetched (or nullish), but no usable name → nothing written, cooldown started
+  | { status: "failed" } // fetch/resolution error or write error → recorded, cooldown started, never thrown
+
+export type RefreshContactProfileInput = {
+  workspaceId: string
+  contactId: string
+  contactInbox: Pick<ContactInboxModel, "id" | "channel">
+  source: ContactProfileNameSource // decides cooldown policy via COOLDOWN_BY_PROFILE_SOURCE
+  accessScope?: ContactAccessScope // builder passes it; worker omits
+  fetchProfile: ContactProfileFetcher // strategy — the app's channel call or the parsed payload
+}
+
+const EXTERNAL_URL_PATTERN = /^https?:\/\//
+
+/**
+ * True when `avatar` is an object we uploaded to our own storage (an
+ * `.../avatars/<id>` key), so it is safe to delete when superseded. External
+ * URLs (http/https) and non-avatar paths are left untouched.
+ */
+const isManagedAvatarObject = (avatar: string): boolean =>
+  !EXTERNAL_URL_PATTERN.test(avatar) && avatar.includes("/avatars/")
+
+/**
+ * Best-effort deletion of a managed avatar object this attempt just uploaded
+ * (via the channel's `getProfile` handler) but is about to discard — either
+ * because the profile carried no usable name, or because the subsequent
+ * write failed. A delete error is logged and ignored.
+ */
+const discardUploadedAvatar = async (avatar: string | null | undefined) => {
+  if (!(avatar && isManagedAvatarObject(avatar))) {
+    return
+  }
+  try {
+    await uploader.deleteObject(avatar)
+  } catch (error) {
+    logger.warn(
+      { error, avatar },
+      "discardUploadedAvatar: failed to delete avatar object",
+    )
+  }
+}
+
+const startCooldownIfApplicable = async (
+  source: ContactProfileNameSource,
+  contactInboxId: string,
+): Promise<void> => {
+  if (!COOLDOWN_BY_PROFILE_SOURCE[source]) {
+    return
+  }
+  await startContactProfileRefreshCooldown(contactInboxId)
+}
+
+/**
+ * Wraps `logProviderErrorForChannel` in its own `try/catch` + `logger.warn`
+ * so an Error-Log write failure can never surface — every caller here is
+ * already inside a `failed` branch.
+ */
+const recordProfileRefreshFailure = async (input: {
+  channel: string
+  workspaceId: string
+  contactId: string
+  error: unknown
+}): Promise<void> => {
+  try {
+    await logProviderErrorForChannel(input.channel, {
+      workspaceId: input.workspaceId,
+      contactId: input.contactId,
+      error: input.error,
+    })
+  } catch (error) {
+    logger.warn(
+      { error, channel: input.channel, workspaceId: input.workspaceId },
+      "recordProfileRefreshFailure: failed to record error log",
+    )
+  }
+}
+
+export type ApplyContactProfileInput = {
+  workspaceId: string
+  contactId: string
+  accessScope?: ContactAccessScope
+  update: ContactProfileUpdate
+}
+
+/**
+ * `contactService.update` (invalidates the contact cache and emits
+ * `emitContactInfoChangeEvents`) plus managed-avatar compensation: capture
+ * the previous avatar, write the new profile, then delete the superseded
+ * managed object. Every `uploader.deleteObject` call is best-effort — logged,
+ * never thrown.
+ */
+export const applyContactProfile = async (
+  input: ApplyContactProfileInput,
+): Promise<ContactModel> => {
+  const { workspaceId, contactId, accessScope, update } = input
+
+  // `getProfile` uploads the fetched picture to a fresh `avatars/<id>` object
+  // on every run, so capture the current avatar first and delete it once the
+  // new one is persisted — otherwise repeated syncs orphan storage objects.
+  const previousAvatar =
+    update.avatar === undefined
+      ? undefined
+      : (
+          await contactService.findById({
+            workspaceId,
+            id: contactId,
+            accessScope,
+          })
+        )?.avatar
+
+  const updated = await contactService.update(
+    { workspaceId, id: contactId, accessScope },
+    update,
+  )
+
+  if (
+    previousAvatar &&
+    previousAvatar !== update.avatar &&
+    isManagedAvatarObject(previousAvatar)
+  ) {
+    try {
+      await uploader.deleteObject(previousAvatar)
+    } catch (error) {
+      logger.warn(
+        { error, path: previousAvatar },
+        "applyContactProfile: failed to delete superseded avatar",
+      )
+    }
+  }
+
+  return updated
+}
+
+/**
+ * Linear pipeline, each step returns early with a typed result. Channel
+ * eligibility is decided by the caller from the capability table — this
+ * function receives `source` and never inspects the channel name (it only
+ * forwards `contactInbox.channel` as opaque data to the error logger).
+ */
+const refresh = async (
+  input: RefreshContactProfileInput,
+): Promise<ContactProfileRefreshResult> => {
+  const {
+    workspaceId,
+    contactId,
+    contactInbox,
+    source,
+    accessScope,
+    fetchProfile,
+  } = input
+
+  const contact = await contactService.findByIdOrFail({
+    workspaceId,
+    id: contactId,
+    accessScope,
+  })
+  if (!hasEmptyProfileName(contact)) {
+    return { status: "skipped", reason: "profileComplete" }
+  }
+
+  const cooldownGated = COOLDOWN_BY_PROFILE_SOURCE[source]
+  if (
+    cooldownGated &&
+    (await isContactProfileRefreshCoolingDown(contactInbox.id))
+  ) {
+    return { status: "skipped", reason: "coolingDown" }
+  }
+
+  let profile: IncomingContact | null | undefined
+  try {
+    profile = await fetchProfile()
+  } catch (error) {
+    await recordProfileRefreshFailure({
+      channel: contactInbox.channel,
+      workspaceId,
+      contactId,
+      error,
+    })
+    await startCooldownIfApplicable(source, contactInbox.id)
+    return { status: "failed" }
+  }
+
+  if (profile == null) {
+    await startCooldownIfApplicable(source, contactInbox.id)
+    return { status: "unavailable" }
+  }
+
+  const update = buildContactProfileUpdate(profile)
+  if (!hasProfileName(update)) {
+    // A nameless write would leave the contact eligible forever and
+    // re-upload an avatar on every attempt — discard everything instead.
+    await discardUploadedAvatar(update.avatar)
+    await startCooldownIfApplicable(source, contactInbox.id)
+    return { status: "unavailable" }
+  }
+
+  try {
+    const updatedContact = await applyContactProfile({
+      workspaceId,
+      contactId,
+      accessScope,
+      update,
+    })
+    return { status: "updated", contact: updatedContact }
+  } catch (error) {
+    await discardUploadedAvatar(update.avatar)
+    await recordProfileRefreshFailure({
+      channel: contactInbox.channel,
+      workspaceId,
+      contactId,
+      error,
+    })
+    await startCooldownIfApplicable(source, contactInbox.id)
+    return { status: "failed" }
+  }
+}
+
+export const contactProfileRefreshService = { refresh }

--- a/packages/business/src/contact/profile-refresh/service.ts
+++ b/packages/business/src/contact/profile-refresh/service.ts
@@ -233,6 +233,21 @@ const refresh = async (
     return { status: "unavailable" }
   }
 
+  // Re-check immediately before the write: an operator (or a concurrent
+  // refresh) may have filled the name while `fetchProfile` was in flight —
+  // the initial `hasEmptyProfileName` check at the top of this function is
+  // now stale. Skip the write rather than clobbering a newer name; no
+  // cooldown (this attempt never actually failed).
+  const contactBeforeWrite = await contactService.findById({
+    workspaceId,
+    id: contactId,
+    accessScope,
+  })
+  if (contactBeforeWrite && !hasEmptyProfileName(contactBeforeWrite)) {
+    await discardUploadedAvatar(update.avatar)
+    return { status: "skipped", reason: "profileComplete" }
+  }
+
   try {
     const updatedContact = await applyContactProfile({
       workspaceId,

--- a/packages/business/src/contact/profile-refresh/service.ts
+++ b/packages/business/src/contact/profile-refresh/service.ts
@@ -119,19 +119,41 @@ export type ApplyContactProfileInput = {
   contactId: string
   accessScope?: ContactAccessScope
   update: ContactProfileUpdate
+  /**
+   * `true` routes the write through `contactService.updateIfProfileNameEmpty`
+   * — a single atomic UPDATE that only lands if the contact's name is STILL
+   * empty at write time, closing the TOCTOU race between an earlier
+   * eligibility check and this write. Defaults to `false` (unconditional
+   * `contactService.update`) — the `updateMessengerContactData` flow step
+   * deliberately overwrites an existing name and must keep doing so.
+   */
+  onlyIfProfileNameEmpty?: boolean
 }
 
+export type ApplyContactProfileResult =
+  | { applied: true; contact: ContactModel }
+  // Only reachable with `onlyIfProfileNameEmpty: true` — the name was filled
+  // concurrently between the caller's eligibility check and this write, so
+  // the conditional UPDATE matched zero rows.
+  | { applied: false }
+
 /**
- * `contactService.update` (invalidates the contact cache and emits
- * `emitContactInfoChangeEvents`) plus managed-avatar compensation: capture
- * the previous avatar, write the new profile, then delete the superseded
- * managed object. Every `uploader.deleteObject` call is best-effort — logged,
- * never thrown.
+ * `contactService.update` / `updateIfProfileNameEmpty` (invalidates the
+ * contact cache and emits `emitContactInfoChangeEvents`) plus managed-avatar
+ * compensation: capture the previous avatar, write the new profile, then
+ * delete the superseded managed object. Every `uploader.deleteObject` call
+ * is best-effort — logged, never thrown.
  */
 export const applyContactProfile = async (
   input: ApplyContactProfileInput,
-): Promise<ContactModel> => {
-  const { workspaceId, contactId, accessScope, update } = input
+): Promise<ApplyContactProfileResult> => {
+  const {
+    workspaceId,
+    contactId,
+    accessScope,
+    update,
+    onlyIfProfileNameEmpty,
+  } = input
 
   // `getProfile` uploads the fetched picture to a fresh `avatars/<id>` object
   // on every run, so capture the current avatar first and delete it once the
@@ -147,10 +169,19 @@ export const applyContactProfile = async (
           })
         )?.avatar
 
-  const updated = await contactService.update(
-    { workspaceId, id: contactId, accessScope },
-    update,
-  )
+  const updated = onlyIfProfileNameEmpty
+    ? await contactService.updateIfProfileNameEmpty(
+        { workspaceId, id: contactId, accessScope },
+        update,
+      )
+    : await contactService.update(
+        { workspaceId, id: contactId, accessScope },
+        update,
+      )
+
+  if (!updated) {
+    return { applied: false }
+  }
 
   if (
     previousAvatar &&
@@ -167,7 +198,7 @@ export const applyContactProfile = async (
     }
   }
 
-  return updated
+  return { applied: true, contact: updated }
 }
 
 /**
@@ -233,29 +264,25 @@ const refresh = async (
     return { status: "unavailable" }
   }
 
-  // Re-check immediately before the write: an operator (or a concurrent
-  // refresh) may have filled the name while `fetchProfile` was in flight —
-  // the initial `hasEmptyProfileName` check at the top of this function is
-  // now stale. Skip the write rather than clobbering a newer name; no
-  // cooldown (this attempt never actually failed).
-  const contactBeforeWrite = await contactService.findById({
-    workspaceId,
-    id: contactId,
-    accessScope,
-  })
-  if (contactBeforeWrite && !hasEmptyProfileName(contactBeforeWrite)) {
-    await discardUploadedAvatar(update.avatar)
-    return { status: "skipped", reason: "profileComplete" }
-  }
-
   try {
-    const updatedContact = await applyContactProfile({
+    // `onlyIfProfileNameEmpty: true` folds the "name still empty" check
+    // into the write itself (a single atomic UPDATE) instead of a separate
+    // read before the write — an operator or a concurrent refresh filling
+    // the name while `fetchProfile` was in flight can no longer be
+    // clobbered: the write simply matches zero rows.
+    const applied = await applyContactProfile({
       workspaceId,
       contactId,
       accessScope,
       update,
+      onlyIfProfileNameEmpty: true,
     })
-    return { status: "updated", contact: updatedContact }
+    if (!applied.applied) {
+      // Raced, not failed — no cooldown.
+      await discardUploadedAvatar(update.avatar)
+      return { status: "skipped", reason: "profileComplete" }
+    }
+    return { status: "updated", contact: applied.contact }
   } catch (error) {
     await discardUploadedAvatar(update.avatar)
     await recordProfileRefreshFailure({

--- a/packages/business/src/contact/profile-refresh/service.ts
+++ b/packages/business/src/contact/profile-refresh/service.ts
@@ -119,41 +119,31 @@ export type ApplyContactProfileInput = {
   contactId: string
   accessScope?: ContactAccessScope
   update: ContactProfileUpdate
-  /**
-   * `true` routes the write through `contactService.updateIfProfileNameEmpty`
-   * — a single atomic UPDATE that only lands if the contact's name is STILL
-   * empty at write time, closing the TOCTOU race between an earlier
-   * eligibility check and this write. Defaults to `false` (unconditional
-   * `contactService.update`) — the `updateMessengerContactData` flow step
-   * deliberately overwrites an existing name and must keep doing so.
-   */
-  onlyIfProfileNameEmpty?: boolean
 }
 
-export type ApplyContactProfileResult =
-  | { applied: true; contact: ContactModel }
-  // Only reachable with `onlyIfProfileNameEmpty: true` — the name was filled
-  // concurrently between the caller's eligibility check and this write, so
-  // the conditional UPDATE matched zero rows.
-  | { applied: false }
+type ContactWriteContext = {
+  workspaceId: string
+  id: string
+  accessScope?: ContactAccessScope
+}
 
 /**
- * `contactService.update` / `updateIfProfileNameEmpty` (invalidates the
- * contact cache and emits `emitContactInfoChangeEvents`) plus managed-avatar
- * compensation: capture the previous avatar, write the new profile, then
- * delete the superseded managed object. Every `uploader.deleteObject` call
- * is best-effort — logged, never thrown.
+ * Shared core behind `applyContactProfile`/`applyContactProfileIfNameEmpty`:
+ * capture the previous avatar, run `write`, then best-effort delete the
+ * superseded managed avatar object. `write` is `contactService.update` for
+ * an unconditional write, `updateIfProfileNameEmpty` for a conditional one —
+ * its own `undefined` return (conditional write matched zero rows) is
+ * passed straight through. Every `uploader.deleteObject` call is
+ * best-effort — logged, never thrown.
  */
-export const applyContactProfile = async (
+const applyProfile = async (
   input: ApplyContactProfileInput,
-): Promise<ApplyContactProfileResult> => {
-  const {
-    workspaceId,
-    contactId,
-    accessScope,
-    update,
-    onlyIfProfileNameEmpty,
-  } = input
+  write: (
+    ctx: ContactWriteContext,
+    update: ContactProfileUpdate,
+  ) => Promise<ContactModel | undefined>,
+): Promise<ContactModel | undefined> => {
+  const { workspaceId, contactId, accessScope, update } = input
 
   // `getProfile` uploads the fetched picture to a fresh `avatars/<id>` object
   // on every run, so capture the current avatar first and delete it once the
@@ -169,18 +159,13 @@ export const applyContactProfile = async (
           })
         )?.avatar
 
-  const updated = onlyIfProfileNameEmpty
-    ? await contactService.updateIfProfileNameEmpty(
-        { workspaceId, id: contactId, accessScope },
-        update,
-      )
-    : await contactService.update(
-        { workspaceId, id: contactId, accessScope },
-        update,
-      )
+  const updated = await write(
+    { workspaceId, id: contactId, accessScope },
+    update,
+  )
 
   if (!updated) {
-    return { applied: false }
+    return
   }
 
   if (
@@ -193,13 +178,39 @@ export const applyContactProfile = async (
     } catch (error) {
       logger.warn(
         { error, path: previousAvatar },
-        "applyContactProfile: failed to delete superseded avatar",
+        "applyProfile: failed to delete superseded avatar",
       )
     }
   }
 
-  return { applied: true, contact: updated }
+  return updated
 }
+
+/**
+ * Unconditional write — `contactService.update` never returns falsy, so
+ * this always resolves. Used by the `updateMessengerContactData` flow step,
+ * which deliberately overwrites an existing name.
+ */
+export const applyContactProfile = async (
+  input: ApplyContactProfileInput,
+): Promise<ContactModel> =>
+  (await applyProfile(input, (ctx, update) =>
+    contactService.update(ctx, update),
+  )) as ContactModel
+
+/**
+ * Conditional write via `contactService.updateIfProfileNameEmpty` — a single
+ * atomic UPDATE that only lands if the contact's name is STILL empty at
+ * write time, closing the TOCTOU race between an earlier eligibility check
+ * and this write. Resolves `undefined` when the write matched zero rows
+ * (the name was filled concurrently).
+ */
+export const applyContactProfileIfNameEmpty = async (
+  input: ApplyContactProfileInput,
+): Promise<ContactModel | undefined> =>
+  await applyProfile(input, (ctx, update) =>
+    contactService.updateIfProfileNameEmpty(ctx, update),
+  )
 
 /**
  * Linear pipeline, each step returns early with a typed result. Channel
@@ -265,24 +276,23 @@ const refresh = async (
   }
 
   try {
-    // `onlyIfProfileNameEmpty: true` folds the "name still empty" check
-    // into the write itself (a single atomic UPDATE) instead of a separate
-    // read before the write — an operator or a concurrent refresh filling
-    // the name while `fetchProfile` was in flight can no longer be
-    // clobbered: the write simply matches zero rows.
-    const applied = await applyContactProfile({
+    // The atomic conditional write folds the "name still empty" check into
+    // the write itself instead of a separate read before the write — an
+    // operator or a concurrent refresh filling the name while `fetchProfile`
+    // was in flight can no longer be clobbered: the write simply matches
+    // zero rows, surfaced here as `undefined`.
+    const updatedContact = await applyContactProfileIfNameEmpty({
       workspaceId,
       contactId,
       accessScope,
       update,
-      onlyIfProfileNameEmpty: true,
     })
-    if (!applied.applied) {
+    if (!updatedContact) {
       // Raced, not failed — no cooldown.
       await discardUploadedAvatar(update.avatar)
       return { status: "skipped", reason: "profileComplete" }
     }
-    return { status: "updated", contact: applied.contact }
+    return { status: "updated", contact: updatedContact }
   } catch (error) {
     await discardUploadedAvatar(update.avatar)
     await recordProfileRefreshFailure({

--- a/packages/business/src/contact/service.ts
+++ b/packages/business/src/contact/service.ts
@@ -42,6 +42,7 @@ import { userQuotaService } from "../user-quota/service"
 import { workspaceService } from "../workspace/service"
 import { workspaceUsageService } from "../workspace-usage/service"
 import { emitContactInfoChangeEvents } from "./contact-info-changes"
+import { PROFILE_NAME_BLANK_CHARACTERS } from "./profile-refresh/rules"
 
 const NUMERIC_RE = /^\d+$/
 
@@ -279,8 +280,8 @@ class ContactService extends BaseService {
         and(
           eq(contactModel.id, ctx.id),
           eq(contactModel.workspaceId, ctx.workspaceId),
-          sql`btrim(coalesce(${contactModel.firstName}, '')) = ''`,
-          sql`btrim(coalesce(${contactModel.lastName}, '')) = ''`,
+          sql`btrim(coalesce(${contactModel.firstName}, ''), ${PROFILE_NAME_BLANK_CHARACTERS}) = ''`,
+          sql`btrim(coalesce(${contactModel.lastName}, ''), ${PROFILE_NAME_BLANK_CHARACTERS}) = ''`,
         ),
       )
       .returning()

--- a/packages/business/src/contact/service.ts
+++ b/packages/business/src/contact/service.ts
@@ -1,10 +1,12 @@
 import { macAnalyticsService } from "@chatbotx.io/analytics"
 import {
+  and,
   type DatabaseClient,
   db,
   eq,
   findOrFail,
   inArray,
+  sql,
 } from "@chatbotx.io/database/client"
 import {
   type ContactSource,
@@ -227,6 +229,66 @@ class ContactService extends BaseService {
       .set(data)
       .where(eq(contactModel.id, ctx.id))
       .returning()
+    await this.invalidate({ workspaceId: ctx.workspaceId, ids: [ctx.id] })
+    if (ownsTransaction) {
+      await emitContactInfoChangeEvents(
+        ctx.workspaceId,
+        ctx.id,
+        existing,
+        updated,
+      )
+    }
+    return updated
+  }
+
+  /**
+   * Conditional write closing the TOCTOU race a plain read-then-`update`
+   * leaves open: checking `hasEmptyProfileName` and then calling `update`
+   * has a window between the two where a concurrent write (an operator
+   * edit, or another refresh attempt) can fill the name and get silently
+   * overwritten. This folds the "both firstName and lastName are still
+   * empty" predicate into the UPDATE's own WHERE clause — matching
+   * `hasEmptyProfileName`'s semantics exactly (NULL or whitespace-only
+   * counts as empty) — so the write only lands if the row still qualifies
+   * at the instant of the write. Returns `undefined` when zero rows matched
+   * (the name was filled concurrently) instead of throwing, so callers can
+   * distinguish "raced, skip" from "wrote".
+   *
+   * `accessScope` authorization is handled the same way `update()` handles
+   * it: via the `findByIdOrFail` read below, which throws if the contact is
+   * outside the caller's scope. Unlike the name predicate, accessScope has
+   * no race to close here, so it is not folded into the WHERE.
+   */
+  async updateIfProfileNameEmpty(
+    ctx: { workspaceId: string; id: string; accessScope?: ContactAccessScope },
+    data: ContactWriteData,
+    tx: DatabaseClient = db,
+  ): Promise<ContactModel | undefined> {
+    const ownsTransaction = tx === db
+    const existing = await this.findByIdOrFail({
+      workspaceId: ctx.workspaceId,
+      id: ctx.id,
+      accessScope: ctx.accessScope,
+      tx,
+    })
+
+    const [updated] = await tx
+      .update(contactModel)
+      .set(data)
+      .where(
+        and(
+          eq(contactModel.id, ctx.id),
+          eq(contactModel.workspaceId, ctx.workspaceId),
+          sql`btrim(coalesce(${contactModel.firstName}, '')) = ''`,
+          sql`btrim(coalesce(${contactModel.lastName}, '')) = ''`,
+        ),
+      )
+      .returning()
+
+    if (!updated) {
+      return
+    }
+
     await this.invalidate({ workspaceId: ctx.workspaceId, ids: [ctx.id] })
     if (ownsTransaction) {
       await emitContactInfoChangeEvents(

--- a/packages/business/src/integration-telegram/index.ts
+++ b/packages/business/src/integration-telegram/index.ts
@@ -1,1 +1,2 @@
 export * from "./schema"
+export * from "./service"

--- a/packages/business/src/integration-telegram/service.ts
+++ b/packages/business/src/integration-telegram/service.ts
@@ -1,0 +1,14 @@
+import { findOrFail } from "@chatbotx.io/database/client"
+import { integrationTelegramModel } from "@chatbotx.io/database/schema"
+import { BaseService } from "../base.service"
+
+class TelegramIntegrationService extends BaseService {
+  findByInboxIdForWorkspace(props: { inboxId: string; workspaceId: string }) {
+    return findOrFail({
+      table: integrationTelegramModel,
+      where: { inboxId: props.inboxId, workspaceId: props.workspaceId },
+    })
+  }
+}
+
+export const telegramIntegrationService = new TelegramIntegrationService()

--- a/packages/business/src/integration-zalo/service.ts
+++ b/packages/business/src/integration-zalo/service.ts
@@ -41,6 +41,13 @@ class ZaloIntegrationService extends BaseService {
     })
   }
 
+  findByInboxIdForWorkspace(props: { inboxId: string; workspaceId: string }) {
+    return findOrFail({
+      table: integrationZaloModel,
+      where: { inboxId: props.inboxId, workspaceId: props.workspaceId },
+    })
+  }
+
   async updateAuth(
     id: string,
     auth: Record<string, unknown>,


### PR DESCRIPTION
## Summary
- Contacts entering through Ads that Click to Messenger (and any referral-only entry point) were stored without a name: Meta only grants profile access after the person replies, the one creation-time `getProfile` call fails, and nothing ever retried. Existing nameless contacts stayed nameless forever.
- Adds a channel-agnostic profile refresh: when a contact with no name sends a real inbound message, the worker re-fetches the profile inline (channel API for Messenger/Instagram/Zalo/Telegram, free webhook-payload data for WhatsApp/API) and persists it only when a usable name comes back — so the very first automated reply already resolves `{{first_name}}`.
- Channel-API refreshes persist the same field set as contact creation: locale and timezone are normalized through the existing `finalizeContactProfile`, and the contact inbox `language` is derived and stored via the existing `updateLanguage` when it was empty — manual/operator-set values are never overwritten.
- Opening such a contact's conversation in the Inbox triggers the same refresh on demand and updates the panel and conversation list in place.
- A 5-minute Redis cooldown bounds retries after a failed channel-API attempt (e.g. Messenger accounts created with a phone number, error 2018218); payload-based refreshes never touch Redis. Failures are best-effort throughout — the receive pipeline can never fail because of profile work.

## Changes
- `packages/business`: new `contact/profile-refresh/` module — exhaustive per-channel capability table (`Record<ChannelType, …>`), profile→contact field mapper (name required before any write), cooldown, and a `refresh()` pipeline with typed results; atomic `contactService.updateIfProfileNameEmpty` (conditional write, blank-name predicate matching JS `trim()` semantics with bound parameters) closes the race against an operator typing a name mid-fetch; client-safe subpath export `@chatbotx.io/business/contact-profile-rules`; `zaloIntegrationService`/`telegramIntegrationService` gain `findByInboxIdForWorkspace`.
- `apps/worker`: after an inbound message is persisted, eligible nameless contacts are refreshed via `getProfileRefreshSource` + per-source fetcher table in the new `contact-profile-refresh.ts` handler; the creation-time fetch keeps its behavior with the channel set now read from the shared capability table; the flow step `updateMessengerContactData` reuses the shared mapper/apply helpers.
- `apps/builder`: `refreshContactProfileAction` (authorization-first, per-channel fetcher factory table, never throws for channel failures) + `useAutoRefreshContactProfile` in the contact panel (once per contact per mount, StrictMode-safe, overlapping attempts applied independently, stale responses and failed re-fetches can't clobber fresh data); `useChatStore().updateContact` now patches every conversation of the contact immutably; `lastMessageAt` exposed on the conversation-scoped contact-inbox resource only (public `/v1/contacts*` schema unchanged).

## Test plan
- [x] `pnpm --filter @chatbotx.io/business test` (1551 tests), `pnpm --filter worker test` (1890), builder suite (2055, excluding two pre-existing untracked test files unrelated to this branch)
- [x] `check-types` clean for business/worker/builder; biome clean on all touched files; `pnpm check:circular` unchanged
- [x] `pnpm --filter builder build` compiles (verifies the business barrel stays out of the client bundle)
- [x] Blank-name SQL predicate validated against a real Postgres instance (NULL / empty / tab / NBSP / ideographic space)
- [ ] Manual verification on a live workspace: CTM referral → first real message backfills name/avatar; opening a nameless contact's conversation backfills on demand; phone-number Messenger account logs at most one provider error per 5 minutes

