### PR TITLE
feat(contacts): persist locale, timezone and language on profile refresh

### DIFF
--- a/apps/builder/__tests__/refresh-contact-profile-action.test.ts
+++ b/apps/builder/__tests__/refresh-contact-profile-action.test.ts
@@ -225,6 +225,39 @@ describe("refreshContactProfileAction — channel capability gate", () => {
   })
 })
 
+describe("refreshContactProfileAction — contactInbox forwarded to the service", () => {
+  test("forwards id, channel, contactId and the inbox's current language to contactProfileRefreshService.refresh", async () => {
+    mocks.findContactInboxByUncached.mockResolvedValueOnce({
+      id: "ci-1",
+      contactId: "contact-1",
+      channel: "messenger",
+      inboxId: "inbox-1",
+      sourceId: "source-1",
+      language: "en",
+    })
+    mocks.messengerFindByInboxIdForWorkspace.mockResolvedValueOnce({
+      id: "messenger-1",
+      auth: { accessToken: "tok" },
+    })
+    mocks.messengerRunChannelHandler.mockResolvedValueOnce({
+      firstName: "Jane",
+    })
+
+    await callAction({})
+
+    expect(mocks.refresh).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contactInbox: {
+          id: "ci-1",
+          channel: "messenger",
+          contactId: "contact-1",
+          language: "en",
+        },
+      }),
+    )
+  })
+})
+
 describe("refreshContactProfileAction — per-channel factory table", () => {
   test("findByInboxIdForWorkspace throwing (disconnected integration) returns failed, never thrown", async () => {
     mocks.findContactInboxByUncached.mockResolvedValueOnce({

--- a/apps/builder/src/features/contacts/actions/refresh-contact-profile.action.ts
+++ b/apps/builder/src/features/contacts/actions/refresh-contact-profile.action.ts
@@ -81,7 +81,12 @@ export const refreshContactProfileAction = workspaceActionClient
       const result = await contactProfileRefreshService.refresh({
         workspaceId,
         contactId,
-        contactInbox: { id: contactInbox.id, channel },
+        contactInbox: {
+          id: contactInbox.id,
+          channel,
+          contactId: contactInbox.contactId,
+          language: contactInbox.language,
+        },
         source: "channelApi",
         accessScope,
         fetchProfile,

--- a/apps/worker/__tests__/contact-profile-refresh-real-service.test.ts
+++ b/apps/worker/__tests__/contact-profile-refresh-real-service.test.ts
@@ -52,9 +52,9 @@ vi.mock("../../../packages/business/src/contact/service", () => ({
   },
 }))
 
-const updateLanguageMock = vi.fn(async () => null)
+const updateLanguageIfEmptyMock = vi.fn(async () => undefined)
 vi.mock("../../../packages/business/src/contact-inbox/service", () => ({
-  contactInboxService: { updateLanguage: updateLanguageMock },
+  contactInboxService: { updateLanguageIfEmpty: updateLanguageIfEmptyMock },
 }))
 
 const logProviderErrorForChannelMock = vi.fn(async () => undefined)
@@ -132,7 +132,7 @@ beforeEach(() => {
     workspaceId: ctx.workspaceId,
     ...data,
   }))
-  updateLanguageMock.mockResolvedValue(null)
+  updateLanguageIfEmptyMock.mockResolvedValue({ id: "ci-1" })
 })
 
 describe("refreshExistingContactProfile against the real contactProfileRefreshService", () => {
@@ -274,7 +274,7 @@ describe("refreshExistingContactProfile against the real contactProfileRefreshSe
       expect.anything(),
       expect.objectContaining({ locale: "vi_VN" }),
     )
-    expect(updateLanguageMock).toHaveBeenCalledWith({
+    expect(updateLanguageIfEmptyMock).toHaveBeenCalledWith({
       workspaceId: "ws-1",
       contactId: "contact-1",
       contactInboxId: "ci-1",

--- a/apps/worker/__tests__/contact-profile-refresh-real-service.test.ts
+++ b/apps/worker/__tests__/contact-profile-refresh-real-service.test.ts
@@ -52,6 +52,11 @@ vi.mock("../../../packages/business/src/contact/service", () => ({
   },
 }))
 
+const updateLanguageMock = vi.fn(async () => null)
+vi.mock("../../../packages/business/src/contact-inbox/service", () => ({
+  contactInboxService: { updateLanguage: updateLanguageMock },
+}))
+
 const logProviderErrorForChannelMock = vi.fn(async () => undefined)
 vi.mock("../../../packages/business/src/error-log/service", () => ({
   logProviderErrorForChannel: logProviderErrorForChannelMock,
@@ -99,6 +104,7 @@ const fakeContactInbox = {
   inboxId: "inbox-1",
   sourceId: "psid-123",
   channel: "messenger",
+  language: null,
 } as unknown as import("@chatbotx.io/database/types").ContactInboxModel
 
 const fakeIncomingContact = { sourceId: "psid-123", firstName: "Jane" }
@@ -126,6 +132,7 @@ beforeEach(() => {
     workspaceId: ctx.workspaceId,
     ...data,
   }))
+  updateLanguageMock.mockResolvedValue(null)
 })
 
 describe("refreshExistingContactProfile against the real contactProfileRefreshService", () => {
@@ -241,6 +248,42 @@ describe("refreshExistingContactProfile against the real contactProfileRefreshSe
     )
     expect(mockLoggerDebug).toHaveBeenCalledWith(
       expect.objectContaining({ result: { status: "failed" } }),
+      expect.any(String),
+    )
+  })
+
+  test("channelApi refresh persists the finalizeContactProfile-normalized locale and writes ContactInbox.language for an empty-language inbox", async () => {
+    const runChannelHandler = vi.fn().mockResolvedValue({
+      firstName: "Jane",
+      locale: "VI-vn",
+    })
+    mockResolveIntegrationContextFromContactInbox.mockResolvedValue({
+      integration: { runChannelHandler },
+      ctx: { workspaceId: "ws-1" },
+    })
+
+    await refreshExistingContactProfile({
+      source: "channelApi",
+      inbox: fakeInbox,
+      contactInbox: fakeContactInbox, // language: null, per the fixture above
+      incomingContact: fakeIncomingContact,
+      contactId: "contact-1",
+    })
+
+    expect(updateIfProfileNameEmptyMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ locale: "vi_VN" }),
+    )
+    expect(updateLanguageMock).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+      contactInboxId: "ci-1",
+      language: "vi",
+    })
+    expect(mockLoggerDebug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        result: expect.objectContaining({ status: "updated" }),
+      }),
       expect.any(String),
     )
   })

--- a/packages/business/__tests__/contact-profile-refresh.test.ts
+++ b/packages/business/__tests__/contact-profile-refresh.test.ts
@@ -34,9 +34,9 @@ vi.mock("../src/contact/service", () => ({
   },
 }))
 
-const updateLanguageMock = vi.fn(async () => null)
+const updateLanguageIfEmptyMock = vi.fn(async () => undefined)
 vi.mock("../src/contact-inbox/service", () => ({
-  contactInboxService: { updateLanguage: updateLanguageMock },
+  contactInboxService: { updateLanguageIfEmpty: updateLanguageIfEmptyMock },
 }))
 
 const logProviderErrorForChannelMock = vi.fn(async () => undefined)
@@ -105,7 +105,7 @@ beforeEach(() => {
   }))
   logProviderErrorForChannelMock.mockResolvedValue(undefined)
   deleteObjectMock.mockResolvedValue(undefined)
-  updateLanguageMock.mockResolvedValue(null)
+  updateLanguageIfEmptyMock.mockResolvedValue({ id: "inbox-1" })
 })
 
 // ─── rules.ts ────────────────────────────────────────────────────────────
@@ -749,12 +749,83 @@ describe("contactProfileRefreshService.refresh — channelApi locale/timezone no
       expect.anything(),
       expect.objectContaining({ locale: "VI-vn", timezone: "+07:00" }),
     )
-    expect(updateLanguageMock).not.toHaveBeenCalled()
+    expect(updateLanguageIfEmptyMock).not.toHaveBeenCalled()
+  })
+
+  test("blank channel timezone alongside a locale → locale is written, timezone is NOT (never falls back to a locale-region-derived value)", async () => {
+    // `finalizeContactProfile` would derive Asia/Ho_Chi_Minh from the
+    // vi_VN region when its own `timezone` input is blank — that fallback
+    // is correct at contact-creation time (no timezone at all yet) but
+    // wrong here: the channel DID return a `timezone` field, it was just
+    // blank, so per the strict "only fields the channel returned" reading
+    // nothing should be written for it.
+    const fetchProfile = vi.fn(async () => ({
+      firstName: "Jane",
+      locale: "vi_VN",
+      timezone: "   ",
+    }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result.status).toBe("updated")
+    const [, writtenUpdate] = updateIfProfileNameEmptyMock.mock.calls[0] as [
+      unknown,
+      Record<string, unknown>,
+    ]
+    expect(writtenUpdate.locale).toBe("vi_VN")
+    expect("timezone" in writtenUpdate).toBe(false)
+  })
+
+  test("locale present, no timezone key at all → timezone is never persisted", async () => {
+    const fetchProfile = vi.fn(async () => ({
+      firstName: "Jane",
+      locale: "vi_VN",
+    }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result.status).toBe("updated")
+    const [, writtenUpdate] = updateIfProfileNameEmptyMock.mock.calls[0] as [
+      unknown,
+      Record<string, unknown>,
+    ]
+    expect(writtenUpdate.locale).toBe("vi_VN")
+    expect("timezone" in writtenUpdate).toBe(false)
+  })
+
+  test("adversarial: a phone-like sourceId never seeds a phone-derived locale/timezone (no phoneHint wiring exists)", async () => {
+    // The profile carries no `locale`/`timezone` at all, but `sourceId`
+    // looks exactly like a phone number a `phoneHint` COULD resolve to a
+    // real locale/timezone at contact-creation time. The refresh path never
+    // threads any field into `finalizeContactProfile`'s `phoneHint` option,
+    // so this must come back with nothing invented, regardless of how
+    // phone-like the identifier looks.
+    const fetchProfile = vi.fn(async () => ({
+      sourceId: "+14155552671",
+      firstName: "Jane",
+    }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result.status).toBe("updated")
+    const [, writtenUpdate] = updateIfProfileNameEmptyMock.mock.calls[0] as [
+      unknown,
+      Record<string, unknown>,
+    ]
+    expect(writtenUpdate).toEqual({ firstName: "Jane" })
+    expect("locale" in writtenUpdate).toBe(false)
+    expect("timezone" in writtenUpdate).toBe(false)
   })
 })
 
 describe("contactProfileRefreshService.refresh — ContactInbox.language write", () => {
-  test("inbox language empty + fetched locale → updateLanguage called with the derived language", async () => {
+  test("inbox language empty + fetched locale → updateLanguageIfEmpty called with the derived language", async () => {
     const fetchProfile = vi.fn(async () => ({
       firstName: "Jane",
       locale: "vi_VN",
@@ -768,8 +839,8 @@ describe("contactProfileRefreshService.refresh — ContactInbox.language write",
     )
 
     expect(result.status).toBe("updated")
-    expect(updateLanguageMock).toHaveBeenCalledTimes(1)
-    expect(updateLanguageMock).toHaveBeenCalledWith({
+    expect(updateLanguageIfEmptyMock).toHaveBeenCalledTimes(1)
+    expect(updateLanguageIfEmptyMock).toHaveBeenCalledWith({
       workspaceId: "ws-1",
       contactId: "contact-1",
       contactInboxId: "inbox-1",
@@ -777,7 +848,7 @@ describe("contactProfileRefreshService.refresh — ContactInbox.language write",
     })
   })
 
-  test("inbox already has a language → updateLanguage is NOT called", async () => {
+  test("inbox already has a language → updateLanguageIfEmpty is NOT called (in-memory fast path)", async () => {
     const fetchProfile = vi.fn(async () => ({
       firstName: "Jane",
       locale: "vi_VN",
@@ -791,11 +862,11 @@ describe("contactProfileRefreshService.refresh — ContactInbox.language write",
     )
 
     expect(result.status).toBe("updated")
-    expect(updateLanguageMock).not.toHaveBeenCalled()
+    expect(updateLanguageIfEmptyMock).not.toHaveBeenCalled()
   })
 
-  test("updateLanguage rejects → result is still updated, warn logged, never thrown", async () => {
-    updateLanguageMock.mockRejectedValueOnce(new Error("db down"))
+  test("updateLanguageIfEmpty rejects → result is still updated, warn logged, never thrown", async () => {
+    updateLanguageIfEmptyMock.mockRejectedValueOnce(new Error("db down"))
     const fetchProfile = vi.fn(async () => ({
       firstName: "Jane",
       locale: "vi_VN",
@@ -812,7 +883,32 @@ describe("contactProfileRefreshService.refresh — ContactInbox.language write",
     expect(warnMock).toHaveBeenCalled()
   })
 
-  test("no locale/language returned by the channel → nothing derived, updateLanguage not called", async () => {
+  test("updateLanguageIfEmpty resolves undefined (lost the race — a concurrent write already set the language) → no clobber attempted, result stays updated", async () => {
+    // The WHERE-clause emptiness predicate inside the real
+    // `updateLanguageIfEmpty` is what makes this race-safe — simulated here
+    // by making it match zero rows, exactly as it would if an operator or
+    // another job set `ContactInbox.language` WHILE this refresh was in
+    // flight. There is no unconditional fallback write to reach for: the
+    // service only ever calls the conditional method.
+    updateLanguageIfEmptyMock.mockResolvedValueOnce(undefined)
+    const fetchProfile = vi.fn(async () => ({
+      firstName: "Jane",
+      locale: "vi_VN",
+    }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({
+        contactInbox: { ...CONTACT_INBOX, language: null },
+        fetchProfile,
+      }),
+    )
+
+    expect(result.status).toBe("updated")
+    expect(updateLanguageIfEmptyMock).toHaveBeenCalledTimes(1)
+    expect(warnMock).not.toHaveBeenCalled()
+  })
+
+  test("no locale/language returned by the channel → nothing derived, updateLanguageIfEmpty not called", async () => {
     const fetchProfile = vi.fn(async () => ({ firstName: "Jane" }))
 
     const result = await contactProfileRefreshService.refresh(
@@ -823,10 +919,45 @@ describe("contactProfileRefreshService.refresh — ContactInbox.language write",
     )
 
     expect(result.status).toBe("updated")
-    expect(updateLanguageMock).not.toHaveBeenCalled()
+    expect(updateLanguageIfEmptyMock).not.toHaveBeenCalled()
   })
 
-  test("unavailable outcome (no usable name) → updateLanguage never called", async () => {
+  test("name already present (skipped/profileComplete before any fetch) → updateLanguageIfEmpty never called", async () => {
+    findByIdOrFailMock.mockResolvedValueOnce({
+      firstName: "Jane",
+      lastName: null,
+    })
+    const fetchProfile = vi.fn()
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({
+        contactInbox: { ...CONTACT_INBOX, language: null },
+        fetchProfile,
+      }),
+    )
+
+    expect(result).toEqual({ status: "skipped", reason: "profileComplete" })
+    expect(fetchProfile).not.toHaveBeenCalled()
+    expect(updateLanguageIfEmptyMock).not.toHaveBeenCalled()
+  })
+
+  test("cooling down (skipped/coolingDown, no fetch) → updateLanguageIfEmpty never called", async () => {
+    existsMock.mockResolvedValueOnce(true)
+    const fetchProfile = vi.fn()
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({
+        contactInbox: { ...CONTACT_INBOX, language: null },
+        fetchProfile,
+      }),
+    )
+
+    expect(result).toEqual({ status: "skipped", reason: "coolingDown" })
+    expect(fetchProfile).not.toHaveBeenCalled()
+    expect(updateLanguageIfEmptyMock).not.toHaveBeenCalled()
+  })
+
+  test("unavailable outcome (no usable name) → updateLanguageIfEmpty never called", async () => {
     const fetchProfile = vi.fn(async () => ({
       locale: "vi_VN",
       avatar: "public/space/ws-1/avatars/orphan",
@@ -840,10 +971,10 @@ describe("contactProfileRefreshService.refresh — ContactInbox.language write",
     )
 
     expect(result).toEqual({ status: "unavailable" })
-    expect(updateLanguageMock).not.toHaveBeenCalled()
+    expect(updateLanguageIfEmptyMock).not.toHaveBeenCalled()
   })
 
-  test("failed outcome (fetch throws) → updateLanguage never called", async () => {
+  test("failed outcome (fetch throws) → updateLanguageIfEmpty never called", async () => {
     const fetchProfile = vi.fn(() => Promise.reject(new Error("graph error")))
 
     const result = await contactProfileRefreshService.refresh(
@@ -854,10 +985,28 @@ describe("contactProfileRefreshService.refresh — ContactInbox.language write",
     )
 
     expect(result).toEqual({ status: "failed" })
-    expect(updateLanguageMock).not.toHaveBeenCalled()
+    expect(updateLanguageIfEmptyMock).not.toHaveBeenCalled()
   })
 
-  test("raced outcome (name filled concurrently) → updateLanguage never called", async () => {
+  test("contact write fails (updateIfProfileNameEmpty throws) → failed, updateLanguageIfEmpty never called", async () => {
+    updateIfProfileNameEmptyMock.mockRejectedValueOnce(new Error("db down"))
+    const fetchProfile = vi.fn(async () => ({
+      firstName: "Jane",
+      locale: "vi_VN",
+    }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({
+        contactInbox: { ...CONTACT_INBOX, language: null },
+        fetchProfile,
+      }),
+    )
+
+    expect(result).toEqual({ status: "failed" })
+    expect(updateLanguageIfEmptyMock).not.toHaveBeenCalled()
+  })
+
+  test("raced outcome (name filled concurrently) → updateLanguageIfEmpty never called", async () => {
     updateIfProfileNameEmptyMock.mockResolvedValueOnce(undefined)
     const fetchProfile = vi.fn(async () => ({
       firstName: "Jane",
@@ -872,7 +1021,7 @@ describe("contactProfileRefreshService.refresh — ContactInbox.language write",
     )
 
     expect(result).toEqual({ status: "skipped", reason: "profileComplete" })
-    expect(updateLanguageMock).not.toHaveBeenCalled()
+    expect(updateLanguageIfEmptyMock).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/business/__tests__/contact-profile-refresh.test.ts
+++ b/packages/business/__tests__/contact-profile-refresh.test.ts
@@ -34,6 +34,11 @@ vi.mock("../src/contact/service", () => ({
   },
 }))
 
+const updateLanguageMock = vi.fn(async () => null)
+vi.mock("../src/contact-inbox/service", () => ({
+  contactInboxService: { updateLanguage: updateLanguageMock },
+}))
+
 const logProviderErrorForChannelMock = vi.fn(async () => undefined)
 vi.mock("../src/error-log/service", () => ({
   logProviderErrorForChannel: logProviderErrorForChannelMock,
@@ -64,7 +69,12 @@ const {
 const { channelTypes } = await import("@chatbotx.io/database/partials")
 
 const NAMELESS_CONTACT = { firstName: null, lastName: null }
-const CONTACT_INBOX = { id: "inbox-1", channel: "messenger" }
+const CONTACT_INBOX = {
+  id: "inbox-1",
+  channel: "messenger",
+  contactId: "contact-1",
+  language: null,
+}
 
 function refreshInput(overrides: Record<string, unknown> = {}) {
   return {
@@ -95,6 +105,7 @@ beforeEach(() => {
   }))
   logProviderErrorForChannelMock.mockResolvedValue(undefined)
   deleteObjectMock.mockResolvedValue(undefined)
+  updateLanguageMock.mockResolvedValue(null)
 })
 
 // ─── rules.ts ────────────────────────────────────────────────────────────
@@ -632,6 +643,236 @@ describe("contactProfileRefreshService.refresh", () => {
       "public/space/ws-1/avatars/new",
     )
     expect(setNumberMock).not.toHaveBeenCalled()
+  })
+})
+
+// ─── service.ts: channelApi locale/timezone normalization + language write ─
+//
+// Owner requirement: a channelApi refresh must persist the SAME full field
+// set, with the SAME normalization (finalizeContactProfile), as the
+// contact-creation path — minus phoneHint/fallbackLocale (the contact
+// already exists, so a guess must never overwrite real stored data) — and
+// derive ContactInbox.language the same way, writing it only when the
+// inbox's current language is empty/null.
+// See .superpowers/sdd/2026-08-31-messenger-ctm-profile-backfill/final-fix-report.md
+// "Full-profile refresh (owner request)".
+
+describe("contactProfileRefreshService.refresh — channelApi locale/timezone normalization", () => {
+  test("fetched locale is written as the finalizeContactProfile-normalized value", async () => {
+    const fetchProfile = vi.fn(async () => ({
+      firstName: "Jane",
+      locale: "VI-vn",
+    }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result.status).toBe("updated")
+    expect(updateIfProfileNameEmptyMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ locale: "vi_VN" }),
+    )
+  })
+
+  test("fetched timezone is normalized the same way (offset → IANA zone)", async () => {
+    const fetchProfile = vi.fn(async () => ({
+      firstName: "Jane",
+      timezone: "+07:00",
+    }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result.status).toBe("updated")
+    expect(updateIfProfileNameEmptyMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ timezone: "Asia/Bangkok" }),
+    )
+  })
+
+  test("profile without locale/timezone → those columns are untouched (absent from the update payload)", async () => {
+    const fetchProfile = vi.fn(async () => ({ firstName: "Jane" }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result.status).toBe("updated")
+    const [, writtenUpdate] = updateIfProfileNameEmptyMock.mock.calls[0] as [
+      unknown,
+      Record<string, unknown>,
+    ]
+    expect(writtenUpdate).toEqual({ firstName: "Jane" })
+    expect("locale" in writtenUpdate).toBe(false)
+    expect("timezone" in writtenUpdate).toBe(false)
+  })
+
+  test("no phoneHint/fallback behaviour: a profile with a name but no locale must not invent locale/timezone", async () => {
+    // No `sourceId`/phone-derivable field is fed into normalization here —
+    // this proves the refresh path never wires a phoneHint or fallbackLocale
+    // the way contact-creation does.
+    const fetchProfile = vi.fn(async () => ({
+      firstName: "Jane",
+      lastName: "Doe",
+    }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ fetchProfile }),
+    )
+
+    expect(result.status).toBe("updated")
+    expect(updateIfProfileNameEmptyMock).toHaveBeenCalledWith(
+      expect.anything(),
+      { firstName: "Jane", lastName: "Doe" },
+    )
+  })
+
+  test("payload source: finalization never runs — raw locale/timezone are never fed to updateIfProfileNameEmpty", async () => {
+    // `payload` always strips locale/timezone/gender before reaching the
+    // service (`pickPayloadNameFields`) — this asserts the service itself
+    // also never invokes normalization for a payload-sourced update, so
+    // even a caller that skipped the worker's picker cannot leak raw values.
+    const fetchProfile = vi.fn(async () => ({
+      firstName: "Jane",
+      locale: "VI-vn",
+      timezone: "+07:00",
+    }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({ source: "payload", fetchProfile }),
+    )
+
+    expect(result.status).toBe("updated")
+    expect(updateIfProfileNameEmptyMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ locale: "VI-vn", timezone: "+07:00" }),
+    )
+    expect(updateLanguageMock).not.toHaveBeenCalled()
+  })
+})
+
+describe("contactProfileRefreshService.refresh — ContactInbox.language write", () => {
+  test("inbox language empty + fetched locale → updateLanguage called with the derived language", async () => {
+    const fetchProfile = vi.fn(async () => ({
+      firstName: "Jane",
+      locale: "vi_VN",
+    }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({
+        contactInbox: { ...CONTACT_INBOX, language: null },
+        fetchProfile,
+      }),
+    )
+
+    expect(result.status).toBe("updated")
+    expect(updateLanguageMock).toHaveBeenCalledTimes(1)
+    expect(updateLanguageMock).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      contactId: "contact-1",
+      contactInboxId: "inbox-1",
+      language: "vi",
+    })
+  })
+
+  test("inbox already has a language → updateLanguage is NOT called", async () => {
+    const fetchProfile = vi.fn(async () => ({
+      firstName: "Jane",
+      locale: "vi_VN",
+    }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({
+        contactInbox: { ...CONTACT_INBOX, language: "en" },
+        fetchProfile,
+      }),
+    )
+
+    expect(result.status).toBe("updated")
+    expect(updateLanguageMock).not.toHaveBeenCalled()
+  })
+
+  test("updateLanguage rejects → result is still updated, warn logged, never thrown", async () => {
+    updateLanguageMock.mockRejectedValueOnce(new Error("db down"))
+    const fetchProfile = vi.fn(async () => ({
+      firstName: "Jane",
+      locale: "vi_VN",
+    }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({
+        contactInbox: { ...CONTACT_INBOX, language: null },
+        fetchProfile,
+      }),
+    )
+
+    expect(result.status).toBe("updated")
+    expect(warnMock).toHaveBeenCalled()
+  })
+
+  test("no locale/language returned by the channel → nothing derived, updateLanguage not called", async () => {
+    const fetchProfile = vi.fn(async () => ({ firstName: "Jane" }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({
+        contactInbox: { ...CONTACT_INBOX, language: null },
+        fetchProfile,
+      }),
+    )
+
+    expect(result.status).toBe("updated")
+    expect(updateLanguageMock).not.toHaveBeenCalled()
+  })
+
+  test("unavailable outcome (no usable name) → updateLanguage never called", async () => {
+    const fetchProfile = vi.fn(async () => ({
+      locale: "vi_VN",
+      avatar: "public/space/ws-1/avatars/orphan",
+    }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({
+        contactInbox: { ...CONTACT_INBOX, language: null },
+        fetchProfile,
+      }),
+    )
+
+    expect(result).toEqual({ status: "unavailable" })
+    expect(updateLanguageMock).not.toHaveBeenCalled()
+  })
+
+  test("failed outcome (fetch throws) → updateLanguage never called", async () => {
+    const fetchProfile = vi.fn(() => Promise.reject(new Error("graph error")))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({
+        contactInbox: { ...CONTACT_INBOX, language: null },
+        fetchProfile,
+      }),
+    )
+
+    expect(result).toEqual({ status: "failed" })
+    expect(updateLanguageMock).not.toHaveBeenCalled()
+  })
+
+  test("raced outcome (name filled concurrently) → updateLanguage never called", async () => {
+    updateIfProfileNameEmptyMock.mockResolvedValueOnce(undefined)
+    const fetchProfile = vi.fn(async () => ({
+      firstName: "Jane",
+      locale: "vi_VN",
+    }))
+
+    const result = await contactProfileRefreshService.refresh(
+      refreshInput({
+        contactInbox: { ...CONTACT_INBOX, language: null },
+        fetchProfile,
+      }),
+    )
+
+    expect(result).toEqual({ status: "skipped", reason: "profileComplete" })
+    expect(updateLanguageMock).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/business/src/contact-inbox/service.ts
+++ b/packages/business/src/contact-inbox/service.ts
@@ -28,6 +28,7 @@ import {
   isSourceUserIdKeyedIdentity,
 } from "@chatbotx.io/sdk"
 import { BaseService } from "../base.service"
+import { PROFILE_NAME_BLANK_CHARACTERS } from "../contact/profile-refresh/rules"
 import { logger } from "../logger"
 
 // Lower bound for message lookups/deletions scoped to a contact-inbox: the
@@ -415,6 +416,53 @@ class ContactInboxService extends BaseService {
     await this.invalidateTracking(invalidation)
 
     return invalidation
+  }
+
+  /**
+   * Race-safe variant of `updateLanguage`: the "language is currently
+   * empty" check is folded into the WHERE clause itself (NULL or blank
+   * after `btrim`, same blank-character set `ContactService.updateIfProfileNameEmpty`
+   * binds for `Contact.firstName`/`lastName`) instead of a separate read
+   * before the write — a language set concurrently (an operator edit,
+   * another job) between a caller's in-memory snapshot and this write can
+   * no longer be clobbered: the UPDATE simply matches zero rows. Returns
+   * the updated row, or `undefined` when nothing matched (raced, or the
+   * scope didn't match — either way, not a caller error).
+   */
+  async updateLanguageIfEmpty(props: {
+    tx?: DatabaseClient
+    workspaceId: string
+    contactId: string
+    contactInboxId: string
+    language: string
+  }): Promise<ContactInboxModel | undefined> {
+    const { tx = db, workspaceId, contactId, contactInboxId, language } = props
+
+    const [updated] = await tx
+      .update(contactInboxModel)
+      .set({ language })
+      .where(
+        and(
+          eq(contactInboxModel.id, contactInboxId),
+          eq(contactInboxModel.contactId, contactId),
+          this.workspaceScope(workspaceId),
+          sql`btrim(coalesce(${contactInboxModel.language}, ''), ${PROFILE_NAME_BLANK_CHARACTERS}) = ''`,
+        ),
+      )
+      .returning()
+
+    if (!updated) {
+      // Zero rows is the expected outcome of a lost race (the common case
+      // this method exists to guard against), not a scope problem — unlike
+      // `updateLanguage` (unconditional; a miss there always means scope),
+      // so this stays silent, mirroring `updateIfProfileNameEmpty`'s
+      // silent-on-race behavior for `Contact`.
+      return
+    }
+
+    await this.invalidateTracking(this.createTrackingInvalidation(contactId))
+
+    return updated
   }
 
   async updateTracking(props: {

--- a/packages/business/src/contact/profile-refresh/service.ts
+++ b/packages/business/src/contact/profile-refresh/service.ts
@@ -4,6 +4,8 @@ import type {
 } from "@chatbotx.io/database/types"
 import { uploader } from "@chatbotx.io/filesystem"
 import type { IncomingContact } from "@chatbotx.io/sdk"
+import { contactInboxService } from "../../contact-inbox/service"
+import { finalizeContactProfile } from "../../contact-locale"
 import { logProviderErrorForChannel } from "../../error-log/service"
 import { logger } from "../../logger"
 import type { ContactAccessScope } from "../service"
@@ -40,7 +42,10 @@ export type ContactProfileRefreshResult =
 export type RefreshContactProfileInput = {
   workspaceId: string
   contactId: string
-  contactInbox: Pick<ContactInboxModel, "id" | "channel">
+  contactInbox: Pick<
+    ContactInboxModel,
+    "id" | "channel" | "contactId" | "language"
+  >
   source: ContactProfileNameSource // decides cooldown policy via COOLDOWN_BY_PROFILE_SOURCE
   accessScope?: ContactAccessScope // builder passes it; worker omits
   fetchProfile: ContactProfileFetcher // strategy — the app's channel call or the parsed payload
@@ -72,6 +77,72 @@ const discardUploadedAvatar = async (avatar: string | null | undefined) => {
     logger.warn(
       { error, avatar },
       "discardUploadedAvatar: failed to delete avatar object",
+    )
+  }
+}
+
+/**
+ * Applies the SAME `locale`/`timezone` normalization the contact-creation
+ * path applies (`finalizeContactProfile`), but WITHOUT `phoneHint` or
+ * `fallbackLocale` — the contact already exists, so a phone-derived or
+ * fallback guess must never overwrite real stored data. Only `channelApi`
+ * refreshes call this (invariant: `payload` stays name+avatar only — see
+ * `PAYLOAD_NAME_FIELDS` in the worker's fetcher). Each field is normalized
+ * independently: `locale`/`timezone` are only replaced in `update` when the
+ * channel actually returned that field (existing mapper rule preserved), and
+ * `language` is derived the same way creation derives it
+ * (`finalizeContactProfile` → `languageFromLocale`) even when the channel
+ * returned no locale at all (e.g. an explicit `language` field).
+ */
+const normalizeChannelApiProfile = (
+  profile: IncomingContact,
+  update: ContactProfileUpdate,
+): { update: ContactProfileUpdate; language: string | undefined } => {
+  const finalized = finalizeContactProfile({
+    locale: update.locale,
+    language: profile.language,
+    timezone: update.timezone,
+  })
+
+  return {
+    update: {
+      ...update,
+      ...(update.locale !== undefined && { locale: finalized.locale }),
+      ...(update.timezone !== undefined && { timezone: finalized.timezone }),
+    },
+    language: finalized.language ?? undefined,
+  }
+}
+
+/**
+ * Best-effort `ContactInbox.language` write, guarded so an operator- or
+ * channel-set language can never be clobbered by a refresh: only writes when
+ * the inbox's CURRENT language is empty/null (creation could set it
+ * unconditionally only because the row was new). A failure here is logged at
+ * `warn` and never changes the refresh result — the `updated` outcome and
+ * the write to `Contact` already succeeded.
+ */
+const writeContactInboxLanguageIfEmpty = async (props: {
+  workspaceId: string
+  contactInbox: Pick<ContactInboxModel, "id" | "contactId" | "language">
+  language: string | undefined
+}): Promise<void> => {
+  const { workspaceId, contactInbox, language } = props
+  if (!(language && !contactInbox.language)) {
+    return
+  }
+
+  try {
+    await contactInboxService.updateLanguage({
+      workspaceId,
+      contactId: contactInbox.contactId,
+      contactInboxId: contactInbox.id,
+      language,
+    })
+  } catch (error) {
+    logger.warn(
+      { error, contactInboxId: contactInbox.id, workspaceId },
+      "writeContactInboxLanguageIfEmpty: failed to update ContactInbox.language",
     )
   }
 }
@@ -275,6 +346,15 @@ const refresh = async (
     return { status: "unavailable" }
   }
 
+  // Only `channelApi` refreshes get the creation-path locale/timezone
+  // normalization and language derivation — `payload` stays name+avatar
+  // only (its raw values are exactly what this normalization protects
+  // against clobbering).
+  const { update: finalizedUpdate, language: finalizedLanguage } =
+    source === "channelApi"
+      ? normalizeChannelApiProfile(profile, update)
+      : { update, language: undefined }
+
   try {
     // The atomic conditional write folds the "name still empty" check into
     // the write itself instead of a separate read before the write — an
@@ -285,16 +365,21 @@ const refresh = async (
       workspaceId,
       contactId,
       accessScope,
-      update,
+      update: finalizedUpdate,
     })
     if (!updatedContact) {
       // Raced, not failed — no cooldown.
-      await discardUploadedAvatar(update.avatar)
+      await discardUploadedAvatar(finalizedUpdate.avatar)
       return { status: "skipped", reason: "profileComplete" }
     }
+    await writeContactInboxLanguageIfEmpty({
+      workspaceId,
+      contactInbox,
+      language: finalizedLanguage,
+    })
     return { status: "updated", contact: updatedContact }
   } catch (error) {
-    await discardUploadedAvatar(update.avatar)
+    await discardUploadedAvatar(finalizedUpdate.avatar)
     await recordProfileRefreshFailure({
       channel: contactInbox.channel,
       workspaceId,

--- a/packages/business/src/contact/profile-refresh/service.ts
+++ b/packages/business/src/contact/profile-refresh/service.ts
@@ -5,7 +5,10 @@ import type {
 import { uploader } from "@chatbotx.io/filesystem"
 import type { IncomingContact } from "@chatbotx.io/sdk"
 import { contactInboxService } from "../../contact-inbox/service"
-import { finalizeContactProfile } from "../../contact-locale"
+import {
+  finalizeContactProfile,
+  normalizeStoredTimezone,
+} from "../../contact-locale"
 import { logProviderErrorForChannel } from "../../error-log/service"
 import { logger } from "../../logger"
 import type { ContactAccessScope } from "../service"
@@ -88,27 +91,46 @@ const discardUploadedAvatar = async (avatar: string | null | undefined) => {
  * fallback guess must never overwrite real stored data. Only `channelApi`
  * refreshes call this (invariant: `payload` stays name+avatar only — see
  * `PAYLOAD_NAME_FIELDS` in the worker's fetcher). Each field is normalized
- * independently: `locale`/`timezone` are only replaced in `update` when the
- * channel actually returned that field (existing mapper rule preserved), and
- * `language` is derived the same way creation derives it
- * (`finalizeContactProfile` → `languageFromLocale`) even when the channel
- * returned no locale at all (e.g. an explicit `language` field).
+ * independently, on the STRICT reading of "only fields the channel
+ * returned":
+ * - `locale` is only replaced when the channel returned a `locale`.
+ * - `timezone` is only replaced when the channel returned a `timezone` AND
+ *   that raw value itself normalizes (`normalizeStoredTimezone`) — a
+ *   blank/unnormalizable channel timezone must NOT be silently swapped for
+ *   a locale-region-derived one; `finalizeContactProfile` would otherwise
+ *   fall back to `timezoneFromLocaleRegion(locale)` for a blank timezone,
+ *   which is correct at contact-creation time but not here.
+ * - `language` is derived the same way creation derives it
+ *   (`finalizeContactProfile` → `languageFromLocale`) even when the channel
+ *   returned no locale at all (e.g. an explicit `language` field).
  */
 const normalizeChannelApiProfile = (
   profile: IncomingContact,
   update: ContactProfileUpdate,
 ): { update: ContactProfileUpdate; language: string | undefined } => {
+  const { locale: rawLocale, timezone: rawTimezone, ...restUpdate } = update
   const finalized = finalizeContactProfile({
-    locale: update.locale,
+    locale: rawLocale,
     language: profile.language,
-    timezone: update.timezone,
+    timezone: rawTimezone,
   })
+  // A channel timezone that was returned but is blank/unnormalizable must
+  // NOT fall back to `finalized.timezone` — `finalizeContactProfile` would
+  // otherwise derive one from the locale's region
+  // (`timezoneFromLocaleRegion`), which is correct at contact-creation time
+  // (no timezone at all yet) but not here: the channel DID answer the
+  // `timezone` field, it just didn't normalize to anything.
+  const channelTimezoneNormalizes =
+    rawTimezone !== undefined && normalizeStoredTimezone(rawTimezone) !== null
 
   return {
+    // Rebuilt from `restUpdate` (raw `locale`/`timezone` stripped out), not
+    // spread from `update` — a raw, unnormalized value must never leak
+    // through when its normalized counterpart is intentionally omitted.
     update: {
-      ...update,
-      ...(update.locale !== undefined && { locale: finalized.locale }),
-      ...(update.timezone !== undefined && { timezone: finalized.timezone }),
+      ...restUpdate,
+      ...(rawLocale !== undefined && { locale: finalized.locale }),
+      ...(channelTimezoneNormalizes && { timezone: finalized.timezone }),
     },
     language: finalized.language ?? undefined,
   }
@@ -118,9 +140,15 @@ const normalizeChannelApiProfile = (
  * Best-effort `ContactInbox.language` write, guarded so an operator- or
  * channel-set language can never be clobbered by a refresh: only writes when
  * the inbox's CURRENT language is empty/null (creation could set it
- * unconditionally only because the row was new). A failure here is logged at
- * `warn` and never changes the refresh result — the `updated` outcome and
- * the write to `Contact` already succeeded.
+ * unconditionally only because the row was new). The in-memory check below
+ * is only a fast path (skips the round trip in the common case) — the real
+ * guarantee against a language set concurrently between this snapshot and
+ * the write is `updateLanguageIfEmpty`'s WHERE-clause emptiness predicate
+ * (see `contact-inbox/service.ts`), which folds the same check into the
+ * UPDATE itself. A failure — or a lost race (zero rows matched) — is
+ * logged at `warn`/no-op respectively and never changes the refresh
+ * result — the `updated` outcome and the write to `Contact` already
+ * succeeded.
  */
 const writeContactInboxLanguageIfEmpty = async (props: {
   workspaceId: string
@@ -133,7 +161,7 @@ const writeContactInboxLanguageIfEmpty = async (props: {
   }
 
   try {
-    await contactInboxService.updateLanguage({
+    await contactInboxService.updateLanguageIfEmpty({
       workspaceId,
       contactId: contactInbox.contactId,
       contactInboxId: contactInbox.id,


### PR DESCRIPTION
## Summary
- Follow-up to #1074: channel-API profile refreshes now persist the same field set as first-webhook contact creation — not just the name. Fetched `locale` and `timezone` go through the existing `finalizeContactProfile` normalization (with no phone/fallback derivation, since the contact already exists), and the inbox `language` is derived the same way creation derives it.
- `ContactInbox.language` is written only when it is currently empty, enforced atomically in the UPDATE itself (new `updateLanguageIfEmpty`, mirroring the conditional-write pattern from #1074) — a language set concurrently by an operator or the channel can never be overwritten.
- A blank or unnormalizable channel timezone is discarded instead of leaking raw values or a locale-derived guess; absent fields keep their stored values. Payload-based refreshes (WhatsApp/API) remain name+avatar only.

## Changes
- `packages/business/src/contact/profile-refresh/service.ts`: channel-API updates are normalized via `finalizeContactProfile` before the conditional write; on a successful name write, the derived language is stored through the new guarded inbox write; language failures log a warning and never change the refresh outcome.
- `packages/business/src/contact-inbox/service.ts`: `updateLanguageIfEmpty` — same scoping and tracking-cache invalidation as `updateLanguage`, with the emptiness check in the WHERE clause (bound parameters); zero matched rows is a silent no-op.
- `apps/builder/src/features/contacts/actions/refresh-contact-profile.action.ts`: forwards the inbox fields the service now needs.
- Tests: business suite covers normalization (locale casing, offset→IANA timezone), absent/blank-field handling, phone-like source ids, the write race, and every non-success path leaving language untouched; worker real-service test covers the end-to-end write; builder call-shape updated.

## Test plan
- [x] `pnpm --filter @chatbotx.io/business test` (1570 tests) and `check-types`
- [x] `pnpm --filter worker test` (1891) and `check-types`
- [x] Builder targeted suites (37 tests) and `check-types`; `pnpm --filter builder build` compiles
- [x] Blank-name/blank-language SQL predicates validated against a real Postgres instance
- [ ] Manual verification on a live workspace: refresh a nameless CTM contact and confirm name, locale, timezone and (previously empty) language are populated; an operator-set language survives a concurrent refresh
