### PR TITLE
fix(sequences): persist delay unit changes after reload

### DIFF
--- a/apps/builder/__tests__/sequence-delay.test.ts
+++ b/apps/builder/__tests__/sequence-delay.test.ts
@@ -335,6 +335,32 @@ describe("stepToDelayView", () => {
     ).toEqual({ unit: "immediate", value: 1, specificDateTime: "" })
   })
 
+  test("stored {-1, 0, 'days'} (negative, consistent but non-positive value) falls back to immediate/1", () => {
+    expect(
+      stepToDelayView({ delayDays: -1, delayMinutes: 0, delayUnit: "days" }),
+    ).toEqual({ unit: "immediate", value: 1, specificDateTime: "" })
+  })
+
+  test("stored {0, -30, 'minutes'} (negative, consistent but non-positive value) falls back to immediate/1", () => {
+    expect(
+      stepToDelayView({
+        delayDays: 0,
+        delayMinutes: -30,
+        delayUnit: "minutes",
+      }),
+    ).toEqual({ unit: "immediate", value: 1, specificDateTime: "" })
+  })
+
+  test("stored {0, NaN, 'minutes'} (consistent but NaN value) falls back to immediate/1", () => {
+    expect(
+      stepToDelayView({
+        delayDays: 0,
+        delayMinutes: Number.NaN,
+        delayUnit: "minutes",
+      }),
+    ).toEqual({ unit: "immediate", value: 1, specificDateTime: "" })
+  })
+
   test("previously chosen specificDateTime is shown even when unit is not specificTime", () => {
     const specificDateTime = new Date(2026, 2, 1, 12, 0)
     expect(

--- a/apps/builder/__tests__/sequence-delay.test.ts
+++ b/apps/builder/__tests__/sequence-delay.test.ts
@@ -1,0 +1,476 @@
+import { describe, expect, test } from "vitest"
+import {
+  delayViewToStored,
+  isDelayUnit,
+  isDelayValueInRange,
+  isStoredDelayConsistent,
+  MAX_DELAY_VALUE,
+  MIN_DELAY_VALUE,
+  oneHourFromNowLocal,
+  type StoredDelay,
+  type StoredDelayFields,
+  stepToDelayView,
+  toLocalDateTimeInputValue,
+} from "../src/features/sequences/lib/delay"
+
+describe("isDelayUnit", () => {
+  test("accepts every DelayUnit value", () => {
+    expect(isDelayUnit("immediate")).toBe(true)
+    expect(isDelayUnit("minutes")).toBe(true)
+    expect(isDelayUnit("hours")).toBe(true)
+    expect(isDelayUnit("days")).toBe(true)
+    expect(isDelayUnit("specificTime")).toBe(true)
+  })
+
+  test("rejects values outside the DelayUnit enum", () => {
+    expect(isDelayUnit("bogus")).toBe(false)
+    expect(isDelayUnit(null)).toBe(false)
+    expect(isDelayUnit(undefined)).toBe(false)
+    expect(isDelayUnit(1)).toBe(false)
+  })
+})
+
+describe("isDelayValueInRange", () => {
+  test("rejects 0", () => {
+    expect(isDelayValueInRange(0)).toBe(false)
+  })
+
+  test("accepts the minimum value", () => {
+    expect(isDelayValueInRange(MIN_DELAY_VALUE)).toBe(true)
+  })
+
+  test("accepts the maximum value", () => {
+    expect(isDelayValueInRange(MAX_DELAY_VALUE)).toBe(true)
+  })
+
+  test("rejects a value above the maximum", () => {
+    expect(isDelayValueInRange(100_000)).toBe(false)
+  })
+
+  test("rejects non-integer values", () => {
+    expect(isDelayValueInRange(1.5)).toBe(false)
+  })
+
+  test("rejects NaN", () => {
+    expect(isDelayValueInRange(Number.NaN)).toBe(false)
+  })
+})
+
+describe("isStoredDelayConsistent", () => {
+  test("immediate: 0/0 is consistent", () => {
+    expect(
+      isStoredDelayConsistent({
+        delayDays: 0,
+        delayMinutes: 0,
+        delayUnit: "immediate",
+      }),
+    ).toBe(true)
+  })
+
+  test("immediate: nonzero days is inconsistent", () => {
+    expect(
+      isStoredDelayConsistent({
+        delayDays: 1,
+        delayMinutes: 0,
+        delayUnit: "immediate",
+      }),
+    ).toBe(false)
+  })
+
+  test("immediate: nonzero minutes is inconsistent", () => {
+    expect(
+      isStoredDelayConsistent({
+        delayDays: 0,
+        delayMinutes: 1,
+        delayUnit: "immediate",
+      }),
+    ).toBe(false)
+  })
+
+  test("minutes: days = 0 with any minutes is consistent", () => {
+    expect(
+      isStoredDelayConsistent({
+        delayDays: 0,
+        delayMinutes: 90,
+        delayUnit: "minutes",
+      }),
+    ).toBe(true)
+    expect(
+      isStoredDelayConsistent({
+        delayDays: 0,
+        delayMinutes: 0,
+        delayUnit: "minutes",
+      }),
+    ).toBe(true)
+  })
+
+  test("minutes: nonzero days is inconsistent", () => {
+    expect(
+      isStoredDelayConsistent({
+        delayDays: 1,
+        delayMinutes: 30,
+        delayUnit: "minutes",
+      }),
+    ).toBe(false)
+  })
+
+  test("hours: days = 0 and minutes % 60 = 0 is consistent", () => {
+    expect(
+      isStoredDelayConsistent({
+        delayDays: 0,
+        delayMinutes: 120,
+        delayUnit: "hours",
+      }),
+    ).toBe(true)
+  })
+
+  test("hours: minutes not a multiple of 60 is inconsistent", () => {
+    expect(
+      isStoredDelayConsistent({
+        delayDays: 0,
+        delayMinutes: 90,
+        delayUnit: "hours",
+      }),
+    ).toBe(false)
+  })
+
+  test("hours: nonzero days is inconsistent", () => {
+    expect(
+      isStoredDelayConsistent({
+        delayDays: 1,
+        delayMinutes: 60,
+        delayUnit: "hours",
+      }),
+    ).toBe(false)
+  })
+
+  test("days: minutes = 0 is consistent regardless of days", () => {
+    expect(
+      isStoredDelayConsistent({
+        delayDays: 120,
+        delayMinutes: 0,
+        delayUnit: "days",
+      }),
+    ).toBe(true)
+  })
+
+  test("days: nonzero minutes is inconsistent", () => {
+    expect(
+      isStoredDelayConsistent({
+        delayDays: 3,
+        delayMinutes: 1,
+        delayUnit: "days",
+      }),
+    ).toBe(false)
+  })
+
+  test("specificTime: 0/0 is consistent", () => {
+    expect(
+      isStoredDelayConsistent({
+        delayDays: 0,
+        delayMinutes: 0,
+        delayUnit: "specificTime",
+      }),
+    ).toBe(true)
+  })
+
+  test("specificTime: nonzero days or minutes is inconsistent", () => {
+    expect(
+      isStoredDelayConsistent({
+        delayDays: 1,
+        delayMinutes: 0,
+        delayUnit: "specificTime",
+      }),
+    ).toBe(false)
+    expect(
+      isStoredDelayConsistent({
+        delayDays: 0,
+        delayMinutes: 1,
+        delayUnit: "specificTime",
+      }),
+    ).toBe(false)
+  })
+})
+
+describe("toLocalDateTimeInputValue", () => {
+  test("formats a date as zero-padded local YYYY-MM-DDTHH:mm", () => {
+    expect(toLocalDateTimeInputValue(new Date(2026, 0, 5, 7, 3))).toBe(
+      "2026-01-05T07:03",
+    )
+  })
+})
+
+describe("oneHourFromNowLocal", () => {
+  test("matches toLocalDateTimeInputValue(now + 1h)", () => {
+    const before = new Date()
+    before.setHours(before.getHours() + 1)
+    const result = oneHourFromNowLocal()
+    const after = new Date()
+    after.setHours(after.getHours() + 1)
+
+    expect(result >= toLocalDateTimeInputValue(before)).toBe(true)
+    expect(result <= toLocalDateTimeInputValue(after)).toBe(true)
+  })
+})
+
+describe("stepToDelayView", () => {
+  test("undefined step defaults to days/1", () => {
+    expect(stepToDelayView(undefined)).toEqual({
+      unit: "days",
+      value: 1,
+      specificDateTime: "",
+    })
+  })
+
+  test("stored {0, 120, 'minutes'} keeps minutes/120 (does not upconvert to hours)", () => {
+    expect(
+      stepToDelayView({
+        delayDays: 0,
+        delayMinutes: 120,
+        delayUnit: "minutes",
+      }),
+    ).toEqual({ unit: "minutes", value: 120, specificDateTime: "" })
+  })
+
+  test("stored {0, 120, 'hours'} yields hours/2", () => {
+    expect(
+      stepToDelayView({
+        delayDays: 0,
+        delayMinutes: 120,
+        delayUnit: "hours",
+      }),
+    ).toEqual({ unit: "hours", value: 2, specificDateTime: "" })
+  })
+
+  test("stored {0, 90, 'hours'} is inconsistent, infers minutes/90", () => {
+    expect(
+      stepToDelayView({
+        delayDays: 0,
+        delayMinutes: 90,
+        delayUnit: "hours",
+      }),
+    ).toEqual({ unit: "minutes", value: 90, specificDateTime: "" })
+  })
+
+  test("stored {0, 90, null} infers minutes/90", () => {
+    expect(
+      stepToDelayView({ delayDays: 0, delayMinutes: 90, delayUnit: null }),
+    ).toEqual({ unit: "minutes", value: 90, specificDateTime: "" })
+  })
+
+  test("stored {0, 120, null} infers hours/2", () => {
+    expect(
+      stepToDelayView({ delayDays: 0, delayMinutes: 120, delayUnit: null }),
+    ).toEqual({ unit: "hours", value: 2, specificDateTime: "" })
+  })
+
+  test("stored {3, 0, null} infers days/3", () => {
+    expect(
+      stepToDelayView({ delayDays: 3, delayMinutes: 0, delayUnit: null }),
+    ).toEqual({ unit: "days", value: 3, specificDateTime: "" })
+  })
+
+  test("stored {1, 30, null} infers minutes/1470", () => {
+    expect(
+      stepToDelayView({ delayDays: 1, delayMinutes: 30, delayUnit: null }),
+    ).toEqual({ unit: "minutes", value: 1470, specificDateTime: "" })
+  })
+
+  test("stored {0, 0, null} infers immediate/1", () => {
+    expect(
+      stepToDelayView({ delayDays: 0, delayMinutes: 0, delayUnit: null }),
+    ).toEqual({ unit: "immediate", value: 1, specificDateTime: "" })
+  })
+
+  test("stored {120, 0, 'days'} is accepted (consistent), yields days/120", () => {
+    expect(
+      stepToDelayView({
+        delayDays: 120,
+        delayMinutes: 0,
+        delayUnit: "days",
+      }),
+    ).toEqual({ unit: "days", value: 120, specificDateTime: "" })
+  })
+
+  test("stored {0, 0, 'minutes'} - zero relative value not accepted, falls back to immediate/1", () => {
+    expect(
+      stepToDelayView({
+        delayDays: 0,
+        delayMinutes: 0,
+        delayUnit: "minutes",
+      }),
+    ).toEqual({ unit: "immediate", value: 1, specificDateTime: "" })
+  })
+
+  test("stored {0, 0, 'specificTime', specificDateTime: Date} yields specificTime with formatted local date", () => {
+    const specificDateTime = new Date(2026, 5, 15, 9, 30)
+    expect(
+      stepToDelayView({
+        delayDays: 0,
+        delayMinutes: 0,
+        delayUnit: "specificTime",
+        specificDateTime,
+      }),
+    ).toEqual({
+      unit: "specificTime",
+      value: 1,
+      specificDateTime: "2026-06-15T09:30",
+    })
+  })
+
+  test("stored {0, 0, 'specificTime', specificDateTime: null} falls back to immediate/1", () => {
+    expect(
+      stepToDelayView({
+        delayDays: 0,
+        delayMinutes: 0,
+        delayUnit: "specificTime",
+        specificDateTime: null,
+      }),
+    ).toEqual({ unit: "immediate", value: 1, specificDateTime: "" })
+  })
+
+  test("stored {0, 0, 'bogus'} falls back to immediate/1", () => {
+    expect(
+      stepToDelayView({ delayDays: 0, delayMinutes: 0, delayUnit: "bogus" }),
+    ).toEqual({ unit: "immediate", value: 1, specificDateTime: "" })
+  })
+
+  test("previously chosen specificDateTime is shown even when unit is not specificTime", () => {
+    const specificDateTime = new Date(2026, 2, 1, 12, 0)
+    expect(
+      stepToDelayView({
+        delayDays: 2,
+        delayMinutes: 0,
+        delayUnit: "days",
+        specificDateTime,
+      }),
+    ).toEqual({
+      unit: "days",
+      value: 2,
+      specificDateTime: "2026-03-01T12:00",
+    })
+  })
+})
+
+describe("round trip via delayViewToStored -> stepToDelayView", () => {
+  function toStepFields(stored: StoredDelay): StoredDelayFields {
+    return {
+      delayDays: stored.delayDays,
+      delayMinutes: stored.delayMinutes,
+      delayUnit: stored.delayUnit,
+    }
+  }
+
+  test("days(2)", () => {
+    const stored = delayViewToStored({ unit: "days", value: 2 })
+    expect(stepToDelayView(toStepFields(stored))).toEqual({
+      unit: "days",
+      value: 2,
+      specificDateTime: "",
+    })
+  })
+
+  test("hours(2)", () => {
+    const stored = delayViewToStored({ unit: "hours", value: 2 })
+    expect(stepToDelayView(toStepFields(stored))).toEqual({
+      unit: "hours",
+      value: 2,
+      specificDateTime: "",
+    })
+  })
+
+  test("minutes(30)", () => {
+    const stored = delayViewToStored({ unit: "minutes", value: 30 })
+    expect(stepToDelayView(toStepFields(stored))).toEqual({
+      unit: "minutes",
+      value: 30,
+      specificDateTime: "",
+    })
+  })
+
+  test("immediate", () => {
+    const stored = delayViewToStored({ unit: "immediate", value: 1 })
+    expect(stepToDelayView(toStepFields(stored))).toEqual({
+      unit: "immediate",
+      value: 1,
+      specificDateTime: "",
+    })
+  })
+})
+
+describe("delayViewToStored", () => {
+  test("days", () => {
+    expect(delayViewToStored({ unit: "days", value: 5 })).toEqual({
+      delayDays: 5,
+      delayMinutes: 0,
+      delayUnit: "days",
+      specificDateTime: null,
+    })
+  })
+
+  test("hours", () => {
+    expect(delayViewToStored({ unit: "hours", value: 3 })).toEqual({
+      delayDays: 0,
+      delayMinutes: 180,
+      delayUnit: "hours",
+      specificDateTime: null,
+    })
+  })
+
+  test("minutes", () => {
+    expect(delayViewToStored({ unit: "minutes", value: 45 })).toEqual({
+      delayDays: 0,
+      delayMinutes: 45,
+      delayUnit: "minutes",
+      specificDateTime: null,
+    })
+  })
+
+  test("immediate", () => {
+    expect(delayViewToStored({ unit: "immediate", value: 1 })).toEqual({
+      delayDays: 0,
+      delayMinutes: 0,
+      delayUnit: "immediate",
+      specificDateTime: null,
+    })
+  })
+
+  test("specificTime passes through the ISO string", () => {
+    expect(
+      delayViewToStored({
+        unit: "specificTime",
+        value: 1,
+        specificDateTimeIso: "2026-06-15T09:30:00.000Z",
+      }),
+    ).toEqual({
+      delayDays: 0,
+      delayMinutes: 0,
+      delayUnit: "specificTime",
+      specificDateTime: "2026-06-15T09:30:00.000Z",
+    })
+  })
+
+  test("specificTime with no ISO string stores null", () => {
+    expect(delayViewToStored({ unit: "specificTime", value: 1 })).toEqual({
+      delayDays: 0,
+      delayMinutes: 0,
+      delayUnit: "specificTime",
+      specificDateTime: null,
+    })
+  })
+
+  test("relative units always store null specificDateTime even if provided", () => {
+    expect(
+      delayViewToStored({
+        unit: "days",
+        value: 1,
+        specificDateTimeIso: "2026-06-15T09:30:00.000Z",
+      }),
+    ).toEqual({
+      delayDays: 1,
+      delayMinutes: 0,
+      delayUnit: "days",
+      specificDateTime: null,
+    })
+  })
+})

--- a/apps/builder/__tests__/sequence-delay.test.ts
+++ b/apps/builder/__tests__/sequence-delay.test.ts
@@ -87,7 +87,7 @@ describe("isStoredDelayConsistent", () => {
     ).toBe(false)
   })
 
-  test("minutes: days = 0 with any minutes is consistent", () => {
+  test("minutes: days = 0 and minutes > 0 is consistent", () => {
     expect(
       isStoredDelayConsistent({
         delayDays: 0,
@@ -95,13 +95,26 @@ describe("isStoredDelayConsistent", () => {
         delayUnit: "minutes",
       }),
     ).toBe(true)
+  })
+
+  test("minutes: zero minutes is inconsistent", () => {
     expect(
       isStoredDelayConsistent({
         delayDays: 0,
         delayMinutes: 0,
         delayUnit: "minutes",
       }),
-    ).toBe(true)
+    ).toBe(false)
+  })
+
+  test("minutes: negative minutes is inconsistent", () => {
+    expect(
+      isStoredDelayConsistent({
+        delayDays: 0,
+        delayMinutes: -30,
+        delayUnit: "minutes",
+      }),
+    ).toBe(false)
   })
 
   test("minutes: nonzero days is inconsistent", () => {
@@ -124,6 +137,16 @@ describe("isStoredDelayConsistent", () => {
     ).toBe(true)
   })
 
+  test("hours: zero minutes is inconsistent", () => {
+    expect(
+      isStoredDelayConsistent({
+        delayDays: 0,
+        delayMinutes: 0,
+        delayUnit: "hours",
+      }),
+    ).toBe(false)
+  })
+
   test("hours: minutes not a multiple of 60 is inconsistent", () => {
     expect(
       isStoredDelayConsistent({
@@ -144,7 +167,7 @@ describe("isStoredDelayConsistent", () => {
     ).toBe(false)
   })
 
-  test("days: minutes = 0 is consistent regardless of days", () => {
+  test("days: minutes = 0 and days > 0 is consistent", () => {
     expect(
       isStoredDelayConsistent({
         delayDays: 120,
@@ -152,6 +175,26 @@ describe("isStoredDelayConsistent", () => {
         delayUnit: "days",
       }),
     ).toBe(true)
+  })
+
+  test("days: zero days is inconsistent", () => {
+    expect(
+      isStoredDelayConsistent({
+        delayDays: 0,
+        delayMinutes: 0,
+        delayUnit: "days",
+      }),
+    ).toBe(false)
+  })
+
+  test("days: negative days is inconsistent", () => {
+    expect(
+      isStoredDelayConsistent({
+        delayDays: -1,
+        delayMinutes: 0,
+        delayUnit: "days",
+      }),
+    ).toBe(false)
   })
 
   test("days: nonzero minutes is inconsistent", () => {

--- a/apps/builder/__tests__/upsert-sequence-step-schema.test.ts
+++ b/apps/builder/__tests__/upsert-sequence-step-schema.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "vitest"
+import { DELAY_UNITS } from "../src/features/sequences/lib/delay"
+import { upsertSequenceStepRequest } from "../src/features/sequences/schema/action"
+
+const BASE = {
+  sequenceId: "seq-1",
+  order: 0,
+}
+
+const CONSISTENT_TRIPLES: Record<
+  (typeof DELAY_UNITS)[number],
+  { delayDays: number; delayMinutes: number }
+> = {
+  immediate: { delayDays: 0, delayMinutes: 0 },
+  minutes: { delayDays: 0, delayMinutes: 5 },
+  hours: { delayDays: 0, delayMinutes: 120 },
+  days: { delayDays: 3, delayMinutes: 0 },
+  specificTime: { delayDays: 0, delayMinutes: 0 },
+}
+
+describe("upsertSequenceStepRequest", () => {
+  describe("consistent delayUnit/delayDays/delayMinutes triples", () => {
+    for (const unit of DELAY_UNITS) {
+      test(`passes for unit "${unit}"`, () => {
+        const payload =
+          unit === "specificTime"
+            ? {
+                ...BASE,
+                delayUnit: unit,
+                ...CONSISTENT_TRIPLES[unit],
+                specificDateTime: "2026-09-10T10:00:00.000Z",
+              }
+            : {
+                ...BASE,
+                delayUnit: unit,
+                ...CONSISTENT_TRIPLES[unit],
+              }
+
+        const result = upsertSequenceStepRequest.safeParse(payload)
+
+        expect(result.success).toBe(true)
+      })
+    }
+  })
+
+  test("fails for days/0/120 (delayDays=0 but delayUnit=days requires delayMinutes=0)", () => {
+    const result = upsertSequenceStepRequest.safeParse({
+      ...BASE,
+      delayUnit: "days",
+      delayDays: 0,
+      delayMinutes: 120,
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (candidate) => candidate.path.join(".") === "delayUnit",
+      )
+      expect(issue?.message).toBe(
+        "delayUnit does not match delayDays/delayMinutes",
+      )
+    }
+  })
+
+  test("fails for hours/0/90 (delayMinutes not a multiple of 60)", () => {
+    const result = upsertSequenceStepRequest.safeParse({
+      ...BASE,
+      delayUnit: "hours",
+      delayDays: 0,
+      delayMinutes: 90,
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (candidate) => candidate.path.join(".") === "delayUnit",
+      )
+      expect(issue?.message).toBe(
+        "delayUnit does not match delayDays/delayMinutes",
+      )
+    }
+  })
+
+  test("fails for minutes/1/5 (delayDays must be 0 for minutes unit)", () => {
+    const result = upsertSequenceStepRequest.safeParse({
+      ...BASE,
+      delayUnit: "minutes",
+      delayDays: 1,
+      delayMinutes: 5,
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (candidate) => candidate.path.join(".") === "delayUnit",
+      )
+      expect(issue?.message).toBe(
+        "delayUnit does not match delayDays/delayMinutes",
+      )
+    }
+  })
+
+  test("passes for a partial payload with only delayDays", () => {
+    const result = upsertSequenceStepRequest.safeParse({
+      ...BASE,
+      delayDays: 3,
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  test("passes for a partial payload with only delayUnit", () => {
+    const result = upsertSequenceStepRequest.safeParse({
+      ...BASE,
+      delayUnit: "hours",
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  test("fails when delayUnit is specificTime with a null specificDateTime", () => {
+    const result = upsertSequenceStepRequest.safeParse({
+      ...BASE,
+      delayUnit: "specificTime",
+      delayDays: 0,
+      delayMinutes: 0,
+      specificDateTime: null,
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (candidate) => candidate.path.join(".") === "specificDateTime",
+      )
+      expect(issue).toBeDefined()
+    }
+  })
+
+  test("passes when delayUnit is specificTime with an ISO specificDateTime", () => {
+    const result = upsertSequenceStepRequest.safeParse({
+      ...BASE,
+      delayUnit: "specificTime",
+      delayDays: 0,
+      delayMinutes: 0,
+      specificDateTime: "2026-09-10T10:00:00.000Z",
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  test("accepts specificDateTime: null on a relative unit", () => {
+    const result = upsertSequenceStepRequest.safeParse({
+      ...BASE,
+      delayUnit: "days",
+      delayDays: 3,
+      delayMinutes: 0,
+      specificDateTime: null,
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  test("fails for an invalid delayUnit value", () => {
+    const result = upsertSequenceStepRequest.safeParse({
+      ...BASE,
+      delayUnit: "bogus",
+      delayDays: 0,
+      delayMinutes: 0,
+    })
+
+    expect(result.success).toBe(false)
+  })
+})

--- a/apps/builder/__tests__/upsert-sequence-step-schema.test.ts
+++ b/apps/builder/__tests__/upsert-sequence-step-schema.test.ts
@@ -3,7 +3,7 @@ import { DELAY_UNITS } from "../src/features/sequences/lib/delay"
 import { upsertSequenceStepRequest } from "../src/features/sequences/schema/action"
 
 const BASE = {
-  sequenceId: "seq-1",
+  sequenceId: "1",
   order: 0,
 }
 

--- a/apps/builder/__tests__/upsert-sequence-step-schema.test.ts
+++ b/apps/builder/__tests__/upsert-sequence-step-schema.test.ts
@@ -100,6 +100,39 @@ describe("upsertSequenceStepRequest", () => {
     }
   })
 
+  test("fails for hours/0/0 (zero relative value is not consistent)", () => {
+    const result = upsertSequenceStepRequest.safeParse({
+      ...BASE,
+      delayUnit: "hours",
+      delayDays: 0,
+      delayMinutes: 0,
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  test("fails for days/0/0 (zero relative value is not consistent)", () => {
+    const result = upsertSequenceStepRequest.safeParse({
+      ...BASE,
+      delayUnit: "days",
+      delayDays: 0,
+      delayMinutes: 0,
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  test("fails for minutes/0/0 (zero relative value is not consistent)", () => {
+    const result = upsertSequenceStepRequest.safeParse({
+      ...BASE,
+      delayUnit: "minutes",
+      delayDays: 0,
+      delayMinutes: 0,
+    })
+
+    expect(result.success).toBe(false)
+  })
+
   test("passes for a partial payload with only delayDays", () => {
     const result = upsertSequenceStepRequest.safeParse({
       ...BASE,

--- a/apps/builder/__tests__/use-delay-state.test.tsx
+++ b/apps/builder/__tests__/use-delay-state.test.tsx
@@ -1,0 +1,243 @@
+import { act, useEffect, useRef } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, describe, expect, test, vi } from "vitest"
+import { useDelayState } from "@/features/sequences/hooks/use-delay-state"
+import type { Step } from "@/features/sequences/hooks/use-sequence-step"
+import { stepToDelayView } from "@/features/sequences/lib/delay"
+
+type HookApi = ReturnType<typeof useDelayState>
+type OnSave = Parameters<typeof useDelayState>[1]
+
+type ViewSnapshot = {
+  unit: HookApi["delayUnit"]
+  value: HookApi["delayValue"]
+  specificDateTime: HookApi["specificDateTime"]
+}
+
+const holder: { current: HookApi | null } = { current: null }
+const historyRef: { current: ViewSnapshot[] } = { current: [] }
+let container: HTMLDivElement | null = null
+let root: Root | null = null
+
+/** Reads the hook's latest return value, failing fast if the probe has not
+ * mounted yet — avoids non-null assertions at every call site. */
+function getApi(): HookApi {
+  if (!holder.current) {
+    throw new Error("useDelayState probe has not rendered yet")
+  }
+  return holder.current
+}
+
+function Probe({ step, onSave }: { step: Step | undefined; onSave: OnSave }) {
+  const api = useDelayState(step, onSave)
+  const history = useRef(historyRef.current)
+
+  useEffect(() => {
+    holder.current = api
+  })
+
+  // Only fires when the derived view's primitive fields actually change —
+  // used to detect whether a rerender clobbered/updated the view.
+  useEffect(() => {
+    history.current.push({
+      unit: api.delayUnit,
+      value: api.delayValue,
+      specificDateTime: api.specificDateTime,
+    })
+  }, [api.delayUnit, api.delayValue, api.specificDateTime])
+
+  return null
+}
+
+function renderProbe(step: Step | undefined, onSave: OnSave) {
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => {
+    root?.render(<Probe onSave={onSave} step={step} />)
+  })
+}
+
+function rerenderProbe(step: Step | undefined, onSave: OnSave) {
+  act(() => {
+    root?.render(<Probe onSave={onSave} step={step} />)
+  })
+}
+
+afterEach(() => {
+  if (root) {
+    act(() => {
+      root?.unmount()
+    })
+  }
+  container?.remove()
+  container = null
+  root = null
+  holder.current = null
+  historyRef.current = []
+})
+
+function makeStep(overrides: Partial<Step>): Step {
+  return {
+    id: "step-1",
+    order: 0,
+    delayDays: 0,
+    delayMinutes: 120,
+    delayUnit: "hours",
+    specificDateTime: null,
+    flowId: "flow-1",
+    flow: { id: "flow-1", name: "Flow" },
+    isActive: true,
+    anytime: true,
+    sendTimeStart: null,
+    sendTimeEnd: null,
+    sendDays: null,
+    ...overrides,
+  }
+}
+
+describe("useDelayState", () => {
+  test("initial view is derived from stepToDelayView(step)", () => {
+    const step = makeStep({
+      delayDays: 0,
+      delayMinutes: 120,
+      delayUnit: "hours",
+    })
+    const onSave = vi.fn(() => Promise.resolve(true))
+
+    renderProbe(step, onSave)
+
+    const expected = stepToDelayView(step)
+    expect(getApi().delayUnit).toBe(expected.unit)
+    expect(getApi().delayValue).toBe(expected.value)
+    expect(getApi().specificDateTime).toBe(expected.specificDateTime)
+  })
+
+  test("handleDelayUnitChange saves the exact payload the hook builds and updates the view optimistically", async () => {
+    const step = makeStep({
+      delayDays: 0,
+      delayMinutes: 120,
+      delayUnit: "hours",
+    })
+    let resolveSave!: (value: boolean) => void
+    const deferred = new Promise<boolean>((resolve) => {
+      resolveSave = resolve
+    })
+    const onSave = vi.fn(() => deferred)
+
+    renderProbe(step, onSave)
+
+    act(() => {
+      getApi().handleDelayUnitChange("minutes")
+    })
+
+    // Optimistic update happens synchronously, before onSave resolves.
+    expect(getApi().delayUnit).toBe("minutes")
+    expect(getApi().delayValue).toBe(2)
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(onSave).toHaveBeenCalledWith({
+      delay: { unit: "minutes", value: 2, specificDateTime: undefined },
+    })
+
+    await act(async () => {
+      resolveSave(true)
+      await deferred
+    })
+  })
+
+  test("view reverts to the last persisted view when onSave resolves false", async () => {
+    const step = makeStep({
+      delayDays: 0,
+      delayMinutes: 120,
+      delayUnit: "hours",
+    })
+    let resolveSave!: (value: boolean) => void
+    const deferred = new Promise<boolean>((resolve) => {
+      resolveSave = resolve
+    })
+    const onSave = vi.fn(() => deferred)
+
+    renderProbe(step, onSave)
+
+    act(() => {
+      getApi().handleDelayUnitChange("minutes")
+    })
+    expect(getApi().delayUnit).toBe("minutes")
+
+    await act(async () => {
+      resolveSave(false)
+      await deferred.catch(() => undefined)
+    })
+
+    expect(getApi().delayUnit).toBe("hours")
+    expect(getApi().delayValue).toBe(2)
+  })
+
+  test("rerender with a step whose stored delay differs re-derives the view; rerender with identical fields leaves it unchanged", async () => {
+    const step = makeStep({
+      delayDays: 0,
+      delayMinutes: 120,
+      delayUnit: "hours",
+    })
+    const onSave = vi.fn(() => Promise.resolve(true))
+
+    renderProbe(step, onSave)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    const historyAfterMount = historyRef.current.length
+    expect(historyAfterMount).toBeGreaterThan(0)
+
+    // Different stored delay -> view must re-derive.
+    const changedStep = makeStep({
+      delayDays: 0,
+      delayMinutes: 30,
+      delayUnit: "minutes",
+    })
+    rerenderProbe(changedStep, onSave)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(getApi().delayUnit).toBe("minutes")
+    expect(getApi().delayValue).toBe(30)
+    const historyAfterChange = historyRef.current.length
+    expect(historyAfterChange).toBeGreaterThan(historyAfterMount)
+
+    // Identical stored fields (new object, same primitive values) -> no clobber.
+    const sameStep = makeStep({
+      delayDays: 0,
+      delayMinutes: 30,
+      delayUnit: "minutes",
+    })
+    rerenderProbe(sameStep, onSave)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(getApi().delayUnit).toBe("minutes")
+    expect(getApi().delayValue).toBe(30)
+    expect(historyRef.current.length).toBe(historyAfterChange)
+  })
+
+  test("handleSpecificDateTimeChange('') does not call onSave", () => {
+    const step = makeStep({
+      delayDays: 0,
+      delayMinutes: 0,
+      delayUnit: "specificTime",
+      specificDateTime: new Date(2026, 5, 15, 9, 30),
+    })
+    const onSave = vi.fn(() => Promise.resolve(true))
+
+    renderProbe(step, onSave)
+
+    act(() => {
+      getApi().handleSpecificDateTimeChange("")
+    })
+
+    expect(onSave).not.toHaveBeenCalled()
+    expect(getApi().specificDateTime).toBe("")
+  })
+})

--- a/apps/builder/__tests__/use-sequence-step.test.tsx
+++ b/apps/builder/__tests__/use-sequence-step.test.tsx
@@ -1,0 +1,237 @@
+import { act, useEffect } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, describe, expect, test, vi } from "vitest"
+import type { Step } from "@/features/sequences/hooks/use-sequence-step"
+import { useSequenceStep } from "@/features/sequences/hooks/use-sequence-step"
+
+/** Echoes the key back so assertions never depend on the English copy. */
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+const toast = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn() }))
+vi.mock("sonner", () => ({ toast }))
+
+const refresh = vi.hoisted(() => vi.fn())
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh }),
+}))
+
+const upsertSequenceStepAction = vi.hoisted(() => vi.fn())
+vi.mock("@/features/sequences/actions/upsert-sequence-step.action", () => ({
+  upsertSequenceStepAction,
+}))
+
+const deleteSequenceStepAction = vi.hoisted(() => vi.fn())
+vi.mock("@/features/sequences/actions/delete-sequence-step.action", () => ({
+  deleteSequenceStepAction,
+}))
+
+type HookApi = ReturnType<typeof useSequenceStep>
+type HookProps = Parameters<typeof useSequenceStep>[0]
+
+const holder: { current: HookApi | null } = { current: null }
+let container: HTMLDivElement | null = null
+let root: Root | null = null
+
+/** Reads the hook's latest return value, failing fast if the probe has not
+ * mounted yet — avoids non-null assertions at every call site. */
+function getApi(): HookApi {
+  if (!holder.current) {
+    throw new Error("useSequenceStep probe has not rendered yet")
+  }
+  return holder.current
+}
+
+function Probe({ props }: { props: HookProps }) {
+  const api = useSequenceStep(props)
+  useEffect(() => {
+    holder.current = api
+  })
+  return null
+}
+
+function renderHook(props: HookProps) {
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => {
+    root?.render(<Probe props={props} />)
+  })
+}
+
+afterEach(() => {
+  if (root) {
+    act(() => {
+      root?.unmount()
+    })
+  }
+  container?.remove()
+  container = null
+  root = null
+  holder.current = null
+  toast.error.mockClear()
+  toast.success.mockClear()
+  refresh.mockClear()
+  upsertSequenceStepAction.mockReset()
+  deleteSequenceStepAction.mockReset()
+})
+
+const BASE_STEP: Step = {
+  id: "step-1",
+  order: 0,
+  delayDays: 0,
+  delayMinutes: 120,
+  delayUnit: "hours",
+  specificDateTime: null,
+  flowId: "flow-1",
+  flow: { id: "flow-1", name: "Flow" },
+  isActive: true,
+  anytime: true,
+  sendTimeStart: null,
+  sendTimeEnd: null,
+  sendDays: null,
+}
+
+const BASE_PROPS: HookProps = {
+  step: BASE_STEP,
+  stepNumber: 1,
+  sequenceId: "seq-1",
+  workspaceId: "ws-1",
+}
+
+describe("useSequenceStep", () => {
+  test("queues saves FIFO: second call is not invoked until the first resolves; isSaving stays true until drained; router.refresh runs once", async () => {
+    let resolveFirst!: (value: unknown) => void
+    const firstDeferred = new Promise((resolve) => {
+      resolveFirst = resolve
+    })
+    upsertSequenceStepAction
+      .mockImplementationOnce(() => firstDeferred)
+      .mockImplementationOnce(() =>
+        Promise.resolve({ data: { stepId: "step-1" } }),
+      )
+
+    renderHook(BASE_PROPS)
+
+    let p1: Promise<boolean> = Promise.resolve(false)
+    let p2: Promise<boolean> = Promise.resolve(false)
+    act(() => {
+      p1 = getApi().handleSave({ isActive: true })
+      p2 = getApi().handleSave({ isActive: false })
+    })
+
+    expect(getApi().isSaving).toBe(true)
+
+    // Flush the microtask that starts the first queued save. The second
+    // save must not have been dispatched yet — this is the FIFO guarantee.
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(upsertSequenceStepAction).toHaveBeenCalledTimes(1)
+    expect(refresh).not.toHaveBeenCalled()
+
+    await act(async () => {
+      resolveFirst({ data: { stepId: "step-1" } })
+      await Promise.all([p1, p2])
+    })
+
+    expect(upsertSequenceStepAction).toHaveBeenCalledTimes(2)
+    expect(getApi().isSaving).toBe(false)
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  test("resolves false and toasts once when the action returns no data", async () => {
+    upsertSequenceStepAction.mockResolvedValueOnce({ data: undefined })
+    renderHook(BASE_PROPS)
+
+    let result: boolean | undefined
+    await act(async () => {
+      result = await getApi().handleSave({ isActive: true })
+    })
+
+    expect(result).toBe(false)
+    expect(toast.error).toHaveBeenCalledTimes(1)
+    expect(toast.error).toHaveBeenCalledWith("messages.unknownError")
+  })
+
+  test("resolves false and toasts once (no unhandled rejection) when the action rejects", async () => {
+    upsertSequenceStepAction.mockRejectedValueOnce(new Error("boom"))
+    renderHook(BASE_PROPS)
+
+    let result: boolean | undefined
+    await act(async () => {
+      result = await getApi().handleSave({ isActive: true })
+    })
+
+    expect(result).toBe(false)
+    expect(toast.error).toHaveBeenCalledTimes(1)
+  })
+
+  test("delay hours/2 payload maps to delayDays:0, delayMinutes:120, delayUnit:hours, specificDateTime:null", async () => {
+    upsertSequenceStepAction.mockResolvedValueOnce({
+      data: { stepId: "step-1" },
+    })
+    renderHook(BASE_PROPS)
+
+    await act(async () => {
+      await getApi().handleSave({ delay: { unit: "hours", value: 2 } })
+    })
+
+    expect(upsertSequenceStepAction).toHaveBeenCalledWith(
+      "ws-1",
+      expect.objectContaining({
+        delayDays: 0,
+        delayMinutes: 120,
+        delayUnit: "hours",
+        specificDateTime: null,
+      }),
+    )
+  })
+
+  test("a specificTime delay in the past resolves false, toasts once, and never calls the action", async () => {
+    renderHook(BASE_PROPS)
+
+    const past = "2020-01-01T00:00"
+    let result: boolean | undefined
+    await act(async () => {
+      result = await getApi().handleSave({
+        delay: { unit: "specificTime", value: 1, specificDateTime: past },
+      })
+    })
+
+    expect(result).toBe(false)
+    expect(toast.error).toHaveBeenCalledTimes(1)
+    expect(upsertSequenceStepAction).not.toHaveBeenCalled()
+  })
+
+  test("F1: a step with no id threads the id returned by the first queued create into the second queued save", async () => {
+    upsertSequenceStepAction
+      .mockResolvedValueOnce({ data: { stepId: "new-step-1" } })
+      .mockResolvedValueOnce({ data: { stepId: "new-step-1" } })
+
+    renderHook({ ...BASE_PROPS, step: undefined })
+
+    let p1: Promise<boolean> = Promise.resolve(false)
+    let p2: Promise<boolean> = Promise.resolve(false)
+    act(() => {
+      p1 = getApi().handleSave({ isActive: true })
+      p2 = getApi().handleSave({ isActive: false })
+    })
+
+    await act(async () => {
+      await Promise.all([p1, p2])
+    })
+
+    expect(upsertSequenceStepAction).toHaveBeenNthCalledWith(
+      1,
+      "ws-1",
+      expect.objectContaining({ stepId: undefined }),
+    )
+    expect(upsertSequenceStepAction).toHaveBeenNthCalledWith(
+      2,
+      "ws-1",
+      expect.objectContaining({ stepId: "new-step-1" }),
+    )
+  })
+})

--- a/apps/builder/src/features/sequences/components/delay-selector.tsx
+++ b/apps/builder/src/features/sequences/components/delay-selector.tsx
@@ -16,6 +16,7 @@ import { memo, useEffect, useState } from "react"
 import {
   DELAY_UNITS,
   type DelayUnit,
+  isDelayUnit,
   isDelayValueInRange,
   MAX_DELAY_VALUE,
   MIN_DELAY_VALUE,
@@ -50,12 +51,22 @@ export const DelaySelector = memo(function DelaySelector({
     setShowDelayValueError(false)
   }, [delayValue])
 
-  const delayUnitItems: { label: string; value: DelayUnit }[] = DELAY_UNITS.map(
-    (unit) => ({
-      label: t(`sequences.delayUnits.${unit}`),
-      value: unit,
-    }),
-  )
+  const delayUnitItems = DELAY_UNITS.map((unit) => ({
+    label: t(`sequences.delayUnits.${unit}`),
+    value: unit,
+  }))
+
+  /** Validates the typed number and saves it when it differs from the committed value. Returns whether it was valid. */
+  const commitLocalValue = (): boolean => {
+    const isValid = isDelayValueInRange(localValue)
+    setShowDelayValueError(!isValid)
+
+    if (isValid && localValue !== delayValue) {
+      onDelayValueChange(localValue)
+    }
+
+    return isValid
+  }
 
   return (
     <div className="flex w-70 items-center gap-2">
@@ -67,12 +78,6 @@ export const DelaySelector = memo(function DelaySelector({
           <Input
             disabled={isSaving}
             min={oneHourFromNowLocal()}
-            onBlur={(e) => {
-              const value = e.target.value
-              if (value && value !== specificDateTime) {
-                onSpecificDateTimeChange(value)
-              }
-            }}
             onChange={(e) => onSpecificDateTimeChange(e.target.value)}
             type="datetime-local"
             value={specificDateTime}
@@ -97,16 +102,9 @@ export const DelaySelector = memo(function DelaySelector({
               max={MAX_DELAY_VALUE}
               min={MIN_DELAY_VALUE}
               onBlur={() => {
-                if (!isDelayValueInRange(localValue)) {
-                  setShowDelayValueError(true)
+                if (!commitLocalValue()) {
                   setLocalValue(delayValue)
-                  return
                 }
-                setShowDelayValueError(false)
-                if (localValue === delayValue) {
-                  return
-                }
-                onDelayValueChange(localValue)
               }}
               onChange={(e) => {
                 const value = Number(e.target.value)
@@ -115,12 +113,7 @@ export const DelaySelector = memo(function DelaySelector({
               }}
               onKeyDown={(e) => {
                 if (e.key === "Enter") {
-                  if (!isDelayValueInRange(localValue)) {
-                    setShowDelayValueError(true)
-                    return
-                  }
-                  setShowDelayValueError(false)
-                  onDelayValueChange(localValue)
+                  commitLocalValue()
                 }
               }}
               step={1}
@@ -131,7 +124,11 @@ export const DelaySelector = memo(function DelaySelector({
           <Select
             disabled={isSaving}
             items={delayUnitItems}
-            onValueChange={(value) => onDelayUnitChange(value as DelayUnit)}
+            onValueChange={(value) => {
+              if (isDelayUnit(value)) {
+                onDelayUnitChange(value)
+              }
+            }}
             value={delayUnit}
           >
             <SelectTrigger className="w-35">

--- a/apps/builder/src/features/sequences/components/delay-selector.tsx
+++ b/apps/builder/src/features/sequences/components/delay-selector.tsx
@@ -11,9 +11,16 @@ import {
 } from "@chatbotx.io/ui/components/ui/select"
 import { RotateCcwIcon } from "lucide-react"
 import { useTranslations } from "next-intl"
-import { memo, useState } from "react"
+import { memo, useEffect, useState } from "react"
 
-type DelayUnit = "immediate" | "minutes" | "hours" | "days" | "specificTime"
+import {
+  DELAY_UNITS,
+  type DelayUnit,
+  isDelayValueInRange,
+  MAX_DELAY_VALUE,
+  MIN_DELAY_VALUE,
+  oneHourFromNowLocal,
+} from "../lib/delay"
 
 type DelaySelectorProps = {
   delayUnit: DelayUnit
@@ -23,17 +30,6 @@ type DelaySelectorProps = {
   onDelayUnitChange: (unit: DelayUnit) => void
   onDelayValueChange: (value: number) => void
   onSpecificDateTimeChange: (dateTime: string) => void
-}
-
-function getOneHourFromNowLocal() {
-  const now = new Date()
-  now.setHours(now.getHours() + 1)
-  const year = now.getFullYear()
-  const month = `${now.getMonth() + 1}`.padStart(2, "0")
-  const day = `${now.getDate()}`.padStart(2, "0")
-  const hour = `${now.getHours()}`.padStart(2, "0")
-  const minute = `${now.getMinutes()}`.padStart(2, "0")
-  return `${year}-${month}-${day}T${hour}:${minute}`
 }
 
 export const DelaySelector = memo(function DelaySelector({
@@ -49,13 +45,17 @@ export const DelaySelector = memo(function DelaySelector({
   const [showDelayValueError, setShowDelayValueError] = useState(false)
   const [localValue, setLocalValue] = useState(delayValue)
 
-  const delayUnitItems: { label: string; value: DelayUnit }[] = [
-    { label: t("sequences.delayUnits.immediate"), value: "immediate" },
-    { label: t("sequences.delayUnits.minutes"), value: "minutes" },
-    { label: t("sequences.delayUnits.hours"), value: "hours" },
-    { label: t("sequences.delayUnits.days"), value: "days" },
-    { label: t("sequences.delayUnits.specificTime"), value: "specificTime" },
-  ]
+  useEffect(() => {
+    setLocalValue(delayValue)
+    setShowDelayValueError(false)
+  }, [delayValue])
+
+  const delayUnitItems: { label: string; value: DelayUnit }[] = DELAY_UNITS.map(
+    (unit) => ({
+      label: t(`sequences.delayUnits.${unit}`),
+      value: unit,
+    }),
+  )
 
   return (
     <div className="flex w-70 items-center gap-2">
@@ -66,7 +66,7 @@ export const DelaySelector = memo(function DelaySelector({
         <div className="flex w-full items-center gap-1">
           <Input
             disabled={isSaving}
-            min={getOneHourFromNowLocal()}
+            min={oneHourFromNowLocal()}
             onBlur={() => {
               if (specificDateTime) {
                 onSpecificDateTimeChange(specificDateTime)
@@ -92,10 +92,10 @@ export const DelaySelector = memo(function DelaySelector({
             <Input
               className={`w-20 ${showDelayValueError ? "border-destructive" : ""}`}
               disabled={isSaving}
-              max={99_999}
-              min={1}
+              max={MAX_DELAY_VALUE}
+              min={MIN_DELAY_VALUE}
               onBlur={() => {
-                if (!localValue || localValue < 1 || localValue > 99_999) {
+                if (!isDelayValueInRange(localValue)) {
                   setShowDelayValueError(true)
                   setLocalValue(delayValue)
                   return
@@ -106,15 +106,11 @@ export const DelaySelector = memo(function DelaySelector({
               onChange={(e) => {
                 const value = Number(e.target.value)
                 setLocalValue(value)
-                if (value >= 1 && value <= 99_999) {
-                  setShowDelayValueError(false)
-                } else {
-                  setShowDelayValueError(true)
-                }
+                setShowDelayValueError(!isDelayValueInRange(value))
               }}
               onKeyDown={(e) => {
                 if (e.key === "Enter") {
-                  if (!localValue || localValue < 1 || localValue > 99_999) {
+                  if (!isDelayValueInRange(localValue)) {
                     setShowDelayValueError(true)
                     return
                   }

--- a/apps/builder/src/features/sequences/components/delay-selector.tsx
+++ b/apps/builder/src/features/sequences/components/delay-selector.tsx
@@ -67,9 +67,10 @@ export const DelaySelector = memo(function DelaySelector({
           <Input
             disabled={isSaving}
             min={oneHourFromNowLocal()}
-            onBlur={() => {
-              if (specificDateTime) {
-                onSpecificDateTimeChange(specificDateTime)
+            onBlur={(e) => {
+              const value = e.target.value
+              if (value && value !== specificDateTime) {
+                onSpecificDateTimeChange(value)
               }
             }}
             onChange={(e) => onSpecificDateTimeChange(e.target.value)}
@@ -78,6 +79,7 @@ export const DelaySelector = memo(function DelaySelector({
           />
           <Button
             className="h-7 w-7 hover:bg-muted hover:text-primary"
+            disabled={isSaving}
             onClick={() => onDelayUnitChange("days")}
             size="icon"
             type="button"
@@ -101,6 +103,9 @@ export const DelaySelector = memo(function DelaySelector({
                   return
                 }
                 setShowDelayValueError(false)
+                if (localValue === delayValue) {
+                  return
+                }
                 onDelayValueChange(localValue)
               }}
               onChange={(e) => {
@@ -118,6 +123,7 @@ export const DelaySelector = memo(function DelaySelector({
                   onDelayValueChange(localValue)
                 }
               }}
+              step={1}
               type="number"
               value={localValue}
             />

--- a/apps/builder/src/features/sequences/components/sequence-step-card.tsx
+++ b/apps/builder/src/features/sequences/components/sequence-step-card.tsx
@@ -5,10 +5,10 @@ import { Card, CardContent } from "@chatbotx.io/ui/components/ui/card"
 import { Switch } from "@chatbotx.io/ui/components/ui/switch"
 import { ChevronDownIcon, XIcon } from "lucide-react"
 import { useTranslations } from "next-intl"
-import { useState } from "react"
+import { useCallback, useState } from "react"
 
 import { useDelayState } from "../hooks/use-delay-state"
-import { type DelayUnit, useSequenceStep } from "../hooks/use-sequence-step"
+import { useSequenceStep } from "../hooks/use-sequence-step"
 import { useTimeRangeState } from "../hooks/use-time-range-state"
 
 import { DelaySelector } from "./delay-selector"
@@ -73,8 +73,6 @@ export function SequenceStepCard({
     isFirst,
     previousStepTime,
     onSaved,
-    currentDelayUnit: (step?.delayUnit as DelayUnit) || "days",
-    currentDelayValue: step?.delayDays || step?.delayMinutes || 1,
   })
 
   const {
@@ -86,6 +84,16 @@ export function SequenceStepCard({
     handleSpecificDateTimeChange,
   } = useDelayState(step, handleSave)
 
+  // useTimeRangeState expects an onSave that resolves Promise<void>;
+  // handleSave resolves Promise<boolean> so callers can react to save
+  // success. Adapt here rather than changing handleSave's contract.
+  const handleSaveIgnoringResult = useCallback(
+    async (fields: Parameters<typeof handleSave>[0]) => {
+      await handleSave(fields)
+    },
+    [handleSave],
+  )
+
   const {
     timeOption,
     startTime,
@@ -95,7 +103,7 @@ export function SequenceStepCard({
     handleStartTimeChange,
     handleEndTimeChange,
     handleSelectedDaysChange,
-  } = useTimeRangeState(step, handleSave)
+  } = useTimeRangeState(step, handleSaveIgnoringResult)
 
   return (
     <div className="grid">

--- a/apps/builder/src/features/sequences/components/sequence-step-card.tsx
+++ b/apps/builder/src/features/sequences/components/sequence-step-card.tsx
@@ -189,6 +189,7 @@ export function SequenceStepCard({
               }`}
             >
               <TimeRangeSelector
+                disabled={isSaving}
                 endTime={endTime}
                 onEndTimeChange={handleEndTimeChange}
                 onSelectedDaysChange={handleSelectedDaysChange}

--- a/apps/builder/src/features/sequences/components/sequence-step-card.tsx
+++ b/apps/builder/src/features/sequences/components/sequence-step-card.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent } from "@chatbotx.io/ui/components/ui/card"
 import { Switch } from "@chatbotx.io/ui/components/ui/switch"
 import { ChevronDownIcon, XIcon } from "lucide-react"
 import { useTranslations } from "next-intl"
-import { useCallback, useState } from "react"
+import { useState } from "react"
 
 import { useDelayState } from "../hooks/use-delay-state"
 import { useSequenceStep } from "../hooks/use-sequence-step"
@@ -84,16 +84,6 @@ export function SequenceStepCard({
     handleSpecificDateTimeChange,
   } = useDelayState(step, handleSave)
 
-  // useTimeRangeState expects an onSave that resolves Promise<void>;
-  // handleSave resolves Promise<boolean> so callers can react to save
-  // success. Adapt here rather than changing handleSave's contract.
-  const handleSaveIgnoringResult = useCallback(
-    async (fields: Parameters<typeof handleSave>[0]) => {
-      await handleSave(fields)
-    },
-    [handleSave],
-  )
-
   const {
     timeOption,
     startTime,
@@ -103,7 +93,7 @@ export function SequenceStepCard({
     handleStartTimeChange,
     handleEndTimeChange,
     handleSelectedDaysChange,
-  } = useTimeRangeState(step, handleSaveIgnoringResult)
+  } = useTimeRangeState(step, handleSave)
 
   return (
     <div className="grid">

--- a/apps/builder/src/features/sequences/components/time-range-selector.tsx
+++ b/apps/builder/src/features/sequences/components/time-range-selector.tsx
@@ -39,6 +39,7 @@ type TimeRangeSelectorProps = {
   startTime: string
   endTime: string
   selectedDays: string[]
+  disabled?: boolean
   onTimeOptionChange: (option: "anytime" | "between") => void
   onStartTimeChange: (time: string) => void
   onEndTimeChange: (time: string) => void
@@ -54,6 +55,7 @@ export const TimeRangeSelector = memo(function TimeRangeSelector({
   startTime,
   endTime,
   selectedDays,
+  disabled = false,
   onTimeOptionChange,
   onStartTimeChange,
   onEndTimeChange,
@@ -121,6 +123,7 @@ export const TimeRangeSelector = memo(function TimeRangeSelector({
       <div className="mb-2 flex items-center space-x-2">
         <Checkbox
           checked={timeOption === "between"}
+          disabled={disabled}
           id={`time-option-${stepId || "new"}`}
           onCheckedChange={(checked) =>
             onTimeOptionChange(checked ? "between" : "anytime")
@@ -138,6 +141,7 @@ export const TimeRangeSelector = memo(function TimeRangeSelector({
         <div className="gap-2">
           <div className="flex items-center gap-2">
             <Select
+              disabled={disabled}
               onValueChange={(value) => handleStartTimeChange(value as string)}
               value={startTime}
             >
@@ -156,6 +160,7 @@ export const TimeRangeSelector = memo(function TimeRangeSelector({
             <span className="text-muted-foreground">-</span>
 
             <Select
+              disabled={disabled}
               onValueChange={(value) => handleEndTimeChange(value as string)}
               value={endTime}
             >
@@ -178,6 +183,7 @@ export const TimeRangeSelector = memo(function TimeRangeSelector({
                 render={
                   <Button
                     className="w-full justify-start font-normal"
+                    disabled={disabled}
                     variant="outline"
                   >
                     {getDaysLabel()}
@@ -191,6 +197,7 @@ export const TimeRangeSelector = memo(function TimeRangeSelector({
                       <div className="flex items-center space-x-2" key={day}>
                         <Checkbox
                           checked={selectedDays.includes(day)}
+                          disabled={disabled}
                           id={`day-${day}`}
                           onCheckedChange={(checked) =>
                             handleDayToggle(day, !!checked)
@@ -207,6 +214,7 @@ export const TimeRangeSelector = memo(function TimeRangeSelector({
                   </div>
                   <Button
                     className="w-full"
+                    disabled={disabled}
                     onClick={handleToggleAllDays}
                     variant="outline"
                   >

--- a/apps/builder/src/features/sequences/hooks/use-delay-state.ts
+++ b/apps/builder/src/features/sequences/hooks/use-delay-state.ts
@@ -20,9 +20,9 @@ function isSameView(a: DelayView, b: DelayView): boolean {
 }
 
 export function useDelayState(step: Step | undefined, onSave: OnSave) {
-  const initialView = stepToDelayView(step)
-  const [view, setView] = useState<DelayView>(initialView)
-  const persistedViewRef = useRef<DelayView>(initialView)
+  const [view, setView] = useState<DelayView>(() => stepToDelayView(step))
+  // Only the first render's `view` seeds the ref; later renders ignore the arg.
+  const persistedViewRef = useRef<DelayView>(view)
 
   const stepId = step?.id
   const delayDays = step?.delayDays

--- a/apps/builder/src/features/sequences/hooks/use-delay-state.ts
+++ b/apps/builder/src/features/sequences/hooks/use-delay-state.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import {
   type DelayUnit,
   type DelayView,
@@ -12,8 +12,18 @@ type OnSave = (fields: {
   delay: { unit: DelayUnit; value: number; specificDateTime?: string }
 }) => Promise<boolean>
 
+function isSameView(a: DelayView, b: DelayView): boolean {
+  return (
+    a.unit === b.unit &&
+    a.value === b.value &&
+    a.specificDateTime === b.specificDateTime
+  )
+}
+
 export function useDelayState(step: Step | undefined, onSave: OnSave) {
-  const [view, setView] = useState<DelayView>(() => stepToDelayView(step))
+  const initialView = stepToDelayView(step)
+  const [view, setView] = useState<DelayView>(initialView)
+  const persistedViewRef = useRef<DelayView>(initialView)
 
   const stepId = step?.id
   const delayDays = step?.delayDays
@@ -38,12 +48,21 @@ export function useDelayState(step: Step | undefined, onSave: OnSave) {
                 : new Date(specificDateTimeMs),
           }
 
-    setView(stepToDelayView(storedFields))
+    const nextView = stepToDelayView(storedFields)
+    persistedViewRef.current = nextView
+
+    setView((current) => (isSameView(current, nextView) ? current : nextView))
   }, [stepId, delayDays, delayMinutes, delayUnit, specificDateTimeMs])
 
-  const saveView = useCallback(
-    async (nextView: DelayView, previousView: DelayView) => {
-      const success = await onSave({
+  // Optimistically shows `nextView`, then persists it. On success, records
+  // it as the last-persisted view. On failure, reverts — but only if no
+  // newer optimistic change has since replaced it (an older failed save
+  // must never clobber a newer in-flight or already-applied edit).
+  const commitView = useCallback(
+    async (nextView: DelayView) => {
+      setView(nextView)
+
+      const saved = await onSave({
         delay: {
           unit: nextView.unit,
           value: nextView.value,
@@ -51,8 +70,12 @@ export function useDelayState(step: Step | undefined, onSave: OnSave) {
         },
       })
 
-      if (!success) {
-        setView(previousView)
+      if (saved) {
+        persistedViewRef.current = nextView
+      } else {
+        setView((current) =>
+          current === nextView ? persistedViewRef.current : current,
+        )
       }
     },
     [onSave],
@@ -60,46 +83,41 @@ export function useDelayState(step: Step | undefined, onSave: OnSave) {
 
   const handleDelayUnitChange = useCallback(
     (unit: DelayUnit) => {
-      const previousView = view
       const specificDateTime =
         unit === "specificTime" && !view.specificDateTime
           ? oneHourFromNowLocal()
           : view.specificDateTime
       const nextView: DelayView = { ...view, unit, specificDateTime }
 
-      setView(nextView)
-      saveView(nextView, previousView)
+      commitView(nextView)
     },
-    [view, saveView],
+    [view, commitView],
   )
 
   const handleDelayValueChange = useCallback(
     (value: number) => {
-      const previousView = view
       const nextView: DelayView = { ...view, value }
 
-      setView(nextView)
-      saveView(nextView, previousView)
+      commitView(nextView)
     },
-    [view, saveView],
+    [view, commitView],
   )
 
   const handleSpecificDateTimeChange = useCallback(
     (dateTime: string) => {
-      const previousView = view
       const nextView: DelayView = {
         ...view,
         unit: "specificTime",
         specificDateTime: dateTime,
       }
 
-      setView(nextView)
-
       if (dateTime) {
-        saveView(nextView, previousView)
+        commitView(nextView)
+      } else {
+        setView(nextView)
       }
     },
-    [view, saveView],
+    [view, commitView],
   )
 
   return {

--- a/apps/builder/src/features/sequences/hooks/use-delay-state.ts
+++ b/apps/builder/src/features/sequences/hooks/use-delay-state.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import {
+  type DelayChange,
   type DelayUnit,
   type DelayView,
   oneHourFromNowLocal,
@@ -8,9 +9,7 @@ import {
 } from "../lib/delay"
 import type { Step } from "./use-sequence-step"
 
-type OnSave = (fields: {
-  delay: { unit: DelayUnit; value: number; specificDateTime?: string }
-}) => Promise<boolean>
+type OnSave = (fields: { delay: DelayChange }) => Promise<boolean>
 
 function isSameView(a: DelayView, b: DelayView): boolean {
   return (

--- a/apps/builder/src/features/sequences/hooks/use-delay-state.ts
+++ b/apps/builder/src/features/sequences/hooks/use-delay-state.ts
@@ -1,126 +1,111 @@
-import { useCallback, useState } from "react"
-import type { DelayUnit, Step } from "./use-sequence-step"
+import { useCallback, useEffect, useState } from "react"
+import {
+  type DelayUnit,
+  type DelayView,
+  oneHourFromNowLocal,
+  type StoredDelayFields,
+  stepToDelayView,
+} from "../lib/delay"
+import type { Step } from "./use-sequence-step"
 
-function getOneHourFromNowLocal() {
-  const now = new Date()
-  now.setHours(now.getHours() + 1)
-  const year = now.getFullYear()
-  const month = `${now.getMonth() + 1}`.padStart(2, "0")
-  const day = `${now.getDate()}`.padStart(2, "0")
-  const hour = `${now.getHours()}`.padStart(2, "0")
-  const minute = `${now.getMinutes()}`.padStart(2, "0")
-  return `${year}-${month}-${day}T${hour}:${minute}`
-}
+type OnSave = (fields: {
+  delay: { unit: DelayUnit; value: number; specificDateTime?: string }
+}) => Promise<boolean>
 
-function getInitialDelayUnit(step?: Step): DelayUnit {
-  if (!step) {
-    return "days"
-  }
-  if (step.delayUnit === "specificTime") {
-    return "specificTime"
-  }
-  if (step.delayUnit === "immediate") {
-    return "immediate"
-  }
-  if (step.delayDays > 0) {
-    return "days"
-  }
-  if (step.delayMinutes >= 60) {
-    return "hours"
-  }
-  if (step.delayMinutes > 0) {
-    return "minutes"
-  }
-  return "immediate"
-}
+export function useDelayState(step: Step | undefined, onSave: OnSave) {
+  const [view, setView] = useState<DelayView>(() => stepToDelayView(step))
 
-function getInitialDelayValue(step?: Step): number {
-  if (!step) {
-    return 1
-  }
-  if (step.delayDays > 0) {
-    return step.delayDays
-  }
-  if (step.delayMinutes >= 60) {
-    return Math.floor(step.delayMinutes / 60)
-  }
-  if (step.delayMinutes > 0) {
-    return step.delayMinutes
-  }
-  return 1
-}
+  const stepId = step?.id
+  const delayDays = step?.delayDays
+  const delayMinutes = step?.delayMinutes
+  const delayUnit = step?.delayUnit
+  const specificDateTimeMs = step?.specificDateTime?.getTime()
 
-function getInitialSpecificDateTime(step?: Step): string {
-  if (step?.specificDateTime) {
-    const date = new Date(step.specificDateTime)
-    const year = date.getFullYear()
-    const month = `${date.getMonth() + 1}`.padStart(2, "0")
-    const day = `${date.getDate()}`.padStart(2, "0")
-    const hour = `${date.getHours()}`.padStart(2, "0")
-    const minute = `${date.getMinutes()}`.padStart(2, "0")
-    return `${year}-${month}-${day}T${hour}:${minute}`
-  }
-  return ""
-}
+  // Re-derive the view from the raw stored delay fields — not `step` object
+  // identity — so a server refresh that returns unchanged delay data does
+  // not clobber a pending local edit.
+  useEffect(() => {
+    const storedFields: StoredDelayFields | undefined =
+      stepId === undefined
+        ? undefined
+        : {
+            delayDays: delayDays ?? 0,
+            delayMinutes: delayMinutes ?? 0,
+            delayUnit,
+            specificDateTime:
+              specificDateTimeMs === undefined
+                ? null
+                : new Date(specificDateTimeMs),
+          }
 
-export function useDelayState(
-  step: Step | undefined,
-  onSave: (fields: {
-    delayUnit?: DelayUnit
-    delayValue?: number
-    specificDateTime?: string
-  }) => Promise<void>,
-) {
-  const [delayUnit, setDelayUnit] = useState<DelayUnit>(() =>
-    getInitialDelayUnit(step),
-  )
-  const [delayValue, setDelayValue] = useState<number>(() =>
-    getInitialDelayValue(step),
-  )
-  const [specificDateTime, setSpecificDateTime] = useState<string>(() =>
-    getInitialSpecificDateTime(step),
+    setView(stepToDelayView(storedFields))
+  }, [stepId, delayDays, delayMinutes, delayUnit, specificDateTimeMs])
+
+  const saveView = useCallback(
+    async (nextView: DelayView, previousView: DelayView) => {
+      const success = await onSave({
+        delay: {
+          unit: nextView.unit,
+          value: nextView.value,
+          specificDateTime: nextView.specificDateTime || undefined,
+        },
+      })
+
+      if (!success) {
+        setView(previousView)
+      }
+    },
+    [onSave],
   )
 
   const handleDelayUnitChange = useCallback(
     (unit: DelayUnit) => {
-      setDelayUnit(unit)
+      const previousView = view
+      const specificDateTime =
+        unit === "specificTime" && !view.specificDateTime
+          ? oneHourFromNowLocal()
+          : view.specificDateTime
+      const nextView: DelayView = { ...view, unit, specificDateTime }
 
-      if (unit === "specificTime") {
-        const newDateTime = specificDateTime || getOneHourFromNowLocal()
-        setSpecificDateTime(newDateTime)
-        onSave({
-          delayUnit: unit,
-          specificDateTime: newDateTime,
-        })
-      } else {
-        onSave({ delayUnit: unit })
-      }
+      setView(nextView)
+      saveView(nextView, previousView)
     },
-    [specificDateTime, onSave],
+    [view, saveView],
   )
 
   const handleDelayValueChange = useCallback(
     (value: number) => {
-      setDelayValue(value)
-      onSave({ delayValue: value })
+      const previousView = view
+      const nextView: DelayView = { ...view, value }
+
+      setView(nextView)
+      saveView(nextView, previousView)
     },
-    [onSave],
+    [view, saveView],
   )
 
   const handleSpecificDateTimeChange = useCallback(
     (dateTime: string) => {
-      setSpecificDateTime(dateTime)
+      const previousView = view
+      const nextView: DelayView = {
+        ...view,
+        unit: "specificTime",
+        specificDateTime: dateTime,
+      }
+
+      setView(nextView)
+
       if (dateTime) {
-        onSave({ specificDateTime: dateTime })
+        saveView(nextView, previousView)
       }
     },
-    [onSave],
+    [view, saveView],
   )
 
   return {
-    delayUnit,
-    delayValue,
-    specificDateTime,
+    delayUnit: view.unit,
+    delayValue: view.value,
+    specificDateTime: view.specificDateTime,
     handleDelayUnitChange,
     handleDelayValueChange,
     handleSpecificDateTimeChange,

--- a/apps/builder/src/features/sequences/hooks/use-sequence-step.ts
+++ b/apps/builder/src/features/sequences/hooks/use-sequence-step.ts
@@ -4,8 +4,10 @@ import { useCallback, useRef, useState } from "react"
 import { toast } from "sonner"
 import { deleteSequenceStepAction } from "../actions/delete-sequence-step.action"
 import { upsertSequenceStepAction } from "../actions/upsert-sequence-step.action"
+import type { DelayUnit } from "../lib/delay"
+import { delayViewToStored } from "../lib/delay"
 
-type DelayUnit = "immediate" | "minutes" | "hours" | "days" | "specificTime"
+export type { DelayUnit } from "../lib/delay"
 
 type SavePayload = {
   stepId?: string
@@ -14,7 +16,7 @@ type SavePayload = {
   delayDays?: number
   delayMinutes?: number
   delayUnit?: DelayUnit
-  specificDateTime?: string
+  specificDateTime?: string | null
   flowId?: string
   isActive?: boolean
   anytime?: boolean
@@ -57,8 +59,16 @@ type UseSequenceStepProps = {
   isFirst?: boolean
   previousStepTime?: Date
   onSaved?: () => void
-  currentDelayUnit: DelayUnit
-  currentDelayValue: number
+}
+
+type ChangedFields = {
+  flowId?: string
+  delay?: { unit: DelayUnit; value: number; specificDateTime?: string }
+  isActive?: boolean
+  anytime?: boolean
+  sendTimeStart?: string | null
+  sendTimeEnd?: string | null
+  sendDays?: string[]
 }
 
 export function useSequenceStep({
@@ -69,42 +79,47 @@ export function useSequenceStep({
   isFirst = false,
   previousStepTime,
   onSaved,
-  currentDelayUnit,
-  currentDelayValue,
 }: UseSequenceStepProps) {
   const t = useTranslations()
   const router = useRouter()
-  const isSavingRef = useRef(false)
+  const saveQueueRef = useRef<Promise<void>>(Promise.resolve())
+  const pendingSavesRef = useRef(0)
 
   const [isSaving, setIsSaving] = useState(false)
   const [showFlowError, setShowFlowError] = useState(false)
 
-  const handleSave = useCallback(
-    async (changedFields: {
-      flowId?: string
-      delayUnit?: DelayUnit
-      delayValue?: number
-      specificDateTime?: string
-      isActive?: boolean
-      anytime?: boolean
-      sendTimeStart?: string | null
-      sendTimeEnd?: string | null
-      sendDays?: string[]
-    }) => {
-      if (isSavingRef.current) {
-        return
-      }
+  const performSave = useCallback(
+    async (payload: SavePayload): Promise<boolean> => {
+      try {
+        const result = await upsertSequenceStepAction(workspaceId, payload)
 
-      if (
-        changedFields.delayUnit === "specificTime" &&
-        changedFields.specificDateTime
-      ) {
-        const currentStepTime = new Date(changedFields.specificDateTime)
+        if (result?.data) {
+          onSaved?.()
+          return true
+        }
+
+        toast.error(t("messages.unknownError"))
+        return false
+      } catch (error) {
+        console.error("Error saving step:", error)
+        toast.error(t("messages.unknownError"))
+        return false
+      }
+    },
+    [workspaceId, onSaved, t],
+  )
+
+  const handleSave = useCallback(
+    (changedFields: ChangedFields): Promise<boolean> => {
+      const { delay } = changedFields
+
+      if (delay?.unit === "specificTime" && delay.specificDateTime) {
+        const currentStepTime = new Date(delay.specificDateTime)
         const now = new Date()
 
         if (currentStepTime <= now) {
           toast.error(t("sequences.timeValidation"))
-          return
+          return Promise.resolve(false)
         }
 
         if (
@@ -113,102 +128,82 @@ export function useSequenceStep({
           currentStepTime <= previousStepTime
         ) {
           toast.error(t("sequences.timeValidation"))
-          return
+          return Promise.resolve(false)
         }
       }
 
-      isSavingRef.current = true
+      const payload: SavePayload = {
+        stepId: step?.id,
+        sequenceId,
+        order: stepNumber - 1,
+      }
+
+      if (changedFields.flowId !== undefined) {
+        payload.flowId = changedFields.flowId
+      }
+
+      if (changedFields.isActive !== undefined) {
+        payload.isActive = changedFields.isActive
+      }
+
+      if (delay !== undefined) {
+        const specificDateTimeIso =
+          delay.unit === "specificTime" && delay.specificDateTime
+            ? new Date(delay.specificDateTime).toISOString()
+            : null
+
+        const stored = delayViewToStored({
+          unit: delay.unit,
+          value: delay.value,
+          specificDateTimeIso,
+        })
+
+        payload.delayDays = stored.delayDays
+        payload.delayMinutes = stored.delayMinutes
+        payload.delayUnit = stored.delayUnit
+        payload.specificDateTime = stored.specificDateTime
+      }
+
+      if (changedFields.anytime !== undefined) {
+        payload.anytime = changedFields.anytime
+      }
+
+      if (changedFields.sendTimeStart !== undefined) {
+        payload.sendTimeStart = changedFields.sendTimeStart
+      }
+
+      if (changedFields.sendTimeEnd !== undefined) {
+        payload.sendTimeEnd = changedFields.sendTimeEnd
+      }
+
+      if (changedFields.sendDays !== undefined) {
+        payload.sendDays = changedFields.sendDays
+      }
+
+      pendingSavesRef.current += 1
       setIsSaving(true)
 
-      try {
-        const payload: SavePayload = {
-          stepId: step?.id,
-          sequenceId,
-          order: stepNumber - 1,
-        }
+      const savePromise = saveQueueRef.current.then(() => performSave(payload))
 
-        if (changedFields.flowId !== undefined) {
-          payload.flowId = changedFields.flowId
-        }
-
-        if (changedFields.isActive !== undefined) {
-          payload.isActive = changedFields.isActive
-        }
-
-        if (
-          changedFields.delayUnit !== undefined ||
-          changedFields.delayValue !== undefined
-        ) {
-          const unit = changedFields.delayUnit ?? currentDelayUnit
-          const value = changedFields.delayValue ?? currentDelayValue
-          let delayDays = 0
-          let delayMinutes = 0
-
-          if (unit === "days") {
-            delayDays = value
-          } else if (unit === "hours") {
-            delayMinutes = value * 60
-          } else if (unit === "minutes") {
-            delayMinutes = value
-          }
-
-          payload.delayDays = delayDays
-          payload.delayMinutes = delayMinutes
-          payload.delayUnit = unit
-        }
-
-        if (changedFields.specificDateTime !== undefined) {
-          const localDate = new Date(changedFields.specificDateTime)
-          payload.specificDateTime = localDate.toISOString()
-          payload.delayDays = 0
-          payload.delayMinutes = 0
-          payload.delayUnit = "specificTime"
-        }
-
-        if (changedFields.anytime !== undefined) {
-          payload.anytime = changedFields.anytime
-        }
-
-        if (changedFields.sendTimeStart !== undefined) {
-          payload.sendTimeStart = changedFields.sendTimeStart
-        }
-
-        if (changedFields.sendTimeEnd !== undefined) {
-          payload.sendTimeEnd = changedFields.sendTimeEnd
-        }
-
-        if (changedFields.sendDays !== undefined) {
-          payload.sendDays = changedFields.sendDays
-        }
-
-        const result = await upsertSequenceStepAction(workspaceId, payload)
-
-        if (result?.data) {
-          onSaved?.()
+      saveQueueRef.current = savePromise.then(() => {
+        pendingSavesRef.current -= 1
+        if (pendingSavesRef.current === 0) {
+          setIsSaving(false)
           router.refresh()
-        } else {
-          toast.error(t("messages.unknownError"))
         }
-      } catch (error) {
-        console.error("Error saving step:", error)
-        toast.error(t("messages.unknownError"))
-      } finally {
-        setIsSaving(false)
-        isSavingRef.current = false
-      }
+      })
+
+      return savePromise
     },
     [
       step?.id,
       t,
       isFirst,
       previousStepTime,
-      workspaceId,
       sequenceId,
       stepNumber,
-      onSaved,
+      performSave,
       router,
-      currentDelayUnit,
-      currentDelayValue,
     ],
   )
 
@@ -273,5 +268,5 @@ export function useSequenceStep({
   }
 }
 
-export type { DelayUnit, Step }
+export type { Step }
 export { WEEKDAY_ORDER }

--- a/apps/builder/src/features/sequences/hooks/use-sequence-step.ts
+++ b/apps/builder/src/features/sequences/hooks/use-sequence-step.ts
@@ -59,14 +59,40 @@ type UseSequenceStepProps = {
   onSaved?: () => void
 }
 
-type ChangedFields = {
-  flowId?: string
+type PassthroughFields = Pick<
+  SavePayload,
+  | "flowId"
+  | "isActive"
+  | "anytime"
+  | "sendTimeStart"
+  | "sendTimeEnd"
+  | "sendDays"
+>
+
+type ChangedFields = PassthroughFields & {
   delay?: DelayChange
-  isActive?: boolean
-  anytime?: boolean
-  sendTimeStart?: string | null
-  sendTimeEnd?: string | null
-  sendDays?: string[]
+}
+
+type StepOrderContext = {
+  isFirst: boolean
+  previousStepTime?: Date
+}
+
+function resolveSpecificDateTime(delay?: DelayChange): Date | null {
+  return delay?.unit === "specificTime" && delay.specificDateTime
+    ? new Date(delay.specificDateTime)
+    : null
+}
+
+function isSpecificDateTimeAllowed(
+  dateTime: Date,
+  { isFirst, previousStepTime }: StepOrderContext,
+): boolean {
+  const isInFuture = dateTime > new Date()
+  const isAfterPreviousStep =
+    isFirst || !previousStepTime || dateTime > previousStepTime
+
+  return isInFuture && isAfterPreviousStep
 }
 
 export function useSequenceStep({
@@ -123,75 +149,34 @@ export function useSequenceStep({
     [workspaceId, onSaved, t],
   )
 
+  // Deliberately not `async`: validation and payload building run
+  // synchronously so every queued item carries the values it was called with.
   const handleSave = useCallback(
-    (changedFields: ChangedFields): Promise<boolean> => {
-      const { delay } = changedFields
+    ({ delay, ...passthrough }: ChangedFields): Promise<boolean> => {
+      const specificDateTime = resolveSpecificDateTime(delay)
 
-      if (delay?.unit === "specificTime" && delay.specificDateTime) {
-        const currentStepTime = new Date(delay.specificDateTime)
-        const now = new Date()
-
-        if (currentStepTime <= now) {
-          toast.error(t("sequences.timeValidation"))
-          return Promise.resolve(false)
-        }
-
-        if (
-          !isFirst &&
-          previousStepTime &&
-          currentStepTime <= previousStepTime
-        ) {
-          toast.error(t("sequences.timeValidation"))
-          return Promise.resolve(false)
-        }
+      if (
+        specificDateTime &&
+        !isSpecificDateTimeAllowed(specificDateTime, {
+          isFirst,
+          previousStepTime,
+        })
+      ) {
+        toast.error(t("sequences.timeValidation"))
+        return Promise.resolve(false)
       }
 
       const payload: SavePayload = {
         stepId: step?.id,
         sequenceId,
         order: stepNumber - 1,
-      }
-
-      if (changedFields.flowId !== undefined) {
-        payload.flowId = changedFields.flowId
-      }
-
-      if (changedFields.isActive !== undefined) {
-        payload.isActive = changedFields.isActive
-      }
-
-      if (delay !== undefined) {
-        const specificDateTimeIso =
-          delay.unit === "specificTime" && delay.specificDateTime
-            ? new Date(delay.specificDateTime).toISOString()
-            : null
-
-        const stored = delayViewToStored({
-          unit: delay.unit,
-          value: delay.value,
-          specificDateTimeIso,
-        })
-
-        payload.delayDays = stored.delayDays
-        payload.delayMinutes = stored.delayMinutes
-        payload.delayUnit = stored.delayUnit
-        payload.specificDateTime = stored.specificDateTime
-      }
-
-      if (changedFields.anytime !== undefined) {
-        payload.anytime = changedFields.anytime
-      }
-
-      if (changedFields.sendTimeStart !== undefined) {
-        payload.sendTimeStart = changedFields.sendTimeStart
-      }
-
-      if (changedFields.sendTimeEnd !== undefined) {
-        payload.sendTimeEnd = changedFields.sendTimeEnd
-      }
-
-      if (changedFields.sendDays !== undefined) {
-        payload.sendDays = changedFields.sendDays
+        ...passthrough,
+        ...(delay &&
+          delayViewToStored({
+            unit: delay.unit,
+            value: delay.value,
+            specificDateTimeIso: specificDateTime?.toISOString() ?? null,
+          })),
       }
 
       pendingSavesRef.current += 1

--- a/apps/builder/src/features/sequences/hooks/use-sequence-step.ts
+++ b/apps/builder/src/features/sequences/hooks/use-sequence-step.ts
@@ -4,10 +4,8 @@ import { useCallback, useRef, useState } from "react"
 import { toast } from "sonner"
 import { deleteSequenceStepAction } from "../actions/delete-sequence-step.action"
 import { upsertSequenceStepAction } from "../actions/upsert-sequence-step.action"
-import type { DelayUnit } from "../lib/delay"
+import type { DelayChange, DelayUnit } from "../lib/delay"
 import { delayViewToStored } from "../lib/delay"
-
-export type { DelayUnit } from "../lib/delay"
 
 type SavePayload = {
   stepId?: string
@@ -63,7 +61,7 @@ type UseSequenceStepProps = {
 
 type ChangedFields = {
   flowId?: string
-  delay?: { unit: DelayUnit; value: number; specificDateTime?: string }
+  delay?: DelayChange
   isActive?: boolean
   anytime?: boolean
   sendTimeStart?: string | null
@@ -84,16 +82,32 @@ export function useSequenceStep({
   const router = useRouter()
   const saveQueueRef = useRef<Promise<void>>(Promise.resolve())
   const pendingSavesRef = useRef(0)
+  // FIFO save queue: a payload built before the CREATE step's response comes
+  // back has no stepId. This ref carries that id forward to every queued
+  // payload after it so a second save updates the created row instead of
+  // creating a duplicate.
+  const createdStepIdRef = useRef<string | undefined>(step?.id)
 
   const [isSaving, setIsSaving] = useState(false)
   const [showFlowError, setShowFlowError] = useState(false)
 
   const performSave = useCallback(
     async (payload: SavePayload): Promise<boolean> => {
+      const isCreate = payload.stepId === undefined
+      const resolvedPayload = isCreate
+        ? { ...payload, stepId: createdStepIdRef.current }
+        : payload
+
       try {
-        const result = await upsertSequenceStepAction(workspaceId, payload)
+        const result = await upsertSequenceStepAction(
+          workspaceId,
+          resolvedPayload,
+        )
 
         if (result?.data) {
+          if (isCreate) {
+            createdStepIdRef.current = result.data.stepId
+          }
           onSaved?.()
           return true
         }

--- a/apps/builder/src/features/sequences/hooks/use-time-range-state.ts
+++ b/apps/builder/src/features/sequences/hooks/use-time-range-state.ts
@@ -8,7 +8,7 @@ export function useTimeRangeState(
     sendTimeStart?: string | null
     sendTimeEnd?: string | null
     sendDays?: string[]
-  }) => Promise<void>,
+  }) => Promise<boolean>,
 ) {
   const [timeOption, setTimeOption] = useState<"anytime" | "between">(
     step?.anytime === false ? "between" : "anytime",

--- a/apps/builder/src/features/sequences/lib/delay.ts
+++ b/apps/builder/src/features/sequences/lib/delay.ts
@@ -33,6 +33,12 @@ export type StoredDelay = {
   specificDateTime: string | null
 }
 
+export type DelayChange = {
+  unit: DelayUnit
+  value: number
+  specificDateTime?: string
+}
+
 export function isDelayUnit(value: unknown): value is DelayUnit {
   return (
     typeof value === "string" &&
@@ -55,10 +61,12 @@ const CONSISTENCY_PREDICATES: Record<
   (fields: RelativeFields) => boolean
 > = {
   immediate: (fields) => fields.delayDays === 0 && fields.delayMinutes === 0,
-  minutes: (fields) => fields.delayDays === 0,
+  minutes: (fields) => fields.delayDays === 0 && fields.delayMinutes > 0,
   hours: (fields) =>
-    fields.delayDays === 0 && fields.delayMinutes % MINUTES_PER_HOUR === 0,
-  days: (fields) => fields.delayMinutes === 0,
+    fields.delayDays === 0 &&
+    fields.delayMinutes > 0 &&
+    fields.delayMinutes % MINUTES_PER_HOUR === 0,
+  days: (fields) => fields.delayMinutes === 0 && fields.delayDays > 0,
   specificTime: (fields) => fields.delayDays === 0 && fields.delayMinutes === 0,
 }
 
@@ -68,9 +76,6 @@ export function isStoredDelayConsistent(
   return CONSISTENCY_PREDICATES[fields.delayUnit](fields)
 }
 
-// immediate/specificTime always return 1 here, so the `> 0` acceptance
-// check below never rejects them — only the relative units (days/hours/
-// minutes) can compute a non-positive value from stored fields.
 const STORED_VALUE_CALCULATORS: Record<
   DelayUnit,
   (fields: RelativeFields) => number
@@ -90,13 +95,7 @@ function isStoredUnitAccepted(
     return false
   }
 
-  if (unit === "specificTime" && !step.specificDateTime) {
-    return false
-  }
-
-  // A stored relative value must be strictly positive (not just non-zero) —
-  // rejects negative and NaN values, which the DB column does not prevent.
-  return STORED_VALUE_CALCULATORS[unit](step) > 0
+  return unit === "specificTime" ? Boolean(step.specificDateTime) : true
 }
 
 type InferenceRule = {

--- a/apps/builder/src/features/sequences/lib/delay.ts
+++ b/apps/builder/src/features/sequences/lib/delay.ts
@@ -76,7 +76,7 @@ export function isStoredDelayConsistent(
   return CONSISTENCY_PREDICATES[fields.delayUnit](fields)
 }
 
-const STORED_VALUE_CALCULATORS: Record<
+const DISPLAY_VALUE_BY_UNIT: Record<
   DelayUnit,
   (fields: RelativeFields) => number
 > = {
@@ -161,7 +161,7 @@ export function stepToDelayView(
   if (isDelayUnit(storedUnit) && isStoredUnitAccepted(step, storedUnit)) {
     return {
       unit: storedUnit,
-      value: STORED_VALUE_CALCULATORS[storedUnit](step),
+      value: DISPLAY_VALUE_BY_UNIT[storedUnit](step),
       specificDateTime,
     }
   }
@@ -170,7 +170,7 @@ export function stepToDelayView(
   return { ...inferred, specificDateTime }
 }
 
-const RELATIVE_MINUTES_CALCULATORS: Record<
+const STORED_FIELDS_BY_UNIT: Record<
   DelayUnit,
   (value: number) => RelativeFields
 > = {
@@ -186,7 +186,7 @@ export function delayViewToStored(view: {
   value: number
   specificDateTimeIso?: string | null
 }): StoredDelay {
-  const { delayDays, delayMinutes } = RELATIVE_MINUTES_CALCULATORS[view.unit](
+  const { delayDays, delayMinutes } = STORED_FIELDS_BY_UNIT[view.unit](
     view.value,
   )
 

--- a/apps/builder/src/features/sequences/lib/delay.ts
+++ b/apps/builder/src/features/sequences/lib/delay.ts
@@ -68,6 +68,9 @@ export function isStoredDelayConsistent(
   return CONSISTENCY_PREDICATES[fields.delayUnit](fields)
 }
 
+// immediate/specificTime always return 1 here, so the `> 0` acceptance
+// check below never rejects them — only the relative units (days/hours/
+// minutes) can compute a non-positive value from stored fields.
 const STORED_VALUE_CALCULATORS: Record<
   DelayUnit,
   (fields: RelativeFields) => number
@@ -83,12 +86,7 @@ function isStoredUnitAccepted(
   step: StoredDelayFields,
   unit: DelayUnit,
 ): boolean {
-  const fields: RelativeFields = {
-    delayDays: step.delayDays,
-    delayMinutes: step.delayMinutes,
-  }
-
-  if (!isStoredDelayConsistent({ ...fields, delayUnit: unit })) {
+  if (!isStoredDelayConsistent({ ...step, delayUnit: unit })) {
     return false
   }
 
@@ -96,13 +94,21 @@ function isStoredUnitAccepted(
     return false
   }
 
-  return STORED_VALUE_CALCULATORS[unit](fields) !== 0
+  // A stored relative value must be strictly positive (not just non-zero) —
+  // rejects negative and NaN values, which the DB column does not prevent.
+  return STORED_VALUE_CALCULATORS[unit](step) > 0
 }
 
 type InferenceRule = {
   unit: DelayUnit
   matches: (days: number, minutes: number) => boolean
   value: (days: number, minutes: number) => number
+}
+
+const IMMEDIATE_RULE: InferenceRule = {
+  unit: "immediate",
+  matches: () => true,
+  value: () => 1,
 }
 
 const INFERENCE_RULES: InferenceRule[] = [
@@ -127,11 +133,7 @@ const INFERENCE_RULES: InferenceRule[] = [
     matches: (_days, minutes) => minutes > 0,
     value: (_days, minutes) => minutes,
   },
-  {
-    unit: "immediate",
-    matches: () => true,
-    value: () => 1,
-  },
+  IMMEDIATE_RULE,
 ]
 
 function inferDelayView(
@@ -140,10 +142,9 @@ function inferDelayView(
 ): { unit: DelayUnit; value: number } {
   const rule =
     INFERENCE_RULES.find((candidate) => candidate.matches(days, minutes)) ??
-    INFERENCE_RULES.at(-1)
+    IMMEDIATE_RULE
 
-  const matchedRule = rule as InferenceRule
-  return { unit: matchedRule.unit, value: matchedRule.value(days, minutes) }
+  return { unit: rule.unit, value: rule.value(days, minutes) }
 }
 
 export function stepToDelayView(
@@ -161,10 +162,7 @@ export function stepToDelayView(
   if (isDelayUnit(storedUnit) && isStoredUnitAccepted(step, storedUnit)) {
     return {
       unit: storedUnit,
-      value: STORED_VALUE_CALCULATORS[storedUnit]({
-        delayDays: step.delayDays,
-        delayMinutes: step.delayMinutes,
-      }),
+      value: STORED_VALUE_CALCULATORS[storedUnit](step),
       specificDateTime,
     }
   }

--- a/apps/builder/src/features/sequences/lib/delay.ts
+++ b/apps/builder/src/features/sequences/lib/delay.ts
@@ -1,0 +1,218 @@
+export const DELAY_UNITS = [
+  "immediate",
+  "minutes",
+  "hours",
+  "days",
+  "specificTime",
+] as const
+
+export type DelayUnit = (typeof DELAY_UNITS)[number]
+
+export const MINUTES_PER_HOUR = 60
+export const MINUTES_PER_DAY = 24 * MINUTES_PER_HOUR
+export const MIN_DELAY_VALUE = 1
+export const MAX_DELAY_VALUE = 99_999
+
+export type StoredDelayFields = {
+  delayDays: number
+  delayMinutes: number
+  delayUnit?: string | null
+  specificDateTime?: Date | null
+}
+
+export type DelayView = {
+  unit: DelayUnit
+  value: number
+  specificDateTime: string
+}
+
+export type StoredDelay = {
+  delayDays: number
+  delayMinutes: number
+  delayUnit: DelayUnit
+  specificDateTime: string | null
+}
+
+export function isDelayUnit(value: unknown): value is DelayUnit {
+  return (
+    typeof value === "string" &&
+    (DELAY_UNITS as readonly string[]).includes(value)
+  )
+}
+
+export function isDelayValueInRange(value: number): boolean {
+  return (
+    Number.isInteger(value) &&
+    value >= MIN_DELAY_VALUE &&
+    value <= MAX_DELAY_VALUE
+  )
+}
+
+type RelativeFields = { delayDays: number; delayMinutes: number }
+
+const CONSISTENCY_PREDICATES: Record<
+  DelayUnit,
+  (fields: RelativeFields) => boolean
+> = {
+  immediate: (fields) => fields.delayDays === 0 && fields.delayMinutes === 0,
+  minutes: (fields) => fields.delayDays === 0,
+  hours: (fields) =>
+    fields.delayDays === 0 && fields.delayMinutes % MINUTES_PER_HOUR === 0,
+  days: (fields) => fields.delayMinutes === 0,
+  specificTime: (fields) => fields.delayDays === 0 && fields.delayMinutes === 0,
+}
+
+export function isStoredDelayConsistent(
+  fields: RelativeFields & { delayUnit: DelayUnit },
+): boolean {
+  return CONSISTENCY_PREDICATES[fields.delayUnit](fields)
+}
+
+const STORED_VALUE_CALCULATORS: Record<
+  DelayUnit,
+  (fields: RelativeFields) => number
+> = {
+  days: (fields) => fields.delayDays,
+  hours: (fields) => fields.delayMinutes / MINUTES_PER_HOUR,
+  minutes: (fields) => fields.delayMinutes,
+  immediate: () => 1,
+  specificTime: () => 1,
+}
+
+function isStoredUnitAccepted(
+  step: StoredDelayFields,
+  unit: DelayUnit,
+): boolean {
+  const fields: RelativeFields = {
+    delayDays: step.delayDays,
+    delayMinutes: step.delayMinutes,
+  }
+
+  if (!isStoredDelayConsistent({ ...fields, delayUnit: unit })) {
+    return false
+  }
+
+  if (unit === "specificTime" && !step.specificDateTime) {
+    return false
+  }
+
+  return STORED_VALUE_CALCULATORS[unit](fields) !== 0
+}
+
+type InferenceRule = {
+  unit: DelayUnit
+  matches: (days: number, minutes: number) => boolean
+  value: (days: number, minutes: number) => number
+}
+
+const INFERENCE_RULES: InferenceRule[] = [
+  {
+    unit: "days",
+    matches: (days, minutes) => days > 0 && minutes === 0,
+    value: (days) => days,
+  },
+  {
+    unit: "minutes",
+    matches: (days, minutes) => days > 0 && minutes > 0,
+    value: (days, minutes) => days * MINUTES_PER_DAY + minutes,
+  },
+  {
+    unit: "hours",
+    matches: (_days, minutes) =>
+      minutes > 0 && minutes % MINUTES_PER_HOUR === 0,
+    value: (_days, minutes) => minutes / MINUTES_PER_HOUR,
+  },
+  {
+    unit: "minutes",
+    matches: (_days, minutes) => minutes > 0,
+    value: (_days, minutes) => minutes,
+  },
+  {
+    unit: "immediate",
+    matches: () => true,
+    value: () => 1,
+  },
+]
+
+function inferDelayView(
+  days: number,
+  minutes: number,
+): { unit: DelayUnit; value: number } {
+  const rule =
+    INFERENCE_RULES.find((candidate) => candidate.matches(days, minutes)) ??
+    INFERENCE_RULES.at(-1)
+
+  const matchedRule = rule as InferenceRule
+  return { unit: matchedRule.unit, value: matchedRule.value(days, minutes) }
+}
+
+export function stepToDelayView(
+  step: StoredDelayFields | undefined,
+): DelayView {
+  if (!step) {
+    return { unit: "days", value: 1, specificDateTime: "" }
+  }
+
+  const specificDateTime = step.specificDateTime
+    ? toLocalDateTimeInputValue(step.specificDateTime)
+    : ""
+
+  const storedUnit = step.delayUnit
+  if (isDelayUnit(storedUnit) && isStoredUnitAccepted(step, storedUnit)) {
+    return {
+      unit: storedUnit,
+      value: STORED_VALUE_CALCULATORS[storedUnit]({
+        delayDays: step.delayDays,
+        delayMinutes: step.delayMinutes,
+      }),
+      specificDateTime,
+    }
+  }
+
+  const inferred = inferDelayView(step.delayDays, step.delayMinutes)
+  return { ...inferred, specificDateTime }
+}
+
+const RELATIVE_MINUTES_CALCULATORS: Record<
+  DelayUnit,
+  (value: number) => RelativeFields
+> = {
+  days: (value) => ({ delayDays: value, delayMinutes: 0 }),
+  hours: (value) => ({ delayDays: 0, delayMinutes: value * MINUTES_PER_HOUR }),
+  minutes: (value) => ({ delayDays: 0, delayMinutes: value }),
+  immediate: () => ({ delayDays: 0, delayMinutes: 0 }),
+  specificTime: () => ({ delayDays: 0, delayMinutes: 0 }),
+}
+
+export function delayViewToStored(view: {
+  unit: DelayUnit
+  value: number
+  specificDateTimeIso?: string | null
+}): StoredDelay {
+  const { delayDays, delayMinutes } = RELATIVE_MINUTES_CALCULATORS[view.unit](
+    view.value,
+  )
+
+  return {
+    delayDays,
+    delayMinutes,
+    delayUnit: view.unit,
+    specificDateTime:
+      view.unit === "specificTime" ? (view.specificDateTimeIso ?? null) : null,
+  }
+}
+
+export function toLocalDateTimeInputValue(date: Date): string {
+  const year = date.getFullYear()
+  const month = `${date.getMonth() + 1}`.padStart(2, "0")
+  const day = `${date.getDate()}`.padStart(2, "0")
+  const hour = `${date.getHours()}`.padStart(2, "0")
+  const minute = `${date.getMinutes()}`.padStart(2, "0")
+  return `${year}-${month}-${day}T${hour}:${minute}`
+}
+
+export function oneHourFromNowLocal(): string {
+  const now = new Date()
+  now.setHours(now.getHours() + 1)
+  return toLocalDateTimeInputValue(now)
+}

--- a/apps/builder/src/features/sequences/schema/action.ts
+++ b/apps/builder/src/features/sequences/schema/action.ts
@@ -10,6 +10,7 @@ import {
 import z from "zod"
 import { parseAsBigInt } from "@/lib/nuqs"
 import { basePaginationRequest } from "@/lib/pagination"
+import { DELAY_UNITS, isStoredDelayConsistent } from "../lib/delay"
 import { sequenceResource } from "./resource"
 
 export const listSequencesRequest = basePaginationRequest.and(
@@ -60,23 +61,50 @@ export const updateSequenceSchema = z
   .partial()
 export type UpdateSequenceSchema = z.infer<typeof updateSequenceSchema>
 
-export const upsertSequenceStepRequest = z.object({
-  stepId: zodBigintAsString().optional(),
-  sequenceId: zodBigintAsString(),
-  order: z.number().int().min(0),
-  delayDays: z.number().int().min(0).optional(),
-  delayMinutes: z.number().int().min(0).optional(),
-  delayUnit: z
-    .enum(["immediate", "minutes", "hours", "days", "specificTime"])
-    .optional(),
-  specificDateTime: z.iso.datetime().optional(),
-  flowId: zodBigintAsString().optional(),
-  isActive: z.boolean().optional(),
-  anytime: z.boolean().optional(),
-  sendTimeStart: z.string().nullable().optional(),
-  sendTimeEnd: z.string().nullable().optional(),
-  sendDays: z.array(z.string()).optional(),
-})
+export const upsertSequenceStepRequest = z
+  .object({
+    stepId: zodBigintAsString().optional(),
+    sequenceId: zodBigintAsString(),
+    order: z.number().int().min(0),
+    delayDays: z.number().int().min(0).optional(),
+    delayMinutes: z.number().int().min(0).optional(),
+    delayUnit: z.enum(DELAY_UNITS).optional(),
+    specificDateTime: z.iso.datetime().nullable().optional(),
+    flowId: zodBigintAsString().optional(),
+    isActive: z.boolean().optional(),
+    anytime: z.boolean().optional(),
+    sendTimeStart: z.string().nullable().optional(),
+    sendTimeEnd: z.string().nullable().optional(),
+    sendDays: z.array(z.string()).optional(),
+  })
+  .superRefine((data, ctx) => {
+    const { delayUnit, delayDays, delayMinutes, specificDateTime } = data
+
+    if (
+      delayUnit === undefined ||
+      delayDays === undefined ||
+      delayMinutes === undefined
+    ) {
+      return
+    }
+
+    if (!isStoredDelayConsistent({ delayUnit, delayDays, delayMinutes })) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["delayUnit"],
+        message: "delayUnit does not match delayDays/delayMinutes",
+      })
+      return
+    }
+
+    if (delayUnit === "specificTime" && typeof specificDateTime !== "string") {
+      ctx.addIssue({
+        code: "custom",
+        path: ["specificDateTime"],
+        message: "specificDateTime is required for delayUnit specificTime",
+      })
+    }
+  })
 
 export type UpsertSequenceStepRequest = z.infer<
   typeof upsertSequenceStepRequest

--- a/docs/plans/2026-09-03-sequence-step-delay-unit-persistence.md
+++ b/docs/plans/2026-09-03-sequence-step-delay-unit-persistence.md
@@ -1,0 +1,344 @@
+# Sequence step delay — unit change not persisted after reload
+
+Status: IMPLEMENTED on branch fix/sequence-step-delay-unit-persistence (5 commits, reviewed by Claude + Codex, browser-verified).
+
+## Reported bug
+
+Sequence editor (`apps/builder/src/features/sequences/`). A step shows "After 2 Hours".
+User switches the unit select Hours → Minutes WITHOUT editing the number. After F5 the
+UI shows "2 Hours" again.
+
+## Root cause (verified by Claude + Codex independent review)
+
+Stored columns: `delayDays`, `delayMinutes` (scheduler source of truth, additive) and
+`delayUnit` (display only, plus the `specificTime` discriminator). The UI has two places
+that "guess" instead of trusting stored data, and they disagree:
+
+1. `sequence-step-card.tsx:80-81` passes `currentDelayValue = step.delayDays || step.delayMinutes || 1`
+   to `useSequenceStep` — the RAW stored minutes (120), not the displayed value (2).
+   `use-delay-state.ts` `handleDelayUnitChange` calls `onSave({ delayUnit })` with no value,
+   so `use-sequence-step.ts:142` falls back to 120 → saves `delayMinutes=120, delayUnit="minutes"`.
+2. `use-delay-state.ts` `getInitialDelayUnit/getInitialDelayValue` ignore stored `delayUnit`
+   for minutes/hours/days and infer from magnitude (`delayMinutes >= 60` → hours). On reload,
+   120 minutes displays as "2 Hours" regardless of stored unit. 90 minutes displays as
+   "1 Hours" (`Math.floor`, lossy). `immediate`/`specificTime` DO honor the stored unit.
+
+Combined: the save is wrong (bug 1) and even a correct save would display wrong (bug 2).
+
+## All defects found in this flow
+
+| # | File | Defect | Impact |
+|---|------|--------|--------|
+| 1 | `components/sequence-step-card.tsx:80-81` | Raw stored value used as "current" display value | Unit-only change double-converts. Hours→Days writes `delayDays=120` → **real scheduling corruption** (scheduler = `delayDays*1440 + delayMinutes`) |
+| 2 | `hooks/use-delay-state.ts:25-49` | Unit/value inferred from magnitude, stored `delayUnit` ignored | 120 min stored as minutes shows "2 Hours"; 90 min shows "1 Hours" |
+| 3 | `hooks/use-sequence-step.ts:94` | `isSavingRef` guard silently DROPS a second save while one is in flight (no toast) | Focused number input → mousedown on Select → blur save #1 → unit pick save #2 dropped. Same guard affects `useTimeRangeState` (send-window controls, which are not even passed `isSaving`) |
+| 4 | `components/delay-selector.tsx:50` | `localValue = useState(delayValue)` never re-syncs | Stale number after parent updates |
+| 5 | `hooks/use-delay-state.ts:110` + `use-sequence-step.ts:98` | Editing an already-chosen specific date sends only `{ specificDateTime }`; "must be in the future" validation requires `delayUnit === "specificTime"` in the same payload | Validation runs only on first pick, bypassed on edit |
+| 6 | `hooks/use-sequence-step.ts:138`, `schema/action.ts` | Leaving `specificTime` never clears `specificDateTime`; schema `z.iso.datetime().optional()` cannot accept `null` | Stale date reused on a later switch back. Scheduler safe (checks `delayUnit === "specificTime"`) |
+| 7 | `schema/action.ts:63` | No cross-field validation: `delayUnit="days"` + `delayMinutes=120` accepted | Allows contradictory rows (how this bug persisted data) |
+| 8 | `hooks/use-delay-state.ts:74` | Hook state initialized once; not reset after `router.refresh()` | If a save fails, UI keeps new value while DB has old |
+
+Out of scope (file separate issues):
+
+- `apps/worker/src/integration/handlers/contact.ts:399-410` — flow "subscribe to sequence"
+  path computes first-step `nextRunAt` from `delayDays/delayMinutes` only, ignoring a
+  first step configured as `specificTime`.
+- `sequence-editor.tsx:148` never passes `previousStepTime`, so cross-step ordering
+  validation in `handleSave` is dead code.
+- `sequence-editor.tsx` `steps` prop type omits `delayUnit`, `specificDateTime`, `isActive`,
+  send-window fields; runtime values arrive from `getSequence`. Type-only gap.
+
+## Backward-compat audit (why this will not break existing flows)
+
+| Surface | Consumers | Impact |
+|---------|-----------|--------|
+| `upsertSequenceStepRequest` / `upsertSequenceStepAction` | Only `sequence-editor.tsx` (Add button), `use-sequence-step.ts`, and `__tests__/upsert-sequence-step.action.test.ts` | No public API / SDK / MCP / CLI consumer. Cross-field validation cannot affect external clients |
+| `useSequenceStep`, `useDelayState`, `DelaySelector` | Only `sequence-step-card.tsx` | Removing `currentDelayUnit/currentDelayValue` props is safe |
+| Flow "Wait" step `DelayUnit` (`features/flows/.../wait/`) | Own type, own component | Untouched |
+| `packages/sequence-scheduler`, `packages/business/contact-sequence`, worker | Read `delayDays + delayMinutes`; read `delayUnit` only for `=== "specificTime"` | No change. Writing `specificDateTime = null` for relative units is invisible to them |
+| DB `delayUnit` column | Nullable since initial migration, no backfill; action always sets it on create | Null rows only possible from seed/external writers; display fallback handles them |
+| Dev DB (scanned read-only) | 7 rows: minutes×5, immediate×1, days×1; zero inconsistent, zero null | No surprise display changes locally. The row the user already changed is stored as 120 minutes and will correctly show "120 Minutes" |
+| Existing action tests | Mock the whole safe-action chain; schema is not exercised; update tests send single delay fields (e.g. only `delayDays: 3`) | Will not break, PROVIDED the new cross-field refine only runs when `delayUnit`, `delayDays`, `delayMinutes` are ALL present |
+
+Three guard rails adopted from the audit:
+
+1. Schema cross-field validation triggers only when the full delay triple is present.
+   Partial payloads (legacy shape) still pass. The Add button already sends `days/1/0`.
+2. `handleSave`'s public signature is unchanged so `useTimeRangeState`, `handleSelectFlow`,
+   `handleActiveChange` need no edits.
+3. Controls stay `disabled` while saving exactly as today. The queue only guarantees the
+   second action is not lost; no visible UX change.
+
+## Design
+
+### Pure helpers — `apps/builder/src/features/sequences/lib/delay.ts`
+
+```ts
+type DelayUnit = "immediate" | "minutes" | "hours" | "days" | "specificTime"
+type DelayView = { unit: DelayUnit; value: number; specificDateTime: string }
+type StoredDelay = { delayDays: number; delayMinutes: number; delayUnit: DelayUnit; specificDateTime: string | null }
+
+stepToDelayView(step): DelayView
+delayViewToStored(unit, value, specificDateTimeIso?): StoredDelay
+```
+
+`stepToDelayView` rules — trust the stored unit ONLY when the numeric columns satisfy it
+exactly; otherwise (or when `delayUnit` is null) fall back to the most precise unit:
+
+| Stored unit | Accepted iff | Fallback |
+|---|---|---|
+| `specificTime` | `specificDateTime` non-null | inference below |
+| `immediate` | days = 0 and minutes = 0 | inference |
+| `days` | minutes = 0 (days ≥ 0) | inference |
+| `hours` | days = 0 and minutes % 60 = 0 | inference |
+| `minutes` | days = 0 | inference |
+| null / other | — | inference |
+
+Inference: days > 0 && minutes = 0 → days; days > 0 && minutes > 0 → minutes (days*1440+minutes);
+minutes % 60 = 0 && minutes > 0 → hours; minutes > 0 → minutes; both 0 → immediate.
+Never truncate (90 minutes is "90 Minutes", never "1 Hours").
+
+`delayViewToStored`: days → `{value,0}`; hours → `{0,value*60}`; minutes → `{0,value}`;
+immediate → `{0,0}`; specificTime → `{0,0, specificDateTime: iso}`. Every relative/immediate
+result carries `specificDateTime: null`.
+
+### Save flow
+
+- `use-delay-state.ts`: unit change and value change BOTH send `{ delayUnit, delayValue }`
+  from the currently displayed state. Specific-date edits always send
+  `{ delayUnit: "specificTime", specificDateTime }` so validation runs every time.
+- `use-sequence-step.ts`: drop `currentDelayUnit/currentDelayValue` props. Build the delay
+  part of the payload with `delayViewToStored`. Replace the `isSavingRef` early-return with
+  a FIFO promise chain (`queueRef = queueRef.then(run)`); each queued item's payload is
+  fully computed at enqueue time (no stale closure). `isSaving` stays true until the chain
+  drains; `router.refresh()` once after drain. `handleStepUpdateImpact` still runs per
+  save (unchanged server behavior).
+- `schema/action.ts`: `specificDateTime: z.iso.datetime().nullable().optional()`; add
+  `superRefine` cross-field check guarded on all three delay fields being present.
+  `buildUpdateData`/`buildCreateData` already map `null` correctly.
+- `sequence-step-card.tsx`: delete the two raw-value lines.
+
+### UI
+
+- `delay-selector.tsx`: re-sync `localValue` when `delayValue` prop changes (effect keyed on
+  prop). Import `DelayUnit` from the hook instead of redeclaring.
+- `use-delay-state.ts`: reset view when `step.id` or the stored delay triple changes
+  (server refresh), without overwriting an in-progress edit.
+- Pass `isSaving` to `TimeRangeSelector` for consistency.
+
+## Phases
+
+1. **Helpers + tests first (TDD).** Create `lib/delay.ts` and
+   `apps/builder/__tests__/sequence-delay.test.ts`: round-trip every unit; 120 min stored
+   as minutes; 90 min stored as hours (→ 90 Minutes); hours→days conversion; null unit;
+   contradictory rows; immediate; specificTime with/without date.
+2. **Save flow.** `use-delay-state.ts`, `use-sequence-step.ts`, `schema/action.ts`,
+   `sequence-step-card.tsx` per Design.
+3. **UI sync.** `delay-selector.tsx`, `useDelayState` reset, `TimeRangeSelector` `isSaving`.
+4. **Verify.** `pnpm --filter builder test -- sequence`, `pnpm lint`,
+   `pnpm --filter builder check-types`. Browser reproduction of 4 scenarios:
+   2 Hours → Minutes → F5 shows "2 Minutes"; Hours → Days → F5 shows days not 120 days;
+   90 Minutes → F5 shows "90 Minutes"; Specific time → Days → F5 shows no stale date.
+
+## Files touched
+
+- `apps/builder/src/features/sequences/lib/delay.ts` (new)
+- `apps/builder/__tests__/sequence-delay.test.ts` (new)
+- `apps/builder/src/features/sequences/hooks/use-delay-state.ts`
+- `apps/builder/src/features/sequences/hooks/use-sequence-step.ts`
+- `apps/builder/src/features/sequences/schema/action.ts`
+- `apps/builder/src/features/sequences/components/sequence-step-card.tsx`
+- `apps/builder/src/features/sequences/components/delay-selector.tsx`
+
+No DB migration. No worker/scheduler change.
+
+## Risks
+
+- MEDIUM: rows previously saved wrong (e.g. 120 min + unit minutes) will now display the
+  truthful "120 Minutes" instead of "2 Hours". Correct per DB; users may notice.
+- LOW: FIFO queue replays every rapid edit, each triggering `handleStepUpdateImpact`.
+  Same per-save cost as today; only the previously-dropped saves are added.
+- LOW: cross-field refine rejects contradictory payloads with a generic toast. Only the
+  builder UI sends this payload and it will always be consistent after the fix.
+
+Complexity: MEDIUM.
+
+## Global Constraints (binding for every task)
+
+- No `any`. No hardcoded user-facing strings (use `useTranslations()`; keys `sequences.delayUnits.*`, `sequences.afterText`, `sequences.timeValidation`, `messages.unknownError` already exist in `apps/builder/messages/en.json`).
+- Business rules expressed as lookup tables (`Record<DelayUnit, ...>` / ordered arrays), not if-else chains.
+- Reuse existing handlers; do not add parallel helpers that duplicate `handleSave`, `buildUpdateData`, etc.
+- `handleSave`'s call sites in `useTimeRangeState`, `handleSelectFlow`, `handleActiveChange` must keep working without edits to their payload shape (`flowId`, `isActive`, `anytime`, `sendTimeStart`, `sendTimeEnd`, `sendDays`).
+- Schema cross-field validation must only run when `delayUnit`, `delayDays` and `delayMinutes` are ALL present in the payload.
+- Scheduler, worker, `packages/*` are NOT touched. No DB migration.
+- Tests live in `apps/builder/__tests__/` (vitest, `describe/test/expect` style, see `update-smart-response-delay-schema.test.ts`). Run with `pnpm --filter builder test -- <pattern>`.
+- Before reporting done: `pnpm fix` on touched files is allowed; `pnpm --filter builder check-types` and `pnpm lint` must pass.
+- Commit per task with `<type>(<scope>): <subject>` (lowercase after colon, ≤100 chars). Stage specific files only, never `git add -A`. Never `--no-verify`.
+- Do not use `git add -A` / `git add .`. Do not touch files outside the list in each task.
+
+## Task 1: Pure delay helpers + unit tests
+
+Files: create `apps/builder/src/features/sequences/lib/delay.ts`, create `apps/builder/__tests__/sequence-delay.test.ts`.
+
+Write the tests first, watch them fail, then implement.
+
+### Exports of `lib/delay.ts`
+
+```ts
+export const DELAY_UNITS = ["immediate", "minutes", "hours", "days", "specificTime"] as const
+export type DelayUnit = (typeof DELAY_UNITS)[number]
+
+export const MINUTES_PER_HOUR = 60
+export const MINUTES_PER_DAY = 24 * MINUTES_PER_HOUR
+export const MIN_DELAY_VALUE = 1
+export const MAX_DELAY_VALUE = 99_999
+
+export type StoredDelayFields = {
+  delayDays: number
+  delayMinutes: number
+  delayUnit?: string | null
+  specificDateTime?: Date | null
+}
+
+export type DelayView = {
+  unit: DelayUnit
+  value: number              // display number; 1 for immediate/specificTime
+  specificDateTime: string   // datetime-local input value ("YYYY-MM-DDTHH:mm") or ""
+}
+
+export type StoredDelay = {
+  delayDays: number
+  delayMinutes: number
+  delayUnit: DelayUnit
+  specificDateTime: string | null   // ISO string for specificTime, null otherwise
+}
+
+export function isDelayUnit(value: unknown): value is DelayUnit
+export function isDelayValueInRange(value: number): boolean   // integer, MIN..MAX inclusive
+export function isStoredDelayConsistent(fields: { delayDays: number; delayMinutes: number; delayUnit: DelayUnit }): boolean
+export function stepToDelayView(step: StoredDelayFields | undefined): DelayView
+export function delayViewToStored(view: { unit: DelayUnit; value: number; specificDateTimeIso?: string | null }): StoredDelay
+export function toLocalDateTimeInputValue(date: Date): string   // "YYYY-MM-DDTHH:mm" in browser local time
+export function oneHourFromNowLocal(): string                    // toLocalDateTimeInputValue(now + 1h)
+```
+
+### Rules
+
+`isStoredDelayConsistent` — one predicate per unit in a `Record<DelayUnit, (f) => boolean>`:
+
+| unit | consistent iff |
+|---|---|
+| immediate | days = 0 and minutes = 0 |
+| minutes | days = 0 (minutes ≥ 0) |
+| hours | days = 0 and minutes % 60 = 0 |
+| days | minutes = 0 |
+| specificTime | days = 0 and minutes = 0 |
+
+`stepToDelayView(step)`:
+- `undefined` step → `{ unit: "days", value: 1, specificDateTime: "" }` (matches current new-step default).
+- If `step.delayUnit` is a valid `DelayUnit` AND (`isStoredDelayConsistent` holds; for `specificTime` additionally `step.specificDateTime` non-null) → use the stored unit. Value: days → `delayDays`; hours → `delayMinutes / 60`; minutes → `delayMinutes`; immediate/specificTime → 1. Exception: a stored relative unit whose value would be 0 (e.g. `minutes` with 0 minutes) is NOT accepted → fall through to inference.
+- Otherwise infer from numbers, first match wins, in this order (an ordered array of `{ unit, matches, value }` entries):
+  1. days > 0 and minutes = 0 → `days`, value = days
+  2. days > 0 and minutes > 0 → `minutes`, value = days*1440 + minutes
+  3. minutes > 0 and minutes % 60 = 0 → `hours`, value = minutes/60
+  4. minutes > 0 → `minutes`, value = minutes
+  5. else → `immediate`, value = 1
+- `specificDateTime` view string: `toLocalDateTimeInputValue(step.specificDateTime)` when non-null, else `""` (regardless of unit — so the previously chosen date is still shown if the user switches back).
+
+`delayViewToStored({ unit, value, specificDateTimeIso })` — a `Record<DelayUnit, (value) => { delayDays, delayMinutes }>`:
+- days → `{ value, 0 }`; hours → `{ 0, value*60 }`; minutes → `{ 0, value }`; immediate → `{ 0, 0 }`; specificTime → `{ 0, 0 }`.
+- `delayUnit` = unit. `specificDateTime` = `specificDateTimeIso ?? null` for `specificTime`, always `null` for every other unit.
+
+`toLocalDateTimeInputValue` — same formatting as the existing `getOneHourFromNowLocal` in `delay-selector.tsx` / `use-delay-state.ts` (zero-padded month/day/hour/minute, local time). This replaces both duplicates in Task 2/3.
+
+### Test cases (all required)
+
+- round-trip for each of days(2), hours(2), minutes(30), immediate through `delayViewToStored` → `stepToDelayView`.
+- stored `{0, 120, "minutes"}` → view `minutes/120` (NOT hours/2).
+- stored `{0, 120, "hours"}` → view `hours/2`.
+- stored `{0, 90, "hours"}` (inconsistent) → view `minutes/90`.
+- stored `{0, 90, null}` → `minutes/90`; `{0, 120, null}` → `hours/2`; `{3, 0, null}` → `days/3`; `{1, 30, null}` → `minutes/1470`; `{0, 0, null}` → `immediate/1`.
+- stored `{120, 0, "days"}` → `days/120` (accepted, consistent).
+- stored `{0, 0, "minutes"}` → `immediate/1` (zero relative value not accepted).
+- stored `{0, 0, "specificTime", specificDateTime: Date}` → `specificTime`, `specificDateTime` formatted local.
+- stored `{0, 0, "specificTime", specificDateTime: null}` → `immediate/1`.
+- stored `{0, 0, "bogus"}` → `immediate/1`.
+- `undefined` → `days/1`.
+- `delayViewToStored` for every unit, including `specificDateTime: null` for relative units and the ISO passthrough for specificTime.
+- `isStoredDelayConsistent` table: every row above, positive and negative.
+- `isDelayValueInRange`: 0 false, 1 true, 99_999 true, 100_000 false, 1.5 false, NaN false.
+- `toLocalDateTimeInputValue(new Date(2026, 0, 5, 7, 3))` → `"2026-01-05T07:03"`.
+
+Commit: `feat(sequences): add pure delay unit conversion helpers`
+
+## Task 2: Save flow — schema, hooks, card
+
+Files: `apps/builder/src/features/sequences/schema/action.ts`, `apps/builder/src/features/sequences/hooks/use-sequence-step.ts`, `apps/builder/src/features/sequences/hooks/use-delay-state.ts`, `apps/builder/src/features/sequences/components/sequence-step-card.tsx`, create `apps/builder/__tests__/upsert-sequence-step-schema.test.ts`.
+
+Depends on Task 1 exports.
+
+### `schema/action.ts`
+
+- `delayUnit: z.enum(DELAY_UNITS).optional()` (import `DELAY_UNITS` from `../lib/delay`).
+- `specificDateTime: z.iso.datetime().nullable().optional()`.
+- Add `.superRefine` on `upsertSequenceStepRequest`: when `delayUnit`, `delayDays` and `delayMinutes` are ALL defined and `!isStoredDelayConsistent(...)`, add an issue on path `["delayUnit"]` with message `"delayUnit does not match delayDays/delayMinutes"`. When `delayUnit === "specificTime"` and all three are present, additionally require `specificDateTime` to be a non-null string (issue on `["specificDateTime"]`). Any payload missing one of the three delay fields is NOT checked (legacy partial payloads must pass unchanged).
+- Tests in `upsert-sequence-step-schema.test.ts`: consistent triple passes for every unit; `days/0/120` fails; `hours/0/90` fails; `minutes/1/5` fails; partial `{ delayDays: 3 }` passes; partial `{ delayUnit: "hours" }` passes; `specificTime` with null date fails, with ISO passes; `specificDateTime: null` accepted on a relative unit; `delayUnit: "bogus"` fails.
+- `buildUpdateData`/`buildCreateData` in the action already map `null` → `null`; do not change the action file.
+
+### `hooks/use-sequence-step.ts`
+
+- Import `DelayUnit`, `DelayView`, `delayViewToStored` from `../lib/delay`. Re-export `DelayUnit` (other files import it from here today) and keep exporting `Step`, `WEEKDAY_ORDER`.
+- Remove props `currentDelayUnit` and `currentDelayValue` from `UseSequenceStepProps`.
+- Replace `changedFields.delayUnit / delayValue / specificDateTime` with a single optional `delay?: { unit: DelayUnit; value: number; specificDateTime?: string }` (`specificDateTime` is the datetime-local string). Other fields unchanged.
+- Payload building for the delay part: `const stored = delayViewToStored({ unit, value, specificDateTimeIso })` where `specificDateTimeIso = unit === "specificTime" && specificDateTime ? new Date(specificDateTime).toISOString() : null`; spread `delayDays`, `delayMinutes`, `delayUnit`, `specificDateTime` from `stored` into the payload. This clears `specificDateTime` (null) on every relative/immediate save.
+- Validation for `specificTime` (must be in the future; after `previousStepTime` when not first) runs whenever `delay.unit === "specificTime"`, i.e. on both first pick and later edits.
+- Replace the `isSavingRef` early-return with a FIFO queue:
+  - `const saveQueueRef = useRef<Promise<void>>(Promise.resolve())`, `const pendingSavesRef = useRef(0)`.
+  - `handleSave` validates and builds the full payload synchronously, increments `pendingSavesRef`, sets `isSaving` true, then chains `saveQueueRef.current = saveQueueRef.current.then(() => performSave(payload))`. `performSave` never rejects (it catches, toasts `messages.unknownError`, and resolves `false`); on success resolves `true` and calls `onSaved?.()`. After each item, decrement `pendingSavesRef`; when it reaches 0 set `isSaving` false and call `router.refresh()` exactly once.
+  - `handleSave` returns `Promise<boolean>` (true = persisted). Validation failures resolve `false` without enqueuing.
+- Keep `handleDelete`, `handleSelectFlow`, `handleActiveChange` behavior unchanged.
+
+### `hooks/use-delay-state.ts`
+
+- Delete the local `getOneHourFromNowLocal`, `getInitialDelayUnit`, `getInitialDelayValue`, `getInitialSpecificDateTime`. Initialize state from `stepToDelayView(step)`.
+- Hold one `DelayView` state object (`view`) instead of three separate states; keep returning `delayUnit`, `delayValue`, `specificDateTime` and the three handlers so `sequence-step-card.tsx` and `DelaySelector` props stay the same.
+- `onSave` type becomes `(fields: { delay: { unit: DelayUnit; value: number; specificDateTime?: string } }) => Promise<boolean>`.
+- `handleDelayUnitChange(unit)`: next view = `{ ...view, unit }`; if `unit === "specificTime"` and `view.specificDateTime` is empty, set `specificDateTime = oneHourFromNowLocal()`. Optimistically set the view, then `onSave({ delay: nextView })`; if it resolves `false`, revert to the previous view.
+- `handleDelayValueChange(value)`: next view = `{ ...view, value }`; same optimistic save + revert.
+- `handleSpecificDateTimeChange(dateTime)`: next view = `{ ...view, unit: "specificTime", specificDateTime: dateTime }`; only save when `dateTime` is non-empty; same revert.
+- Add `useEffect` that re-derives the view via `stepToDelayView(step)` when `step?.id`, `step?.delayDays`, `step?.delayMinutes`, `step?.delayUnit` or `step?.specificDateTime?.getTime()` change, so a server refresh with different data wins. No effect on first render beyond the initializer.
+
+### `components/sequence-step-card.tsx`
+
+- Remove the `currentDelayUnit` / `currentDelayValue` arguments.
+- Pass `isSaving` to `TimeRangeSelector` as a new optional `disabled` prop ONLY if that component already exposes one; otherwise leave `TimeRangeSelector` untouched (Task 3 handles it).
+
+Run `pnpm --filter builder test -- sequence`, `pnpm --filter builder check-types`, `pnpm lint`.
+
+Commit: `fix(sequences): persist delay unit changes and queue step saves`
+
+## Task 3: UI sync — DelaySelector and TimeRangeSelector
+
+Files: `apps/builder/src/features/sequences/components/delay-selector.tsx`, `apps/builder/src/features/sequences/components/time-range-selector.tsx`, `apps/builder/src/features/sequences/components/sequence-step-card.tsx`.
+
+Depends on Task 1 and Task 2.
+
+### `delay-selector.tsx`
+
+- Import `DelayUnit`, `DELAY_UNITS`, `isDelayValueInRange`, `MIN_DELAY_VALUE`, `MAX_DELAY_VALUE`, `oneHourFromNowLocal` from `../lib/delay`. Delete the local `DelayUnit` type and `getOneHourFromNowLocal`.
+- Build `delayUnitItems` by mapping `DELAY_UNITS` to `{ value, label: t(\`sequences.delayUnits.${unit}\`) }` (translation keys already exist for every unit; keep the `t()` call type-safe with the project's typed messages — check `apps/builder/messages/en.d.json.ts` for how nested keys are typed and mirror an existing dynamic-key usage if one exists, otherwise use an explicit `Record<DelayUnit, string>` of labels).
+- Replace the three inline `!localValue || localValue < 1 || localValue > 99_999` checks with `isDelayValueInRange(localValue)`; use `MIN_DELAY_VALUE` / `MAX_DELAY_VALUE` for the input `min`/`max`.
+- Re-sync `localValue` when the `delayValue` prop changes: `useEffect(() => { setLocalValue(delayValue) }, [delayValue])`. Also clear `showDelayValueError` in that effect.
+- Do not change the disabled behavior or layout.
+
+### `time-range-selector.tsx`
+
+- Add optional prop `disabled?: boolean` and forward it to every interactive control (radio/select/time inputs/day toggles) so they mirror the DelaySelector while a save is in flight. Default `false`.
+
+### `sequence-step-card.tsx`
+
+- Pass `disabled={isSaving}` to `TimeRangeSelector`.
+
+Run `pnpm --filter builder test -- sequence`, `pnpm --filter builder check-types`, `pnpm lint`.
+
+Commit: `fix(sequences): keep delay input in sync and disable send-window controls while saving`


### PR DESCRIPTION
## Summary
- Fixes the sequence editor losing a step's delay unit: switching a step from Hours to Minutes (or Days) without editing the number saved the raw stored minutes as the new value, and after a reload the unit was re-inferred from the number, so "2 Hours → Minutes" came back as "2 Hours". Hours → Days also wrote the raw minutes as days (2 Hours became 120 Days), which changed real send schedules.
- The delay display now trusts the stored `delayUnit` whenever it agrees with `delayDays`/`delayMinutes` and only falls back to inference for legacy or inconsistent rows, so 90 minutes reads "90 Minutes" instead of "1 Hours". Every delay save sends the complete unit + value from what is on screen.
- Step saves are queued in order instead of silently dropping a second save that arrives while one is in flight (this also covered the send-window controls). A failed save reverts the row to the last persisted value; the number input re-syncs after a refresh; send-window controls are disabled while a save is pending.
- Leaving "Specific time" now clears the stored date, editing an already-chosen date re-runs the "must be in the future" check, and the server rejects a `delayUnit` that contradicts `delayDays`/`delayMinutes`.

## Changes
- `apps/builder/src/features/sequences/lib/delay.ts`: pure delay rules as per-unit lookup tables — consistency check, stored-unit-first display resolution with ordered inference fallback, view ↔ stored conversion, datetime-local formatting.
- `hooks/use-sequence-step.ts`: FIFO save queue with a pending counter (`isSaving` until drain, one `router.refresh()` per drain), complete delay payload via the shared converter, `specificDateTime: null` on relative units, created-step id threaded to queued saves; `handleSave` returns whether the save persisted.
- `hooks/use-delay-state.ts`: single `DelayView` state derived from the stored fields, optimistic commit with revert to the last persisted view, re-derive on server refresh without clobbering equal views.
- `schema/action.ts`: `delayUnit` enum from the shared unit list, `specificDateTime` nullable, cross-field refine that only runs when the full delay triple is present so partial payloads keep working.
- `components/delay-selector.tsx` / `time-range-selector.tsx` / `sequence-step-card.tsx`: shared validation and unit list from `lib/delay`, number input re-sync and no-op save guard, `disabled` on the send-window controls while saving.
- Tests: `sequence-delay.test.ts` (helpers, legacy/inconsistent rows, negatives, NaN), `upsert-sequence-step-schema.test.ts` (refine incl. partial payloads), `use-sequence-step.test.tsx` and `use-delay-state.test.tsx` (queue ordering, drain/refresh, failure paths, optimistic revert, re-derive).
- `docs/plans/2026-09-03-sequence-step-delay-unit-persistence.md`: root cause, defect list, compatibility audit and design notes.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [x] Vitest builder: 360 files / 2429 tests
- [x] Manual check on a live workspace: 2 Hours → Minutes → reload shows 2 Minutes; 2 Hours → Days stores 2 days; 90 Minutes survives reload; Specific time → Days clears the stored date; row values verified in the database after each change
- [ ] Manual check after deploy on an existing sequence with legacy rows

## Notes
- No migration. Scheduler and worker are untouched (they read `delayDays`/`delayMinutes` only).
- Rows previously saved with a mismatched unit (e.g. 120 minutes with unit `minutes`) now display their true stored value ("120 Minutes") rather than "2 Hours".
- Out of scope, tracked in the plan: the worker enroll-from-flow path ignores a first step set to Specific time; `previousStepTime` is never passed to the step card.
