### PR TITLE
fix(builder): derive the inbox height from the shell instead of hard-coded dvh

### DIFF
--- a/apps/builder/__tests__/chat-layout-mobile.test.tsx
+++ b/apps/builder/__tests__/chat-layout-mobile.test.tsx
@@ -75,6 +75,14 @@ vi.mock("@/features/chat/store/chat-store-provider", () => ({
 
 const { ChatLayout } = await import("@/features/chat/chat-layout")
 
+/**
+ * Any `height` class on an inbox container is a bug, not a style choice: the
+ * height belongs to the shell (`FullBleed` grows to it), and on the desktop
+ * group a `height` class is outright dead — `PanelGroup` sets an inline
+ * `height: 100%` that no stylesheet rule can beat.
+ */
+const HEIGHT_CLASS = /(?:^|\s)h-/
+
 describe("ChatLayout", () => {
   let container: HTMLDivElement
   let root: Root
@@ -113,16 +121,21 @@ describe("ChatLayout", () => {
     expect(find("list-pane")).not.toBeNull()
     expect(find("thread-pane")).toBeNull()
     // The three-column group must not mount on a phone.
-    expect(container.querySelector("[data-panel-group]")).toBeNull()
+    expect(
+      container.querySelector('[data-slot="resizable-panel-group"]'),
+    ).toBeNull()
   })
 
   test("fills the viewport, with the pane owning the whole screen", () => {
     setViewportWidth(375)
     render()
 
-    // The mobile shell has no top bar to subtract height for.
+    // The height is derived from the shell (`FullBleed` is a grown flex item),
+    // never hand-copied as a viewport unit: a `dvh` here ignores whatever else
+    // shares the shell's column, such as the trial banner.
     const pane = find("list-pane")?.closest("div.flex")
-    expect(pane?.className).toContain("h-[100dvh]")
+    expect(pane?.className).toContain("flex-1")
+    expect(pane?.className).not.toMatch(HEIGHT_CLASS)
   })
 
   test("does not auto-select a conversation on mobile", () => {
@@ -191,6 +204,18 @@ describe("ChatLayout", () => {
     // No mobile-only affordances leak into the desktop layout.
     expect(find("back")).toBeNull()
     expect(find("open-contact")).toBeNull()
+  })
+
+  test("grows the desktop group instead of giving it a dead height class", () => {
+    storeState.activeConversationId = "c1"
+    setViewportWidth(1440)
+    render()
+
+    const group = container.querySelector<HTMLElement>(
+      '[data-slot="resizable-panel-group"]',
+    )
+    expect(group?.className).toContain("flex-1")
+    expect(group?.className).not.toMatch(HEIGHT_CLASS)
   })
 
   test("keeps the realtime socket mounted in every layout", () => {

--- a/apps/builder/__tests__/full-bleed.test.tsx
+++ b/apps/builder/__tests__/full-bleed.test.tsx
@@ -1,0 +1,86 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, describe, expect, test } from "vitest"
+import { FullBleed } from "@/components/full-bleed"
+
+/**
+ * A `height` class here would be the bug this component exists to avoid: the
+ * height is derived from the shell, never hand-copied as a viewport unit.
+ */
+const HEIGHT_CLASS = /(?:^|\s)h-/
+
+const WORKSPACE_LAYOUT = join(
+  process.cwd(),
+  "src/app/space/[workspaceId]/layout.tsx",
+)
+
+/** `<main>` must be able to shrink to the cap, or the cap does nothing. */
+const MAIN_CAN_SHRINK = /<main className="[^"]*\bmin-h-0\b/
+
+let container: HTMLDivElement | null = null
+let root: Root | null = null
+
+function renderFullBleed() {
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => {
+    root?.render(
+      <FullBleed>
+        <div data-testid="page" />
+      </FullBleed>,
+    )
+  })
+
+  const el = container.firstElementChild
+  expect(el).not.toBeNull()
+  return el as HTMLElement
+}
+
+afterEach(() => {
+  if (root) {
+    act(() => {
+      root?.unmount()
+    })
+  }
+  container?.remove()
+  container = null
+  root = null
+})
+
+describe("FullBleed", () => {
+  test("grows into the shell's column instead of naming its own height", () => {
+    const el = renderFullBleed()
+
+    expect(el.className).toContain("flex-1")
+    expect(el.className).toContain("min-h-0")
+    expect(el.className).not.toMatch(HEIGHT_CLASS)
+  })
+
+  test("marks itself so the shell can cap its height", () => {
+    const el = renderFullBleed()
+
+    expect(el.hasAttribute("data-full-bleed")).toBe(true)
+  })
+})
+
+/**
+ * The shell half of the pair lives in an async Server Component that reaches
+ * for the session, quota and integration services, so it cannot be rendered
+ * here. These assertions still pin the two classes that make `FullBleed`'s
+ * `flex-1` resolve to the viewport — drop either one and the inbox composer
+ * silently falls below the fold on a short viewport, with no test to catch it.
+ */
+describe("workspace shell", () => {
+  const source = readFileSync(WORKSPACE_LAYOUT, "utf8")
+
+  test("caps itself at the viewport for full-bleed pages only", () => {
+    expect(source).toContain("has-data-full-bleed:h-svh")
+  })
+
+  test("lets its content column shrink to that cap", () => {
+    expect(source).toMatch(MAIN_CAN_SHRINK)
+  })
+})

--- a/apps/builder/__tests__/message-thread-pane-scroll.test.tsx
+++ b/apps/builder/__tests__/message-thread-pane-scroll.test.tsx
@@ -1,0 +1,111 @@
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+vi.mock("next-safe-action/hooks", () => ({
+  useAction: () => ({ execute: vi.fn(), isExecuting: false }),
+}))
+
+vi.mock("@/features/conversations/actions/disable-bot.action", () => ({
+  disableBotAction: { bind: () => vi.fn() },
+}))
+
+// The three panes import each other's heavy leaves at module scope; only the
+// thread pane's own column is under test here.
+vi.mock("@/features/contacts/contact-inbox-panel", () => ({
+  ContactInboxPanel: () => <div data-testid="contact-panel" />,
+}))
+
+vi.mock("@/features/conversations/conversation-list", () => ({
+  default: () => <div data-testid="conversation-list" />,
+}))
+
+vi.mock("@/features/messages/message-head", () => ({
+  default: () => <div data-testid="head" />,
+}))
+
+vi.mock("@/features/messages/message-list", () => ({
+  MessageList: () => <div data-testid="list" />,
+}))
+
+vi.mock("@/features/messages/components/message-input", () => ({
+  MessageInput: () => <div data-testid="composer" />,
+}))
+
+const storeState = { updateConversation: vi.fn() }
+
+vi.mock("@/features/chat/store/chat-store-provider", () => ({
+  useChatStore: (selector: (state: typeof storeState) => unknown) =>
+    selector(storeState),
+}))
+
+const { MessageThreadPane } = await import("@/features/chat/chat-panes")
+
+const activeConversation = {
+  id: "c1",
+  workspaceId: "w1",
+  botEnabled: false,
+  botResumeAt: null,
+  contactInboxes: [],
+  sourceId: null,
+} as never
+
+describe("MessageThreadPane", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+    container = document.createElement("div")
+    document.body.append(container)
+    root = createRoot(container)
+    act(() => {
+      root.render(
+        <MessageThreadPane
+          activeConversation={activeConversation}
+          isResolvingConversation={false}
+          shouldShowEmptyState={false}
+          workspaceId="w1"
+        />,
+      )
+    })
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+  })
+
+  /**
+   * The pane sits in a `ResizablePanel`, whose inner element carries an inline
+   * `max-height: 100%; overflow: auto`. `h-full` makes the column fill that
+   * box and `min-h-0` lets it shrink inside it — without the pair the column
+   * grows to its content and the panel scrolls as a whole, carrying the
+   * composer out of view instead of scrolling the message list.
+   */
+  test("fills its panel and can shrink inside it", () => {
+    const column = container.querySelector<HTMLElement>(
+      "[data-testid='head']",
+    )?.parentElement
+
+    expect(column?.className).toContain("h-full")
+    expect(column?.className).toContain("min-h-0")
+    expect(column?.className).toContain("flex-col")
+  })
+
+  test("keeps the composer as the column's last child", () => {
+    const column = container.querySelector<HTMLElement>(
+      "[data-testid='head']",
+    )?.parentElement
+
+    expect(column?.lastElementChild?.getAttribute("data-testid")).toBe(
+      "composer",
+    )
+  })
+})

--- a/apps/builder/__tests__/quick-replies-popover.test.tsx
+++ b/apps/builder/__tests__/quick-replies-popover.test.tsx
@@ -1,0 +1,76 @@
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, describe, expect, test, vi } from "vitest"
+import { SavedReplyStoreProvider } from "@/features/saved-replies/provider/saved-reply-store-context"
+import { QuickRepliesPopover } from "@/features/saved-replies/quick-replies-popover"
+
+/** Echoes the key back so assertions never depend on the English copy. */
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+let container: HTMLDivElement | null = null
+let root: Root | null = null
+
+function renderComponent(ui: React.ReactElement) {
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => {
+    root?.render(ui)
+  })
+  return container
+}
+
+function renderPopover(inputValue: string) {
+  const el = renderComponent(
+    <SavedReplyStoreProvider autoInitialize={false} workspaceId="ws-1">
+      <QuickRepliesPopover inputValue={inputValue} onSelect={() => undefined}>
+        <textarea defaultValue={inputValue} />
+      </QuickRepliesPopover>
+    </SavedReplyStoreProvider>,
+  )
+
+  const textarea = el.querySelector("textarea")
+  expect(textarea).not.toBeNull()
+  return textarea as HTMLTextAreaElement
+}
+
+afterEach(() => {
+  if (root) {
+    act(() => {
+      root?.unmount()
+    })
+  }
+  container?.remove()
+  container = null
+  root = null
+})
+
+describe("QuickRepliesPopover", () => {
+  // Regression: the textarea used to be the Popover.Trigger with
+  // `nativeButton={false}`, so Base UI's non-native button keyboard handling
+  // called preventDefault() on every Space keypress and no space could be typed
+  // into the inbox composer.
+  test("does not swallow the Space key typed into the wrapped input", () => {
+    const textarea = renderPopover("hello")
+
+    const spaceKeyDown = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: " ",
+    })
+
+    act(() => {
+      textarea.dispatchEvent(spaceKeyDown)
+    })
+
+    expect(spaceKeyDown.defaultPrevented).toBe(false)
+  })
+
+  test("leaves the wrapped input's own semantics intact", () => {
+    const textarea = renderPopover("hello")
+
+    expect(textarea.getAttribute("role")).toBeNull()
+  })
+})

--- a/apps/builder/src/app/space/[workspaceId]/layout.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/layout.tsx
@@ -111,7 +111,17 @@ export default async function WorkspaceLayout({
   )
 
   return (
-    <SidebarProvider defaultOpen={defaultOpen}>
+    // `has-data-full-bleed:h-svh` caps the shell at the viewport for pages
+    // that own the whole screen (the inbox — see `components/full-bleed.tsx`).
+    // The wrapper's own `min-h-svh` is only a floor, so without this a
+    // full-bleed page's `flex-1` has no definite height to resolve against and
+    // grows with its content instead: the inbox composer ends up below the fold
+    // on a short viewport. Scoping it to `:has()` keeps every ordinary page
+    // scrolling the body exactly as before.
+    <SidebarProvider
+      className="has-data-full-bleed:h-svh"
+      defaultOpen={defaultOpen}
+    >
       <AppSidebar
         allWorkspaces={allWorkspaces}
         isPlatformAdmin={platformAdmin}
@@ -122,7 +132,12 @@ export default async function WorkspaceLayout({
         workspaceId={workspaceId}
       />
       <SidebarInset>
-        <main className="flex min-w-0 flex-1 flex-col gap-4 p-4 md:p-6">
+        {/*
+          `min-h-0` lets this column shrink to the capped shell above instead of
+          being floored at its content height — without it the cap is inert and
+          a full-bleed page still overflows.
+        */}
+        <main className="flex min-h-0 min-w-0 flex-1 flex-col gap-4 p-4 md:p-6">
           <WorkspaceDeletionTabSync
             scheduledForDeletion={scheduledForDeletion}
             workspaceId={workspaceId}

--- a/apps/builder/src/components/full-bleed.tsx
+++ b/apps/builder/src/components/full-bleed.tsx
@@ -7,7 +7,7 @@ type FullBleedProps = {
 }
 
 /**
- * Cancels the workspace shell's content padding so a page can run edge to edge.
+ * Hands a page the whole shell viewport: no content padding, full height.
  *
  * The shell (`app/space/[workspaceId]/layout.tsx`) pads its `<main>` with
  * `p-4 md:p-6`. Surfaces that own the whole viewport — the inbox, primarily —
@@ -17,7 +17,30 @@ type FullBleedProps = {
  *
  * Keeping the mirror here makes the pair greppable and gives it one place to
  * change. **The margins below must stay the negation of the shell's padding.**
+ *
+ * The shell's `<main>` is a flex column stretched to at least the viewport, so
+ * `flex-1` is what makes the height *derived* rather than a hand-copied `dvh`
+ * value: a page nested here ends exactly where the shell ends, whatever else
+ * (a trial banner, a deletion banner) shares the column. `min-h-0` keeps that
+ * true in the other direction — the page's own content can never push the
+ * column past the viewport — so a full-bleed page must scroll its overflow
+ * inside its own panes.
+ *
+ * `flex-1` can only resolve to the viewport if some ancestor has a *definite*
+ * height, and the shell's wrapper is `min-h-svh` — a floor, not a height — so
+ * on its own it grows with content and the page runs off the bottom. That is
+ * what `data-full-bleed` is for: the shell matches it with `:has()` and caps
+ * itself at the viewport for exactly the pages that opt in, leaving every
+ * ordinary (body-scrolling) page alone. **Both halves live in
+ * `app/space/[workspaceId]/layout.tsx` — grep `data-full-bleed`.**
  */
 export function FullBleed({ children, className }: FullBleedProps) {
-  return <div className={cn("-m-4 md:-m-6", className)}>{children}</div>
+  return (
+    <div
+      className={cn("-m-4 flex min-h-0 flex-1 flex-col md:-m-6", className)}
+      data-full-bleed
+    >
+      {children}
+    </div>
+  )
 }

--- a/apps/builder/src/features/chat/chat-layout.tsx
+++ b/apps/builder/src/features/chat/chat-layout.tsx
@@ -104,14 +104,14 @@ export const ChatLayout = (props: ChatLayoutProps) => {
       */}
       <ChatRealtime />
       {isMobile === undefined && (
-        <div className="flex h-64 items-center justify-center">
+        <div className="flex min-h-0 flex-1 items-center justify-center">
           <Loader2Icon className="animate-spin" />
         </div>
       )}
       {isMobile === true && (
-        // The shell has no mobile top bar to subtract: the page owns the
-        // whole viewport. `dvh` for the same reason as the desktop group.
-        <div className="flex h-[100dvh] flex-col">
+        // Fills the height `FullBleed` derives from the shell rather than
+        // naming a viewport unit of its own — see the desktop group below.
+        <div className="flex min-h-0 flex-1 flex-col">
           {activeConversationId ? (
             <MessageThreadPane
               {...paneState}
@@ -149,10 +149,12 @@ export const ChatLayout = (props: ChatLayoutProps) => {
         </div>
       )}
       {isMobile === false && (
-        // `dvh` rather than `vh`: the panel group is the page's full-height
-        // element, and `vh` overshoots the visible area while mobile browser
-        // chrome is showing.
-        <ResizablePanelGroup className="h-[100dvh] items-stretch">
+        // Height comes from `flex-1`, never a `height` class: `PanelGroup`
+        // hard-codes an inline `height: 100%`, which beats any stylesheet rule,
+        // so `h-[100dvh]`/`h-full` here are silently dead and the group
+        // collapses to its panes' content height — a short inbox with dead
+        // space under it on a tall viewport.
+        <ResizablePanelGroup className="min-h-0 flex-1 items-stretch">
           {/* CONVERSATION LIST */}
           <ResizablePanel
             className="p-3"

--- a/apps/builder/src/features/chat/chat-panes.tsx
+++ b/apps/builder/src/features/chat/chat-panes.tsx
@@ -124,7 +124,7 @@ export function MessageThreadPane({
           <MessageHead onBack={onBack} onOpenContact={onOpenContact} />
           {isConversationActive(activeConversation) && (
             <Button
-              className="rounded-none"
+              className="shrink-0 rounded-none"
               disabled={isDisablingBot}
               onClick={() => {
                 disableBot({ ids: [activeConversation.id] })

--- a/apps/builder/src/features/conversations/conversation-list.tsx
+++ b/apps/builder/src/features/conversations/conversation-list.tsx
@@ -121,8 +121,8 @@ export default function ConversationList({
 
   return (
     <Form {...form}>
-      <form className="flex h-full flex-col">
-        <div className="mb-2 flex items-center gap-1">
+      <form className="flex h-full min-h-0 flex-col">
+        <div className="mb-2 flex shrink-0 items-center gap-1">
           <SelectField
             name="botCategory"
             options={[
@@ -156,21 +156,28 @@ export default function ConversationList({
           <ConversationFilter canViewEmailAndPhone={canViewEmailAndPhone} />
         </div>
 
-        <div className="flex-1">
-          {showSearchInput && (
-            <InputField
-              className="mb-2"
-              name="keyword"
-              placeholder={t("actions.search")}
-              {...{
-                onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => {
-                  if (event.key === "Enter") {
-                    event.preventDefault()
-                  }
-                },
-              }}
-            />
-          )}
+        {/* A sibling of the scroller, not a child of it: inside the `flex-1`
+            block this would stack on top of Virtuoso's `height: 100%` scroller
+            and overflow the pane by its own height. */}
+        {showSearchInput && (
+          <InputField
+            formItemClassName="mb-2 shrink-0"
+            name="keyword"
+            placeholder={t("actions.search")}
+            {...{
+              onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => {
+                if (event.key === "Enter") {
+                  event.preventDefault()
+                }
+              },
+            }}
+          />
+        )}
+
+        {/* `min-h-0` for the same reason as the message list: Virtuoso's
+            scroller is `height: 100%` and would otherwise floor this item at
+            the full list height. */}
+        <div className="min-h-0 flex-1">
           <Virtuoso
             components={{
               List: ConversationListList,

--- a/apps/builder/src/features/messages/components/message-input.tsx
+++ b/apps/builder/src/features/messages/components/message-input.tsx
@@ -382,7 +382,7 @@ export const MessageInput = () => {
 
   if (isMessengerHumanAgentWindowExpired) {
     return (
-      <div className="m-3 rounded-xl border pt-2">
+      <div className="m-3 shrink-0 rounded-xl border pt-2">
         <div className="flex flex-col items-center justify-center gap-3 px-4 py-6 text-center">
           <p className="text-muted-foreground text-sm">
             {t("messages.humanAgentWindowExpired")}
@@ -394,7 +394,7 @@ export const MessageInput = () => {
 
   if (isDirectChannelWindowClosed) {
     return (
-      <div className="m-3 rounded-xl border pt-2">
+      <div className="m-3 shrink-0 rounded-xl border pt-2">
         <div className="flex flex-col items-center justify-center gap-3 px-4 py-6 text-center">
           <p className="text-muted-foreground text-sm">
             {t("messages.messagingWindowClosed")}
@@ -405,7 +405,7 @@ export const MessageInput = () => {
   }
 
   return (
-    <div className="m-3 rounded-xl border pt-2">
+    <div className="m-3 shrink-0 rounded-xl border pt-2">
       <Form {...form}>
         <form
           aria-label="Message input form"

--- a/apps/builder/src/features/messages/message-head.tsx
+++ b/apps/builder/src/features/messages/message-head.tsx
@@ -64,7 +64,7 @@ export default function MessageHead({
 
   return (
     activeConversation && (
-      <div className="flex items-center gap-2 border-b px-3 pb-3">
+      <div className="flex shrink-0 items-center gap-2 border-b px-3 pb-3">
         {onBack && (
           <Button
             aria-label={t("actions.back")}

--- a/apps/builder/src/features/messages/message-list.tsx
+++ b/apps/builder/src/features/messages/message-list.tsx
@@ -236,7 +236,10 @@ export function MessageList() {
   }
 
   return (
-    <div className="flex flex-1 flex-col px-3">
+    // `min-h-0`: Virtuoso's scroller is `height: 100%`, so without it this item
+    // is floored at the full list height and pushes the composer below the fold
+    // instead of scrolling inside itself.
+    <div className="flex min-h-0 flex-1 flex-col px-3">
       <Virtuoso
         alignToBottom={true}
         components={{

--- a/apps/builder/src/features/saved-replies/quick-replies-popover.tsx
+++ b/apps/builder/src/features/saved-replies/quick-replies-popover.tsx
@@ -1,11 +1,7 @@
 "use client"
 
 import { Button } from "@chatbotx.io/ui/components/ui/button"
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@chatbotx.io/ui/components/ui/popover"
+import { Popover, PopoverContent } from "@chatbotx.io/ui/components/ui/popover"
 import { useTranslations } from "next-intl"
 import {
   type ReactElement,
@@ -32,6 +28,7 @@ export const QuickRepliesPopover = ({
   const t = useTranslations()
   const [open, setOpen] = useState(false)
   const [activeIndex, setActiveIndex] = useState(0)
+  const anchorRef = useRef<HTMLDivElement>(null)
   const optionRefs = useRef<Array<HTMLButtonElement | null>>([])
   const {
     savedReplies,
@@ -140,11 +137,16 @@ export const QuickRepliesPopover = ({
   )
 
   return (
-    <div onKeyDownCapture={onKeyDownCapture}>
+    // The popover is driven entirely by the input's value (a leading "/"), so
+    // it needs an anchor, not a trigger: `Popover.Trigger` would apply Base UI's
+    // non-native button keyboard handling to the textarea and swallow every
+    // Space keypress (and stamp it with `role="button"`).
+    <div onKeyDownCapture={onKeyDownCapture} ref={anchorRef}>
       <Popover onOpenChange={setOpen} open={open && shouldShow}>
-        <PopoverTrigger nativeButton={false} render={children} />
+        {children}
         <PopoverContent
           align="start"
+          anchor={anchorRef}
           className="max-h-75 w-[min(100vw-2rem,25rem)] overflow-y-auto p-0"
           initialFocus={false}
           side="top"

--- a/apps/worker/__tests__/received-message.test.ts
+++ b/apps/worker/__tests__/received-message.test.ts
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest"
 const {
   mockCreateOrUpdate,
   mockCreateOrUpdateWithAttachments,
+  mockFindLastByConversation,
   mockCreateMessageRepository,
   mockDbUpdate,
   mockFindOrFail,
@@ -62,14 +63,17 @@ const {
 
   const mockCreateOrUpdate = vi.fn()
   const mockCreateOrUpdateWithAttachments = vi.fn()
+  const mockFindLastByConversation = vi.fn().mockResolvedValue([])
   const mockCreateMessageRepository = vi.fn().mockResolvedValue({
     createOrUpdate: mockCreateOrUpdate,
     createOrUpdateWithAttachments: mockCreateOrUpdateWithAttachments,
+    findLastByConversation: mockFindLastByConversation,
   })
 
   return {
     mockCreateOrUpdate,
     mockCreateOrUpdateWithAttachments,
+    mockFindLastByConversation,
     mockCreateMessageRepository,
     mockDbUpdate,
     mockFindContactInbox,
@@ -331,6 +335,7 @@ vi.mock("@chatbotx.io/worker-config", () => ({
   isNoRedisEnv: () => true,
   ChatJobAction: {
     sendChatMessage: "sendChatMessage",
+    checkOutboundAutomatedResponse: "checkOutboundAutomatedResponse",
   },
   chatQueue: {
     add: mockChatQueueAdd,
@@ -549,6 +554,7 @@ describe("receiveMessage — message repository branch", () => {
     mockCreateMessageRepository.mockResolvedValue({
       createOrUpdate: mockCreateOrUpdate,
       createOrUpdateWithAttachments: mockCreateOrUpdateWithAttachments,
+      findLastByConversation: mockFindLastByConversation,
     })
     mockCreateOrUpdate.mockResolvedValue({
       message: fakeCreatedMessage,
@@ -1144,6 +1150,7 @@ describe("receiveMessage — new contact MAC gate", () => {
     mockCreateMessageRepository.mockResolvedValue({
       createOrUpdate: mockCreateOrUpdate,
       createOrUpdateWithAttachments: mockCreateOrUpdateWithAttachments,
+      findLastByConversation: mockFindLastByConversation,
     })
     mockCreateOrUpdate.mockResolvedValue({
       message: fakeCreatedMessage,
@@ -1847,6 +1854,7 @@ describe("receiveMessage — existing contact profile refresh (post-save)", () =
     mockCreateMessageRepository.mockResolvedValue({
       createOrUpdate: mockCreateOrUpdate,
       createOrUpdateWithAttachments: mockCreateOrUpdateWithAttachments,
+      findLastByConversation: mockFindLastByConversation,
     })
     mockCreateOrUpdate.mockResolvedValue({
       message: fakeCreatedMessage,
@@ -2724,6 +2732,7 @@ describe("contact source taxonomy", () => {
     mockCreateMessageRepository.mockResolvedValue({
       createOrUpdate: mockCreateOrUpdate,
       createOrUpdateWithAttachments: mockCreateOrUpdateWithAttachments,
+      findLastByConversation: mockFindLastByConversation,
     })
     mockCreateOrUpdate.mockResolvedValue({
       message: fakeCreatedMessage,
@@ -2816,6 +2825,7 @@ describe("receiveMessage — BSUID resolver chain (D3)", () => {
     mockCreateMessageRepository.mockResolvedValue({
       createOrUpdate: mockCreateOrUpdate,
       createOrUpdateWithAttachments: mockCreateOrUpdateWithAttachments,
+      findLastByConversation: mockFindLastByConversation,
     })
     mockCreateOrUpdate.mockResolvedValue({
       message: fakeCreatedMessage,
@@ -2937,6 +2947,7 @@ describe("receiveMessage — new BSUID-keyed contact creation (D2/D8/§8.1)", ()
     mockCreateMessageRepository.mockResolvedValue({
       createOrUpdate: mockCreateOrUpdate,
       createOrUpdateWithAttachments: mockCreateOrUpdateWithAttachments,
+      findLastByConversation: mockFindLastByConversation,
     })
     mockCreateOrUpdate.mockResolvedValue({
       message: fakeCreatedMessage,
@@ -3101,5 +3112,155 @@ describe("receiveMessage — new BSUID-keyed contact creation (D2/D8/§8.1)", ()
     await expect(
       receiveMessage({ ...baseProps, integrationType: "whatsapp" }),
     ).rejects.toThrow("connection reset")
+  })
+})
+
+describe("receiveMessage — outbound automated response on message echoes", () => {
+  const echoMessage = {
+    ...baseIncomingMessage,
+    sourceId: "echo-src-1",
+    messageType: "outgoing" as const,
+    text: "shipping info",
+    attachments: [],
+  }
+
+  const echoCreatedMessage = {
+    ...fakeCreatedMessage,
+    id: "msg-echo",
+    sourceId: "echo-src-1",
+    messageType: "outgoing",
+    senderType: "user",
+    text: "shipping info",
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockFindContactInbox.mockResolvedValue({
+      ...fakeContactInbox,
+      contact: fakeContact,
+    })
+    mockFindOrFail.mockResolvedValue(fakeConversation)
+    mockConversationFindOrCreate.mockResolvedValue(fakeConversation)
+
+    vi.mocked(
+      integrationService.identifyInboxAndIntegrationAuthFromIdentifier,
+    ).mockResolvedValue({
+      inbox: fakeInbox,
+      integrationRow: fakeIntegrationRow,
+    } as never)
+
+    mockBuildContext.mockResolvedValue({ workspaceId: "ws-1" })
+    mockresolveTenantSettings.mockResolvedValue({
+      storageUrl: "https://files.example.test",
+    })
+    mockCreateMessageRepository.mockResolvedValue({
+      createOrUpdate: mockCreateOrUpdate,
+      createOrUpdateWithAttachments: mockCreateOrUpdateWithAttachments,
+      findLastByConversation: mockFindLastByConversation,
+    })
+    mockCreateOrUpdate.mockResolvedValue({
+      message: echoCreatedMessage,
+      isNew: true,
+    })
+    mockFindLastByConversation.mockResolvedValue([])
+    mockParseAppointmentCancelPostback.mockReturnValue(null)
+    mockWorkspaceIsActiveNow.mockReturnValue(true)
+    mockRunChannelHandler.mockResolvedValue({
+      message: echoMessage,
+      contact: { sourceId: "psid-123", firstName: "Test" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+  })
+
+  const outboundCheckCalls = () =>
+    mockChatQueueAdd.mock.calls.filter(
+      ([action]) => action === "checkOutboundAutomatedResponse",
+    )
+
+  test("enqueues the check for an echo of a human agent's own reply", async () => {
+    await receiveMessage(baseProps)
+
+    expect(mockFindLastByConversation).toHaveBeenCalledWith(
+      "conv-1",
+      expect.objectContaining({
+        messageTypes: ["outgoing"],
+        workspaceId: "ws-1",
+      }),
+    )
+    expect(outboundCheckCalls()).toHaveLength(1)
+    expect(outboundCheckCalls()[0]?.[1]).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          message: { id: "msg-echo", text: "shipping info" },
+        }),
+      }),
+    )
+  })
+
+  test("skips the check when the echo duplicates a message ChatbotX itself sent", async () => {
+    // A sourceId dedupe miss: our own row is already there, so the echo was
+    // inserted a second time. Running keyword automation over it would let an
+    // outbound rule match the bot's own reply.
+    mockFindLastByConversation.mockResolvedValue([
+      { id: "msg-bot-send", text: "shipping info" },
+    ])
+
+    await receiveMessage(baseProps)
+
+    expect(outboundCheckCalls()).toHaveLength(0)
+  })
+
+  test("does not treat the echo's own row as a duplicate of itself", async () => {
+    mockFindLastByConversation.mockResolvedValue([
+      { id: "msg-echo", text: "shipping info" },
+      { id: "msg-other", text: "something else" },
+    ])
+
+    await receiveMessage(baseProps)
+
+    expect(outboundCheckCalls()).toHaveLength(1)
+  })
+
+  test("fails closed when the self-send lookup throws", async () => {
+    mockFindLastByConversation.mockRejectedValue(new Error("shard down"))
+
+    await receiveMessage(baseProps)
+
+    expect(outboundCheckCalls()).toHaveLength(0)
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: "conv-1" }),
+      "Skipped outbound automated response check after an error",
+    )
+  })
+
+  test("does not run for inbound messages", async () => {
+    mockRunChannelHandler.mockResolvedValue({
+      message: { ...baseIncomingMessage, attachments: [] },
+      contact: { sourceId: "psid-123", firstName: "Test" },
+      postbackAction: null,
+      quickReplyAction: null,
+      ref: null,
+    })
+    mockCreateOrUpdate.mockResolvedValue({
+      message: fakeCreatedMessage,
+      isNew: true,
+    })
+
+    await receiveMessage(baseProps)
+
+    expect(mockFindLastByConversation).not.toHaveBeenCalled()
+    expect(outboundCheckCalls()).toHaveLength(0)
+  })
+
+  test("does not run for an inactive workspace", async () => {
+    mockWorkspaceIsActiveNow.mockReturnValue(false)
+
+    await receiveMessage(baseProps)
+
+    expect(mockFindLastByConversation).not.toHaveBeenCalled()
+    expect(outboundCheckCalls()).toHaveLength(0)
   })
 })

--- a/apps/worker/src/integration/handlers/received-message.ts
+++ b/apps/worker/src/integration/handlers/received-message.ts
@@ -471,6 +471,43 @@ export const receiveMessage = async (
           )
         }
       }
+
+      // Message echoes (agent replying from the channel's own native UI,
+      // e.g. Meta Business Suite, rather than the ChatbotX inbox) never go
+      // through `create-message.action.ts`, so "Page" keyword automation
+      // must be checked here too — mirrors the enqueue in that action,
+      // including its `user &&` gate (see isEchoOfOwnSend).
+      if (
+        isWorkspaceActive &&
+        incomingMessage.messageType === "outgoing" &&
+        incomingMessage.text
+      ) {
+        try {
+          if (
+            !(await isEchoOfOwnSend({ conversation, message: createdMessage }))
+          ) {
+            await chatQueue.add(ChatJobAction.checkOutboundAutomatedResponse, {
+              type: ChatJobAction.checkOutboundAutomatedResponse,
+              data: {
+                conversation,
+                contactInbox,
+                message: { id: createdMessage.id, text: incomingMessage.text },
+              },
+            })
+          }
+        } catch (error) {
+          // Deliberately fail closed: a failed self-send check must not let a
+          // bot echo through, or an outbound rule can match its own reply.
+          logger.warn(
+            {
+              err: normalizeError(error),
+              conversationId: conversation.id,
+              contactInboxId: contactInbox.id,
+            },
+            "Skipped outbound automated response check after an error",
+          )
+        }
+      }
     }
   }
 
@@ -612,6 +649,59 @@ async function sendAppointmentCancelFeedback(input: {
       "Failed to send appointment cancel feedback",
     )
   }
+}
+
+/**
+ * How far back to look for the ChatbotX-side row an echo may be duplicating.
+ * The race it covers is sub-second — `updateSourceId` runs right after the
+ * channel send returns — so this only needs to be generous, not wide: a
+ * longer window would start suppressing genuine agent replies that happen to
+ * repeat something the bot said.
+ */
+const SELF_SENT_ECHO_WINDOW_MS = 2 * 60 * 1000
+
+/** Outgoing rows to compare against — enough to cover a multi-message reply. */
+const SELF_SENT_ECHO_LOOKBACK = 10
+
+/**
+ * Mirrors the `user &&` gate on the inbox call site
+ * (`apps/builder/src/features/messages/actions/create-message.action.ts`):
+ * only a message a human agent actually typed may trigger "Page" keyword
+ * automation.
+ *
+ * Echoes are stamped `senderType: "user"` whatever their origin, so a bot send
+ * is otherwise indistinguishable from an agent one. Normally the echo is
+ * deduped by `sourceId` and never reaches this code, but `updateSourceId`
+ * only runs after the channel send returns (`chat/handlers/send-message.ts`)
+ * and swallows its errors, so a fast webhook can insert a second row first. On
+ * such a miss the bot would run keyword automation over its own text — and,
+ * because an outbound rule replies through the same channel, that reply echoes
+ * back and can match itself in a loop.
+ *
+ * Every ChatbotX send persists its Message row *before* hitting the channel,
+ * so a recent outgoing row carrying the same text is our own send, not an
+ * agent's.
+ */
+const isEchoOfOwnSend = async (props: {
+  conversation: ConversationModel
+  message: MessageModel
+}): Promise<boolean> => {
+  const { conversation, message } = props
+  const repository = await createMessageRepository()
+  const recentOutgoing = await repository.findLastByConversation(
+    conversation.id,
+    {
+      limit: SELF_SENT_ECHO_LOOKBACK,
+      messageTypes: ["outgoing"],
+      sinceTime: new Date(Date.now() - SELF_SENT_ECHO_WINDOW_MS),
+      workspaceId: conversation.workspaceId,
+    },
+  )
+
+  return recentOutgoing.some(
+    (candidate) =>
+      candidate.id !== message.id && candidate.text === message.text,
+  )
 }
 
 // Creates or updates the message row (deduplicates webhook retries via sourceId),


### PR DESCRIPTION
## Summary

- The inbox hard-coded `h-[100dvh]` in two places. On the desktop `ResizablePanelGroup` that class was **dead** — `PanelGroup` sets an inline `height: 100%`, which no stylesheet rule can beat — so the group collapsed to its panes' content height and left dead space under a short inbox on a tall viewport. On mobile the `dvh` ignored whatever else shares the shell's column (trial/deletion banner), pushing the composer below the fold.
- Height is now **derived** from the shell rather than named: `FullBleed` is a grown flex item that marks itself `data-full-bleed`, and the workspace shell matches it with `:has()` to cap itself at `h-svh` for exactly the pages that opt in. Ordinary body-scrolling pages are untouched.
- Two bugs found while reviewing that diff: the quick-replies popover was swallowing Space in the composer, and the message-echo path in the worker could make the bot run keyword automation over its own reply.

## Changes

**Inbox viewport height** — `app/space/[workspaceId]/layout.tsx` (the `:has()` cap + `min-h-0` on `<main>`), `components/full-bleed.tsx` (`min-h-0 flex-1` + the `data-full-bleed` marker), `features/chat/chat-layout.tsx` (both branches grow instead of naming `dvh`), `chat-panes.tsx`, `messages/message-list.tsx`, `messages/message-head.tsx`, `messages/components/message-input.tsx`, `conversations/conversation-list.tsx`. Every Virtuoso scroller gets `min-h-0` (its scroller is `height: 100%` and would otherwise floor its flex item at the full list height); every fixed chrome row gets `shrink-0`. The conversation-list search input moves out of the scroller's flex item — nested there it stacked on top of the 100%-tall scroller and overflowed the pane by its own height.

**Quick replies popover** — `saved-replies/quick-replies-popover.tsx`. The popover is driven entirely by the composer's value (a leading `/`), so it needs an anchor, not a trigger: `Popover.Trigger` applied Base UI's non-native button keyboard handling to the textarea, eating every Space keypress and stamping it `role="button"`. Focus return is unaffected — with no `domReference` Base UI falls back to `elementFocusedBeforeOpen`.

**Outbound keyword automation on echoes** — `worker/src/integration/handlers/received-message.ts`. The echo path enqueued `checkOutboundAutomatedResponse` without the `user &&` gate its mirrored call site in `create-message.action.ts` applies. Echoes are stamped `senderType: "user"` whatever their origin, and the only defence was the `sourceId` dedupe — but `updateSourceId` runs only *after* the channel send returns and swallows its errors, so a fast webhook can insert a second row first (Zalo `oa_send_text` has no skip marker at the webhook layer the way Messenger does). On such a miss the bot ran keyword automation over its own text, and since an outbound rule replies through the same channel that reply echoes back and can match itself in a loop. New `isEchoOfOwnSend` uses the fact that every ChatbotX send persists its Message row *before* hitting the channel, so a recent outgoing row with the same text identifies the echo as ours. Fails closed.

**Tests** — new `__tests__/full-bleed.test.tsx`, `__tests__/message-thread-pane-scroll.test.tsx`, `__tests__/quick-replies-popover.test.tsx`; extended `__tests__/chat-layout-mobile.test.tsx` (now asserts *no* `h-` class on either inbox container, since one there is a bug rather than a style choice); 6 new cases in `worker/__tests__/received-message.test.ts` covering the echo gate.

## Not in scope

The quick-replies popover still has no reopen path after an outside-press or Escape dismissal — the effect that opens it is keyed on `shouldShow`, which stays `true` for the whole draft, so the list only comes back once the agent deletes and retypes the leading `/`. Pre-existing behaviour of this refactor's shape; left for a follow-up.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm --filter builder check-types`
- [x] `pnpm --filter worker check-types`
- [x] `pnpm --filter builder test` — 2502 passed
- [x] `pnpm --filter worker test` — 1943 passed
- [ ] Manual: inbox on a short desktop viewport — composer visible, no dead space under the panel group
- [ ] Manual: inbox on a phone viewport, and again with the trial banner showing
- [ ] Manual: type a space in the composer, and type `/` to open quick replies