### PR TITLE
fix(variables): localise the gender salutation by workspace language

### DIFF
--- a/packages/variables/__tests__/contact-variable.test.ts
+++ b/packages/variables/__tests__/contact-variable.test.ts
@@ -424,7 +424,7 @@ describe("contactVariableService.replaceAll gender casing", () => {
 
 describe("contactVariableService.replaceAll gender language", () => {
   const render = (input: {
-    workspaceLanguage: string
+    workspaceLanguage: string | null
     contactLocale?: string | null
     inboxLanguage?: string | null
   }) =>
@@ -448,45 +448,36 @@ describe("contactVariableService.replaceAll gender language", () => {
       },
     })
 
-  test("prefers the contact channel language over the workspace language", async () => {
-    await expect(
-      render({ inboxLanguage: "vi", workspaceLanguage: "en" }),
-    ).resolves.toBe("Chị")
-  })
-
-  test("falls back to the language read from the contact locale", async () => {
-    await expect(
-      render({ contactLocale: "vi_VN", workspaceLanguage: "en" }),
-    ).resolves.toBe("Chị")
-  })
-
-  test("prefers the channel language over the contact locale", async () => {
-    await expect(
-      render({
-        contactLocale: "vi_VN",
-        inboxLanguage: "en",
-        workspaceLanguage: "vi",
-      }),
-    ).resolves.toBe("Female")
-  })
-
-  test("falls back to the workspace language when the contact has none", async () => {
+  test("renders Vietnamese for a Vietnamese workspace", async () => {
     await expect(render({ workspaceLanguage: "vi" })).resolves.toBe("Chị")
   })
 
-  test("treats a blank contact language as unknown so the workspace wins", async () => {
+  test("renders English for any non-Vietnamese workspace", async () => {
+    await expect(render({ workspaceLanguage: "en" })).resolves.toBe("Female")
+    await expect(render({ workspaceLanguage: "de" })).resolves.toBe("Female")
+  })
+
+  test("ignores the contact channel language", async () => {
     await expect(
-      render({
-        contactLocale: "",
-        inboxLanguage: "",
-        workspaceLanguage: "vi",
-      }),
+      render({ inboxLanguage: "vi", workspaceLanguage: "en" }),
+    ).resolves.toBe("Female")
+    await expect(
+      render({ inboxLanguage: "en", workspaceLanguage: "vi" }),
     ).resolves.toBe("Chị")
   })
 
-  test("keeps the contact language even when it differs from the workspace", async () => {
+  test("ignores the contact locale", async () => {
+    await expect(
+      render({ contactLocale: "vi_VN", workspaceLanguage: "en" }),
+    ).resolves.toBe("Female")
     await expect(
       render({ contactLocale: "en_US", workspaceLanguage: "vi" }),
+    ).resolves.toBe("Chị")
+  })
+
+  test("falls back to English when the workspace has no language", async () => {
+    await expect(
+      render({ contactLocale: "vi_VN", workspaceLanguage: null }),
     ).resolves.toBe("Female")
   })
 })

--- a/packages/variables/__tests__/system-fields.test.ts
+++ b/packages/variables/__tests__/system-fields.test.ts
@@ -1384,13 +1384,17 @@ describe("getSystemFieldValue — contact profile columns", () => {
     ).resolves.toBe("")
   })
 
-  test("gender is localised through the workspace language", async () => {
+  test("gender is localised through the workspace language even when the contact speaks another", async () => {
     mockResolveGenderLabel.mockReturnValue("Chị")
 
     await expect(
       getSystemFieldValue(
         createContext({
-          contact: profileContact,
+          contact: { ...profileContact, locale: "en_US" } as ContactModel,
+          contactInbox: {
+            ...contactInbox,
+            language: "en",
+          } as ContactInboxModel,
           workspace: { ...workspace, language: "vi" } as WorkspaceModel,
         }),
         systemFieldTypes.enum.gender,
@@ -1400,14 +1404,21 @@ describe("getSystemFieldValue — contact profile columns", () => {
   })
 
   test("gender passes an undefined language when there is no workspace", async () => {
-    mockResolveGenderLabel.mockReturnValue("Anh/Chị")
+    mockResolveGenderLabel.mockReturnValue("Male/Female")
 
     await expect(
       getSystemFieldValue(
-        createContext({ contact: profileContact, workspace: null }),
+        createContext({
+          contact: { ...profileContact, locale: "vi_VN" } as ContactModel,
+          contactInbox: {
+            ...contactInbox,
+            language: "vi",
+          } as ContactInboxModel,
+          workspace: null,
+        }),
         systemFieldTypes.enum.gender,
       ),
-    ).resolves.toBe("Anh/Chị")
+    ).resolves.toBe("Male/Female")
     expect(mockResolveGenderLabel).toHaveBeenCalledWith(undefined, "female")
   })
 

--- a/packages/variables/src/utils.ts
+++ b/packages/variables/src/utils.ts
@@ -271,16 +271,6 @@ const getCommentMessagePostId = (
   return typeof postId === "string" ? postId : null
 }
 
-// The contact's own language, in the order the platform learns it: the channel
-// language we recorded, then the locale their profile reports. Undefined when
-// the contact never told us, so the caller picks the fallback. Blank values
-// normalise away here rather than shadowing that fallback.
-const getContactLanguage = (
-  context: ContactVariableContext,
-): string | undefined =>
-  languageFromLocale(context.contactInbox?.language) ??
-  languageFromLocale(context.contact.locale)
-
 const getAppointment = async (
   context: ContactVariableContext,
 ): Promise<Awaited<ReturnType<typeof appointmentService.findBy>> | null> => {
@@ -329,10 +319,10 @@ export const getSystemFieldValue = async (
     case systemFieldTypes.enum.profile_pic:
       return await toPublicStorageUrl(contact.avatar, contact.workspaceId)
     case systemFieldTypes.enum.gender:
-      return resolveGenderLabel(
-        getContactLanguage(context) ?? workspace?.language,
-        contact.gender,
-      )
+      // Salutation follows the workspace language, not the contact's own
+      // locale: a Vietnamese workspace greets every contact as Anh/Chị, and
+      // everything else renders English (see resolveGenderLabel).
+      return resolveGenderLabel(workspace?.language, contact.gender)
     case systemFieldTypes.enum.user_country:
       return contact.country
     case systemFieldTypes.enum.user_state:


### PR DESCRIPTION
## Summary
- The `{{gender}}` system field rendered its salutation from the contact's own language (the channel language we recorded, then the locale from their profile) and only fell back to the workspace language when neither was known. A Vietnamese workspace could therefore greet a contact whose Facebook locale is `en_US` as "Female" in the middle of a Vietnamese message, and an English workspace could emit "Chị" for a Vietnamese-locale contact.
- The salutation now follows the workspace language only: a Vietnamese workspace renders "Anh" / "Chị" / "Anh/Chị", every other workspace (or no workspace) renders "Male" / "Female" / "Male/Female". This matches how the self-service data export already localised gender.

## Changes
- `packages/variables/src/utils.ts`: `{{gender}}` resolves through the existing `resolveGenderLabel` with `workspace.language` only; the contact-language lookup helper is removed. The `{{language}}` field is untouched and still reads the contact's channel language / locale.
- `packages/variables/__tests__/contact-variable.test.ts`: the gender-language cases now pin the workspace rule — Vietnamese vs non-Vietnamese workspace, channel language and contact locale ignored in both directions, English fallback when the workspace has no language.
- `packages/variables/__tests__/system-fields.test.ts`: the two call-site gender tests set a conflicting contact locale / channel language so they prove the workspace language is what reaches the resolver.

## Test plan
- [x] `pnpm exec ultracite check packages/variables`
- [x] `pnpm --filter @chatbotx.io/variables check-types`
- [x] Vitest variables: 13 files / 173 tests
- [x] Vitest business `system-field-service.test.ts`: 9 tests
- [ ] Manual on a Vietnamese workspace: send a flow message containing `{{gender}}` to a contact whose profile locale is `en_US` and confirm it renders "Anh"/"Chị"
- [ ] Manual on an English workspace: same message to a Vietnamese-locale contact renders "Male"/"Female"

## Notes
- No migration, no schema change. Only the rendered text of `{{gender}}` changes; stored contact gender and the `{{language}}` field are unaffected.
- Behaviour change: contacts whose locale differs from the workspace language will now see the workspace-language salutation instead of their own.
