### PR TITLE
fix(automated-response): match page keywords exactly, not by substring

### DIFF
--- a/packages/automated-response/__tests__/keyword-match.test.ts
+++ b/packages/automated-response/__tests__/keyword-match.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest"
-import { keywordMatchesText, matchesAnyKeywordRule } from "../src/keyword-match"
+import {
+  keywordMatchesText,
+  keywordMatchModeByAutomatedResponseType,
+  matchesAnyKeywordRule,
+} from "../src/keyword-match"
 
 describe("keywordMatchesText", () => {
   test("matches keywords case-insensitively", () => {
@@ -12,6 +16,34 @@ describe("keywordMatchesText", () => {
 
   test("returns false for empty keyword lists", () => {
     expect(keywordMatchesText([], "hello")).toBe(false)
+  })
+
+  test("exact mode requires the full text to equal a keyword", () => {
+    expect(keywordMatchesText(["price"], "price", "exact")).toBe(true)
+    expect(keywordMatchesText(["price"], "what is the price?", "exact")).toBe(
+      false,
+    )
+  })
+
+  test("exact mode is case-insensitive and trims whitespace", () => {
+    expect(keywordMatchesText(["PRICE"], "  price  ", "exact")).toBe(true)
+  })
+
+  test("a whitespace-only keyword never matches, in either mode", () => {
+    expect(keywordMatchesText([" "], "hello world", "contains")).toBe(false)
+    expect(keywordMatchesText([" "], "", "exact")).toBe(false)
+    expect(keywordMatchesText([" "], "   ", "exact")).toBe(false)
+  })
+
+  test("contains mode trims keyword whitespace before matching", () => {
+    expect(keywordMatchesText([" price "], "the price is high")).toBe(true)
+  })
+})
+
+describe("keywordMatchModeByAutomatedResponseType", () => {
+  test("maps Contact rules to contains and Page rules to exact", () => {
+    expect(keywordMatchModeByAutomatedResponseType.inbound).toBe("contains")
+    expect(keywordMatchModeByAutomatedResponseType.outbound).toBe("exact")
   })
 })
 

--- a/packages/automated-response/src/dispatch-reply.ts
+++ b/packages/automated-response/src/dispatch-reply.ts
@@ -1,6 +1,7 @@
 import { trackingResponseTypes } from "@chatbotx.io/analytics"
 import { adsConversionService } from "@chatbotx.io/business"
 import { db } from "@chatbotx.io/database/client"
+import type { AutomatedResponseType } from "@chatbotx.io/database/partials"
 import type {
   AutomatedResponseModel,
   ContactInboxModel,
@@ -14,7 +15,10 @@ import {
   IntegrationJobAction,
   integrationQueue,
 } from "@chatbotx.io/worker-config"
-import { keywordMatchesText } from "./keyword-match"
+import {
+  keywordMatchesText,
+  keywordMatchModeByAutomatedResponseType,
+} from "./keyword-match"
 
 export const dispatchAutomatedResponseReply = async (props: {
   conversation: ConversationModel
@@ -32,7 +36,16 @@ export const dispatchAutomatedResponseReply = async (props: {
   const lowerCaseText = text.toLowerCase()
 
   for (const rule of rules) {
-    const matched = keywordMatchesText(rule.keywords, lowerCaseText)
+    // Match mode is derived from `rule.type` — see the Contact/Page
+    // distinction documented at automated-response.ts's
+    // `automatedResponseFolderTypeByType`.
+    const matched = keywordMatchesText(
+      rule.keywords,
+      lowerCaseText,
+      keywordMatchModeByAutomatedResponseType[
+        rule.type as AutomatedResponseType
+      ],
+    )
 
     if (!matched) {
       continue

--- a/packages/automated-response/src/keyword-match.ts
+++ b/packages/automated-response/src/keyword-match.ts
@@ -1,12 +1,34 @@
+import type { AutomatedResponseType } from "@chatbotx.io/database/partials"
 import type { AutomatedResponseModel } from "@chatbotx.io/database/types"
+
+export type KeywordMatchMode = "contains" | "exact"
+
+// Mirrors the `Record<AutomatedResponseType, ...>` cascade convention used
+// for `automatedResponseFolderTypeByType` — a future third type fails to
+// compile here instead of silently falling back to "contains".
+export const keywordMatchModeByAutomatedResponseType: Record<
+  AutomatedResponseType,
+  KeywordMatchMode
+> = {
+  inbound: "contains",
+  outbound: "exact",
+}
 
 export const keywordMatchesText = (
   keywords: readonly string[],
   lowerCaseText: string,
-): boolean =>
-  keywords
-    .map((keyword) => keyword.toLowerCase())
-    .some((keyword) => lowerCaseText.includes(keyword))
+  mode: KeywordMatchMode = "contains",
+): boolean => {
+  const trimmedText = lowerCaseText.trim()
+  return keywords
+    .map((keyword) => keyword.trim().toLowerCase())
+    .filter((keyword) => keyword.length > 0)
+    .some((keyword) =>
+      mode === "exact"
+        ? trimmedText === keyword
+        : lowerCaseText.includes(keyword),
+    )
+}
 
 export const matchesAnyKeywordRule = (
   text: string,


### PR DESCRIPTION
## Summary
- "Page" (outbound) automated-response keyword rules matched with `includes()` (substring/"contains"), the same behavior as "Contact" (inbound) rules — so a short keyword could fire on any message that merely contained it.
- Page rules now require the full message text to equal a keyword (trimmed, case-insensitive); Contact rules keep the existing "contains" behavior unchanged.

## Changes
- `packages/automated-response/src/keyword-match.ts` — `keywordMatchesText` gains a `mode: "contains" | "exact"` parameter; keywords are now trimmed consistently before comparison in both modes, and a whitespace-only keyword can no longer match everything. Added `keywordMatchModeByAutomatedResponseType`, an exhaustive `Record<AutomatedResponseType, KeywordMatchMode>` mapping (mirrors the existing `automatedResponseFolderTypeByType` cascade convention) so a future third rule type fails to compile instead of silently defaulting to "contains".
- `packages/automated-response/src/dispatch-reply.ts` — looks up the match mode from that map instead of an inline two-branch ternary.
- `packages/automated-response/__tests__/keyword-match.test.ts` — covers exact-mode matching, the whitespace-only-keyword edge case, and the mode map.

## Test plan
- [x] `pnpm --filter @chatbotx.io/automated-response test` (35/35 pass)
- [x] `pnpm --filter @chatbotx.io/automated-response check-types`
- [x] `pnpm --filter worker check-types`
- [x] `pnpm lint`
- [ ] Manual verification: create a Page keyword rule, confirm it only fires on an exact message match, and confirm a Contact keyword rule still fires on partial/substring matches