### PR TITLE
fix(errors): keep meta's code, subcode and both sentences in graph error text

### DIFF
--- a/integrations/facebook-ads/package.json
+++ b/integrations/facebook-ads/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@chatbotx.io/logger": "workspace:*",
     "@chatbotx.io/sdk": "workspace:*",
+    "@chatbotx.io/utils": "workspace:*",
     "ky": "^2.0.2",
     "libphonenumber-js": "^1.12.42",
     "zod": "^4.3.6"

--- a/integrations/facebook-ads/src/exception.ts
+++ b/integrations/facebook-ads/src/exception.ts
@@ -1,4 +1,5 @@
 import { SdkException, UNKNOWN_ERROR } from "@chatbotx.io/sdk"
+import { formatGraphError } from "@chatbotx.io/utils/graph-error"
 import { isHTTPError } from "ky"
 import { facebookAdsLogger } from "./logger"
 
@@ -17,20 +18,6 @@ type GraphErrorBody = {
 
 function asObject<T>(value: unknown): T | undefined {
   return typeof value === "object" && value !== null ? (value as T) : undefined
-}
-
-// Prefer Facebook's human-readable error (error_user_title/error_user_msg)
-// over the terse generic `message` (e.g. "Invalid parameter").
-function pickErrorMessage(err?: GraphErrorBody["error"]): string | undefined {
-  if (!err) {
-    return
-  }
-  if (err.error_user_msg) {
-    return err.error_user_title
-      ? `${err.error_user_title}: ${err.error_user_msg}`
-      : err.error_user_msg
-  }
-  return err.message
 }
 
 export class FacebookAdsException extends SdkException {
@@ -86,7 +73,7 @@ export const rescue = async <T>(
     if (isHTTPError(error)) {
       const err = asObject<GraphErrorBody>(error.data)?.error
       throw new FacebookAdsException(
-        pickErrorMessage(err) ?? UNKNOWN_ERROR.message,
+        formatGraphError(err) ?? UNKNOWN_ERROR.message,
         error.response.status,
         err?.code ?? "facebookAdsError",
         err?.error_subcode,

--- a/integrations/instagram-facebook/src/exception.ts
+++ b/integrations/instagram-facebook/src/exception.ts
@@ -1,4 +1,5 @@
 import { SdkException } from "@chatbotx.io/sdk"
+import { formatGraphError } from "@chatbotx.io/utils/graph-error"
 import { isHTTPError } from "ky"
 import { logger } from "./lib/logger"
 
@@ -13,6 +14,8 @@ type ErrorBody = {
     code?: number
     type?: string
     message?: string
+    error_user_title?: string
+    error_user_msg?: string
     error_subcode?: number | string
     subcode?: number | string
   }
@@ -37,7 +40,7 @@ export function parseOriginError(originError: unknown): ChannelErrorSource {
       code: err?.code,
       subCode: err?.error_subcode ?? err?.subcode,
       type: err?.type,
-      message: err?.message,
+      message: formatGraphError(err),
     }
   }
 
@@ -49,7 +52,7 @@ export function parseOriginError(originError: unknown): ChannelErrorSource {
       code: err?.code,
       subCode: err?.error_subcode ?? err?.subcode,
       type: err?.type,
-      message: err?.message,
+      message: formatGraphError(err),
     }
   }
 
@@ -61,7 +64,7 @@ export function parseOriginError(originError: unknown): ChannelErrorSource {
       code: err.code,
       subCode: err.error_subcode ?? err.subcode,
       type: err.type,
-      message: err.message,
+      message: formatGraphError(err),
     }
   }
 

--- a/integrations/instagram/src/exception.ts
+++ b/integrations/instagram/src/exception.ts
@@ -1,4 +1,5 @@
 import { SdkException } from "@chatbotx.io/sdk"
+import { formatGraphError } from "@chatbotx.io/utils/graph-error"
 import { isHTTPError } from "ky"
 import { logger } from "./lib/logger"
 
@@ -13,6 +14,8 @@ type ErrorBody = {
     code?: number
     type?: string
     message?: string
+    error_user_title?: string
+    error_user_msg?: string
     error_subcode?: number | string
     subcode?: number | string
   }
@@ -37,7 +40,7 @@ export function parseOriginError(originError: unknown): ChannelErrorSource {
       code: err?.code,
       subCode: err?.error_subcode ?? err?.subcode,
       type: err?.type,
-      message: err?.message,
+      message: formatGraphError(err),
     }
   }
 
@@ -49,7 +52,7 @@ export function parseOriginError(originError: unknown): ChannelErrorSource {
       code: err?.code,
       subCode: err?.error_subcode ?? err?.subcode,
       type: err?.type,
-      message: err?.message,
+      message: formatGraphError(err),
     }
   }
 
@@ -61,7 +64,7 @@ export function parseOriginError(originError: unknown): ChannelErrorSource {
       code: err.code,
       subCode: err.error_subcode ?? err.subcode,
       type: err.type,
-      message: err.message,
+      message: formatGraphError(err),
     }
   }
 

--- a/integrations/messenger/__tests__/graph-error-message.test.ts
+++ b/integrations/messenger/__tests__/graph-error-message.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "vitest"
+import { parseOriginError } from "../src/exception"
+import { mapToChannelError } from "../src/lib/error-mapper"
+
+/**
+ * The Graph body Meta returns when a Page is temporarily restricted from
+ * messaging a thread. Every piece of it has to survive into `ErrorLog.detail`:
+ * code 10 alone covers a dozen unrelated permission failures, and the subcode
+ * is the only thing that names this one.
+ */
+const RESTRICTED_THREAD_ERROR = {
+  message: "Application does not have permission for this action",
+  type: "OAuthException",
+  code: 10,
+  error_subcode: 1_893_063,
+  error_user_title: "Bạn không thể gửi tin nhắn đến cuộc trò chuyện này",
+  error_user_msg:
+    "Bạn tạm thời bị hạn chế gửi tin nhắn. Tìm hiểu thêm về thời gian và lý do chúng tôi hạn chế khả năng nhắn tin.",
+  fbtrace_id: "Ae1wFHiG1XvSn1TtWwjWxPZ",
+}
+
+const EXPECTED_DETAIL =
+  "#(10 - 1893063) Application does not have permission for this action. Bạn tạm thời bị hạn chế gửi tin nhắn. Tìm hiểu thêm về thời gian và lý do chúng tôi hạn chế khả năng nhắn tin."
+
+describe("parseOriginError message composition", () => {
+  test("keeps the code pair and both sentences of a restricted-thread failure", () => {
+    expect(
+      parseOriginError({
+        httpStatus: 403,
+        errorBody: { error: RESTRICTED_THREAD_ERROR },
+      }),
+    ).toMatchObject({
+      httpStatusCode: 403,
+      code: 10,
+      subCode: 1_893_063,
+      type: "OAuthException",
+      message: EXPECTED_DETAIL,
+    })
+  })
+
+  test("composes the same string from the explicit response shape", () => {
+    expect(
+      parseOriginError({ response: { error: RESTRICTED_THREAD_ERROR } }),
+    ).toMatchObject({ message: EXPECTED_DETAIL })
+  })
+
+  test("falls back to the user title when Meta sent no user message", () => {
+    expect(
+      parseOriginError({
+        httpStatus: 400,
+        errorBody: {
+          error: {
+            message: "Invalid parameter",
+            code: 100,
+            error_subcode: 2_018_001,
+            error_user_title: "Message not sent",
+          },
+        },
+      }),
+    ).toMatchObject({
+      message: "#(100 - 2018001) Invalid parameter. Message not sent",
+    })
+  })
+
+  test("adds no prefix to a failure that never reached Graph", () => {
+    expect(parseOriginError(new Error("socket hang up"))).toMatchObject({
+      httpStatusCode: 400,
+      message: "socket hang up",
+    })
+  })
+})
+
+describe("the string that reaches ErrorLog.detail", () => {
+  /**
+   * `toEntry` in `@chatbotx.io/business` writes `error.message` verbatim into
+   * `ErrorLog.detail`, and `parseSdkError` is what hands it over. Nothing
+   * between here and the row re-derives the message, so pinning it at
+   * `getErrorData()` pins the column.
+   */
+  test("survives mapToChannelError and getErrorData unchanged", async () => {
+    const channelError = mapToChannelError({
+      httpStatus: 403,
+      errorBody: { error: RESTRICTED_THREAD_ERROR },
+    })
+
+    expect(channelError.message).toBe(EXPECTED_DETAIL)
+
+    const errorData = await channelError.getErrorData()
+    expect(errorData).toMatchObject({
+      message: EXPECTED_DETAIL,
+      code: 10,
+      subcode: 1_893_063,
+      statusCode: 403,
+      // Terminal, so `recordProviderErrorLog` writes the row on this emission.
+      isRetryable: false,
+    })
+  })
+})

--- a/integrations/messenger/src/exception.ts
+++ b/integrations/messenger/src/exception.ts
@@ -1,4 +1,5 @@
 import { SdkException } from "@chatbotx.io/sdk"
+import { formatGraphError } from "@chatbotx.io/utils/graph-error"
 import { isHTTPError } from "ky"
 import { logger } from "./lib/logger"
 
@@ -22,20 +23,6 @@ type ErrorBody = {
 type OriginShape = { httpStatus?: number; errorBody?: ErrorBody }
 type ExplicitShape = { response?: { error?: ErrorBody["error"] } }
 
-// Prefer Facebook's human-readable error (error_user_title/error_user_msg) over
-// the terse generic `message` (e.g. "Invalid parameter").
-function pickErrorMessage(err?: ErrorBody["error"]): string | undefined {
-  if (!err) {
-    return
-  }
-  if (err.error_user_msg) {
-    return err.error_user_title
-      ? `${err.error_user_title}: ${err.error_user_msg}`
-      : err.error_user_msg
-  }
-  return err.message
-}
-
 export type ChannelErrorSource = {
   httpStatusCode: number
   code?: number | string
@@ -53,7 +40,7 @@ export function parseOriginError(originError: unknown): ChannelErrorSource {
       code: err?.code,
       subCode: err?.error_subcode ?? err?.subcode,
       type: err?.type,
-      message: pickErrorMessage(err),
+      message: formatGraphError(err),
     }
   }
 
@@ -65,7 +52,7 @@ export function parseOriginError(originError: unknown): ChannelErrorSource {
       code: err?.code,
       subCode: err?.error_subcode ?? err?.subcode,
       type: err?.type,
-      message: pickErrorMessage(err),
+      message: formatGraphError(err),
     }
   }
 
@@ -78,7 +65,7 @@ export function parseOriginError(originError: unknown): ChannelErrorSource {
       code: err.code,
       subCode: err.error_subcode ?? err.subcode,
       type: err.type,
-      message: pickErrorMessage(err),
+      message: formatGraphError(err),
     }
   }
   return {

--- a/integrations/meta-catalog/__tests__/http-client.test.ts
+++ b/integrations/meta-catalog/__tests__/http-client.test.ts
@@ -46,7 +46,7 @@ describe("metaCatalogGraphClient error mapping", () => {
       metaCatalogGraphClient.get("v24.0/catalog-1/products"),
     ).rejects.toMatchObject({
       message:
-        "Invalid parameter — This catalog is not connected to a commerce account yet.",
+        "#(100 - 33) Invalid parameter. This catalog is not connected to a commerce account yet.",
       fbTraceId: "trace-1",
       graphCode: 100,
       graphSubcode: 33,

--- a/integrations/meta-catalog/package.json
+++ b/integrations/meta-catalog/package.json
@@ -8,6 +8,7 @@
     "@chatbotx.io/integration-messenger": "workspace:*",
     "@chatbotx.io/logger": "workspace:*",
     "@chatbotx.io/sdk": "workspace:*",
+    "@chatbotx.io/utils": "workspace:*",
     "ky": "^2.0.2",
     "zod": "^4.3.6"
   },

--- a/integrations/meta-catalog/src/lib/http-client.ts
+++ b/integrations/meta-catalog/src/lib/http-client.ts
@@ -1,3 +1,4 @@
+import { formatGraphError } from "@chatbotx.io/utils/graph-error"
 import ky, { isHTTPError, type KyInstance } from "ky"
 import { GRAPH_API_URL } from "../constants"
 import { MetaCatalogException } from "../exception"
@@ -36,26 +37,6 @@ type GraphErrorBody = {
     error_subcode?: number
     fbtrace_id?: string
   }
-}
-
-/**
- * Graph's `message` is written for developers ("Invalid parameter"); when it
- * also sends `error_user_msg` that one says what to actually do about it. Both
- * end up in the exception because the pair is what makes a failure in the sync
- * history diagnosable — dropping either leaves the workspace guessing.
- */
-const graphErrorMessage = (
-  error: GraphErrorBody["error"],
-): string | undefined => {
-  const parts = [
-    error?.message,
-    error?.error_user_msg ?? error?.error_user_title,
-  ]
-    .map((part) => part?.trim())
-    .filter((part): part is string => Boolean(part))
-  // Graph sometimes repeats itself across the two fields; a Set keeps the
-  // sentence from being printed twice.
-  return [...new Set(parts)].join(" — ") || undefined
 }
 
 export type GraphResponse<T> = {
@@ -101,7 +82,7 @@ class MetaCatalogHttpClient {
         // "Body has already been consumed" and bury the real Graph error.
         const body: GraphErrorBody = isRecord(error.data) ? error.data : {}
         throw new MetaCatalogException(
-          graphErrorMessage(body.error) ?? `Meta Graph request failed: ${url}`,
+          formatGraphError(body.error) ?? `Meta Graph request failed: ${url}`,
           error.response.status,
           body.error?.code,
           {

--- a/integrations/meta-conversions/src/exception.ts
+++ b/integrations/meta-conversions/src/exception.ts
@@ -1,3 +1,5 @@
+import { formatGraphErrorMessage } from "@chatbotx.io/utils/graph-error"
+
 const FALLBACK_HTTP_STATUS = 400
 
 type MetaErrorData = { details?: string }
@@ -130,7 +132,16 @@ export class MetaConversionsException extends Error {
     ),
     originError?: unknown,
   ) {
-    super(source.message ?? "Meta Conversions API call failed")
+    // The readonly fields below still carry each piece on its own; this is
+    // where they become the one string every surface reads.
+    super(
+      formatGraphErrorMessage({
+        code: source.code,
+        subCode: source.subCode,
+        message: source.message,
+        userMessage: source.userMessage ?? source.userTitle,
+      }) ?? "Meta Conversions API call failed",
+    )
     this.name = "MetaConversionsException"
     this.httpStatusCode = source.httpStatusCode
     this.code = source.code ?? "metaConversionsError"

--- a/integrations/whatsapp/__tests__/outgoing-template-params.test.ts
+++ b/integrations/whatsapp/__tests__/outgoing-template-params.test.ts
@@ -649,7 +649,10 @@ describe("raw Meta error surfacing", () => {
     const error = await rejectWith(400)
     expect(error).toBeInstanceOf(ChannelError)
     expect(error.code).toBe(100)
-    expect(error.message).toContain("(#100) Invalid parameter")
+    // Meta's own `(#100) ` prefix is folded into the one `#(code) ` prefix the
+    // formatter writes, so the code still reads once, not twice.
+    expect(error.message).toContain("#(100) Invalid parameter")
+    expect(error.message).not.toContain("#(100) (#100)")
   })
 
   test("getErrorData reports the real code and a categorized (non-unknown) error", async () => {

--- a/integrations/whatsapp/src/lib/error-mapper.ts
+++ b/integrations/whatsapp/src/lib/error-mapper.ts
@@ -3,6 +3,7 @@ import {
   ChannelErrorCategory,
   UNKNOWN_ERROR,
 } from "@chatbotx.io/sdk"
+import { formatGraphErrorMessage } from "@chatbotx.io/utils/graph-error"
 import {
   type ChannelErrorSource,
   parseOriginError,
@@ -177,7 +178,12 @@ function mapApiFields(fields: ChannelErrorSource): ChannelError {
   const category = categorize(numCode, fields.type)
 
   const channelError = new ChannelError(
-    fields.message ?? "WhatsApp API call failed",
+    formatGraphErrorMessage({
+      code: fields.code,
+      subCode: fields.subCode,
+      message: fields.message,
+      userMessage: fields.userMessage ?? fields.userTitle,
+    }) ?? "WhatsApp API call failed",
     category,
     {
       code: fields.code ?? UNKNOWN_ERROR.code,

--- a/packages/business/__tests__/errors.test.ts
+++ b/packages/business/__tests__/errors.test.ts
@@ -96,6 +96,23 @@ describe("toPublicErrorMessage", () => {
     )
   })
 
+  test("prints the user sentence once when the mapper already composed it into the message", () => {
+    // WhatsApp's mapper folds `error_user_msg` into `ChannelError.message` and
+    // still parks a copy on `originError` for its structured fields.
+    const error = new ChannelError(
+      "#(133010) Phone number is not verified. Phone number is not verified through SMS or voice.",
+      ChannelErrorCategory.AUTH_FAILED,
+      { code: 133_010 },
+    ).setOriginError({
+      userTitle: "Phone number is not verified",
+      userMessage: "Phone number is not verified through SMS or voice.",
+    })
+
+    expect(toPublicErrorMessage(error, FALLBACK)).toBe(
+      "#(133010) Phone number is not verified. Phone number is not verified through SMS or voice.",
+    )
+  })
+
   test("falls back to the title when the channel gave no user message", () => {
     const error = new ChannelError(
       "Messenger API call failed",

--- a/packages/business/src/errors.ts
+++ b/packages/business/src/errors.ts
@@ -73,9 +73,12 @@ const channelErrorMessage = (error: unknown): string | undefined => {
   const detail =
     trimmedText(origin?.userMessage) ?? trimmedText(origin?.userTitle)
   const base = trimmedText(error.message)
-  const text = [base, detail === base ? undefined : detail]
-    .filter(Boolean)
-    .join(": ")
+  // Channel mappers that compose Meta's user sentence into `message` still park
+  // a copy on `originError` for its structured fields, so appending it here
+  // unconditionally would print that sentence twice.
+  const extra =
+    detail !== undefined && base?.includes(detail) ? undefined : detail
+  const text = [base, extra].filter(Boolean).join(": ")
   if (!text) {
     return
   }

--- a/packages/utils/__tests__/graph-error.test.ts
+++ b/packages/utils/__tests__/graph-error.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest"
+import { formatGraphErrorMessage } from "../src/graph-error"
+
+describe("formatGraphErrorMessage", () => {
+  it("keeps the code, the subcode, and both sentences", () => {
+    // The reported Messenger failure, verbatim.
+    expect(
+      formatGraphErrorMessage({
+        code: 10,
+        subCode: 1_893_063,
+        message: "Application does not have permission for this action",
+        userMessage:
+          "Bạn tạm thời bị hạn chế gửi tin nhắn. Tìm hiểu thêm về thời gian và lý do chúng tôi hạn chế khả năng nhắn tin.",
+      }),
+    ).toBe(
+      "#(10 - 1893063) Application does not have permission for this action. Bạn tạm thời bị hạn chế gửi tin nhắn. Tìm hiểu thêm về thời gian và lý do chúng tôi hạn chế khả năng nhắn tin.",
+    )
+  })
+
+  it("prints the code alone when Meta sent no subcode", () => {
+    expect(
+      formatGraphErrorMessage({
+        code: 190,
+        message: "Access token expired",
+      }),
+    ).toBe("#(190) Access token expired")
+  })
+
+  it("writes no prefix at all when there is no code", () => {
+    expect(formatGraphErrorMessage({ message: "boom" })).toBe("boom")
+  })
+
+  it("treats the -1 unknown sentinel as no code, never as #(-1)", () => {
+    expect(
+      formatGraphErrorMessage({ code: -1, subCode: -1, message: "boom" }),
+    ).toBe("boom")
+  })
+
+  it("ignores our own placeholder codes, which identify nothing", () => {
+    expect(
+      formatGraphErrorMessage({
+        code: "messengerError",
+        message: "Messenger API call failed",
+      }),
+    ).toBe("Messenger API call failed")
+  })
+
+  it("reads a numeric subcode sent as a string", () => {
+    expect(
+      formatGraphErrorMessage({ code: 100, subCode: "33", message: "boom" }),
+    ).toBe("#(100 - 33) boom")
+  })
+
+  it("prints a repeated sentence only once", () => {
+    expect(
+      formatGraphErrorMessage({
+        message: "Token expired",
+        userMessage: "Token expired",
+      }),
+    ).toBe("Token expired")
+  })
+
+  it("does not add a second period to a message that already ends in one", () => {
+    expect(
+      formatGraphErrorMessage({
+        code: 4,
+        message: "Rate limit reached.",
+        userMessage: "Try again later.",
+      }),
+    ).toBe("#(4) Rate limit reached. Try again later.")
+  })
+
+  it("uses whichever sentence Meta sent when only one is present", () => {
+    expect(
+      formatGraphErrorMessage({ code: 10, userMessage: "Bạn bị hạn chế" }),
+    ).toBe("#(10) Bạn bị hạn chế")
+  })
+
+  it("does not repeat the code Meta already put in front of its own message", () => {
+    expect(
+      formatGraphErrorMessage({
+        code: 100,
+        subCode: 2_018_001,
+        message: "(#100) Param recipient[id] must be a valid ID string",
+      }),
+    ).toBe("#(100 - 2018001) Param recipient[id] must be a valid ID string")
+  })
+
+  it("keeps a bracketed code that belongs to some other failure", () => {
+    expect(
+      formatGraphErrorMessage({
+        code: 100,
+        message: "(#190) Access token expired",
+      }),
+    ).toBe("#(100) (#190) Access token expired")
+  })
+
+  it("falls back to the caller's text when the code prefix was the whole message", () => {
+    expect(
+      formatGraphErrorMessage({ code: 100, message: "(#100)" }),
+    ).toBeUndefined()
+  })
+
+  it("returns undefined when the body carried no text, so callers can fall back", () => {
+    expect(formatGraphErrorMessage({ code: 10 })).toBeUndefined()
+    expect(formatGraphErrorMessage({ message: "   " })).toBeUndefined()
+    expect(formatGraphErrorMessage({})).toBeUndefined()
+  })
+})

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -23,6 +23,7 @@
     "./custom-field": "./src/custom-field.ts",
     "./datetime": "./src/datetime.ts",
     "./error-log": "./src/error-log.ts",
+    "./graph-error": "./src/graph-error.ts",
     "./id": "./src/id.ts",
     "./meta-capi": "./src/meta-capi.ts",
     "./temporal-input": "./src/temporal-input/index.ts",

--- a/packages/utils/src/graph-error.ts
+++ b/packages/utils/src/graph-error.ts
@@ -1,0 +1,145 @@
+/**
+ * Meta's Graph errors carry four useful pieces and every integration used to
+ * throw away two of them: `code`/`error_subcode` had nowhere to go (`ErrorLog`
+ * has no columns for them), and the developer-facing `message` was discarded
+ * whenever `error_user_msg` was present.
+ *
+ * `#(10 - 1893063) Application does not have permission for this action. <the
+ * sentence Meta wrote for the user>` keeps all four in the one `text` column
+ * every surface already reads — the error-log table, the inbox's failed-message
+ * tooltip, and the app logger.
+ */
+
+export type GraphErrorSource = {
+  code?: number | string | null
+  subCode?: number | string | null
+  /** Graph's `error.message` — written for developers ("Invalid parameter"). */
+  message?: string
+  /** Graph's `error_user_msg`, or `error_user_title` when only that was sent. */
+  userMessage?: string
+}
+
+/**
+ * `UNKNOWN_ERROR` in `@chatbotx.io/sdk` uses -1 for "no code", and an
+ * `SdkException` built without one reports -1 too. Printing `#(-1 - -1)` would
+ * dress up an absent code as a real one.
+ */
+const UNKNOWN_CODE = -1
+
+/**
+ * Only a real number becomes part of the prefix. Codes like `"messengerError"`
+ * and `"channelError"` are our own placeholders, not Meta's — they identify
+ * nothing a workspace or Meta's docs can look up.
+ */
+const toCode = (
+  value: number | string | null | undefined,
+): number | undefined => {
+  if (value === null || value === undefined) {
+    return
+  }
+  if (typeof value === "string" && value.trim().length === 0) {
+    return
+  }
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed === UNKNOWN_CODE) {
+    return
+  }
+  return parsed
+}
+
+const codePrefix = (
+  code: number | undefined,
+  subCode: number | undefined,
+): string => {
+  if (code === undefined) {
+    // No code at all — a plain thrown `Error`, a non-Meta provider. The row
+    // reads exactly as it did before this format existed.
+    return ""
+  }
+  return subCode === undefined ? `#(${code}) ` : `#(${code} - ${subCode}) `
+}
+
+/**
+ * Meta already opens most Graph messages with its own `(#100) `. Ours wins —
+ * it is the only one that also carries the subcode — so its copy is stripped
+ * rather than printed a second time as `#(100 - 2018001) (#100) …`.
+ *
+ * Only an exact code match is removed: a `(#190)` sitting in front of a body we
+ * read the code `100` from is Meta quoting some other failure, not a duplicate.
+ */
+const META_CODE_PREFIX = /^\(#(\d+)\)\s*/
+
+const withoutMetaCodePrefix = (
+  part: string | undefined,
+  code: number | undefined,
+): string | undefined => {
+  if (part === undefined || code === undefined) {
+    return part
+  }
+  const match = META_CODE_PREFIX.exec(part)
+  if (match === null || Number(match[1]) !== code) {
+    return part
+  }
+  // `(#100)` with nothing behind it carried no sentence; returning "" lets the
+  // caller's own fallback text stand instead of a bare prefix.
+  return part.slice(match[0].length)
+}
+
+/** Graph's `message` often already ends in punctuation; `action.. Bạn` is not a sentence. */
+const SENTENCE_END = /[.!?…]$/
+
+const joinSentences = (first: string, second: string): string =>
+  SENTENCE_END.test(first) ? `${first} ${second}` : `${first}. ${second}`
+
+/**
+ * Composes one Graph failure into the stored/displayed string.
+ *
+ * Returns `undefined` when the body carried no text at all, so every caller
+ * keeps its own `?? "<endpoint> failed"` fallback rather than rendering a bare
+ * code prefix.
+ */
+export function formatGraphErrorMessage(
+  source: GraphErrorSource,
+): string | undefined {
+  const code = toCode(source.code)
+  const sentences = [source.message, source.userMessage]
+    .map((part) => withoutMetaCodePrefix(part, code)?.trim())
+    .filter((part): part is string => Boolean(part))
+
+  // Graph repeats itself across the two fields often enough that printing the
+  // same sentence twice would be the common case, not the edge case.
+  const unique = [...new Set(sentences)]
+  if (unique.length === 0) {
+    return
+  }
+
+  return `${codePrefix(code, toCode(source.subCode))}${unique.reduce(joinSentences)}`
+}
+
+/** Graph's `error` object, spelled the way it arrives on the wire. */
+export type GraphErrorFields = {
+  code?: number | string | null
+  error_subcode?: number | string | null
+  /** Some endpoints spell the subcode without the `error_` prefix. */
+  subcode?: number | string | null
+  message?: string
+  error_user_title?: string
+  error_user_msg?: string
+}
+
+/**
+ * `formatGraphErrorMessage` for a raw Graph `error` body. Keeps the
+ * `error_subcode`/`subcode` and `error_user_msg`/`error_user_title` fallbacks
+ * in one place rather than once per integration.
+ */
+export function formatGraphError(error?: GraphErrorFields): string | undefined {
+  if (!error) {
+    return
+  }
+  return formatGraphErrorMessage({
+    code: error.code,
+    subCode: error.error_subcode ?? error.subcode,
+    message: error.message,
+    userMessage: error.error_user_msg ?? error.error_user_title,
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1071,6 +1071,9 @@ importers:
       '@chatbotx.io/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
+      '@chatbotx.io/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
       ky:
         specifier: ^2.0.2
         version: 2.0.2
@@ -1456,6 +1459,9 @@ importers:
       '@chatbotx.io/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
+      '@chatbotx.io/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
       ky:
         specifier: ^2.0.2
         version: 2.0.2


### PR DESCRIPTION
Every Meta integration threw away half of each Graph failure: `code` and `error_subcode` had nowhere to go (`ErrorLog` has no columns for them), and the developer-facing `message` was discarded whenever `error_user_msg` was present.

`formatGraphError` in `@chatbotx.io/utils` composes all four into the one `text` column the error-log table, the inbox failed-message tooltip and the app logger already read, and replaces the per-integration `pickErrorMessage` copies.

Meta already opens most Graph messages with its own `(#100) `, so that copy is stripped rather than printed twice. `channelErrorMessage` now skips an `originError` detail the composed message already contains, for the same reason.