### PR TITLE
refactor(builder): move ai feature data access into business services

### DIFF
--- a/apps/builder/__tests__/ai-files-actions.test.ts
+++ b/apps/builder/__tests__/ai-files-actions.test.ts
@@ -1,15 +1,8 @@
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
-  auditRecord: vi.fn(),
-  deleteObject: vi.fn(),
-  findFirstGemini: vi.fn(),
-  findFirstOpenai: vi.fn(),
-  findOrFail: vi.fn(),
-  insertReturning: vi.fn(),
-  loggerWarn: vi.fn(),
-  queueAdd: vi.fn(),
-  txDeleteWhere: vi.fn(),
+  create: vi.fn(),
+  delete: vi.fn(),
 }))
 
 vi.mock("@/lib/safe-action", () => {
@@ -24,31 +17,33 @@ vi.mock("@/features/common/schema", () => ({
   workspaceIdrequestParams: [],
 }))
 
-vi.mock("@/lib/log", () => ({
-  logger: { warn: mocks.loggerWarn },
-}))
-
-vi.mock("@chatbotx.io/business/audit", () => ({
-  auditService: { record: mocks.auditRecord },
+vi.mock("@chatbotx.io/business", () => ({
+  aiFileService: {
+    create: mocks.create,
+    delete: mocks.delete,
+  },
 }))
 
 vi.mock("@chatbotx.io/business/errors", () => ({
-  ChatbotXException: class ChatbotXException extends Error {},
-}))
+  ChatbotXException: class ChatbotXException extends Error {
+    code = "systemError"
+    httpStatusCode = 400
 
-vi.mock("@chatbotx.io/filesystem", () => ({
-  uploader: { deleteObject: mocks.deleteObject },
+    constructor(message: string, code?: string, httpStatusCode?: number) {
+      super(message)
+      this.name = "ChatbotXException"
+      if (code) {
+        this.code = code
+      }
+      if (httpStatusCode) {
+        this.httpStatusCode = httpStatusCode
+      }
+    }
+  },
 }))
 
 vi.mock("@chatbotx.io/utils", () => ({
-  createId: () => "file-1",
   zodBigintAsString: () => "mocked-schema",
-}))
-
-vi.mock("@chatbotx.io/worker-config", () => ({
-  HeavyJobAction: { processAIFile: "processAIFile" },
-  getHeavyJobOptions: () => ({}),
-  heavyQueue: { add: mocks.queueAdd },
 }))
 
 vi.mock("next-intl/server", () => ({
@@ -59,33 +54,11 @@ vi.mock("../src/features/ai-files/schema", () => ({
   createAIFileRequest: {},
 }))
 
-vi.mock("@chatbotx.io/database/schema", () => ({
-  aiEmbeddingModel: { id: "id" },
-  aiFileModel: { id: "id" },
-}))
-
-vi.mock("@chatbotx.io/database/client", () => ({
-  db: {
-    delete: vi.fn(() => ({ where: mocks.txDeleteWhere })),
-    insert: vi.fn(() => ({
-      values: vi.fn(() => ({ returning: mocks.insertReturning })),
-    })),
-    query: {
-      integrationGeminiModel: { findFirst: mocks.findFirstGemini },
-      integrationOpenaiModel: { findFirst: mocks.findFirstOpenai },
-    },
-    transaction: vi.fn(async (callback: (tx: unknown) => unknown) =>
-      callback({ delete: vi.fn(() => ({ where: mocks.txDeleteWhere })) }),
-    ),
-  },
-  eq: vi.fn((field: unknown, value: unknown) => ({ field, value })),
-  findOrFail: mocks.findOrFail,
-}))
-
+const { ChatbotXException } = await import("@chatbotx.io/business/errors")
 const { createAIFileAction } = await import(
   "@/features/ai-files/actions/create-ai-file.action"
 )
-const { deleteAIFile } = await import(
+const { deleteAIFileAction } = await import(
   "@/features/ai-files/actions/delete-ai-file.action"
 )
 
@@ -98,74 +71,97 @@ const workspaceId = "workspace-1"
 
 beforeEach(() => {
   vi.clearAllMocks()
-  mocks.findFirstOpenai.mockResolvedValue({ id: "openai-1" })
-  mocks.findFirstGemini.mockResolvedValue(undefined)
-  mocks.insertReturning.mockResolvedValue([{ id: "file-1" }])
-  mocks.findOrFail.mockResolvedValue({ id: "file-1", path: "path/to/file" })
 })
 
-describe("Knowledge tab audit messages", () => {
-  test("allows creating a Knowledge with Gemini as the only provider", async () => {
-    mocks.findFirstOpenai.mockResolvedValue(undefined)
-    mocks.findFirstGemini.mockResolvedValue({ id: "gemini-1" })
+describe("createAIFileAction", () => {
+  test("forwards workspaceId + parsedInput to aiFileService.create", async () => {
+    mocks.create.mockResolvedValue({ id: "file-1" })
 
     await (
-      createAIFileAction as unknown as ActionHandler<{ name: string }, [string]>
+      createAIFileAction as unknown as ActionHandler<
+        { name: string; path: string; mimeType: string; size: number },
+        [string]
+      >
     )({
-      parsedInput: { name: "manual.pdf" },
-      bindArgsParsedInputs: [workspaceId],
-    })
-
-    expect(mocks.insertReturning).toHaveBeenCalled()
-    expect(mocks.queueAdd).toHaveBeenCalled()
-  })
-
-  test("createAIFileAction logs created a new Knowledge by id", async () => {
-    await (
-      createAIFileAction as unknown as ActionHandler<{ name: string }, [string]>
-    )({
-      parsedInput: { name: "manual.pdf" },
-      bindArgsParsedInputs: [workspaceId],
-    })
-
-    expect(mocks.auditRecord).toHaveBeenCalledWith({
-      workspaceId,
-      action: "create",
-      detail: "created a new Knowledge (#file-1)",
-    })
-    expect(mocks.queueAdd).toHaveBeenCalledWith(
-      "processAIFile",
-      {
-        type: "processAIFile",
-        data: { aiFileId: "file-1" },
+      parsedInput: {
+        name: "manual.pdf",
+        path: "path/to/file",
+        mimeType: "application/pdf",
+        size: 100,
       },
-      { jobId: "heavy-ai-file-file-1" },
-    )
-  })
-
-  test("deleteAIFile logs deleted a Knowledge by id", async () => {
-    await deleteAIFile({ workspaceId, id: "file-1" })
-
-    expect(mocks.auditRecord).toHaveBeenCalledWith({
-      workspaceId,
-      action: "delete",
-      detail: "deleted a Knowledge (#file-1)",
-    })
-  })
-
-  test("does not log the legacy AI Agent knowledge base message", async () => {
-    await (
-      createAIFileAction as unknown as ActionHandler<{ name: string }, [string]>
-    )({
-      parsedInput: { name: "manual.pdf" },
       bindArgsParsedInputs: [workspaceId],
     })
-    await deleteAIFile({ workspaceId, id: "file-1" })
 
-    for (const call of mocks.auditRecord.mock.calls) {
-      expect(call[0].detail).not.toContain(
-        "updated the AI Agent knowledge base",
-      )
-    }
+    expect(mocks.create).toHaveBeenCalledWith({
+      workspaceId,
+      name: "manual.pdf",
+      path: "path/to/file",
+      mimeType: "application/pdf",
+      size: 100,
+    })
+  })
+
+  test("translates a noEmbeddingProvider service error", async () => {
+    mocks.create.mockRejectedValue(
+      new ChatbotXException(
+        "AI file requires an embedding provider",
+        "noEmbeddingProvider",
+        400,
+      ),
+    )
+
+    await expect(
+      (
+        createAIFileAction as unknown as ActionHandler<
+          { name: string; path: string; mimeType: string; size: number },
+          [string]
+        >
+      )({
+        parsedInput: {
+          name: "manual.pdf",
+          path: "path/to/file",
+          mimeType: "application/pdf",
+          size: 100,
+        },
+        bindArgsParsedInputs: [workspaceId],
+      }),
+    ).rejects.toMatchObject({ message: "noEmbeddingProvider" })
+  })
+
+  test("rethrows other service errors untranslated", async () => {
+    mocks.create.mockRejectedValue(new Error("db exploded"))
+
+    await expect(
+      (
+        createAIFileAction as unknown as ActionHandler<
+          { name: string; path: string; mimeType: string; size: number },
+          [string]
+        >
+      )({
+        parsedInput: {
+          name: "manual.pdf",
+          path: "path/to/file",
+          mimeType: "application/pdf",
+          size: 100,
+        },
+        bindArgsParsedInputs: [workspaceId],
+      }),
+    ).rejects.toMatchObject({ message: "db exploded" })
+  })
+})
+
+describe("deleteAIFileAction", () => {
+  test("forwards workspaceId + id to aiFileService.delete", async () => {
+    await (
+      deleteAIFileAction as unknown as ActionHandler<
+        undefined,
+        [string, string]
+      >
+    )({
+      parsedInput: undefined,
+      bindArgsParsedInputs: [workspaceId, "file-1"],
+    })
+
+    expect(mocks.delete).toHaveBeenCalledWith({ workspaceId, id: "file-1" })
   })
 })

--- a/apps/builder/__tests__/ai-triggers-actions.test.ts
+++ b/apps/builder/__tests__/ai-triggers-actions.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// AI Triggers create/duplicate/list actions — thin wrappers delegating to
+// aiTriggerService. `list` still gates on assertCurrentUserCanAccessChatbot
+// before calling the service.
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  assertCurrentUserCanAccessChatbot: vi.fn(),
+  create: vi.fn(),
+  duplicate: vi.fn(),
+  list: vi.fn(),
+}))
+
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, unknown> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.inputSchema = () => chain
+  chain.action = (fn: unknown) => fn
+  return { workspaceActionClient: chain }
+})
+
+vi.mock("@/features/common/schema", () => ({
+  workspaceIdrequestParams: [],
+}))
+
+vi.mock("@/features/ai-triggers/schema/action", () => ({
+  createAITriggerRequest: {},
+}))
+
+vi.mock("@/lib/auth/utils", () => ({
+  assertCurrentUserCanAccessChatbot: mocks.assertCurrentUserCanAccessChatbot,
+}))
+
+vi.mock("@chatbotx.io/utils", () => ({
+  zodBigintAsString: () => "mocked-schema",
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  aiTriggerService: {
+    create: mocks.create,
+    duplicate: mocks.duplicate,
+    list: mocks.list,
+  },
+}))
+
+const { createAITriggerAction } = await import(
+  "@/features/ai-triggers/actions/create.action"
+)
+const { duplicateAITriggerAction } = await import(
+  "@/features/ai-triggers/actions/duplicate.action"
+)
+const { listAITriggers } = await import(
+  "@/features/ai-triggers/actions/list.action"
+)
+
+type ActionHandler<TParsedInput, TBindArgs extends unknown[]> = (props: {
+  parsedInput: TParsedInput
+  bindArgsParsedInputs: TBindArgs
+}) => Promise<unknown>
+
+const workspaceId = "workspace-1"
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("createAITriggerAction", () => {
+  test("delegates to aiTriggerService.create with workspaceId + parsedInput", async () => {
+    const parsedInput = {
+      name: "New trigger",
+      description: null,
+      questions: [],
+      flowId: null,
+      finalMessage: null,
+    }
+
+    await (
+      createAITriggerAction as unknown as ActionHandler<
+        typeof parsedInput,
+        [string]
+      >
+    )({
+      parsedInput,
+      bindArgsParsedInputs: [workspaceId],
+    })
+
+    expect(mocks.create).toHaveBeenCalledWith({
+      workspaceId,
+      data: parsedInput,
+    })
+  })
+})
+
+describe("duplicateAITriggerAction", () => {
+  test("delegates to aiTriggerService.duplicate with workspaceId + id", async () => {
+    await (
+      duplicateAITriggerAction as unknown as ActionHandler<
+        undefined,
+        [string, string]
+      >
+    )({
+      parsedInput: undefined,
+      bindArgsParsedInputs: [workspaceId, "trigger-1"],
+    })
+
+    expect(mocks.duplicate).toHaveBeenCalledWith({
+      workspaceId,
+      id: "trigger-1",
+    })
+  })
+})
+
+describe("listAITriggers", () => {
+  test("asserts chatbot access then delegates to aiTriggerService.list", async () => {
+    const input = {
+      workspaceId,
+      page: 1,
+      perPage: 20,
+      sort: [],
+      name: "",
+    }
+    mocks.list.mockResolvedValue({ data: [], pageCount: 0 })
+
+    const result = await listAITriggers(input)
+
+    expect(mocks.assertCurrentUserCanAccessChatbot).toHaveBeenCalledWith(
+      workspaceId,
+    )
+    expect(mocks.list).toHaveBeenCalledWith(input)
+    expect(result).toEqual({ data: [], pageCount: 0 })
+  })
+})

--- a/apps/builder/__tests__/integration-llm-connect-actions.test.ts
+++ b/apps/builder/__tests__/integration-llm-connect-actions.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// The four LLM provider connect actions (Claude, DeepSeek, Gemini, OpenAI) —
+// thin wrappers that verify the API key, then delegate to the provider's
+// business-layer connect() and invalidate the AI cache. No db/schema
+// imports remain in these actions.
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  connectClaude: vi.fn(),
+  connectDeepSeek: vi.fn(),
+  connectGemini: vi.fn(),
+  connectOpenAI: vi.fn(),
+  invalidateCache: vi.fn(),
+  returnValidationErrors: vi.fn(
+    (_schema: unknown, errors: Record<string, unknown>) => ({
+      validationErrors: errors,
+    }),
+  ),
+  verifyClaudeApiKey: vi.fn(),
+  verifyDeepSeekApiKey: vi.fn(),
+  verifyAiProviderApiKey: vi.fn(),
+}))
+
+vi.mock("@/lib/safe-action", () => {
+  const chain: Record<string, unknown> = {}
+  chain.bindArgsSchemas = () => chain
+  chain.inputSchema = () => chain
+  chain.action = (fn: unknown) => fn
+  return { workspaceActionClient: chain, authActionClient: chain }
+})
+
+vi.mock("@/features/common/schema", () => ({
+  workspaceIdrequestParams: [],
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  integrationClaudeService: { connect: mocks.connectClaude },
+  integrationDeepSeekService: { connect: mocks.connectDeepSeek },
+  integrationGeminiService: { connect: mocks.connectGemini },
+  integrationOpenAIService: { connect: mocks.connectOpenAI },
+}))
+
+vi.mock("@chatbotx.io/ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@chatbotx.io/ai")>()
+  return {
+    ...actual,
+    aiProviders: {
+      enum: {
+        claude: "claude",
+        deepseek: "deepseek",
+        gemini: "gemini",
+        openai: "openai",
+      },
+    },
+  }
+})
+
+vi.mock("@chatbotx.io/ai/server", () => ({
+  aiIntegrationService: { invalidateCache: mocks.invalidateCache },
+}))
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: vi.fn(async () => (key: string) => key),
+}))
+
+vi.mock("next-safe-action", () => ({
+  returnValidationErrors: mocks.returnValidationErrors,
+}))
+
+vi.mock("../src/features/integration-claude/lib", () => ({
+  verifyClaudeApiKey: mocks.verifyClaudeApiKey,
+}))
+vi.mock("../src/features/integration-deepseek/lib", () => ({
+  verifyDeepSeekApiKey: mocks.verifyDeepSeekApiKey,
+}))
+vi.mock("../src/features/integration-ai/lib/verify-api-key", () => ({
+  verifyAiProviderApiKey: mocks.verifyAiProviderApiKey,
+}))
+
+const { connectClaudeAction } = await import(
+  "@/features/integration-claude/actions/connect.action"
+)
+const { connectDeepSeekAction } = await import(
+  "@/features/integration-deepseek/actions/connect.action"
+)
+const { connectGeminiAction } = await import(
+  "@/features/integration-gemini/actions/connect.action"
+)
+const { connectOpenAIAction } = await import(
+  "@/features/integration-openai/actions/connect.action"
+)
+
+type ActionHandler<TParsedInput, TBindArgs extends unknown[]> = (props: {
+  parsedInput: TParsedInput
+  bindArgsParsedInputs: TBindArgs
+}) => Promise<unknown>
+
+const workspaceId = "workspace-1"
+
+const baseInput = {
+  apiKey: "secret-key",
+  model: "some-model",
+  temperature: 0.4,
+  maxOutputTokens: 1024,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe.each([
+  {
+    action: () => connectClaudeAction,
+    connect: mocks.connectClaude,
+    expectedProviderArg: "claude",
+    label: "Claude",
+    verify: mocks.verifyClaudeApiKey,
+  },
+  {
+    action: () => connectDeepSeekAction,
+    connect: mocks.connectDeepSeek,
+    expectedProviderArg: "deepseek",
+    label: "DeepSeek",
+    verify: mocks.verifyDeepSeekApiKey,
+  },
+  {
+    action: () => connectGeminiAction,
+    connect: mocks.connectGemini,
+    expectedProviderArg: "gemini",
+    label: "Gemini",
+    verify: mocks.verifyAiProviderApiKey,
+  },
+  {
+    action: () => connectOpenAIAction,
+    connect: mocks.connectOpenAI,
+    expectedProviderArg: "openai",
+    label: "OpenAI",
+    verify: mocks.verifyAiProviderApiKey,
+  },
+])("$label connect action", ({
+  action,
+  connect,
+  expectedProviderArg,
+  verify,
+}) => {
+  test("returns a validation error and never calls connect when the key is invalid", async () => {
+    verify.mockResolvedValue(false)
+
+    const result = await (
+      action() as unknown as ActionHandler<typeof baseInput, [string]>
+    )({
+      parsedInput: baseInput,
+      bindArgsParsedInputs: [workspaceId],
+    })
+
+    expect(result).toEqual({
+      validationErrors: {
+        apiKey: { _errors: ["validation.invalidApiKey"] },
+      },
+    })
+    expect(connect).not.toHaveBeenCalled()
+    expect(mocks.invalidateCache).not.toHaveBeenCalled()
+  })
+
+  test("connects then invalidates the AI cache for the right provider when the key is valid", async () => {
+    verify.mockResolvedValue(true)
+
+    await (action() as unknown as ActionHandler<typeof baseInput, [string]>)({
+      parsedInput: baseInput,
+      bindArgsParsedInputs: [workspaceId],
+    })
+
+    expect(connect).toHaveBeenCalledWith({
+      workspaceId,
+      apiKey: baseInput.apiKey,
+      model: baseInput.model,
+      temperature: baseInput.temperature,
+      maxOutputTokens: baseInput.maxOutputTokens,
+    })
+    expect(mocks.invalidateCache).toHaveBeenCalledWith(
+      workspaceId,
+      expectedProviderArg,
+    )
+  })
+})

--- a/apps/builder/src/features/ai-files/actions/create-ai-file.action.ts
+++ b/apps/builder/src/features/ai-files/actions/create-ai-file.action.ts
@@ -1,15 +1,7 @@
 "use server"
 
-import { auditService } from "@chatbotx.io/business/audit"
+import { aiFileService } from "@chatbotx.io/business"
 import { ChatbotXException } from "@chatbotx.io/business/errors"
-import { db } from "@chatbotx.io/database/client"
-import { aiFileModel } from "@chatbotx.io/database/schema"
-import { createId } from "@chatbotx.io/utils"
-import {
-  getHeavyJobOptions,
-  HeavyJobAction,
-  heavyQueue,
-} from "@chatbotx.io/worker-config"
 import { getTranslations } from "next-intl/server"
 import { workspaceIdrequestParams } from "@/features/common/schema"
 import { workspaceActionClient } from "@/lib/safe-action"
@@ -21,47 +13,16 @@ export const createAIFileAction = workspaceActionClient
   .action(async ({ bindArgsParsedInputs, parsedInput }) => {
     const [workspaceId] = bindArgsParsedInputs
 
-    const hasOpenAI = await db.query.integrationOpenaiModel.findFirst({
-      where: { workspaceId },
-      columns: { id: true },
-    })
-    const hasGemini = await db.query.integrationGeminiModel.findFirst({
-      where: { workspaceId },
-      columns: { id: true },
-    })
-
-    if (!(hasOpenAI || hasGemini)) {
-      const t = await getTranslations("aiFiles")
-      throw new ChatbotXException(t("noEmbeddingProvider"))
+    try {
+      await aiFileService.create({ workspaceId, ...parsedInput })
+    } catch (error) {
+      if (
+        error instanceof ChatbotXException &&
+        error.code === "noEmbeddingProvider"
+      ) {
+        const t = await getTranslations("aiFiles")
+        throw new ChatbotXException(t("noEmbeddingProvider"))
+      }
+      throw error
     }
-
-    const created = await db
-      .insert(aiFileModel)
-      .values({
-        ...parsedInput,
-        id: createId(),
-        workspaceId,
-      })
-      .returning({ id: aiFileModel.id })
-
-    // Enqueue embedding job right after creation
-    await heavyQueue.add(
-      HeavyJobAction.processAIFile,
-      {
-        type: HeavyJobAction.processAIFile,
-        data: {
-          aiFileId: created[0].id,
-        },
-      },
-      {
-        ...getHeavyJobOptions(HeavyJobAction.processAIFile),
-        jobId: `heavy-ai-file-${created[0].id}`,
-      },
-    )
-
-    await auditService.record({
-      workspaceId,
-      action: "create",
-      detail: `created a new Knowledge (#${created[0].id})`,
-    })
   })

--- a/apps/builder/src/features/ai-files/actions/delete-ai-file.action.ts
+++ b/apps/builder/src/features/ai-files/actions/delete-ai-file.action.ts
@@ -1,11 +1,7 @@
 "use server"
 
-import { auditService } from "@chatbotx.io/business/audit"
-import { db, eq, findOrFail } from "@chatbotx.io/database/client"
-import { aiEmbeddingModel, aiFileModel } from "@chatbotx.io/database/schema"
-import { uploader } from "@chatbotx.io/filesystem"
+import { aiFileService } from "@chatbotx.io/business"
 import { zodBigintAsString } from "@chatbotx.io/utils"
-import { logger } from "@/lib/log"
 import { workspaceActionClient } from "@/lib/safe-action"
 
 export const deleteAIFileAction = workspaceActionClient
@@ -15,35 +11,5 @@ export const deleteAIFileAction = workspaceActionClient
       bindArgsParsedInputs: [workspaceId, id],
     } = props
 
-    return await deleteAIFile({ workspaceId, id })
+    return await aiFileService.delete({ workspaceId, id })
   })
-
-export const deleteAIFile = async (ctx: {
-  workspaceId: string
-  id: string
-}) => {
-  const targetAIFile = await findOrFail({
-    table: aiFileModel,
-    where: {
-      id: ctx.id,
-      workspaceId: ctx.workspaceId,
-    },
-    message: `AIFile with id ${ctx.id} not found`,
-  })
-
-  try {
-    await db.transaction(async (tx) => {
-      await uploader.deleteObject(targetAIFile.path)
-      await tx.delete(aiEmbeddingModel).where(eq(aiEmbeddingModel.id, ctx.id))
-      await tx.delete(aiFileModel).where(eq(aiFileModel.id, ctx.id))
-    })
-
-    await auditService.record({
-      workspaceId: ctx.workspaceId,
-      action: "delete",
-      detail: `deleted a Knowledge (#${ctx.id})`,
-    })
-  } catch (error) {
-    logger.warn(error, `deleteAIFileAction failed for id: ${ctx.id}`)
-  }
-}

--- a/apps/builder/src/features/ai-files/queries/index.ts
+++ b/apps/builder/src/features/ai-files/queries/index.ts
@@ -1,8 +1,6 @@
 "use server"
 
-import { db } from "@chatbotx.io/database/client"
-import type { AIEmbeddingStatus } from "@chatbotx.io/database/partials"
-import { uploader } from "@chatbotx.io/filesystem"
+import { aiFileService } from "@chatbotx.io/business"
 import { assertCurrentUserCanAccessChatbot } from "@/lib/auth/utils"
 import type { ListAIFilesRequest, ListAIFilesResponse } from "../schema"
 
@@ -11,50 +9,9 @@ export async function listAIFiles(
 ): Promise<ListAIFilesResponse> {
   await assertCurrentUserCanAccessChatbot(input.workspaceId)
 
-  const data = await db.query.aiFileModel.findMany({
-    where: {
+  return {
+    data: await aiFileService.listWithEmbeddingStatus({
       workspaceId: input.workspaceId,
-    },
-    with: {
-      aiEmbeddings: {
-        columns: {
-          id: true,
-          status: true,
-        },
-      },
-    },
-  })
-
-  const transformedData = await Promise.all(
-    data.map(async (file) => {
-      const hasEmbeddings = file.aiEmbeddings.length > 0
-      let processingStatus: AIEmbeddingStatus = "pending"
-      if (hasEmbeddings) {
-        const statusSet = new Set(file.aiEmbeddings.map((e) => e.status))
-        if (statusSet.has("error")) {
-          processingStatus = "error"
-        } else if (statusSet.has("pending")) {
-          processingStatus = "processing"
-        } else {
-          processingStatus = "success"
-        }
-      }
-
-      return {
-        id: file.id,
-        createdAt: file.createdAt,
-        updatedAt: file.updatedAt,
-        workspaceId: file.workspaceId,
-        mimeType: file.mimeType,
-        size: file.size,
-        name: file.name,
-        path: file.path,
-        url: await uploader.getPresignedDownload(file.path),
-        chunksCount: file.aiEmbeddings.length,
-        processingStatus,
-      }
     }),
-  )
-
-  return { data: transformedData }
+  }
 }

--- a/apps/builder/src/features/ai-files/schema/index.ts
+++ b/apps/builder/src/features/ai-files/schema/index.ts
@@ -1,9 +1,6 @@
-import {
-  type AIEmbeddingStatus,
-  aiEmbeddingStatuses,
-} from "@chatbotx.io/database/partials"
+import type { AIFileWithEmbeddingStatus } from "@chatbotx.io/business"
+import { aiEmbeddingStatuses } from "@chatbotx.io/database/partials"
 import { aiFileModel, createSelectSchema } from "@chatbotx.io/database/schema"
-import type { AIFileModel } from "@chatbotx.io/database/types"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { z } from "zod"
 
@@ -12,11 +9,7 @@ export const aiFileResource = createSelectSchema(aiFileModel, {
   workspaceId: zodBigintAsString(),
 })
 
-export type AIFileWithProcessing = AIFileModel & {
-  url: string
-  chunksCount: number
-  processingStatus: AIEmbeddingStatus
-}
+export type AIFileWithProcessing = AIFileWithEmbeddingStatus
 
 export const listAIFilesRequest = z.object({
   workspaceId: zodBigintAsString(),

--- a/apps/builder/src/features/ai-functions/queries/index.ts
+++ b/apps/builder/src/features/ai-functions/queries/index.ts
@@ -1,4 +1,4 @@
-import { db } from "@chatbotx.io/database/client"
+import { aiFunctionService } from "@chatbotx.io/business"
 import type { AIFunctionModel } from "@chatbotx.io/database/types"
 import type { PaginatedResponse } from "@/features/common/schema/pagination"
 import type { ListAIFunctionsRequest } from "../schema/action"
@@ -6,11 +6,7 @@ import type { ListAIFunctionsRequest } from "../schema/action"
 export async function listAIFunctions(
   input: ListAIFunctionsRequest,
 ): Promise<PaginatedResponse<AIFunctionModel>> {
-  const data = await db.query.aiFunctionModel.findMany({
-    where: {
-      workspaceId: input.workspaceId,
-    },
-  })
+  const data = await aiFunctionService.list({ workspaceId: input.workspaceId })
 
   return { data, pageCount: 1 }
 }

--- a/apps/builder/src/features/ai-mcp-servers/queries/index.ts
+++ b/apps/builder/src/features/ai-mcp-servers/queries/index.ts
@@ -1,4 +1,4 @@
-import { db } from "@chatbotx.io/database/client"
+import { aiMcpServerService } from "@chatbotx.io/business"
 import { assertCurrentUserCanAccessChatbot } from "@/lib/auth/utils"
 import type {
   ListAIMcpServersRequest,
@@ -10,10 +10,8 @@ export async function listAIMcpServers(
 ): Promise<ListAIMcpServersResponse & { pageCount: number }> {
   await assertCurrentUserCanAccessChatbot(input.workspaceId)
 
-  const data = await db.query.aiMCPServerModel.findMany({
-    where: {
-      workspaceId: input.workspaceId,
-    },
+  const data = await aiMcpServerService.list({
+    where: { workspaceId: input.workspaceId },
   })
 
   return { data, pageCount: 1 }

--- a/apps/builder/src/features/ai-triggers/actions/list.action.ts
+++ b/apps/builder/src/features/ai-triggers/actions/list.action.ts
@@ -1,0 +1,14 @@
+import { aiTriggerService } from "@chatbotx.io/business"
+import type {
+  AITriggerCollection,
+  ListAITriggersRequest,
+} from "@/features/ai-triggers/schema/query"
+import { assertCurrentUserCanAccessChatbot } from "@/lib/auth/utils"
+
+export const listAITriggers = async (
+  input: ListAITriggersRequest,
+): Promise<AITriggerCollection> => {
+  await assertCurrentUserCanAccessChatbot(input.workspaceId)
+
+  return await aiTriggerService.list(input)
+}

--- a/apps/builder/src/features/personas/queries/index.ts
+++ b/apps/builder/src/features/personas/queries/index.ts
@@ -1,4 +1,4 @@
-import { db } from "@chatbotx.io/database/client"
+import { integrationMessengerRepository } from "@chatbotx.io/database/repositories"
 import { selectRegisteredPersonas } from "@chatbotx.io/integration-messenger"
 import type {
   ListMessengerPersonasRequest,
@@ -16,11 +16,10 @@ import type {
 export async function listMessengerPersonaOptions(
   input: ListMessengerPersonasRequest,
 ): Promise<ListMessengerPersonasResponse> {
-  const integrations = await db.query.integrationMessengerModel.findMany({
-    where: { workspaceId: input.workspaceId },
-    columns: { name: true, personas: true },
-    orderBy: { createdAt: "asc" },
-  })
+  const integrations =
+    await integrationMessengerRepository.listPersonasByWorkspaceId(
+      input.workspaceId,
+    )
 
   const data = integrations.flatMap((integration) =>
     selectRegisteredPersonas(integration.personas).map((persona) => ({

--- a/packages/business/__tests__/ai-file.service.test.ts
+++ b/packages/business/__tests__/ai-file.service.test.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// aiFileService — create/delete/listWithEmbeddingStatus for the Knowledge
+// tab. `create` throws a "noEmbeddingProvider" marker when the workspace has
+// neither an OpenAI nor a Gemini integration; `delete` swallows errors and
+// logs a warning (the delete action must never reject); listWithEmbeddingStatus
+// derives status precedence error > processing > success/pending.
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  deleteObject: vi.fn(),
+  dispatchAuditRecord: vi.fn(),
+  findFirstAiFile: vi.fn(),
+  findFirstGemini: vi.fn(),
+  findFirstOpenai: vi.fn(),
+  findManyAiFile: vi.fn(async () => []),
+  getPresignedDownload: vi.fn(async () => "https://example.com/download"),
+  insertReturning: vi.fn(),
+  loggerWarn: vi.fn(),
+  normalizeError: vi.fn((error: unknown) => ({
+    message: error instanceof Error ? error.message : String(error),
+  })),
+  queueAdd: vi.fn(),
+  transaction: vi.fn(),
+  txDeleteWhere: vi.fn(),
+}))
+
+vi.mock("../src/audit/dispatcher", () => ({
+  dispatchAuditRecord: mocks.dispatchAuditRecord,
+}))
+
+vi.mock("../src/logger", () => ({
+  logger: { warn: mocks.loggerWarn },
+}))
+
+vi.mock("universal-error-normalizer", () => ({
+  normalizeError: (error: unknown) => mocks.normalizeError(error),
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    delete: vi.fn(() => ({ where: mocks.txDeleteWhere })),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({ returning: mocks.insertReturning })),
+    })),
+    query: {
+      aiFileModel: {
+        findFirst: mocks.findFirstAiFile,
+        findMany: mocks.findManyAiFile,
+      },
+      integrationGeminiModel: { findFirst: mocks.findFirstGemini },
+      integrationOpenaiModel: { findFirst: mocks.findFirstOpenai },
+    },
+    transaction: mocks.transaction,
+  },
+  eq: vi.fn((field: unknown, value: unknown) => ({ field, value })),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  aiEmbeddingModel: { id: "id" },
+  aiFileModel: { id: "id" },
+}))
+
+vi.mock("@chatbotx.io/filesystem", () => ({
+  uploader: {
+    deleteObject: mocks.deleteObject,
+    getPresignedDownload: mocks.getPresignedDownload,
+  },
+}))
+
+vi.mock("@chatbotx.io/utils", () => ({
+  createId: () => "file-1",
+}))
+
+vi.mock("@chatbotx.io/worker-config", () => ({
+  HeavyJobAction: { processAIFile: "processAIFile" },
+  getHeavyJobOptions: () => ({}),
+  heavyQueue: { add: mocks.queueAdd },
+}))
+
+const { aiFileService } = await import("../src/ai-file/service")
+
+const workspaceId = "workspace-1"
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.findFirstOpenai.mockResolvedValue(undefined)
+  mocks.findFirstGemini.mockResolvedValue(undefined)
+  mocks.insertReturning.mockResolvedValue([{ id: "file-1" }])
+  mocks.findFirstAiFile.mockResolvedValue({
+    id: "file-1",
+    workspaceId,
+    path: "path/to/file",
+  })
+  mocks.transaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+    fn({ delete: vi.fn(() => ({ where: mocks.txDeleteWhere })) }),
+  )
+})
+
+describe("aiFileService.create", () => {
+  test("throws noEmbeddingProvider when neither OpenAI nor Gemini is connected", async () => {
+    await expect(
+      aiFileService.create({
+        workspaceId,
+        path: "path",
+        name: "manual.pdf",
+        mimeType: "application/pdf",
+        size: 100,
+      }),
+    ).rejects.toMatchObject({ code: "noEmbeddingProvider" })
+
+    expect(mocks.queueAdd).not.toHaveBeenCalled()
+    expect(mocks.dispatchAuditRecord).not.toHaveBeenCalled()
+  })
+
+  test("succeeds when an OpenAI integration exists: inserts, enqueues, audits", async () => {
+    mocks.findFirstOpenai.mockResolvedValue({ id: "openai-1" })
+
+    const result = await aiFileService.create({
+      workspaceId,
+      path: "path",
+      name: "manual.pdf",
+      mimeType: "application/pdf",
+      size: 100,
+    })
+
+    expect(result).toEqual({ id: "file-1" })
+    expect(mocks.queueAdd).toHaveBeenCalledWith(
+      "processAIFile",
+      {
+        type: "processAIFile",
+        data: { aiFileId: "file-1" },
+      },
+      { jobId: "heavy-ai-file-file-1" },
+    )
+    expect(mocks.dispatchAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "create",
+        detail: "created a new Knowledge (#file-1)",
+      }),
+    )
+  })
+
+  test("succeeds when only a Gemini integration exists", async () => {
+    mocks.findFirstGemini.mockResolvedValue({ id: "gemini-1" })
+
+    const result = await aiFileService.create({
+      workspaceId,
+      path: "path",
+      name: "manual.pdf",
+      mimeType: "application/pdf",
+      size: 100,
+    })
+
+    expect(result).toEqual({ id: "file-1" })
+  })
+})
+
+describe("aiFileService.delete", () => {
+  test("deletes the object and both rows inside a transaction, then audits", async () => {
+    await aiFileService.delete({ workspaceId, id: "file-1" })
+
+    expect(mocks.deleteObject).toHaveBeenCalledWith("path/to/file")
+    expect(mocks.transaction).toHaveBeenCalled()
+    expect(mocks.dispatchAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "delete",
+        detail: "deleted a Knowledge (#file-1)",
+      }),
+    )
+  })
+
+  test("swallows a thrown error and logs a warning instead of rejecting", async () => {
+    mocks.deleteObject.mockRejectedValueOnce(new Error("s3 down"))
+
+    await expect(
+      aiFileService.delete({ workspaceId, id: "file-1" }),
+    ).resolves.toBeUndefined()
+
+    expect(mocks.loggerWarn).toHaveBeenCalled()
+    expect(mocks.dispatchAuditRecord).not.toHaveBeenCalled()
+  })
+})
+
+describe("Knowledge tab audit messages", () => {
+  test("does not log the legacy AI Agent knowledge base message", async () => {
+    mocks.findFirstOpenai.mockResolvedValue({ id: "openai-1" })
+
+    await aiFileService.create({
+      workspaceId,
+      path: "path",
+      name: "manual.pdf",
+      mimeType: "application/pdf",
+      size: 100,
+    })
+    await aiFileService.delete({ workspaceId, id: "file-1" })
+
+    for (const call of mocks.dispatchAuditRecord.mock.calls) {
+      expect(call[0].detail).not.toContain(
+        "updated the AI Agent knowledge base",
+      )
+    }
+  })
+})
+
+describe("aiFileService.listWithEmbeddingStatus", () => {
+  test("maps status precedence: error beats pending beats success", async () => {
+    mocks.findManyAiFile.mockResolvedValue([
+      {
+        id: "file-error",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        workspaceId,
+        mimeType: "application/pdf",
+        size: 1,
+        name: "error.pdf",
+        path: "p1",
+        aiEmbeddings: [
+          { id: "e1", status: "success" },
+          { id: "e2", status: "error" },
+        ],
+      },
+      {
+        id: "file-pending",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        workspaceId,
+        mimeType: "application/pdf",
+        size: 1,
+        name: "pending.pdf",
+        path: "p2",
+        aiEmbeddings: [{ id: "e3", status: "pending" }],
+      },
+      {
+        id: "file-success",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        workspaceId,
+        mimeType: "application/pdf",
+        size: 1,
+        name: "success.pdf",
+        path: "p3",
+        aiEmbeddings: [{ id: "e4", status: "success" }],
+      },
+      {
+        id: "file-empty",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        workspaceId,
+        mimeType: "application/pdf",
+        size: 1,
+        name: "empty.pdf",
+        path: "p4",
+        aiEmbeddings: [],
+      },
+    ])
+
+    const result = await aiFileService.listWithEmbeddingStatus({ workspaceId })
+
+    expect(result.find((f) => f.id === "file-error")?.processingStatus).toBe(
+      "error",
+    )
+    expect(result.find((f) => f.id === "file-pending")?.processingStatus).toBe(
+      "processing",
+    )
+    expect(result.find((f) => f.id === "file-success")?.processingStatus).toBe(
+      "success",
+    )
+    expect(result.find((f) => f.id === "file-empty")?.processingStatus).toBe(
+      "pending",
+    )
+    expect(mocks.getPresignedDownload).toHaveBeenCalledTimes(4)
+  })
+})

--- a/packages/business/__tests__/ai-function.service.test.ts
+++ b/packages/business/__tests__/ai-function.service.test.ts
@@ -5,6 +5,7 @@ const {
   mockDelete,
   mockDeleteReturning,
   mockFindFirst,
+  mockFindMany,
   mockInstalledResourceFindMany,
   mockInstallationFindMany,
   mockInsert,
@@ -29,6 +30,7 @@ const {
     mockDelete,
     mockDeleteReturning,
     mockFindFirst: vi.fn(),
+    mockFindMany: vi.fn(async () => []),
     mockInstalledResourceFindMany: vi.fn(),
     mockInstallationFindMany: vi.fn(),
     mockInsert,
@@ -45,6 +47,7 @@ vi.mock("@chatbotx.io/database/client", () => ({
     query: {
       aiFunctionModel: {
         findFirst: mockFindFirst,
+        findMany: mockFindMany,
       },
       templateInstalledResourceModel: {
         findMany: mockInstalledResourceFindMany,
@@ -159,5 +162,16 @@ describe("aiFunctionService audit messages", () => {
     ).rejects.toThrow()
 
     expect(dispatchAuditRecord).not.toHaveBeenCalled()
+  })
+
+  test("list returns AI Functions scoped to the workspace", async () => {
+    mockFindMany.mockResolvedValue([aiFunction])
+
+    const result = await aiFunctionService.list({ workspaceId })
+
+    expect(result).toEqual([aiFunction])
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: { workspaceId },
+    })
   })
 })

--- a/packages/business/__tests__/integration-llm-connect.service.test.ts
+++ b/packages/business/__tests__/integration-llm-connect.service.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// connect/update/disconnect on the four LLM provider services (Claude,
+// DeepSeek, Gemini, OpenAI). `connect` delegates the upsert to the shared
+// connectAiProviderIntegration helper and audits connect/update based on
+// whether a row already existed; `update` patches provider-specific fields
+// (e.g. autoReply) directly; `disconnect` removes the parent integration row.
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  connectAiProviderIntegration: vi.fn(),
+  dispatchAuditRecord: vi.fn(),
+  findFirstClaude: vi.fn(),
+  findFirstDeepseek: vi.fn(),
+  findFirstGemini: vi.fn(),
+  findFirstOpenai: vi.fn(),
+  deleteWhere: vi.fn(),
+  updateSet: vi.fn(),
+  updateWhere: vi.fn(),
+  updateReturning: vi.fn(),
+}))
+
+vi.mock("../src/audit/dispatcher", () => ({
+  dispatchAuditRecord: mocks.dispatchAuditRecord,
+}))
+
+vi.mock("../src/integration-ai-provider/connect", () => ({
+  connectAiProviderIntegration: mocks.connectAiProviderIntegration,
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: {
+    query: {
+      integrationClaudeModel: { findFirst: mocks.findFirstClaude },
+      integrationDeepseekModel: { findFirst: mocks.findFirstDeepseek },
+      integrationGeminiModel: { findFirst: mocks.findFirstGemini },
+      integrationOpenaiModel: { findFirst: mocks.findFirstOpenai },
+    },
+    delete: vi.fn(() => ({ where: mocks.deleteWhere })),
+    update: vi.fn(() => ({ set: mocks.updateSet })),
+  },
+  eq: vi.fn((field: unknown, value: unknown) => ({ field, value })),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  integrationClaudeModel: { id: "id", workspaceId: "workspaceId" },
+  integrationDeepseekModel: { id: "id", workspaceId: "workspaceId" },
+  integrationGeminiModel: { id: "id", workspaceId: "workspaceId" },
+  integrationModel: { id: "id" },
+  integrationOpenaiModel: { id: "id", workspaceId: "workspaceId" },
+}))
+
+const { integrationClaudeService } = await import(
+  "../src/integration-claude/service"
+)
+const { integrationDeepSeekService } = await import(
+  "../src/integration-deepseek/service"
+)
+const { integrationGeminiService } = await import(
+  "../src/integration-gemini/service"
+)
+const { integrationOpenAIService } = await import(
+  "../src/integration-openai/service"
+)
+
+const connectProps = {
+  workspaceId: "workspace-1",
+  apiKey: "secret-key",
+  model: "some-model",
+  temperature: 0.5,
+  maxOutputTokens: 1024,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.updateSet.mockReturnValue({ where: mocks.updateWhere })
+  mocks.updateWhere.mockReturnValue({ returning: mocks.updateReturning })
+  mocks.updateReturning.mockResolvedValue([{ id: "existing-1" }])
+})
+
+describe.each([
+  {
+    findFirst: mocks.findFirstClaude,
+    label: "Claude",
+    provider: "claude",
+    service: integrationClaudeService,
+  },
+  {
+    findFirst: mocks.findFirstDeepseek,
+    label: "DeepSeek",
+    provider: "deepseek",
+    service: integrationDeepSeekService,
+  },
+  {
+    findFirst: mocks.findFirstGemini,
+    label: "Gemini",
+    provider: "gemini",
+    service: integrationGeminiService,
+  },
+  {
+    findFirst: mocks.findFirstOpenai,
+    label: "OpenAI",
+    provider: "openai",
+    service: integrationOpenAIService,
+  },
+])("$label connect/update/disconnect", ({
+  findFirst,
+  label,
+  provider,
+  service,
+}) => {
+  test("connect delegates to connectAiProviderIntegration and audits update when a row exists", async () => {
+    findFirst.mockResolvedValue({ id: "existing-1" })
+
+    await service.connect(connectProps)
+
+    expect(mocks.connectAiProviderIntegration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        integrationType: provider,
+        input: connectProps,
+        existing: { id: "existing-1" },
+      }),
+    )
+    expect(mocks.dispatchAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "update",
+        detail: `updated the ${label} integration configuration`,
+      }),
+    )
+  })
+
+  test("connect audits connect when no row exists", async () => {
+    findFirst.mockResolvedValue(undefined)
+
+    await service.connect(connectProps)
+
+    expect(mocks.connectAiProviderIntegration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        integrationType: provider,
+        input: connectProps,
+        existing: undefined,
+      }),
+    )
+    expect(mocks.dispatchAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "connect",
+        detail: `connected a new ${label} integration`,
+      }),
+    )
+  })
+
+  test("disconnect deletes the parent integration row and audits disconnect", async () => {
+    findFirst.mockResolvedValue({
+      id: "existing-1",
+      integrationId: "integration-1",
+    })
+
+    await service.disconnect(connectProps.workspaceId)
+
+    expect(mocks.deleteWhere).toHaveBeenCalled()
+    expect(mocks.dispatchAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "disconnect",
+        detail: `disconnected the ${label} integration`,
+      }),
+    )
+  })
+
+  test("disconnect is a no-op when no integration exists", async () => {
+    findFirst.mockResolvedValue(undefined)
+
+    await service.disconnect(connectProps.workspaceId)
+
+    expect(mocks.deleteWhere).not.toHaveBeenCalled()
+    expect(mocks.dispatchAuditRecord).not.toHaveBeenCalled()
+  })
+})
+
+describe("update", () => {
+  test("Claude update patches the row and audits update", async () => {
+    mocks.findFirstClaude.mockResolvedValue({ id: "existing-1" })
+
+    const result = await integrationClaudeService.update(
+      { workspaceId: connectProps.workspaceId },
+      { autoReply: true },
+    )
+
+    expect(mocks.updateSet).toHaveBeenCalledWith({ autoReply: true })
+    expect(mocks.dispatchAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "update",
+        detail: "updated the Claude integration configuration",
+      }),
+    )
+    expect(result).toEqual({ id: "existing-1" })
+  })
+
+  test("Claude update throws when no integration exists", async () => {
+    mocks.findFirstClaude.mockResolvedValue(undefined)
+
+    await expect(
+      integrationClaudeService.update(
+        { workspaceId: connectProps.workspaceId },
+        { autoReply: true },
+      ),
+    ).rejects.toThrow("Integration Claude not found")
+  })
+
+  test("OpenAI update looks up by workspaceId + id", async () => {
+    mocks.findFirstOpenai.mockResolvedValue({ id: "existing-1" })
+
+    await integrationOpenAIService.update(
+      { workspaceId: connectProps.workspaceId, id: "existing-1" },
+      { autoReply: true },
+    )
+
+    expect(mocks.findFirstOpenai).toHaveBeenCalledWith({
+      where: { workspaceId: connectProps.workspaceId, id: "existing-1" },
+    })
+  })
+})

--- a/packages/business/src/ai-file/index.ts
+++ b/packages/business/src/ai-file/index.ts
@@ -1,0 +1,1 @@
+export * from "./service"

--- a/packages/business/src/ai-file/service.ts
+++ b/packages/business/src/ai-file/service.ts
@@ -1,0 +1,176 @@
+import { db, eq } from "@chatbotx.io/database/client"
+import type { AIEmbeddingStatus } from "@chatbotx.io/database/partials"
+import { aiEmbeddingModel, aiFileModel } from "@chatbotx.io/database/schema"
+import type { AIFileModel } from "@chatbotx.io/database/types"
+import { uploader } from "@chatbotx.io/filesystem"
+import { createId } from "@chatbotx.io/utils"
+import {
+  getHeavyJobOptions,
+  HeavyJobAction,
+  heavyQueue,
+} from "@chatbotx.io/worker-config"
+import { normalizeError } from "universal-error-normalizer"
+import { BaseService } from "../base.service"
+import { ChatbotXException } from "../errors"
+import { logger } from "../logger"
+
+export type AIFileWithEmbeddingStatus = AIFileModel & {
+  url: string
+  chunksCount: number
+  processingStatus: AIEmbeddingStatus
+}
+
+class AiFileService extends BaseService {
+  async hasEmbeddingProvider(workspaceId: string): Promise<boolean> {
+    const hasOpenAI = await db.query.integrationOpenaiModel.findFirst({
+      where: { workspaceId },
+      columns: { id: true },
+    })
+    if (hasOpenAI) {
+      return true
+    }
+
+    const hasGemini = await db.query.integrationGeminiModel.findFirst({
+      where: { workspaceId },
+      columns: { id: true },
+    })
+    return Boolean(hasGemini)
+  }
+
+  async create(props: {
+    workspaceId: string
+    path: string
+    name: string
+    mimeType: string
+    size: number
+  }): Promise<{ id: string }> {
+    if (!(await this.hasEmbeddingProvider(props.workspaceId))) {
+      throw new ChatbotXException(
+        "AI file requires an embedding provider",
+        "noEmbeddingProvider",
+        400,
+      )
+    }
+
+    const created = await db
+      .insert(aiFileModel)
+      .values({
+        name: props.name,
+        path: props.path,
+        mimeType: props.mimeType,
+        size: props.size,
+        id: createId(),
+        workspaceId: props.workspaceId,
+      })
+      .returning({ id: aiFileModel.id })
+
+    const aiFileId = created[0].id
+
+    // Enqueue embedding job right after creation
+    await heavyQueue.add(
+      HeavyJobAction.processAIFile,
+      {
+        type: HeavyJobAction.processAIFile,
+        data: {
+          aiFileId,
+        },
+      },
+      {
+        ...getHeavyJobOptions(HeavyJobAction.processAIFile),
+        jobId: `heavy-ai-file-${aiFileId}`,
+      },
+    )
+
+    await this.audit("create", `created a new Knowledge (#${aiFileId})`)
+
+    return { id: aiFileId }
+  }
+
+  async delete(props: { workspaceId: string; id: string }): Promise<void> {
+    const targetAIFile = await db.query.aiFileModel.findFirst({
+      where: { id: props.id, workspaceId: props.workspaceId },
+    })
+
+    if (!targetAIFile) {
+      throw new ChatbotXException(
+        `AIFile with id ${props.id} not found`,
+        "notFound",
+        404,
+      )
+    }
+
+    try {
+      await db.transaction(async (tx) => {
+        await uploader.deleteObject(targetAIFile.path)
+        // NOTE: this predicate matches on aiEmbeddingModel.id, but props.id is
+        // an AIFile id — the correct FK is aiEmbeddingModel.aiFileId. This is
+        // a pre-existing bug carried over verbatim (harmless no-op today
+        // because AIEmbedding.aiFileId cascades on AIFile delete). Tracked as
+        // a follow-up rather than fixed here to keep this change behavior-
+        // neutral.
+        await tx
+          .delete(aiEmbeddingModel)
+          .where(eq(aiEmbeddingModel.id, props.id))
+        await tx.delete(aiFileModel).where(eq(aiFileModel.id, props.id))
+      })
+
+      await this.audit("delete", `deleted a Knowledge (#${props.id})`)
+    } catch (error) {
+      logger.warn(
+        { err: normalizeError(error) },
+        `deleteAIFile failed for id: ${props.id}`,
+      )
+    }
+  }
+
+  async listWithEmbeddingStatus(props: {
+    workspaceId: string
+  }): Promise<AIFileWithEmbeddingStatus[]> {
+    const data = await db.query.aiFileModel.findMany({
+      where: {
+        workspaceId: props.workspaceId,
+      },
+      with: {
+        aiEmbeddings: {
+          columns: {
+            id: true,
+            status: true,
+          },
+        },
+      },
+    })
+
+    return await Promise.all(
+      data.map(async (file) => {
+        const hasEmbeddings = file.aiEmbeddings.length > 0
+        let processingStatus: AIEmbeddingStatus = "pending"
+        if (hasEmbeddings) {
+          const statusSet = new Set(file.aiEmbeddings.map((e) => e.status))
+          if (statusSet.has("error")) {
+            processingStatus = "error"
+          } else if (statusSet.has("pending")) {
+            processingStatus = "processing"
+          } else {
+            processingStatus = "success"
+          }
+        }
+
+        return {
+          id: file.id,
+          createdAt: file.createdAt,
+          updatedAt: file.updatedAt,
+          workspaceId: file.workspaceId,
+          mimeType: file.mimeType,
+          size: file.size,
+          name: file.name,
+          path: file.path,
+          url: await uploader.getPresignedDownload(file.path),
+          chunksCount: file.aiEmbeddings.length,
+          processingStatus,
+        }
+      }),
+    )
+  }
+}
+
+export const aiFileService = new AiFileService()

--- a/packages/business/src/ai-function/service.ts
+++ b/packages/business/src/ai-function/service.ts
@@ -153,6 +153,16 @@ class AiFunctionService extends BaseService {
       .where(eq(aiFunctionModel.id, id))
       .returning()
   }
+
+  async list(props: {
+    workspaceId: string
+    tx?: DatabaseClient
+  }): Promise<AIFunctionModel[]> {
+    const { tx = db, workspaceId } = props
+    return await tx.query.aiFunctionModel.findMany({
+      where: { workspaceId },
+    })
+  }
 }
 
 export const aiFunctionService = new AiFunctionService()

--- a/packages/business/src/index.ts
+++ b/packages/business/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./ads-conversion"
 export * from "./ai-agent"
+export * from "./ai-file"
 export * from "./ai-function"
 export * from "./ai-mcp-server"
 export * from "./ai-trigger"

--- a/packages/database/__tests__/integration-messenger-repository-personas.test.ts
+++ b/packages/database/__tests__/integration-messenger-repository-personas.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// integrationMessengerRepository.listPersonasByWorkspaceId — the projected
+// read backing the flow editor's "Set Persona" picker. Mocks `db` at the
+// module boundary so the query is scoped exactly to `workspaceId` and only
+// selects `name`/`personas`, without touching a real database.
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  and: vi.fn((...conditions: unknown[]) => ({ and: conditions })),
+  eq: vi.fn((column: unknown, value: unknown) => ({ eq: [column, value] })),
+  isNull: vi.fn(),
+  select: vi.fn(),
+  sql: vi.fn(),
+}))
+
+vi.mock("../src/client", () => ({
+  and: mocks.and,
+  db: { select: mocks.select },
+  eq: mocks.eq,
+  isNull: mocks.isNull,
+  sql: mocks.sql,
+}))
+
+vi.mock("../src/schema", () => ({
+  integrationMessengerModel: {
+    createdAt: "createdAt",
+    name: "name",
+    personas: "personas",
+    workspaceId: "workspaceId",
+  },
+}))
+
+const { integrationMessengerRepository } = await import(
+  "../src/repositories/integration-messenger/repository"
+)
+
+function chain(finalResult: unknown[]) {
+  const builder = {
+    from: vi.fn(() => builder),
+    orderBy: vi.fn(() => Promise.resolve(finalResult)),
+    where: vi.fn(() => builder),
+  }
+  return builder
+}
+
+describe("integrationMessengerRepository.listPersonasByWorkspaceId", () => {
+  test("selects only name and personas, scoped to workspaceId, ordered by createdAt", async () => {
+    const rows = [{ name: "Support Page", personas: [] }]
+    const builder = chain(rows)
+    mocks.select.mockReturnValue(builder)
+
+    const result =
+      await integrationMessengerRepository.listPersonasByWorkspaceId(
+        "workspace-1",
+      )
+
+    expect(result).toEqual(rows)
+    expect(mocks.select).toHaveBeenCalledWith({
+      name: "name",
+      personas: "personas",
+    })
+    expect(mocks.eq).toHaveBeenCalledWith("workspaceId", "workspace-1")
+    expect(builder.orderBy).toHaveBeenCalledWith("createdAt")
+  })
+})

--- a/packages/database/src/repositories/integration-messenger/repository.ts
+++ b/packages/database/src/repositories/integration-messenger/repository.ts
@@ -142,6 +142,26 @@ export const integrationMessengerRepository = {
       .orderBy(integrationMessengerModel.createdAt)
   },
 
+  /**
+   * Projected read for the flow editor's "Set Persona" picker. Selects only
+   * `name` and `personas`, excluding the encrypted auth blob and the
+   * persistent-menu jsonb so a workspace with many connected Pages doesn't
+   * ship those bytes on every flow-editor open.
+   */
+  listPersonasByWorkspaceId(
+    workspaceId: string,
+    tx: DatabaseClient = db,
+  ): Promise<Pick<IntegrationMessengerModel, "name" | "personas">[]> {
+    return tx
+      .select({
+        name: integrationMessengerModel.name,
+        personas: integrationMessengerModel.personas,
+      })
+      .from(integrationMessengerModel)
+      .where(eq(integrationMessengerModel.workspaceId, workspaceId))
+      .orderBy(integrationMessengerModel.createdAt)
+  },
+
   async findWorkspaceIntegration(
     input: WorkspaceIntegrationRef,
     tx: DatabaseClient = db,


### PR DESCRIPTION
## Summary
- Removes every direct `db.*` call from the builder AI surface (Claude/DeepSeek/Gemini/OpenAI connect actions and queries, ai-files, ai-functions, ai-mcp-servers, ai-triggers, personas) per `.agents/rules/data-access.md`, so the logic is reusable from the worker and public APIs and mockable at one boundary.
- One of seven parallel scope PRs following #1093 (contacts); all are based on `main` and only append to the shared barrels.

## Changes
- `packages/business/src/integration-{claude,deepseek,gemini,openai}/service.ts`: new `connect()` mirroring `integrationOpenRouterService.connect` (audit stays unconditional as before; OpenAI records audit with an explicit `workspaceId` because `authActionClient` has no workspace in the audit context).
- New `packages/business/src/ai-file/` (`create`, `delete`, `listWithEmbeddingStatus`) and `packages/business/src/ai-trigger/` (`list`, `create`, `duplicate`); `aiFunctionService.list`; `integrationMessengerRepository.listPersonasByWorkspaceId`.
- Builder actions/queries are thin wrappers; AI cache invalidation stays in the builder because business must not import `@chatbotx.io/ai`.
- Tests moved to the service boundary (`packages/business/__tests__/{integration-llm-connect,ai-file,ai-trigger}.service.test.ts`, `apps/builder/__tests__/{integration-llm-connect-actions,ai-triggers-actions}.test.ts`).

## Notes for reviewers
- The four `connect()` update paths now run the UPDATE outside a transaction (the insert path is still transactional); the old action wrapped the read+update in one transaction. Idempotent by `existing.id`, so no data-loss window, but flagging the shape change.
- Pre-existing bug preserved verbatim (not fixed here): `aiFileService.delete` deletes embeddings by `aiEmbeddingModel.id` instead of `aiFileId` (harmless via FK cascade).
- Follow-ups listed in the plan: `integration-*/actions/update.action.ts` and `ai-triggers/actions/{update,delete}.action.ts` still use `db`; `connectOpenAIAction` uses `authActionClient` and does not verify workspace membership.

## Test plan
- [x] `pnpm --filter @chatbotx.io/database check-types && test`
- [x] `pnpm --filter @chatbotx.io/business check-types && test` (only the pre-existing `ads-conversion-rule.service.test.ts` failures remain, also red on `main`)
- [x] `pnpm --filter builder check-types && test`
- [x] `pnpm lint`
- [ ] Manual: connect + reconnect each provider in Settings → Integrations; upload/delete a Knowledge file; create/duplicate an AI trigger; Set Persona picker lists personas