### PR TITLE
fix(tests): use numeric id fixtures in flow-config schema tests

### DIFF
--- a/packages/flow-config/__tests__/appointment-scheduling-schema.test.ts
+++ b/packages/flow-config/__tests__/appointment-scheduling-schema.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, test } from "vitest"
 import { appointmentSchedulingStepSchema, metadataSchema } from "../src"
 
 const baseStep = {
-  id: "step-1",
+  id: "1",
   stepType: "appointmentScheduling",
   mode: "checkAvailability",
-  calendarId: "calendar-1",
+  calendarId: "1",
   outputCustomFieldId: "output-field",
   states: [
     { id: "1", stateType: "success" },
@@ -46,10 +46,10 @@ describe("appointment scheduling schemas", () => {
 
   test("bookFromCustomField requires dateTimeFieldId", () => {
     const step = {
-      id: "step-1",
+      id: "1",
       stepType: "appointmentScheduling",
       mode: "bookFromCustomField",
-      calendarId: "calendar-1",
+      calendarId: "1",
       states: [
         { id: "1", stateType: "success" },
         { id: "2", stateType: "error" },

--- a/packages/flow-config/__tests__/import-export.test.ts
+++ b/packages/flow-config/__tests__/import-export.test.ts
@@ -46,12 +46,12 @@ const buildFixtureFlow = (): FlowExportedFlow => {
     detailProps: {
       steps: [
         {
-          id: "cond-1",
+          id: "20",
           stepType: stepTypes.enum.condition,
-          otherwiseId: "otherwise-1",
+          otherwiseId: "21",
           cases: [
             {
-              id: "case-1",
+              id: "22",
               operator: "and",
               conditions: [{ field: "name", operator: "equals", value: "Ada" }],
             },

--- a/packages/flow-config/__tests__/messenger-template.test.ts
+++ b/packages/flow-config/__tests__/messenger-template.test.ts
@@ -441,7 +441,7 @@ describe("extractMessengerFlowButtons", () => {
 
 describe("sendMessengerTemplateMessageStepSchema", () => {
   const base = {
-    id: "step-1",
+    id: "1",
     stepType: "sendMessengerTemplateMessage" as const,
     nodeId: "node-1",
     template: {
@@ -479,7 +479,7 @@ describe("sendMessengerTemplateMessageStepSchema", () => {
       ...base,
       buttons: [
         {
-          id: "b1",
+          id: "1",
           label: "Accept",
           steps: [],
           beforeStep: null,
@@ -488,7 +488,7 @@ describe("sendMessengerTemplateMessageStepSchema", () => {
       ],
     })
     expect(result.buttons).toHaveLength(1)
-    expect(result.buttons[0]).toMatchObject({ id: "b1", label: "Accept" })
+    expect(result.buttons[0]).toMatchObject({ id: "1", label: "Accept" })
   })
 
   test("empty template.id (whitespace) → parse fails", () => {

--- a/packages/flow-config/__tests__/openai-compatible-ai-steps.test.ts
+++ b/packages/flow-config/__tests__/openai-compatible-ai-steps.test.ts
@@ -122,7 +122,7 @@ describe("OpenAI-compatible AI flow steps", () => {
       provider: "openaiCompatible",
       integrationId: "integration-1",
       model: "agent-model",
-      aiAgentId: "agent-1",
+      aiAgentId: "1",
       message: "Reply from this message",
       outputFieldId: "output-field",
     })
@@ -133,7 +133,7 @@ describe("OpenAI-compatible AI flow steps", () => {
   test("rejects OpenAI-compatible generate text agent without integration or model", () => {
     const step = aiGenerateTextAgentDefaultFn({
       provider: "openaiCompatible",
-      aiAgentId: "agent-1",
+      aiAgentId: "1",
       message: "Reply from this message",
       outputFieldId: "output-field",
     })

--- a/packages/flow-config/__tests__/send-multiple-images.test.ts
+++ b/packages/flow-config/__tests__/send-multiple-images.test.ts
@@ -6,7 +6,7 @@ import {
 } from "../src/steps/send-multiple-images"
 
 const baseStep = {
-  id: "step-1",
+  id: "1",
   stepType: "sendMultipleImages" as const,
 }
 

--- a/packages/flow-config/__tests__/tiktok-text-rules.test.ts
+++ b/packages/flow-config/__tests__/tiktok-text-rules.test.ts
@@ -64,7 +64,7 @@ describe("isTiktokCardTitleTruncated", () => {
 
 describe("sendTextValidator", () => {
   const step = {
-    id: "step-1",
+    id: "1",
     stepType: "sendText" as const,
     text: "x".repeat(TIKTOK_CARD_TITLE_MAX + 1),
     buttons: [button()],

--- a/packages/flow-config/__tests__/wa-template-mpm-rules.test.ts
+++ b/packages/flow-config/__tests__/wa-template-mpm-rules.test.ts
@@ -12,7 +12,7 @@ const refinedStepSchema =
   sendWaTemplateMessageValidator[channelTypes.enum.omnichannel]
 
 const baseStep = {
-  id: "step-1",
+  id: "1",
   nodeId: "node-1",
   stepType: stepTypes.enum.sendWaTemplateMessage,
   template: {

--- a/packages/flow-config/__tests__/wa-template-quick-reply-buttons.test.ts
+++ b/packages/flow-config/__tests__/wa-template-quick-reply-buttons.test.ts
@@ -161,7 +161,7 @@ describe("seedWaTemplateStepButtons", () => {
 
 describe("sendWaTemplateMessageStepSchema — legacy data and configured buttons", () => {
   const baseStep = {
-    id: "step-1",
+    id: "1",
     nodeId: "node-1",
     stepType: stepTypes.enum.sendWaTemplateMessage,
     template: {


### PR DESCRIPTION
## Summary

`main` fails `pnpm test` in `@chatbotx.io/flow-config`. #1069 anchored `zodBigintAsString` to `/^\d+$/`, and #1104 updated the worker and business fixtures that broke — but eight flow-config test files still carry the old `"step-1"`-shaped ids and now fail validation (26 tests across 8 files).

This PR is fixtures only — no production code changes.

## Changes

Only ids that a `zodBigintAsString()` schema field validates are changed; fields that are plain `z.string()` (`template.id`, `nodeId`, edge ids, image ids) are left as they are.

- `appointment-scheduling-schema.test.ts` — step `id` and `calendarId` → numeric
- `import-export.test.ts` — condition step `id`, `otherwiseId` and case `id` in the fixture flow → numeric
- `messenger-template.test.ts` — step `id` and button `id` (plus the matching `toMatchObject` assertion) → numeric
- `openai-compatible-ai-steps.test.ts` — `aiAgentId` → numeric (both the accept and reject cases, so the reject case fails for the intended reason)
- `send-multiple-images.test.ts`, `tiktok-text-rules.test.ts`, `wa-template-mpm-rules.test.ts`, `wa-template-quick-reply-buttons.test.ts` — step `id` → numeric

## Test plan

- [x] `pnpm --filter @chatbotx.io/flow-config test` — 35 files, 437 tests
- [x] `pnpm --filter builder test` — 407 files, 2726 tests
- [x] `pnpm turbo run test --continue` — every other workspace green
- [x] `pnpm lint`
- [x] `pnpm --filter @chatbotx.io/flow-config check-types`