### PR TITLE
fix(minigame): make save work after adding a prize

### DIFF
--- a/apps/builder/messages/ar.json
+++ b/apps/builder/messages/ar.json
@@ -5635,7 +5635,8 @@
       "generalSettingsTitle": "الإعدادات العامة",
       "appearanceTitle": "المظهر",
       "playerSettingsTitle": "إعدادات اللاعب",
-      "prizeSettingsTitle": "إعدادات الجوائز"
+      "prizeSettingsTitle": "إعدادات الجوائز",
+      "validationFailed": "يرجى تصحيح الحقول المميزة قبل الحفظ."
     },
     "generalSettings": {
       "showName": "مرئي",

--- a/apps/builder/messages/da.json
+++ b/apps/builder/messages/da.json
@@ -5635,7 +5635,8 @@
       "generalSettingsTitle": "Generelle indstillinger",
       "appearanceTitle": "Udseende",
       "playerSettingsTitle": "Spillerindstillinger",
-      "prizeSettingsTitle": "Gevinstindstillinger"
+      "prizeSettingsTitle": "Gevinstindstillinger",
+      "validationFailed": "Ret venligst de markerede felter, før du gemmer."
     },
     "generalSettings": {
       "showName": "Synlig",

--- a/apps/builder/messages/de.json
+++ b/apps/builder/messages/de.json
@@ -5635,7 +5635,8 @@
       "generalSettingsTitle": "Allgemeine Einstellungen",
       "appearanceTitle": "Erscheinungsbild",
       "playerSettingsTitle": "Spielereinstellungen",
-      "prizeSettingsTitle": "Gewinneinstellungen"
+      "prizeSettingsTitle": "Gewinneinstellungen",
+      "validationFailed": "Bitte korrigieren Sie die markierten Felder, bevor Sie speichern."
     },
     "generalSettings": {
       "showName": "Sichtbar",

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -5635,7 +5635,8 @@
       "generalSettingsTitle": "General Setting",
       "appearanceTitle": "Appearance",
       "playerSettingsTitle": "Player Settings",
-      "prizeSettingsTitle": "Prize Settings"
+      "prizeSettingsTitle": "Prize Settings",
+      "validationFailed": "Please fix the highlighted fields before saving."
     },
     "generalSettings": {
       "showName": "Visible",

--- a/apps/builder/messages/es.json
+++ b/apps/builder/messages/es.json
@@ -5635,7 +5635,8 @@
       "generalSettingsTitle": "Configuración general",
       "appearanceTitle": "Apariencia",
       "playerSettingsTitle": "Configuración del jugador",
-      "prizeSettingsTitle": "Configuración de premios"
+      "prizeSettingsTitle": "Configuración de premios",
+      "validationFailed": "Corrige los campos resaltados antes de guardar."
     },
     "generalSettings": {
       "showName": "Visible",

--- a/apps/builder/messages/fi.json
+++ b/apps/builder/messages/fi.json
@@ -5635,7 +5635,8 @@
       "generalSettingsTitle": "Yleiset asetukset",
       "appearanceTitle": "Ulkoasu",
       "playerSettingsTitle": "Pelaaja-asetukset",
-      "prizeSettingsTitle": "Palkintoasetukset"
+      "prizeSettingsTitle": "Palkintoasetukset",
+      "validationFailed": "Korjaa korostetut kentät ennen tallentamista."
     },
     "generalSettings": {
       "showName": "Näkyvä",

--- a/apps/builder/messages/fr.json
+++ b/apps/builder/messages/fr.json
@@ -5635,7 +5635,8 @@
       "generalSettingsTitle": "Paramètres généraux",
       "appearanceTitle": "Apparence",
       "playerSettingsTitle": "Paramètres du joueur",
-      "prizeSettingsTitle": "Paramètres des lots"
+      "prizeSettingsTitle": "Paramètres des lots",
+      "validationFailed": "Veuillez corriger les champs en surbrillance avant d'enregistrer."
     },
     "generalSettings": {
       "showName": "Visible",

--- a/apps/builder/messages/he.json
+++ b/apps/builder/messages/he.json
@@ -5635,7 +5635,8 @@
       "generalSettingsTitle": "הגדרות כלליות",
       "appearanceTitle": "מראה",
       "playerSettingsTitle": "הגדרות שחקן",
-      "prizeSettingsTitle": "הגדרות פרסים"
+      "prizeSettingsTitle": "הגדרות פרסים",
+      "validationFailed": "יש לתקן את השדות המסומנים לפני השמירה."
     },
     "generalSettings": {
       "showName": "גלוי",

--- a/apps/builder/messages/id.json
+++ b/apps/builder/messages/id.json
@@ -5635,7 +5635,8 @@
       "generalSettingsTitle": "Pengaturan Umum",
       "appearanceTitle": "Tampilan",
       "playerSettingsTitle": "Pengaturan Pemain",
-      "prizeSettingsTitle": "Pengaturan Hadiah"
+      "prizeSettingsTitle": "Pengaturan Hadiah",
+      "validationFailed": "Perbaiki kolom yang ditandai sebelum menyimpan."
     },
     "generalSettings": {
       "showName": "Terlihat",

--- a/apps/builder/messages/it.json
+++ b/apps/builder/messages/it.json
@@ -5635,7 +5635,8 @@
       "generalSettingsTitle": "Impostazioni generali",
       "appearanceTitle": "Aspetto",
       "playerSettingsTitle": "Impostazioni giocatore",
-      "prizeSettingsTitle": "Impostazioni premi"
+      "prizeSettingsTitle": "Impostazioni premi",
+      "validationFailed": "Correggi i campi evidenziati prima di salvare."
     },
     "generalSettings": {
       "showName": "Visibile",

--- a/apps/builder/messages/ja.json
+++ b/apps/builder/messages/ja.json
@@ -5635,7 +5635,8 @@
       "generalSettingsTitle": "一般設定",
       "appearanceTitle": "デザイン",
       "playerSettingsTitle": "プレイヤー設定",
-      "prizeSettingsTitle": "景品設定"
+      "prizeSettingsTitle": "景品設定",
+      "validationFailed": "保存する前に、ハイライトされた項目を修正してください。"
     },
     "generalSettings": {
       "showName": "表示",

--- a/apps/builder/messages/nl.json
+++ b/apps/builder/messages/nl.json
@@ -5635,7 +5635,8 @@
       "generalSettingsTitle": "Algemene instellingen",
       "appearanceTitle": "Uiterlijk",
       "playerSettingsTitle": "Spelerinstellingen",
-      "prizeSettingsTitle": "Prijsinstellingen"
+      "prizeSettingsTitle": "Prijsinstellingen",
+      "validationFailed": "Corrigeer de gemarkeerde velden voordat je opslaat."
     },
     "generalSettings": {
       "showName": "Zichtbaar",

--- a/apps/builder/messages/pt-BR.json
+++ b/apps/builder/messages/pt-BR.json
@@ -5635,7 +5635,8 @@
       "generalSettingsTitle": "Configuração Geral",
       "appearanceTitle": "Aparência",
       "playerSettingsTitle": "Configurações do jogador",
-      "prizeSettingsTitle": "Configurações de Prêmios"
+      "prizeSettingsTitle": "Configurações de Prêmios",
+      "validationFailed": "Corrija os campos destacados antes de salvar."
     },
     "generalSettings": {
       "showName": "Visível",

--- a/apps/builder/messages/pt-PT.json
+++ b/apps/builder/messages/pt-PT.json
@@ -5635,7 +5635,8 @@
       "generalSettingsTitle": "Definição Geral",
       "appearanceTitle": "Aparência",
       "playerSettingsTitle": "Definições do jogador",
-      "prizeSettingsTitle": "Definições de Prémios"
+      "prizeSettingsTitle": "Definições de Prémios",
+      "validationFailed": "Corrija os campos destacados antes de guardar."
     },
     "generalSettings": {
       "showName": "Visível",

--- a/apps/builder/messages/ro.json
+++ b/apps/builder/messages/ro.json
@@ -5635,7 +5635,8 @@
       "generalSettingsTitle": "Setări generale",
       "appearanceTitle": "Aspect",
       "playerSettingsTitle": "Setări jucător",
-      "prizeSettingsTitle": "Setări premii"
+      "prizeSettingsTitle": "Setări premii",
+      "validationFailed": "Corectați câmpurile evidențiate înainte de a salva."
     },
     "generalSettings": {
       "showName": "Vizibil",

--- a/apps/builder/messages/sv.json
+++ b/apps/builder/messages/sv.json
@@ -5635,7 +5635,8 @@
       "generalSettingsTitle": "Allmänna inställningar",
       "appearanceTitle": "Utseende",
       "playerSettingsTitle": "Spelarinställningar",
-      "prizeSettingsTitle": "Prisinställningar"
+      "prizeSettingsTitle": "Prisinställningar",
+      "validationFailed": "Åtgärda de markerade fälten innan du sparar."
     },
     "generalSettings": {
       "showName": "Synlig",

--- a/apps/builder/messages/tr.json
+++ b/apps/builder/messages/tr.json
@@ -5635,7 +5635,8 @@
       "generalSettingsTitle": "Genel Ayar",
       "appearanceTitle": "Görünüm",
       "playerSettingsTitle": "Oyuncu Ayarları",
-      "prizeSettingsTitle": "Ödül Ayarları"
+      "prizeSettingsTitle": "Ödül Ayarları",
+      "validationFailed": "Kaydetmeden önce vurgulanan alanları düzeltin."
     },
     "generalSettings": {
       "showName": "Görünür",

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -5635,7 +5635,8 @@
       "generalSettingsTitle": "Thiết lập chung",
       "appearanceTitle": "Giao diện",
       "playerSettingsTitle": "Cài đặt người chơi",
-      "prizeSettingsTitle": "Thiết lập giải thưởng"
+      "prizeSettingsTitle": "Thiết lập giải thưởng",
+      "validationFailed": "Vui lòng sửa các trường được đánh dấu trước khi lưu."
     },
     "generalSettings": {
       "showName": "Hiển thị",

--- a/apps/builder/messages/zh-CN.json
+++ b/apps/builder/messages/zh-CN.json
@@ -5611,7 +5611,8 @@
       "generalSettingsTitle": "常规设置",
       "appearanceTitle": "外观",
       "playerSettingsTitle": "玩家设置",
-      "prizeSettingsTitle": "奖品设置"
+      "prizeSettingsTitle": "奖品设置",
+      "validationFailed": "保存前请修正标红的字段。"
     },
     "generalSettings": {
       "showName": "可见",

--- a/apps/builder/messages/zh-TW.json
+++ b/apps/builder/messages/zh-TW.json
@@ -5635,7 +5635,8 @@
       "generalSettingsTitle": "一般設定",
       "appearanceTitle": "外觀",
       "playerSettingsTitle": "玩家設定",
-      "prizeSettingsTitle": "獎項設定"
+      "prizeSettingsTitle": "獎項設定",
+      "validationFailed": "儲存前請修正標紅的欄位。"
     },
     "generalSettings": {
       "showName": "可見",

--- a/apps/builder/src/features/minigames/components/prize-list-editor.tsx
+++ b/apps/builder/src/features/minigames/components/prize-list-editor.tsx
@@ -8,12 +8,12 @@ import { InputNumberField } from "@chatbotx.io/ui/components/form/input-number-f
 import { Badge } from "@chatbotx.io/ui/components/ui/badge"
 import { Button } from "@chatbotx.io/ui/components/ui/button"
 import { cn } from "@chatbotx.io/ui/lib/utils"
-import { createId } from "@chatbotx.io/utils"
 import { PencilIcon, PlusIcon, TrashIcon } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { useState } from "react"
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form"
 import { CustomFieldSelect } from "@/features/custom-fields/custom-field-select"
+import { createDefaultMinigamePrize } from "../constants"
 import { PrizeItemEditDialog } from "./prize-item-edit-dialog"
 
 type EditTarget =
@@ -22,8 +22,26 @@ type EditTarget =
 
 export function PrizeListEditor({ workspaceId }: { workspaceId: string }) {
   const t = useTranslations()
-  const { control } = useFormContext()
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext()
   const [editTarget, setEditTarget] = useState<EditTarget | null>(null)
+
+  // `name`/`title` live inside the edit dialog, so their `FormMessage` is not
+  // mounted while the list is shown. Surface the error on the badge instead —
+  // otherwise a blank name blocks submit with nothing visible on screen.
+  const prizeErrors = (
+    errors as {
+      prizeSettings?: {
+        prizes?: { name?: unknown }[]
+        nonWinning?: { title?: unknown }
+      }
+    }
+  ).prizeSettings
+  const hasPrizeNameError = (index: number) =>
+    Boolean(prizeErrors?.prizes?.[index]?.name)
+  const hasNonWinningTitleError = Boolean(prizeErrors?.nonWinning?.title)
 
   const { fields, append, remove } = useFieldArray({
     control,
@@ -79,7 +97,11 @@ export function PrizeListEditor({ workspaceId }: { workspaceId: string }) {
         {fields.map((field, index) => (
           <div className="flex items-center gap-3" key={field.id}>
             <Badge
-              className="w-40 cursor-pointer gap-1.5 rounded-full bg-blue-100 px-3 py-1.5 text-blue-700 hover:bg-blue-200 dark:bg-blue-950 dark:text-blue-300"
+              className={cn(
+                "w-40 cursor-pointer gap-1.5 rounded-full bg-blue-100 px-3 py-1.5 text-blue-700 hover:bg-blue-200 dark:bg-blue-950 dark:text-blue-300",
+                hasPrizeNameError(index) &&
+                  "bg-destructive/10 text-destructive ring-1 ring-destructive dark:bg-destructive/20 dark:text-destructive",
+              )}
               render={
                 <button
                   onClick={() => setEditTarget({ variant: "prize", index })}
@@ -115,7 +137,11 @@ export function PrizeListEditor({ workspaceId }: { workspaceId: string }) {
 
         <div className="flex items-center gap-3">
           <Badge
-            className="w-40 cursor-pointer gap-1.5 rounded-full bg-slate-700 px-3 py-1.5 text-white hover:bg-slate-800"
+            className={cn(
+              "w-40 cursor-pointer gap-1.5 rounded-full bg-slate-700 px-3 py-1.5 text-white hover:bg-slate-800",
+              hasNonWinningTitleError &&
+                "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+            )}
             render={
               <button
                 onClick={() => setEditTarget({ variant: "nonWinning" })}
@@ -143,14 +169,7 @@ export function PrizeListEditor({ workspaceId }: { workspaceId: string }) {
 
       <Button
         className="w-fit"
-        onClick={() =>
-          append({
-            id: createId(),
-            name: "",
-            icon: { mode: "file", url: "" },
-            winRate: 0,
-          })
-        }
+        onClick={() => append(createDefaultMinigamePrize(fields.length, 0))}
         type="button"
         variant="outline"
       >

--- a/apps/builder/src/features/minigames/constants.ts
+++ b/apps/builder/src/features/minigames/constants.ts
@@ -3,6 +3,7 @@ import type {
   MinigameGeneralSettings,
   MinigameNonWinningMessageSettings,
   MinigamePlayerSettings,
+  MinigamePrizeItem,
   MinigamePrizeSettings,
   MinigameType,
   MinigameWinningMessageSettings,
@@ -199,14 +200,29 @@ export function getDefaultMinigamePlayerSettings(): MinigamePlayerSettings {
 
 const DEFAULT_PRIZE_COUNT = 3
 
+/**
+ * A prize row that already satisfies `minigamePrizeItemSchema`. The name must
+ * never start out empty: `name` is `min(1)` and is only editable inside the
+ * prize dialog, so a blank one makes the form fail validation with the error
+ * attached to a field that isn't rendered — the Save button then looks dead.
+ */
+export function createDefaultMinigamePrize(
+  index: number,
+  winRate: number,
+): MinigamePrizeItem {
+  return {
+    id: createId(),
+    name: `Prize ${index + 1}`,
+    icon: { mode: "file", url: "" },
+    winRate,
+  }
+}
+
 export function getDefaultMinigamePrizeSettings(): MinigamePrizeSettings {
   return {
-    prizes: Array.from({ length: DEFAULT_PRIZE_COUNT }, (_, index) => ({
-      id: createId(),
-      name: `Prize ${index + 1}`,
-      icon: { mode: "file" as const, url: "" },
-      winRate: 25,
-    })),
+    prizes: Array.from({ length: DEFAULT_PRIZE_COUNT }, (_, index) =>
+      createDefaultMinigamePrize(index, 25),
+    ),
     nonWinning: {
       title: "Non-winning",
       loseRate: 25,

--- a/apps/builder/src/features/minigames/minigame-form.tsx
+++ b/apps/builder/src/features/minigames/minigame-form.tsx
@@ -289,7 +289,14 @@ export function MinigameForm(props: MinigameFormProps) {
     prizeNameCustomFieldId: prizeSettings?.prizeNameCustomFieldId ?? null,
   }
 
-  const onSubmit = form.handleSubmit((values) => action.execute(values))
+  // Several required fields (prize name, non-winning title, outcome messages)
+  // only render inside dialogs, so their `FormMessage` is unmounted when Save
+  // is pressed. Without this toast a failed validation is completely silent
+  // and the button reads as broken.
+  const onSubmit = form.handleSubmit(
+    (values) => action.execute(values),
+    () => toast.error(t("minigames.form.validationFailed")),
+  )
 
   return (
     <Form {...form}>


### PR DESCRIPTION
## Summary

- Adding a prize made the Save button look dead: a new prize row started with an empty `name`, which fails `minigamePrizeItemSchema`'s `min(1)`.
- The `name` field only renders inside the prize dialog, so its `FormMessage` was unmounted when Save was pressed — `handleSubmit` rejected with nothing visible on screen and no toast.
- Fixed the root cause and made any future dialog-only validation failure visible instead of silent.

## Changes

- `features/minigames/constants.ts` — extracted `createDefaultMinigamePrize(index, winRate)` so the initial prize set and the "New Prize" button share one definition; new prizes are named `Prize N` and are valid on creation.
- `features/minigames/components/prize-list-editor.tsx` — appends via the shared helper; a prize (or the non-winning row) whose dialog-only field is invalid is now highlighted in the list.
- `features/minigames/minigame-form.tsx` — added an `onInvalid` handler to `form.handleSubmit` that raises a toast, so a rejected submit is never silent.
- `apps/builder/messages/*.json` — new `minigames.form.validationFailed` key added to all 20 locales.

## Test plan

- [ ] `pnpm lint`
- [ ] `pnpm --filter builder check-types`
- [ ] Open a minigame → click **New Prize** → click **Save**: saves successfully (prize gets a default name)
- [ ] Clear a prize's name inside the dialog → **Save**: error toast appears and that prize's badge turns red
- [ ] Set win rates so the total is not 100% → **Save**: existing lose-rate error still shows as before