### PR TITLE
fix(webchat): accept the minted guest conversation id in message schemas

### DIFF
--- a/apps/builder/__tests__/webchat-message-schema.test.ts
+++ b/apps/builder/__tests__/webchat-message-schema.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest"
+import { createGuestConversationId } from "@/features/integration-webchat/lib/guest-conversation-id"
+import { createWebchatMessageRequest } from "@/features/messages/schema/mutation"
+import { listGuestMessagesRequest } from "@/features/messages/schema/query"
+
+const WORKSPACE_ID = "11530439376896"
+const WEBCHAT_ID = "11616773281153024"
+
+const baseInput = (guestConversationId: string) => ({
+  text: "hello",
+  workspaceId: WORKSPACE_ID,
+  webchatId: WEBCHAT_ID,
+  guestConversationId,
+})
+
+describe("createWebchatMessageRequest — guestConversationId", () => {
+  test("accepts the `<workspaceId>:<uuid>` id the server actually mints — a digits-only rule here leaves the widget's send button permanently disabled, since the form only enables it on formState.isValid", () => {
+    const result = createWebchatMessageRequest.safeParse(
+      baseInput(createGuestConversationId(WORKSPACE_ID)),
+    )
+
+    expect(result.success).toBe(true)
+  })
+
+  test("still accepts a legacy digits-only Snowflake id, which returning visitors carry in localStorage", () => {
+    const result = createWebchatMessageRequest.safeParse(
+      baseInput("11616773281153025"),
+    )
+
+    expect(result.success).toBe(true)
+  })
+
+  test("rejects an arbitrary string — the id is the only proof a caller owns the guest session, so the format stays tight", () => {
+    const result = createWebchatMessageRequest.safeParse(
+      baseInput("../../not-an-id"),
+    )
+
+    expect(result.success).toBe(false)
+  })
+
+  test("rejects a non-uuid suffix", () => {
+    const result = createWebchatMessageRequest.safeParse(
+      baseInput(`${WORKSPACE_ID}:guest-1`),
+    )
+
+    expect(result.success).toBe(false)
+  })
+})
+
+describe("listGuestMessagesRequest — guestConversationId", () => {
+  test("accepts the minted id so history loads for a new visitor", () => {
+    const result = listGuestMessagesRequest.safeParse({
+      workspaceId: WORKSPACE_ID,
+      webchatId: WEBCHAT_ID,
+      guestConversationId: createGuestConversationId(WORKSPACE_ID),
+    })
+
+    expect(result.success).toBe(true)
+  })
+})

--- a/apps/builder/src/features/integration-webchat/lib/guest-conversation-id.ts
+++ b/apps/builder/src/features/integration-webchat/lib/guest-conversation-id.ts
@@ -1,3 +1,5 @@
+import { z } from "zod"
+
 // A cryptographically random (128-bit), unguessable id — not the sequential
 // Snowflake createId(). The webchat access token is session-scoped only (see
 // webchat-access-token.ts) and does not bind to this id, so possession of the
@@ -6,3 +8,15 @@
 // valid token for a stranger's conversation just by guessing nearby ids.
 export const createGuestConversationId = (workspaceId: string) =>
   `${workspaceId}:${crypto.randomUUID()}`
+
+// Two accepted shapes, and both must stay accepted: the `<workspaceId>:<uuid>`
+// form minted above, and the legacy digits-only Snowflake that returning
+// visitors still carry in localStorage (migrated by readLegacyGuestId). This is
+// deliberately NOT zodBigintAsString() — the current form is not digits-only,
+// and validating it as a bigint leaves every new visitor's message input
+// permanently invalid (the send button never enables).
+const GUEST_CONVERSATION_ID_REGEX =
+  /^\d+(?::[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?$/i
+
+export const zodGuestConversationId = () =>
+  z.string().regex(GUEST_CONVERSATION_ID_REGEX)

--- a/apps/builder/src/features/messages/schema/mutation.ts
+++ b/apps/builder/src/features/messages/schema/mutation.ts
@@ -1,6 +1,7 @@
 import { channelTypes } from "@chatbotx.io/database/partials"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { z } from "zod"
+import { zodGuestConversationId } from "@/features/integration-webchat/lib/guest-conversation-id"
 
 const MAX_FILE_SIZE = 5 * 1000 * 1000
 
@@ -115,7 +116,7 @@ export const createWebchatMessageRequest = z
       clientId: z.string().optional(),
       workspaceId: zodBigintAsString(),
       webchatId: zodBigintAsString(),
-      guestConversationId: zodBigintAsString(),
+      guestConversationId: zodGuestConversationId(),
       ref: z.string().optional(),
       parentUrl: z.url().max(2048).optional(),
       locale: z.string().max(35).optional(),

--- a/apps/builder/src/features/messages/schema/query.ts
+++ b/apps/builder/src/features/messages/schema/query.ts
@@ -2,6 +2,7 @@ import { zodBigintAsString } from "@chatbotx.io/utils"
 import { z } from "zod"
 import { attachmentResource } from "@/features/attachments/schema/resource"
 import { contactResource } from "@/features/contacts/schema/resource"
+import { zodGuestConversationId } from "@/features/integration-webchat/lib/guest-conversation-id"
 import { userResource } from "@/features/users/schema/resource"
 import { messageResource } from "./resource"
 
@@ -42,7 +43,7 @@ export const listGuestMessagesRequest = z.object({
   webchatId: zodBigintAsString(),
   perPage: z.coerce.number().optional().default(20),
   cursor: z.string().optional(),
-  guestConversationId: zodBigintAsString(),
+  guestConversationId: zodGuestConversationId(),
   accessToken: z.string().optional(),
   parentOrigin: z.string().optional(),
 })


### PR DESCRIPTION
## Summary

- `createGuestConversationId` mints `<workspaceId>:<uuid>`, but the webchat send mutation and the guest message list both validated that field with `zodBigintAsString()` — a digits-only rule. Every new visitor therefore failed input validation, and since the widget's form only enables the send button on `formState.isValid`, the button never enabled.
- Replaces both with a dedicated `zodGuestConversationId()` that accepts the current `<workspaceId>:<uuid>` form **and** the legacy digits-only Snowflake that returning visitors still carry in localStorage (migrated by `readLegacyGuestId`).
- The regex stays tight rather than falling back to a bare `z.string()`: the guest conversation id is the only proof a caller owns that guest session.

## Changes

- `apps/builder/src/features/integration-webchat/lib/guest-conversation-id.ts` — add `zodGuestConversationId()` next to the minting helper, with a comment on why it is deliberately not `zodBigintAsString()`.
- `apps/builder/src/features/messages/schema/mutation.ts` — `createWebchatMessageRequest.guestConversationId` uses the new validator.
- `apps/builder/src/features/messages/schema/query.ts` — same for `listGuestMessagesRequest`.
- `apps/builder/__tests__/webchat-message-schema.test.ts` — new: covers the minted form, the legacy digits-only form, and rejection of an arbitrary string, for both schemas.

## Test plan

- [x] `pnpm ultracite fix` + full `check-types` (ran via the pre-commit hook, clean)
- [ ] `pnpm --filter builder test -- webchat-message-schema`
- [ ] Manual: open the webchat widget as a brand-new visitor — the send button enables and the message sends
- [ ] Manual: returning visitor with a legacy digits-only id in localStorage still loads history and can send