### PR TITLE
fix(inbox): keep a conversation unread when a bot reply arrives

### DIFF
--- a/apps/builder/__tests__/chat-store.test.ts
+++ b/apps/builder/__tests__/chat-store.test.ts
@@ -33,7 +33,8 @@ type TestConversation = {
   contactId: string
   messages: unknown[]
   lastActivityAt: Date | null
-  agentLastReadAt?: Date
+  agentLastReadAt?: Date | null
+  adminRepliedAt?: Date | null
 }
 
 type TestMessage = {
@@ -42,6 +43,8 @@ type TestMessage = {
   conversationId: string
   createdAt: Date
   messageType: string
+  senderType?: string
+  senderId?: string | null
 }
 
 const makeConversation = (id: string, lastActivityAt: Date) =>
@@ -60,6 +63,22 @@ const makeMessage = (conversationId: string, createdAt: Date) =>
     conversationId,
     createdAt,
     messageType: "incoming",
+  }) as TestMessage
+
+const makeOutgoingMessage = (
+  conversationId: string,
+  createdAt: Date,
+  senderType: "user" | "api" | "bot" | "system",
+  // `received-message` stamps a channel echo senderType "user" with a null
+  // senderId; `createOutgoing` always carries the acting user's id.
+  senderId: string | null = senderType === "user" ? "user-1" : null,
+) =>
+  ({
+    ...makeMessage(conversationId, createdAt),
+    id: `msg-${conversationId}-${senderType}`,
+    messageType: "outgoing",
+    senderType,
+    senderId,
   }) as TestMessage
 
 const setConversationUrl = (conversationId: string | null) => {
@@ -387,6 +406,131 @@ describe("chat store conversation updates", () => {
     expect(conversations[1]).toEqual({
       ...second,
       agentLastReadAt: new Date("2026-01-02T00:00:00Z"),
+    })
+  })
+})
+
+describe("chat store handleNewMessage read state", () => {
+  const AGENT_LAST_READ_AT = new Date("2026-01-01T00:00:00Z")
+
+  const makeUnreadStore = (activeConversationId: string | null = null) => {
+    const store = createChatStore()
+    const conversation = {
+      ...makeConversation("conv-1", new Date("2026-01-01T01:00:00Z")),
+      agentLastReadAt: AGENT_LAST_READ_AT,
+      adminRepliedAt: null,
+    }
+    store.setState({
+      conversations: [conversation] as never,
+      activeConversationId,
+    })
+    return store
+  }
+
+  const readStateOf = (store: ReturnType<typeof createChatStore>) => {
+    const conversation = store
+      .getState()
+      .conversations.find((c) => c.id === "conv-1") as TestConversation
+    return {
+      agentLastReadAt: conversation.agentLastReadAt,
+      adminRepliedAt: conversation.adminRepliedAt,
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setConversationUrl(null)
+  })
+
+  test.each([
+    "bot",
+    "system",
+  ] as const)("a %s outgoing message leaves the conversation unread", async (senderType) => {
+    const store = makeUnreadStore()
+
+    await store
+      .getState()
+      .handleNewMessage(
+        makeOutgoingMessage(
+          "conv-1",
+          new Date("2026-01-01T02:00:00Z"),
+          senderType,
+        ) as never,
+      )
+
+    expect(readStateOf(store)).toEqual({
+      agentLastReadAt: AGENT_LAST_READ_AT,
+      adminRepliedAt: null,
+    })
+  })
+
+  test.each([
+    "user",
+    "api",
+  ] as const)("a %s outgoing message marks the conversation read and replied", async (senderType) => {
+    const store = makeUnreadStore()
+
+    await store
+      .getState()
+      .handleNewMessage(
+        makeOutgoingMessage(
+          "conv-1",
+          new Date("2026-01-01T02:00:00Z"),
+          senderType,
+        ) as never,
+      )
+
+    const { agentLastReadAt, adminRepliedAt } = readStateOf(store)
+    expect(agentLastReadAt).not.toEqual(AGENT_LAST_READ_AT)
+    expect(agentLastReadAt).toEqual(adminRepliedAt)
+  })
+
+  test("a channel echo (senderType user, no senderId) leaves the conversation unread", async () => {
+    const store = makeUnreadStore()
+
+    await store
+      .getState()
+      .handleNewMessage(
+        makeOutgoingMessage(
+          "conv-1",
+          new Date("2026-01-01T02:00:00Z"),
+          "user",
+          null,
+        ) as never,
+      )
+
+    expect(readStateOf(store)).toEqual({
+      agentLastReadAt: AGENT_LAST_READ_AT,
+      adminRepliedAt: null,
+    })
+  })
+
+  test("an incoming message on the open conversation marks it read without an admin reply", async () => {
+    const store = makeUnreadStore("conv-1")
+
+    await store
+      .getState()
+      .handleNewMessage(
+        makeMessage("conv-1", new Date("2026-01-01T02:00:00Z")) as never,
+      )
+
+    const { agentLastReadAt, adminRepliedAt } = readStateOf(store)
+    expect(agentLastReadAt).not.toEqual(AGENT_LAST_READ_AT)
+    expect(adminRepliedAt).toBeNull()
+  })
+
+  test("an incoming message on a background conversation stays unread", async () => {
+    const store = makeUnreadStore("conv-other")
+
+    await store
+      .getState()
+      .handleNewMessage(
+        makeMessage("conv-1", new Date("2026-01-01T02:00:00Z")) as never,
+      )
+
+    expect(readStateOf(store)).toEqual({
+      agentLastReadAt: AGENT_LAST_READ_AT,
+      adminRepliedAt: null,
     })
   })
 })

--- a/apps/builder/src/features/chat/store/chat-store.ts
+++ b/apps/builder/src/features/chat/store/chat-store.ts
@@ -694,14 +694,38 @@ export const createChatStore = () => {
             : {}),
         })
       }
-      if (
-        message.messageType === "outgoing" ||
-        (message.messageType === "incoming" &&
-          message.conversationId === activeConversationId)
-      ) {
+      // Only an outgoing message that `createOutgoing` itself produced clears
+      // the unread state — a bot/system reply (flow step, template, comment
+      // automation) must leave it alone. This mirrors the server exactly:
+      // `createOutgoing` is the only writer that calls `markAgentReplied`,
+      // and it stamps senderType "user" with a senderId (inbox composer) or
+      // "api" with none (public API); the worker handlers that send on the
+      // bot's behalf only bump `lastActivityAt`. Without this guard a flow
+      // reply broadcast over realtime marked every open inbox tab as read
+      // even though nobody had opened the conversation.
+      //
+      // The senderId check is what excludes a channel echo: `received-message`
+      // stamps every outgoing echo senderType "user" with a null senderId
+      // whatever its origin (see its `isEchoOfOwnSend` comment), so a bot send
+      // whose sourceId dedup missed comes back looking like an agent reply.
+      // Echoes never persist a read state server-side either, so honouring
+      // them here would only produce a state that reverts on reload.
+      const isAgentReply =
+        message.messageType === "outgoing" &&
+        ((message.senderType === "user" && message.senderId !== null) ||
+          message.senderType === "api")
+      // An incoming message only counts as read while the agent has that
+      // conversation open — and it is never an admin reply, so it must not
+      // touch `adminRepliedAt` (that drives the "no admin reply" filter).
+      const isReadWhileConversationOpen =
+        message.messageType === "incoming" &&
+        message.conversationId === activeConversationId
+
+      if (isAgentReply || isReadWhileConversationOpen) {
+        const readAt = new Date()
         updateConversation(message.conversationId, {
-          agentLastReadAt: new Date(),
-          adminRepliedAt: new Date(),
+          agentLastReadAt: readAt,
+          ...(isAgentReply ? { adminRepliedAt: readAt } : {}),
         })
       }
 


### PR DESCRIPTION
## Summary

- `handleNewMessage` in the chat store treated **every** outgoing message as an agent reply. A flow step, template or comment-automation send broadcast over realtime therefore stamped `agentLastReadAt` **and** `adminRepliedAt` on every open inbox tab — the conversation went read even though no agent had opened it, and it dropped out of the "no admin reply" filter.
- Now mirrors the server exactly: `createOutgoing` is the only writer that calls `markAgentReplied`, and it stamps senderType `"user"` with a senderId (inbox composer) or `"api"` with none (public API). Worker handlers sending on the bot's behalf only bump `lastActivityAt`.
- The `senderId !== null` check is what excludes a **channel echo**: `received-message` stamps every outgoing echo `"user"` with a null senderId whatever its origin, so a bot send whose `sourceId` dedup missed comes back looking like an agent reply. Echoes persist no read state server-side either, so honouring them would only produce state that reverts on reload.
- An incoming message on the currently open conversation still marks it read, but no longer touches `adminRepliedAt` — an inbound message is never an admin reply.

## Changes

- `apps/builder/src/features/chat/store/chat-store.ts` — split the single condition into `isAgentReply` / `isReadWhileConversationOpen`, and apply `adminRepliedAt` only for the former.
- `apps/builder/__tests__/chat-store.test.ts` — new `handleNewMessage read state` suite: bot/system outgoing stays unread; user/api outgoing marks read + replied; channel echo (user + null senderId) stays unread; incoming on the open conversation marks read without an admin reply; incoming on a background conversation stays unread.

## Test plan

- [x] `pnpm ultracite fix` + full `check-types` (ran via the pre-commit hook, clean)
- [ ] `pnpm --filter builder test -- chat-store`
- [ ] Manual: leave the inbox open on the conversation list, trigger a flow reply on a conversation you have not opened — it stays bold/unread and remains in the "no admin reply" filter
- [ ] Manual: reply from the inbox composer — the conversation goes read and leaves the "no admin reply" filter