### PR TITLE
feat(api): add ecommerce-scoped public API for products, categories, …

### DIFF
--- a/apps/builder/__tests__/__snapshots__/public-spec-operations.test.ts.snap
+++ b/apps/builder/__tests__/__snapshots__/public-spec-operations.test.ts.snap
@@ -314,6 +314,61 @@ exports[`public API spec — operation naming guard > operation list (operationI
   },
   {
     "method": "POST",
+    "operationId": "coupons.archiveTopic",
+    "path": "/v1/coupon-topics/{id}/archive",
+  },
+  {
+    "method": "POST",
+    "operationId": "coupons.createTopic",
+    "path": "/v1/coupon-topics",
+  },
+  {
+    "method": "DELETE",
+    "operationId": "coupons.deleteTopic",
+    "path": "/v1/coupon-topics/{id}",
+  },
+  {
+    "method": "GET",
+    "operationId": "coupons.getTopic",
+    "path": "/v1/coupon-topics/{id}",
+  },
+  {
+    "method": "POST",
+    "operationId": "coupons.issueCoupon",
+    "path": "/v1/coupon-topics/{id}/issue",
+  },
+  {
+    "method": "GET",
+    "operationId": "coupons.listContactCoupons",
+    "path": "/v1/contacts/{contactId}/coupons",
+  },
+  {
+    "method": "GET",
+    "operationId": "coupons.listCoupons",
+    "path": "/v1/coupons",
+  },
+  {
+    "method": "GET",
+    "operationId": "coupons.listTopics",
+    "path": "/v1/coupon-topics",
+  },
+  {
+    "method": "POST",
+    "operationId": "coupons.markCouponUsed",
+    "path": "/v1/coupon-topics/{id}/mark-used",
+  },
+  {
+    "method": "POST",
+    "operationId": "coupons.unarchiveTopic",
+    "path": "/v1/coupon-topics/{id}/unarchive",
+  },
+  {
+    "method": "PATCH",
+    "operationId": "coupons.updateTopic",
+    "path": "/v1/coupon-topics/{id}",
+  },
+  {
+    "method": "POST",
     "operationId": "customFields.create",
     "path": "/v1/custom-fields",
   },
@@ -406,6 +461,51 @@ exports[`public API spec — operation naming guard > operation list (operationI
     "method": "GET",
     "operationId": "keywords.list",
     "path": "/v1/keywords",
+  },
+  {
+    "method": "POST",
+    "operationId": "productCategories.create",
+    "path": "/v1/product-categories",
+  },
+  {
+    "method": "DELETE",
+    "operationId": "productCategories.delete",
+    "path": "/v1/product-categories/{id}",
+  },
+  {
+    "method": "GET",
+    "operationId": "productCategories.list",
+    "path": "/v1/product-categories",
+  },
+  {
+    "method": "PATCH",
+    "operationId": "productCategories.update",
+    "path": "/v1/product-categories/{id}",
+  },
+  {
+    "method": "POST",
+    "operationId": "products.create",
+    "path": "/v1/products",
+  },
+  {
+    "method": "DELETE",
+    "operationId": "products.delete",
+    "path": "/v1/products/{id}",
+  },
+  {
+    "method": "GET",
+    "operationId": "products.get",
+    "path": "/v1/products/{id}",
+  },
+  {
+    "method": "GET",
+    "operationId": "products.list",
+    "path": "/v1/products",
+  },
+  {
+    "method": "PATCH",
+    "operationId": "products.update",
+    "path": "/v1/products/{id}",
   },
   {
     "method": "GET",

--- a/apps/builder/__tests__/coupons-public-api.test.ts
+++ b/apps/builder/__tests__/coupons-public-api.test.ts
@@ -108,6 +108,7 @@ describe("POST /v1/coupon-topics/{id}/issue", () => {
   const procedure = findProcedure("POST", "/v1/coupon-topics/{id}/issue")
 
   test("returns the coupon on success", async () => {
+    contactService.findByIdOrFail.mockResolvedValueOnce({ id: "contact-1" })
     couponService.issueCoupon.mockResolvedValueOnce({
       ok: true,
       reason: "issued",
@@ -126,6 +127,27 @@ describe("POST /v1/coupon-topics/{id}/issue", () => {
       topicId: "t-1",
       contactId: "contact-1",
     })
+  })
+
+  // The coupon row is workspace-scoped but `issuedContactId` is written
+  // unchecked, so a contact from another workspace must never reach it.
+  test("404s before issuing when the contact belongs to another workspace", async () => {
+    contactService.findByIdOrFail.mockRejectedValueOnce(
+      new Error("Contact not found"),
+    )
+
+    await expect(
+      procedure.handler?.({
+        context: { workspace: { id: "workspace-1" } },
+        input: { id: "t-1", contactId: "foreign-contact" },
+      }),
+    ).rejects.toThrow("Contact not found")
+
+    expect(contactService.findByIdOrFail).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      id: "foreign-contact",
+    })
+    expect(couponService.issueCoupon).not.toHaveBeenCalled()
   })
 
   test("throws couponIssueUnavailable with the reason when no coupon is available", async () => {
@@ -151,6 +173,7 @@ describe("POST /v1/coupon-topics/{id}/mark-used", () => {
   const procedure = findProcedure("POST", "/v1/coupon-topics/{id}/mark-used")
 
   test("throws couponNotIssued when the contact has no issued coupon", async () => {
+    contactService.findByIdOrFail.mockResolvedValueOnce({ id: "contact-1" })
     couponService.markCouponUsed.mockResolvedValueOnce({
       ok: false,
       reason: "noIssuedCoupon",
@@ -166,6 +189,43 @@ describe("POST /v1/coupon-topics/{id}/mark-used", () => {
       code: "couponNotIssued",
       data: { reason: "noIssuedCoupon" },
     })
+  })
+
+  test("returns the coupon once marked used", async () => {
+    contactService.findByIdOrFail.mockResolvedValueOnce({ id: "contact-1" })
+    couponService.markCouponUsed.mockResolvedValueOnce({
+      ok: true,
+      reason: "markedUsed",
+      coupon: { id: "cpn-1", code: "SAVE10" },
+    })
+
+    await expect(
+      procedure.handler?.({
+        context: { workspace: { id: "workspace-1" } },
+        input: { id: "t-1", contactId: "contact-1" },
+      }),
+    ).resolves.toEqual({ id: "cpn-1", code: "SAVE10" })
+
+    expect(couponService.markCouponUsed).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      topicId: "t-1",
+      contactId: "contact-1",
+    })
+  })
+
+  test("404s before marking used when the contact belongs to another workspace", async () => {
+    contactService.findByIdOrFail.mockRejectedValueOnce(
+      new Error("Contact not found"),
+    )
+
+    await expect(
+      procedure.handler?.({
+        context: { workspace: { id: "workspace-1" } },
+        input: { id: "t-1", contactId: "foreign-contact" },
+      }),
+    ).rejects.toThrow("Contact not found")
+
+    expect(couponService.markCouponUsed).not.toHaveBeenCalled()
   })
 })
 
@@ -203,6 +263,112 @@ describe("GET /v1/contacts/{contactId}/coupons", () => {
     expect(couponService.listIssuedCouponsForContact).toHaveBeenCalledWith({
       workspaceId: "workspace-1",
       contactId: "contact-1",
+    })
+  })
+})
+
+describe("coupon topic routes forward workspace-scoped arguments", () => {
+  test("GET /v1/coupon-topics lists topics with paging", async () => {
+    couponService.listTopics.mockResolvedValueOnce({
+      data: [{ id: "t-1", couponCount: 3 }],
+      pageCount: 2,
+    })
+
+    await expect(
+      findProcedure("GET", "/v1/coupon-topics").handler?.({
+        context: { workspace: { id: "workspace-1" } },
+        input: { page: 1, perPage: 50, archived: false },
+      }),
+    ).resolves.toEqual({ data: [{ id: "t-1", couponCount: 3 }], pageCount: 2 })
+
+    expect(couponService.listTopics).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      page: 1,
+      perPage: 50,
+      archived: false,
+    })
+  })
+
+  test("GET /v1/coupon-topics/{id} fetches one topic", async () => {
+    couponService.getTopic.mockResolvedValueOnce({ id: "t-1" })
+
+    await expect(
+      findProcedure("GET", "/v1/coupon-topics/{id}").handler?.({
+        context: { workspace: { id: "workspace-1" } },
+        input: { id: "t-1" },
+      }),
+    ).resolves.toEqual({ id: "t-1" })
+
+    expect(couponService.getTopic).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      topicId: "t-1",
+    })
+  })
+
+  test("PATCH /v1/coupon-topics/{id} maps id to topicId", async () => {
+    couponService.updateTopic.mockResolvedValueOnce({ id: "t-1" })
+
+    await findProcedure("PATCH", "/v1/coupon-topics/{id}").handler?.({
+      context: { workspace: { id: "workspace-1" } },
+      input: { id: "t-1", name: "Renamed" },
+    })
+
+    expect(couponService.updateTopic).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      topicId: "t-1",
+      name: "Renamed",
+    })
+  })
+
+  test.each([
+    ["/v1/coupon-topics/{id}/archive", "archiveTopic"],
+    ["/v1/coupon-topics/{id}/unarchive", "unarchiveTopic"],
+  ] as const)("POST %s calls %s", async (path, method) => {
+    couponService[method].mockResolvedValueOnce({ id: "t-1" })
+
+    await findProcedure("POST", path).handler?.({
+      context: { workspace: { id: "workspace-1" } },
+      input: { id: "t-1" },
+    })
+
+    expect(couponService[method]).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      topicId: "t-1",
+    })
+  })
+
+  test("DELETE /v1/coupon-topics/{id} deletes the topic", async () => {
+    couponService.deleteTopic.mockResolvedValueOnce({ id: "t-1" })
+
+    await findProcedure("DELETE", "/v1/coupon-topics/{id}").handler?.({
+      context: { workspace: { id: "workspace-1" } },
+      input: { id: "t-1" },
+    })
+
+    expect(couponService.deleteTopic).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      topicId: "t-1",
+    })
+  })
+
+  test("GET /v1/coupons lists coupons with filters", async () => {
+    couponService.listCoupons.mockResolvedValueOnce({
+      data: [{ id: "cpn-1" }],
+      pageCount: 1,
+    })
+
+    await expect(
+      findProcedure("GET", "/v1/coupons").handler?.({
+        context: { workspace: { id: "workspace-1" } },
+        input: { page: 1, perPage: 50, topicId: "t-1" },
+      }),
+    ).resolves.toEqual({ data: [{ id: "cpn-1" }], pageCount: 1 })
+
+    expect(couponService.listCoupons).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      page: 1,
+      perPage: 50,
+      topicId: "t-1",
     })
   })
 })

--- a/apps/builder/__tests__/coupons-public-api.test.ts
+++ b/apps/builder/__tests__/coupons-public-api.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+type RouteConfig = {
+  method: string
+  path: string
+  summary: string
+  tags: string[]
+  successStatus?: number
+}
+
+type CapturedProcedure = {
+  route: RouteConfig
+  handler?: (...args: any[]) => any
+}
+
+const { workspaceTokenAuthAPIForScope, capturedProcedures } = vi.hoisted(() => {
+  const capturedProcedures: CapturedProcedure[] = []
+
+  const makeProcedure = (route: RouteConfig) => {
+    const record: CapturedProcedure = { route }
+    capturedProcedures.push(record)
+
+    const chain = {
+      input: vi.fn(() => chain),
+      output: vi.fn(() => chain),
+      errors: vi.fn(() => chain),
+      handler: vi.fn((fn: (...args: any[]) => any) => {
+        record.handler = fn
+        return { handler: fn }
+      }),
+    }
+    return chain
+  }
+
+  const workspaceTokenAuthAPI = {
+    route: vi.fn((config: RouteConfig) => makeProcedure(config)),
+  }
+
+  return {
+    workspaceTokenAuthAPIForScope: vi.fn(
+      (_scope: string) => workspaceTokenAuthAPI,
+    ),
+    capturedProcedures,
+  }
+})
+
+vi.mock("@/orpc", () => ({ workspaceTokenAuthAPIForScope }))
+
+const couponService = {
+  listTopics: vi.fn(),
+  getTopic: vi.fn(),
+  createTopic: vi.fn(),
+  updateTopic: vi.fn(),
+  archiveTopic: vi.fn(),
+  unarchiveTopic: vi.fn(),
+  deleteTopic: vi.fn(),
+  listCoupons: vi.fn(),
+  issueCoupon: vi.fn(),
+  markCouponUsed: vi.fn(),
+  listIssuedCouponsForContact: vi.fn(),
+}
+const contactService = { findByIdOrFail: vi.fn() }
+
+vi.mock("@chatbotx.io/business", () => ({ couponService, contactService }))
+
+await import("@/features/coupons/api/public")
+
+const findProcedure = (method: string, path: string) => {
+  const found = capturedProcedures.find(
+    (p) => p.route.method === method && p.route.path === path,
+  )
+  if (!found) {
+    throw new Error(`No procedure registered for ${method} ${path}`)
+  }
+  return found
+}
+
+const scopeArgAtImport = workspaceTokenAuthAPIForScope.mock.calls[0]?.[0]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+test("registers the coupons public router under the ecommerce scope", () => {
+  expect(scopeArgAtImport).toBe("ecommerce")
+})
+
+describe("POST /v1/coupon-topics", () => {
+  const procedure = findProcedure("POST", "/v1/coupon-topics")
+
+  test("creates a topic with no createdById — workspace tokens have no user", async () => {
+    couponService.createTopic.mockResolvedValueOnce({ id: "t-1" })
+
+    await procedure.handler?.({
+      context: { workspace: { id: "workspace-1" } },
+      input: { name: "Summer sale" },
+    })
+
+    expect(couponService.createTopic).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      createdById: null,
+      name: "Summer sale",
+    })
+  })
+})
+
+describe("POST /v1/coupon-topics/{id}/issue", () => {
+  const procedure = findProcedure("POST", "/v1/coupon-topics/{id}/issue")
+
+  test("returns the coupon on success", async () => {
+    couponService.issueCoupon.mockResolvedValueOnce({
+      ok: true,
+      reason: "issued",
+      coupon: { id: "cpn-1", code: "SAVE10" },
+    })
+
+    await expect(
+      procedure.handler?.({
+        context: { workspace: { id: "workspace-1" } },
+        input: { id: "t-1", contactId: "contact-1" },
+      }),
+    ).resolves.toEqual({ id: "cpn-1", code: "SAVE10" })
+
+    expect(couponService.issueCoupon).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      topicId: "t-1",
+      contactId: "contact-1",
+    })
+  })
+
+  test("throws couponIssueUnavailable with the reason when no coupon is available", async () => {
+    couponService.issueCoupon.mockResolvedValueOnce({
+      ok: false,
+      reason: "noAvailableCoupon",
+      coupon: null,
+    })
+
+    await expect(
+      procedure.handler?.({
+        context: { workspace: { id: "workspace-1" } },
+        input: { id: "t-1", contactId: "contact-1" },
+      }),
+    ).rejects.toMatchObject({
+      code: "couponIssueUnavailable",
+      data: { reason: "noAvailableCoupon" },
+    })
+  })
+})
+
+describe("POST /v1/coupon-topics/{id}/mark-used", () => {
+  const procedure = findProcedure("POST", "/v1/coupon-topics/{id}/mark-used")
+
+  test("throws couponNotIssued when the contact has no issued coupon", async () => {
+    couponService.markCouponUsed.mockResolvedValueOnce({
+      ok: false,
+      reason: "noIssuedCoupon",
+      coupon: null,
+    })
+
+    await expect(
+      procedure.handler?.({
+        context: { workspace: { id: "workspace-1" } },
+        input: { id: "t-1", contactId: "contact-1" },
+      }),
+    ).rejects.toMatchObject({
+      code: "couponNotIssued",
+      data: { reason: "noIssuedCoupon" },
+    })
+  })
+})
+
+describe("GET /v1/contacts/{contactId}/coupons", () => {
+  const procedure = findProcedure("GET", "/v1/contacts/{contactId}/coupons")
+
+  test("404s when the contact does not exist", async () => {
+    contactService.findByIdOrFail.mockRejectedValueOnce(
+      new Error("Contact not found"),
+    )
+
+    await expect(
+      procedure.handler?.({
+        context: { workspace: { id: "workspace-1" } },
+        input: { contactId: "missing" },
+      }),
+    ).rejects.toThrow("Contact not found")
+
+    expect(couponService.listIssuedCouponsForContact).not.toHaveBeenCalled()
+  })
+
+  test("lists coupons issued to the contact", async () => {
+    contactService.findByIdOrFail.mockResolvedValueOnce({ id: "contact-1" })
+    couponService.listIssuedCouponsForContact.mockResolvedValueOnce([
+      { id: "cpn-1" },
+    ])
+
+    await expect(
+      procedure.handler?.({
+        context: { workspace: { id: "workspace-1" } },
+        input: { contactId: "contact-1" },
+      }),
+    ).resolves.toEqual({ data: [{ id: "cpn-1" }] })
+
+    expect(couponService.listIssuedCouponsForContact).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      contactId: "contact-1",
+    })
+  })
+})

--- a/apps/builder/__tests__/coupons-public-scope.test.ts
+++ b/apps/builder/__tests__/coupons-public-scope.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+  findWorkspaceByTokenHash,
+  isWorkspaceScheduledForDeletion,
+  getAccessState,
+  isAtLimit,
+  assertApiNotRateLimited,
+} = vi.hoisted(() => ({
+  findWorkspaceByTokenHash: vi.fn(),
+  isWorkspaceScheduledForDeletion: vi.fn().mockReturnValue(false),
+  getAccessState: vi.fn().mockResolvedValue({ blocked: false }),
+  isAtLimit: vi.fn().mockResolvedValue(false),
+  assertApiNotRateLimited: vi.fn().mockResolvedValue(undefined),
+}))
+
+const couponService = { listTopics: vi.fn() }
+const contactService = { findByIdOrFail: vi.fn() }
+
+vi.mock("@chatbotx.io/business", () => ({
+  workspaceApiTokenService: { findWorkspaceByTokenHash },
+  isWorkspaceScheduledForDeletion,
+  userQuotaService: { getAccessState },
+  quotaEnforcementService: { isAtLimit },
+  couponService,
+  contactService,
+}))
+
+vi.mock("@/lib/log", () => ({
+  logger: { warn: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock("@/lib/rate-limit/api-rate-limit", () => ({
+  assertApiNotRateLimited,
+}))
+
+vi.mock("@/lib/rate-limit/guest-rate-limit", () => ({
+  getGuestClientIp: () => "203.0.113.9",
+}))
+
+vi.mock("@/env", () => ({ isCloud: () => true }))
+
+// `@/orpc` also exports `authorizedAPI`, which pulls in the full better-auth
+// stack via `authMiddleware` — irrelevant here and unsafe to initialize in a
+// unit test. Same stub as workspace-token-scope-enforcement.test.ts.
+vi.mock("@/middlewares/auth", () => ({
+  authMiddleware: vi.fn(),
+}))
+
+const { call } = await import("@orpc/server")
+const { couponsPublicRouter } = await import(
+  "../src/features/coupons/api/public"
+)
+
+const TOKEN = "cbx_ws_fixture"
+
+const authResult = (scopes: string[] | null) => ({
+  workspace: { id: "ws-1", ownerId: "owner-1" },
+  apiToken: { id: "token-1", permission: "full" as const, scopes },
+})
+
+const invoke = (procedure: typeof couponsPublicRouter.listTopics) =>
+  call(
+    procedure,
+    {},
+    {
+      context: { headers: new Headers({ Authorization: `Bearer ${TOKEN}` }) },
+    },
+  )
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  isWorkspaceScheduledForDeletion.mockReturnValue(false)
+  getAccessState.mockResolvedValue({ blocked: false })
+  isAtLimit.mockResolvedValue(false)
+  assertApiNotRateLimited.mockResolvedValue(undefined)
+})
+
+describe("real router: coupons public API scope wiring", () => {
+  test("a contacts-scoped token is denied the real GET /v1/coupon-topics route with FORBIDDEN", async () => {
+    findWorkspaceByTokenHash.mockResolvedValue(authResult(["contacts"]))
+
+    await expect(invoke(couponsPublicRouter.listTopics)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "Token is not authorized for the 'ecommerce' scope",
+    })
+  })
+
+  test("null scopes (unrestricted) passes the real GET /v1/coupon-topics route", async () => {
+    findWorkspaceByTokenHash.mockResolvedValue(authResult(null))
+    couponService.listTopics.mockResolvedValue({ data: [], pageCount: 1 })
+
+    await expect(invoke(couponsPublicRouter.listTopics)).resolves.toMatchObject(
+      { data: [], pageCount: 1 },
+    )
+  })
+})

--- a/apps/builder/__tests__/product-categories-public-api.test.ts
+++ b/apps/builder/__tests__/product-categories-public-api.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+type RouteConfig = {
+  method: string
+  path: string
+  summary: string
+  tags: string[]
+  successStatus?: number
+}
+
+type CapturedProcedure = {
+  route: RouteConfig
+  handler?: (...args: any[]) => any
+}
+
+const { workspaceTokenAuthAPIForScope, capturedProcedures } = vi.hoisted(() => {
+  const capturedProcedures: CapturedProcedure[] = []
+
+  const makeProcedure = (route: RouteConfig) => {
+    const record: CapturedProcedure = { route }
+    capturedProcedures.push(record)
+
+    const chain = {
+      input: vi.fn(() => chain),
+      output: vi.fn(() => chain),
+      errors: vi.fn(() => chain),
+      handler: vi.fn((fn: (...args: any[]) => any) => {
+        record.handler = fn
+        return { handler: fn }
+      }),
+    }
+    return chain
+  }
+
+  const workspaceTokenAuthAPI = {
+    route: vi.fn((config: RouteConfig) => makeProcedure(config)),
+  }
+
+  return {
+    workspaceTokenAuthAPIForScope: vi.fn(
+      (_scope: string) => workspaceTokenAuthAPI,
+    ),
+    capturedProcedures,
+  }
+})
+
+vi.mock("@/orpc", () => ({ workspaceTokenAuthAPIForScope }))
+
+const productCategoryService = {
+  list: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+}
+vi.mock("@chatbotx.io/business", () => ({ productCategoryService }))
+
+await import("@/features/product-categories/api/public")
+
+const findProcedure = (method: string, path: string) => {
+  const found = capturedProcedures.find(
+    (p) => p.route.method === method && p.route.path === path,
+  )
+  if (!found) {
+    throw new Error(`No procedure registered for ${method} ${path}`)
+  }
+  return found
+}
+
+const scopeArgAtImport = workspaceTokenAuthAPIForScope.mock.calls[0]?.[0]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+test("registers the product categories public router under the ecommerce scope", () => {
+  expect(scopeArgAtImport).toBe("ecommerce")
+})
+
+describe("GET /v1/product-categories", () => {
+  const procedure = findProcedure("GET", "/v1/product-categories")
+
+  test("lists categories scoped to the token's workspace", async () => {
+    productCategoryService.list.mockResolvedValueOnce([
+      {
+        id: "c-1",
+        parentId: null,
+        name: "Electronics",
+        rank: 10,
+        productCount: 2,
+      },
+    ])
+
+    await expect(
+      procedure.handler?.({
+        context: { workspace: { id: "workspace-1" } },
+      }),
+    ).resolves.toEqual({
+      data: [
+        {
+          id: "c-1",
+          parentId: null,
+          name: "Electronics",
+          rank: 10,
+          productCount: 2,
+        },
+      ],
+    })
+
+    expect(productCategoryService.list).toHaveBeenCalledWith("workspace-1")
+  })
+})
+
+describe("POST /v1/product-categories", () => {
+  const procedure = findProcedure("POST", "/v1/product-categories")
+
+  test("creates a top-level category when parentId is omitted", async () => {
+    productCategoryService.create.mockResolvedValueOnce({ id: "c-1" })
+
+    await procedure.handler?.({
+      context: { workspace: { id: "workspace-1" } },
+      input: { name: "Electronics" },
+    })
+
+    expect(productCategoryService.create).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      name: "Electronics",
+      rank: undefined,
+      parentId: null,
+    })
+  })
+})
+
+describe("PATCH /v1/product-categories/{id}", () => {
+  const procedure = findProcedure("PATCH", "/v1/product-categories/{id}")
+
+  test("updates a category scoped to the token's workspace", async () => {
+    productCategoryService.update.mockResolvedValueOnce({ id: "c-1" })
+
+    await procedure.handler?.({
+      context: { workspace: { id: "workspace-1" } },
+      input: { id: "c-1", name: "Renamed", parentId: null },
+    })
+
+    expect(productCategoryService.update).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      categoryId: "c-1",
+      name: "Renamed",
+      parentId: null,
+    })
+  })
+})
+
+describe("DELETE /v1/product-categories/{id}", () => {
+  const procedure = findProcedure("DELETE", "/v1/product-categories/{id}")
+
+  test("deletes a category scoped to the token's workspace", async () => {
+    productCategoryService.delete.mockResolvedValueOnce(undefined)
+
+    await procedure.handler?.({
+      context: { workspace: { id: "workspace-1" } },
+      input: { id: "c-1" },
+    })
+
+    expect(productCategoryService.delete).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      categoryId: "c-1",
+    })
+  })
+})

--- a/apps/builder/__tests__/product-categories-public-api.test.ts
+++ b/apps/builder/__tests__/product-categories-public-api.test.ts
@@ -148,6 +148,42 @@ describe("PATCH /v1/product-categories/{id}", () => {
       parentId: null,
     })
   })
+
+  // `parentId` has three states, and the service branches on `undefined` to
+  // decide whether to run the reparent guards. Collapsing an absent key into
+  // `null` would silently un-parent a sub-category on a rename-only request.
+  test("omits parentId entirely when the caller did not send it", async () => {
+    productCategoryService.update.mockResolvedValueOnce({ id: "c-1" })
+
+    await procedure.handler?.({
+      context: { workspace: { id: "workspace-1" } },
+      input: { id: "c-1", name: "Renamed" },
+    })
+
+    expect(productCategoryService.update).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      categoryId: "c-1",
+      name: "Renamed",
+    })
+    const [call] = productCategoryService.update.mock.calls
+    expect(call?.[0]).not.toHaveProperty("parentId")
+  })
+
+  test("files the category under a parent when parentId is an id", async () => {
+    productCategoryService.update.mockResolvedValueOnce({ id: "c-1" })
+
+    await procedure.handler?.({
+      context: { workspace: { id: "workspace-1" } },
+      input: { id: "c-1", name: "Phones", parentId: "c-parent" },
+    })
+
+    expect(productCategoryService.update).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      categoryId: "c-1",
+      name: "Phones",
+      parentId: "c-parent",
+    })
+  })
 })
 
 describe("DELETE /v1/product-categories/{id}", () => {

--- a/apps/builder/__tests__/product-categories-public-scope.test.ts
+++ b/apps/builder/__tests__/product-categories-public-scope.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+  findWorkspaceByTokenHash,
+  isWorkspaceScheduledForDeletion,
+  getAccessState,
+  isAtLimit,
+  assertApiNotRateLimited,
+} = vi.hoisted(() => ({
+  findWorkspaceByTokenHash: vi.fn(),
+  isWorkspaceScheduledForDeletion: vi.fn().mockReturnValue(false),
+  getAccessState: vi.fn().mockResolvedValue({ blocked: false }),
+  isAtLimit: vi.fn().mockResolvedValue(false),
+  assertApiNotRateLimited: vi.fn().mockResolvedValue(undefined),
+}))
+
+const productCategoryService = { list: vi.fn() }
+
+vi.mock("@chatbotx.io/business", () => ({
+  workspaceApiTokenService: { findWorkspaceByTokenHash },
+  isWorkspaceScheduledForDeletion,
+  userQuotaService: { getAccessState },
+  quotaEnforcementService: { isAtLimit },
+  productCategoryService,
+}))
+
+vi.mock("@/lib/log", () => ({
+  logger: { warn: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock("@/lib/rate-limit/api-rate-limit", () => ({
+  assertApiNotRateLimited,
+}))
+
+vi.mock("@/lib/rate-limit/guest-rate-limit", () => ({
+  getGuestClientIp: () => "203.0.113.9",
+}))
+
+vi.mock("@/env", () => ({ isCloud: () => true }))
+
+// `@/orpc` also exports `authorizedAPI`, which pulls in the full better-auth
+// stack via `authMiddleware` — irrelevant here and unsafe to initialize in a
+// unit test. Same stub as workspace-token-scope-enforcement.test.ts.
+vi.mock("@/middlewares/auth", () => ({
+  authMiddleware: vi.fn(),
+}))
+
+const { call } = await import("@orpc/server")
+const { productCategoriesPublicRouter } = await import(
+  "../src/features/product-categories/api/public"
+)
+
+const TOKEN = "cbx_ws_fixture"
+
+const authResult = (scopes: string[] | null) => ({
+  workspace: { id: "ws-1", ownerId: "owner-1" },
+  apiToken: { id: "token-1", permission: "full" as const, scopes },
+})
+
+const invoke = (procedure: typeof productCategoriesPublicRouter.list) =>
+  call(
+    procedure,
+    {},
+    {
+      context: { headers: new Headers({ Authorization: `Bearer ${TOKEN}` }) },
+    },
+  )
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  isWorkspaceScheduledForDeletion.mockReturnValue(false)
+  getAccessState.mockResolvedValue({ blocked: false })
+  isAtLimit.mockResolvedValue(false)
+  assertApiNotRateLimited.mockResolvedValue(undefined)
+})
+
+describe("real router: product categories public API scope wiring", () => {
+  test("a contacts-scoped token is denied the real GET /v1/product-categories route with FORBIDDEN", async () => {
+    findWorkspaceByTokenHash.mockResolvedValue(authResult(["contacts"]))
+
+    await expect(
+      invoke(productCategoriesPublicRouter.list),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "Token is not authorized for the 'ecommerce' scope",
+    })
+  })
+
+  test("null scopes (unrestricted) passes the real GET /v1/product-categories route", async () => {
+    findWorkspaceByTokenHash.mockResolvedValue(authResult(null))
+    productCategoryService.list.mockResolvedValue([])
+
+    await expect(
+      invoke(productCategoriesPublicRouter.list),
+    ).resolves.toMatchObject({ data: [] })
+  })
+})

--- a/apps/builder/__tests__/products-public-api.test.ts
+++ b/apps/builder/__tests__/products-public-api.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+type RouteConfig = {
+  method: string
+  path: string
+  summary: string
+  tags: string[]
+  successStatus?: number
+}
+
+type CapturedProcedure = {
+  route: RouteConfig
+  handler?: (...args: any[]) => any
+}
+
+const { workspaceTokenAuthAPIForScope, capturedProcedures } = vi.hoisted(() => {
+  const capturedProcedures: CapturedProcedure[] = []
+
+  const makeProcedure = (route: RouteConfig) => {
+    const record: CapturedProcedure = { route }
+    capturedProcedures.push(record)
+
+    const chain = {
+      input: vi.fn(() => chain),
+      output: vi.fn(() => chain),
+      errors: vi.fn(() => chain),
+      handler: vi.fn((fn: (...args: any[]) => any) => {
+        record.handler = fn
+        return { handler: fn }
+      }),
+    }
+    return chain
+  }
+
+  const workspaceTokenAuthAPI = {
+    route: vi.fn((config: RouteConfig) => makeProcedure(config)),
+  }
+
+  return {
+    workspaceTokenAuthAPIForScope: vi.fn(
+      (_scope: string) => workspaceTokenAuthAPI,
+    ),
+    capturedProcedures,
+  }
+})
+
+vi.mock("@/orpc", () => ({ workspaceTokenAuthAPIForScope }))
+
+const productService = {
+  list: vi.fn(),
+  findById: vi.fn(),
+  createFull: vi.fn(),
+  updateFull: vi.fn(),
+  delete: vi.fn(),
+}
+vi.mock("@chatbotx.io/business", () => ({ productService }))
+
+await import("@/features/products/api/public")
+
+const findProcedure = (method: string, path: string) => {
+  const found = capturedProcedures.find(
+    (p) => p.route.method === method && p.route.path === path,
+  )
+  if (!found) {
+    throw new Error(`No procedure registered for ${method} ${path}`)
+  }
+  return found
+}
+
+const scopeArgAtImport = workspaceTokenAuthAPIForScope.mock.calls[0]?.[0]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+test("registers the products public router under the ecommerce scope", () => {
+  expect(scopeArgAtImport).toBe("ecommerce")
+})
+
+describe("GET /v1/products", () => {
+  const procedure = findProcedure("GET", "/v1/products")
+
+  test("lists products scoped to the token's workspace", async () => {
+    productService.list.mockResolvedValueOnce({ data: [], pageCount: 1 })
+
+    await procedure.handler?.({
+      context: { workspace: { id: "workspace-1" } },
+      input: { page: 1, perPage: 50 },
+    })
+
+    expect(productService.list).toHaveBeenCalledWith({
+      page: 1,
+      perPage: 50,
+      workspaceId: "workspace-1",
+    })
+  })
+})
+
+describe("GET /v1/products/{id}", () => {
+  const procedure = findProcedure("GET", "/v1/products/{id}")
+
+  test("fetches a product scoped to the token's workspace", async () => {
+    productService.findById.mockResolvedValueOnce({ id: "p-1" })
+
+    await procedure.handler?.({
+      context: { workspace: { id: "workspace-1" } },
+      input: { id: "p-1" },
+    })
+
+    expect(productService.findById).toHaveBeenCalledWith("p-1", "workspace-1")
+  })
+})
+
+describe("POST /v1/products", () => {
+  const procedure = findProcedure("POST", "/v1/products")
+
+  test("creates a product scoped to the token's workspace", async () => {
+    productService.createFull.mockResolvedValueOnce({ id: "p-1" })
+
+    await procedure.handler?.({
+      context: { workspace: { id: "workspace-1" } },
+      input: { name: "New product" },
+    })
+
+    expect(productService.createFull).toHaveBeenCalledWith({
+      name: "New product",
+      workspaceId: "workspace-1",
+    })
+  })
+})
+
+describe("PATCH /v1/products/{id}", () => {
+  const procedure = findProcedure("PATCH", "/v1/products/{id}")
+
+  test("replaces a product scoped to the token's workspace", async () => {
+    productService.updateFull.mockResolvedValueOnce(undefined)
+
+    await procedure.handler?.({
+      context: { workspace: { id: "workspace-1" } },
+      input: { id: "p-1", name: "Updated" },
+    })
+
+    expect(productService.updateFull).toHaveBeenCalledWith({
+      productId: "p-1",
+      workspaceId: "workspace-1",
+      name: "Updated",
+    })
+  })
+})
+
+describe("DELETE /v1/products/{id}", () => {
+  const procedure = findProcedure("DELETE", "/v1/products/{id}")
+
+  test("deletes a product scoped to the token's workspace after confirming it exists", async () => {
+    productService.findById.mockResolvedValueOnce({ id: "p-1" })
+    productService.delete.mockResolvedValueOnce(undefined)
+
+    await procedure.handler?.({
+      context: { workspace: { id: "workspace-1" } },
+      input: { id: "p-1" },
+    })
+
+    expect(productService.findById).toHaveBeenCalledWith("p-1", "workspace-1")
+    expect(productService.delete).toHaveBeenCalledWith({
+      ids: ["p-1"],
+      workspaceId: "workspace-1",
+    })
+  })
+
+  test("404s (does not call delete) when the product does not exist", async () => {
+    productService.findById.mockRejectedValueOnce(
+      new Error("Product does not exist."),
+    )
+
+    await expect(
+      procedure.handler?.({
+        context: { workspace: { id: "workspace-1" } },
+        input: { id: "missing" },
+      }),
+    ).rejects.toThrow("Product does not exist.")
+
+    expect(productService.delete).not.toHaveBeenCalled()
+  })
+})

--- a/apps/builder/__tests__/products-public-scope.test.ts
+++ b/apps/builder/__tests__/products-public-scope.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+  findWorkspaceByTokenHash,
+  isWorkspaceScheduledForDeletion,
+  getAccessState,
+  isAtLimit,
+  assertApiNotRateLimited,
+} = vi.hoisted(() => ({
+  findWorkspaceByTokenHash: vi.fn(),
+  isWorkspaceScheduledForDeletion: vi.fn().mockReturnValue(false),
+  getAccessState: vi.fn().mockResolvedValue({ blocked: false }),
+  isAtLimit: vi.fn().mockResolvedValue(false),
+  assertApiNotRateLimited: vi.fn().mockResolvedValue(undefined),
+}))
+
+const productService = { list: vi.fn() }
+
+vi.mock("@chatbotx.io/business", () => ({
+  workspaceApiTokenService: { findWorkspaceByTokenHash },
+  isWorkspaceScheduledForDeletion,
+  userQuotaService: { getAccessState },
+  quotaEnforcementService: { isAtLimit },
+  productService,
+}))
+
+vi.mock("@/lib/log", () => ({
+  logger: { warn: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock("@/lib/rate-limit/api-rate-limit", () => ({
+  assertApiNotRateLimited,
+}))
+
+vi.mock("@/lib/rate-limit/guest-rate-limit", () => ({
+  getGuestClientIp: () => "203.0.113.9",
+}))
+
+vi.mock("@/env", () => ({ isCloud: () => true }))
+
+// `@/orpc` also exports `authorizedAPI`, which pulls in the full better-auth
+// stack via `authMiddleware` — irrelevant here and unsafe to initialize in a
+// unit test. Same stub as workspace-token-scope-enforcement.test.ts.
+vi.mock("@/middlewares/auth", () => ({
+  authMiddleware: vi.fn(),
+}))
+
+const { call } = await import("@orpc/server")
+const { productsPublicRouter } = await import(
+  "../src/features/products/api/public"
+)
+
+const TOKEN = "cbx_ws_fixture"
+
+const authResult = (scopes: string[] | null) => ({
+  workspace: { id: "ws-1", ownerId: "owner-1" },
+  apiToken: { id: "token-1", permission: "full" as const, scopes },
+})
+
+const invoke = (procedure: typeof productsPublicRouter.list) =>
+  call(
+    procedure,
+    {},
+    {
+      context: { headers: new Headers({ Authorization: `Bearer ${TOKEN}` }) },
+    },
+  )
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  isWorkspaceScheduledForDeletion.mockReturnValue(false)
+  getAccessState.mockResolvedValue({ blocked: false })
+  isAtLimit.mockResolvedValue(false)
+  assertApiNotRateLimited.mockResolvedValue(undefined)
+})
+
+describe("real router: products public API scope wiring", () => {
+  test("a contacts-scoped token is denied the real GET /v1/products route with FORBIDDEN", async () => {
+    findWorkspaceByTokenHash.mockResolvedValue(authResult(["contacts"]))
+
+    await expect(invoke(productsPublicRouter.list)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "Token is not authorized for the 'ecommerce' scope",
+    })
+  })
+
+  test("null scopes (unrestricted) passes the real GET /v1/products route", async () => {
+    findWorkspaceByTokenHash.mockResolvedValue(authResult(null))
+    productService.list.mockResolvedValue({ data: [], pageCount: 1 })
+
+    await expect(invoke(productsPublicRouter.list)).resolves.toMatchObject({
+      data: [],
+      pageCount: 1,
+    })
+  })
+})

--- a/apps/builder/src/features/coupons/api/public.ts
+++ b/apps/builder/src/features/coupons/api/public.ts
@@ -200,6 +200,15 @@ export const couponsPublicRouter = {
       },
     })
     .handler(async ({ context, input }) => {
+      // The coupon row is workspace-scoped but `issuedContactId` is written
+      // unchecked, so an unvalidated `contactId` would stamp a foreign
+      // workspace's contact onto this workspace's coupon. Every other caller
+      // (the flow step) takes `contactId` from the conversation, which is
+      // already workspace-bound; a token-supplied id is not.
+      await contactService.findByIdOrFail({
+        workspaceId: context.workspace.id,
+        id: input.contactId,
+      })
       const result = await couponService.issueCoupon({
         workspaceId: context.workspace.id,
         topicId: input.id,
@@ -234,6 +243,12 @@ export const couponsPublicRouter = {
       },
     })
     .handler(async ({ context, input }) => {
+      // Same reason as `issueCoupon`: scope the caller-supplied contact to
+      // this workspace before it reaches the coupon row.
+      await contactService.findByIdOrFail({
+        workspaceId: context.workspace.id,
+        id: input.contactId,
+      })
       const result = await couponService.markCouponUsed({
         workspaceId: context.workspace.id,
         topicId: input.id,

--- a/apps/builder/src/features/coupons/api/public.ts
+++ b/apps/builder/src/features/coupons/api/public.ts
@@ -1,0 +1,272 @@
+import { contactService, couponService } from "@chatbotx.io/business"
+import { zodBigintAsString } from "@chatbotx.io/utils"
+import { ORPCError } from "@orpc/server"
+import { z } from "zod"
+import {
+  possibleErrorsOnCreatingResource,
+  possibleErrorsOnDeletingResource,
+  possibleErrorsOnFindingResource,
+  possibleErrorsOnListingResource,
+  possibleErrorsOnMutatingResource,
+} from "@/lib/orpc/orpc-error-helper"
+import { withPublicPaging } from "@/lib/public-api/list"
+import { workspaceTokenAuthAPIForScope } from "@/orpc"
+import {
+  couponIssueErrorData,
+  couponMarkUsedErrorData,
+  createCouponTopicPublicRequest,
+  issueCouponPublicRequest,
+  listContactCouponsPublicResponse,
+  listCouponsPublicRequest,
+  listCouponsPublicResponse,
+  listCouponTopicsPublicRequest,
+  listCouponTopicsPublicResponse,
+  markCouponUsedPublicRequest,
+  publicCouponTopicResource,
+  publicIssuedCouponResource,
+  updateCouponTopicPublicRequest,
+} from "../schema/public"
+
+const workspaceTokenAuthAPI = workspaceTokenAuthAPIForScope("ecommerce")
+
+const tags = ["Coupons"]
+
+export const couponsPublicRouter = {
+  listTopics: workspaceTokenAuthAPI
+    .route({
+      method: "GET",
+      path: "/v1/coupon-topics",
+      summary: "List coupon topics",
+      tags,
+    })
+    .input(withPublicPaging(listCouponTopicsPublicRequest.omit({ sort: true })))
+    .output(listCouponTopicsPublicResponse)
+    .errors(possibleErrorsOnListingResource)
+    .handler(async ({ context, input }) => {
+      const result = await couponService.listTopics({
+        ...input,
+        workspaceId: context.workspace.id,
+      })
+      return { data: result.data, pageCount: result.pageCount }
+    }),
+
+  getTopic: workspaceTokenAuthAPI
+    .route({
+      method: "GET",
+      path: "/v1/coupon-topics/{id}",
+      summary: "Get a coupon topic",
+      tags,
+    })
+    .input(z.object({ id: zodBigintAsString() }))
+    .output(publicCouponTopicResource)
+    .errors(possibleErrorsOnFindingResource)
+    .handler(
+      async ({ context, input }) =>
+        await couponService.getTopic({
+          workspaceId: context.workspace.id,
+          topicId: input.id,
+        }),
+    ),
+
+  createTopic: workspaceTokenAuthAPI
+    .route({
+      method: "POST",
+      path: "/v1/coupon-topics",
+      summary: "Create a coupon topic",
+      description:
+        "Creates a coupon topic. The topic is created without a `createdById` — workspace API tokens have no associated user.",
+      tags,
+    })
+    .input(createCouponTopicPublicRequest)
+    .output(publicCouponTopicResource)
+    .errors(possibleErrorsOnCreatingResource)
+    .handler(
+      async ({ context, input }) =>
+        await couponService.createTopic({
+          workspaceId: context.workspace.id,
+          createdById: null,
+          ...input,
+        }),
+    ),
+
+  updateTopic: workspaceTokenAuthAPI
+    .route({
+      method: "PATCH",
+      path: "/v1/coupon-topics/{id}",
+      summary: "Update a coupon topic",
+      tags,
+    })
+    .input(updateCouponTopicPublicRequest)
+    .output(publicCouponTopicResource)
+    .errors(possibleErrorsOnMutatingResource)
+    .handler(async ({ context, input }) => {
+      const { id, ...data } = input
+      return await couponService.updateTopic({
+        workspaceId: context.workspace.id,
+        topicId: id,
+        ...data,
+      })
+    }),
+
+  archiveTopic: workspaceTokenAuthAPI
+    .route({
+      method: "POST",
+      path: "/v1/coupon-topics/{id}/archive",
+      summary: "Archive a coupon topic",
+      tags,
+    })
+    .input(z.object({ id: zodBigintAsString() }))
+    .output(publicCouponTopicResource)
+    .errors(possibleErrorsOnMutatingResource)
+    .handler(
+      async ({ context, input }) =>
+        await couponService.archiveTopic({
+          workspaceId: context.workspace.id,
+          topicId: input.id,
+        }),
+    ),
+
+  unarchiveTopic: workspaceTokenAuthAPI
+    .route({
+      method: "POST",
+      path: "/v1/coupon-topics/{id}/unarchive",
+      summary: "Unarchive a coupon topic",
+      tags,
+    })
+    .input(z.object({ id: zodBigintAsString() }))
+    .output(publicCouponTopicResource)
+    .errors(possibleErrorsOnMutatingResource)
+    .handler(
+      async ({ context, input }) =>
+        await couponService.unarchiveTopic({
+          workspaceId: context.workspace.id,
+          topicId: input.id,
+        }),
+    ),
+
+  deleteTopic: workspaceTokenAuthAPI
+    .route({
+      method: "DELETE",
+      path: "/v1/coupon-topics/{id}",
+      summary: "Delete a coupon topic",
+      tags,
+    })
+    .input(z.object({ id: zodBigintAsString() }))
+    .output(publicCouponTopicResource)
+    .errors(possibleErrorsOnDeletingResource)
+    .handler(
+      async ({ context, input }) =>
+        await couponService.deleteTopic({
+          workspaceId: context.workspace.id,
+          topicId: input.id,
+        }),
+    ),
+
+  listCoupons: workspaceTokenAuthAPI
+    .route({
+      method: "GET",
+      path: "/v1/coupons",
+      summary: "List coupons",
+      tags,
+    })
+    .input(withPublicPaging(listCouponsPublicRequest.omit({ sort: true })))
+    .output(listCouponsPublicResponse)
+    .errors(possibleErrorsOnListingResource)
+    .handler(async ({ context, input }) => {
+      const result = await couponService.listCoupons({
+        ...input,
+        workspaceId: context.workspace.id,
+      })
+      return { data: result.data, pageCount: result.pageCount }
+    }),
+
+  issueCoupon: workspaceTokenAuthAPI
+    .route({
+      method: "POST",
+      path: "/v1/coupon-topics/{id}/issue",
+      summary: "Issue a coupon to a contact",
+      description:
+        "Issues a coupon from the topic to the contact. Idempotent: reissuing to the same contact returns the coupon already issued to them (`existing`) rather than a duplicate. Fails with `couponIssueUnavailable` when the topic is not issueable (`topicUnavailable`) or has no available coupon left (`noAvailableCoupon`).",
+      tags,
+    })
+    .input(issueCouponPublicRequest)
+    .output(publicIssuedCouponResource)
+    .errors({
+      ...possibleErrorsOnMutatingResource,
+      couponIssueUnavailable: {
+        message: "No coupon could be issued for this topic",
+        status: 409,
+        data: couponIssueErrorData,
+      },
+    })
+    .handler(async ({ context, input }) => {
+      const result = await couponService.issueCoupon({
+        workspaceId: context.workspace.id,
+        topicId: input.id,
+        contactId: input.contactId,
+      })
+      if (!result.ok) {
+        throw new ORPCError("couponIssueUnavailable", {
+          message: "No coupon could be issued for this topic",
+          data: { reason: result.reason },
+        })
+      }
+      return result.coupon
+    }),
+
+  markCouponUsed: workspaceTokenAuthAPI
+    .route({
+      method: "POST",
+      path: "/v1/coupon-topics/{id}/mark-used",
+      summary: "Mark an issued coupon as used",
+      description:
+        "Marks the coupon issued to the contact as used. Fails with `couponNotIssued` (`noIssuedCoupon`) when the contact has no coupon issued from this topic.",
+      tags,
+    })
+    .input(markCouponUsedPublicRequest)
+    .output(publicIssuedCouponResource)
+    .errors({
+      ...possibleErrorsOnMutatingResource,
+      couponNotIssued: {
+        message: "No coupon has been issued to this contact for this topic",
+        status: 404,
+        data: couponMarkUsedErrorData,
+      },
+    })
+    .handler(async ({ context, input }) => {
+      const result = await couponService.markCouponUsed({
+        workspaceId: context.workspace.id,
+        topicId: input.id,
+        contactId: input.contactId,
+      })
+      if (!result.ok) {
+        throw new ORPCError("couponNotIssued", {
+          message: "No coupon has been issued to this contact for this topic",
+          data: { reason: result.reason },
+        })
+      }
+      return result.coupon
+    }),
+
+  listContactCoupons: workspaceTokenAuthAPI
+    .route({
+      method: "GET",
+      path: "/v1/contacts/{contactId}/coupons",
+      summary: "List coupons issued to a contact",
+      tags,
+    })
+    .input(z.object({ contactId: zodBigintAsString() }))
+    .output(listContactCouponsPublicResponse)
+    .errors(possibleErrorsOnFindingResource)
+    .handler(async ({ context, input }) => {
+      await contactService.findByIdOrFail({
+        workspaceId: context.workspace.id,
+        id: input.contactId,
+      })
+      const data = await couponService.listIssuedCouponsForContact({
+        workspaceId: context.workspace.id,
+        contactId: input.contactId,
+      })
+      return { data }
+    }),
+}

--- a/apps/builder/src/features/coupons/schema/public.ts
+++ b/apps/builder/src/features/coupons/schema/public.ts
@@ -1,0 +1,84 @@
+import {
+  couponIssueStatuses,
+  couponUsageStatuses,
+} from "@chatbotx.io/database/partials"
+import { zodBigintAsString } from "@chatbotx.io/utils"
+import { z } from "zod"
+import { basePaginationRequest } from "@/lib/pagination"
+import {
+  contactCouponResource,
+  couponResource,
+  couponTopicResource,
+} from "./resource"
+
+export const publicCouponTopicResource = couponTopicResource
+
+export const listCouponTopicsPublicRequest = basePaginationRequest.extend({
+  archived: z.boolean().optional(),
+  search: z.string().optional(),
+})
+
+export const listCouponTopicsPublicResponse = z.object({
+  data: z.array(couponTopicResource.extend({ couponCount: z.number() })),
+  pageCount: z.number(),
+})
+
+export const createCouponTopicPublicRequest = z.object({
+  name: z.string().trim().min(1).max(255),
+  description: z.string().trim().max(1000).optional().nullable(),
+  expiresAt: z.coerce.date().optional().nullable(),
+})
+
+export const updateCouponTopicPublicRequest =
+  createCouponTopicPublicRequest.extend({
+    id: zodBigintAsString(),
+  })
+
+export const listCouponsPublicRequest = basePaginationRequest.extend({
+  topicId: zodBigintAsString().optional(),
+  issueStatus: couponIssueStatuses.optional(),
+  usageStatus: couponUsageStatuses.optional(),
+  search: z.string().optional(),
+})
+
+export const listCouponsPublicResponse = z.object({
+  data: z.array(couponResource),
+  pageCount: z.number(),
+})
+
+export const issueCouponPublicRequest = z.object({
+  id: zodBigintAsString(),
+  contactId: zodBigintAsString(),
+})
+
+export const markCouponUsedPublicRequest = z.object({
+  id: zodBigintAsString(),
+  contactId: zodBigintAsString(),
+})
+
+export const listContactCouponsPublicResponse = z.object({
+  data: z.array(contactCouponResource),
+})
+
+export const couponIssueErrorData = z.object({
+  reason: z.enum(["topicUnavailable", "noAvailableCoupon"]),
+})
+
+export const couponMarkUsedErrorData = z.object({
+  reason: z.enum(["noIssuedCoupon"]),
+})
+
+// `issueCoupon`/`markCouponUsed` return the bare coupon row (no joined
+// `topicName`/derived status columns), unlike `couponResource` used for
+// `listCoupons`.
+export const publicIssuedCouponResource = z.object({
+  id: z.string(),
+  workspaceId: z.string(),
+  topicId: z.string(),
+  code: z.string(),
+  issuedContactId: z.string().nullable(),
+  issuedAt: z.date().nullable(),
+  usedAt: z.date().nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+})

--- a/apps/builder/src/features/coupons/schema/public.ts
+++ b/apps/builder/src/features/coupons/schema/public.ts
@@ -11,15 +11,33 @@ import {
   couponTopicResource,
 } from "./resource"
 
-export const publicCouponTopicResource = couponTopicResource
+// Explicit allow-list, not the internal resource: every field picked here
+// becomes a stable contract MCP agents depend on, so `createdById` (an internal
+// member id) and `deletedAt` (soft-delete bookkeeping already surfaced through
+// `status`) stay out. See products/schema/public.ts for the same pattern.
+export const publicCouponTopicResource = couponTopicResource.pick({
+  id: true,
+  workspaceId: true,
+  name: true,
+  description: true,
+  expiresAt: true,
+  status: true,
+  hasEverHadCoupon: true,
+  createdAt: true,
+  updatedAt: true,
+})
 
 export const listCouponTopicsPublicRequest = basePaginationRequest.extend({
   archived: z.boolean().optional(),
   search: z.string().optional(),
 })
 
+// `list` is the only topic route that joins the coupon count; the six
+// single-topic routes return the bare row, so `couponCount` belongs here rather
+// than on `publicCouponTopicResource` where it would be an optional field that
+// is in practice never present.
 export const listCouponTopicsPublicResponse = z.object({
-  data: z.array(couponTopicResource.extend({ couponCount: z.number() })),
+  data: z.array(publicCouponTopicResource.extend({ couponCount: z.number() })),
   pageCount: z.number(),
 })
 

--- a/apps/builder/src/features/product-categories/api/public.ts
+++ b/apps/builder/src/features/product-categories/api/public.ts
@@ -1,0 +1,95 @@
+import { productCategoryService } from "@chatbotx.io/business"
+import { zodBigintAsString } from "@chatbotx.io/utils"
+import { z } from "zod"
+import {
+  possibleErrorsOnCreatingResource,
+  possibleErrorsOnDeletingResource,
+  possibleErrorsOnListingResource,
+  possibleErrorsOnMutatingResource,
+} from "@/lib/orpc/orpc-error-helper"
+import { workspaceTokenAuthAPIForScope } from "@/orpc"
+import {
+  createProductCategoryPublicRequest,
+  listProductCategoriesPublicResponse,
+  publicProductCategoryWriteResource,
+  updateProductCategoryPublicRequest,
+} from "../schema/public"
+
+const workspaceTokenAuthAPI = workspaceTokenAuthAPIForScope("ecommerce")
+
+export const productCategoriesPublicRouter = {
+  list: workspaceTokenAuthAPI
+    .route({
+      method: "GET",
+      path: "/v1/product-categories",
+      summary: "List product categories",
+      description:
+        "Lists product categories as a flat two-level list. `parentId` is null for a top-level category, or the id of its top-level parent for a sub-category.",
+      tags: ["Product Categories"],
+    })
+    .output(listProductCategoriesPublicResponse)
+    .errors(possibleErrorsOnListingResource)
+    .handler(async ({ context }) => {
+      const data = await productCategoryService.list(context.workspace.id)
+      return { data }
+    }),
+
+  create: workspaceTokenAuthAPI
+    .route({
+      method: "POST",
+      path: "/v1/product-categories",
+      summary: "Create a product category",
+      description:
+        "Omit `parentId` to create a top-level category, or pass an existing top-level category's id to create a sub-category.",
+      tags: ["Product Categories"],
+    })
+    .input(createProductCategoryPublicRequest)
+    .output(publicProductCategoryWriteResource)
+    .errors(possibleErrorsOnCreatingResource)
+    .handler(
+      async ({ context, input }) =>
+        await productCategoryService.create({
+          workspaceId: context.workspace.id,
+          name: input.name,
+          rank: input.rank,
+          parentId: input.parentId ?? null,
+        }),
+    ),
+
+  update: workspaceTokenAuthAPI
+    .route({
+      method: "PATCH",
+      path: "/v1/product-categories/{id}",
+      summary: "Update a product category",
+      tags: ["Product Categories"],
+    })
+    .input(updateProductCategoryPublicRequest)
+    .output(publicProductCategoryWriteResource)
+    .errors(possibleErrorsOnMutatingResource)
+    .handler(async ({ context, input }) => {
+      const { id, ...data } = input
+      return await productCategoryService.update({
+        workspaceId: context.workspace.id,
+        categoryId: id,
+        name: data.name,
+        parentId: data.parentId ?? null,
+      })
+    }),
+
+  delete: workspaceTokenAuthAPI
+    .route({
+      method: "DELETE",
+      path: "/v1/product-categories/{id}",
+      summary: "Delete a product category",
+      successStatus: 204,
+      tags: ["Product Categories"],
+    })
+    .input(z.object({ id: zodBigintAsString() }))
+    .errors(possibleErrorsOnDeletingResource)
+    .handler(async ({ context, input }) => {
+      await productCategoryService.delete({
+        workspaceId: context.workspace.id,
+        categoryId: input.id,
+      })
+    }),
+}

--- a/apps/builder/src/features/product-categories/api/public.ts
+++ b/apps/builder/src/features/product-categories/api/public.ts
@@ -72,7 +72,13 @@ export const productCategoriesPublicRouter = {
         workspaceId: context.workspace.id,
         categoryId: id,
         name: data.name,
-        parentId: data.parentId ?? null,
+        // Three distinct states, so absent must not collapse to null: omitting
+        // `parentId` leaves the category where it is, `null` promotes it to the
+        // top level, and an id files it under that parent. Coercing absent to
+        // null would un-parent a sub-category on a rename-only request, and
+        // would also skip the service's reparent guards, which branch on
+        // `undefined`.
+        ...("parentId" in data ? { parentId: data.parentId ?? null } : {}),
       })
     }),
 

--- a/apps/builder/src/features/product-categories/schema/public.ts
+++ b/apps/builder/src/features/product-categories/schema/public.ts
@@ -1,0 +1,37 @@
+import { zodBigintAsString } from "@chatbotx.io/utils"
+import { z } from "zod"
+
+// Two-level tree: `parentId` is null for a top-level category, or the id of
+// its top-level parent. Dropping this field would silently flatten the tree
+// on the client (see product-categories/api/authorized.ts).
+export const publicProductCategoryResource = z.object({
+  id: z.string(),
+  parentId: z.string().nullable(),
+  name: z.string(),
+  rank: z.number(),
+  productCount: z.number(),
+})
+
+export const listProductCategoriesPublicResponse = z.object({
+  data: z.array(publicProductCategoryResource),
+})
+
+// `create`/`update` return the bare row (no joined product count), unlike
+// `list`'s `publicProductCategoryResource`.
+export const publicProductCategoryWriteResource = z.object({
+  id: z.string(),
+  parentId: z.string().nullable(),
+  name: z.string(),
+  rank: z.number(),
+})
+
+export const createProductCategoryPublicRequest = z.object({
+  name: z.string().trim().min(1).max(255),
+  parentId: zodBigintAsString().nullish(),
+  rank: z.number().int().optional(),
+})
+
+export const updateProductCategoryPublicRequest =
+  createProductCategoryPublicRequest.extend({
+    id: zodBigintAsString(),
+  })

--- a/apps/builder/src/features/products/api/public.ts
+++ b/apps/builder/src/features/products/api/public.ts
@@ -1,0 +1,119 @@
+import { productService } from "@chatbotx.io/business"
+import { zodBigintAsString } from "@chatbotx.io/utils"
+import { z } from "zod"
+import {
+  possibleErrorsOnCreatingResource,
+  possibleErrorsOnDeletingResource,
+  possibleErrorsOnFindingResource,
+  possibleErrorsOnListingResource,
+  possibleErrorsOnMutatingResource,
+} from "@/lib/orpc/orpc-error-helper"
+import { withPublicPaging } from "@/lib/public-api/list"
+import { workspaceTokenAuthAPIForScope } from "@/orpc"
+import {
+  createProductPublicRequest,
+  listProductsPublicResponse,
+  publicProductDetailResource,
+  publicProductResource,
+  updateProductPublicRequest,
+} from "../schema/public"
+import { listProductsRequest } from "../schema/query"
+
+const workspaceTokenAuthAPI = workspaceTokenAuthAPIForScope("ecommerce")
+
+export const productsPublicRouter = {
+  list: workspaceTokenAuthAPI
+    .route({
+      method: "GET",
+      path: "/v1/products",
+      summary: "List products",
+      tags: ["Products"],
+    })
+    .input(withPublicPaging(listProductsRequest.omit({ sort: true })))
+    .output(listProductsPublicResponse)
+    .errors(possibleErrorsOnListingResource)
+    .handler(
+      async ({ context, input }) =>
+        await productService.list({
+          ...input,
+          workspaceId: context.workspace.id,
+        }),
+    ),
+
+  get: workspaceTokenAuthAPI
+    .route({
+      method: "GET",
+      path: "/v1/products/{id}",
+      summary: "Get a product",
+      description:
+        "Returns full product detail, including variant options, variants, and addons.",
+      tags: ["Products"],
+    })
+    .input(z.object({ id: zodBigintAsString() }))
+    .output(publicProductDetailResource)
+    .errors(possibleErrorsOnFindingResource)
+    .handler(
+      async ({ context, input }) =>
+        await productService.findById(input.id, context.workspace.id),
+    ),
+
+  create: workspaceTokenAuthAPI
+    .route({
+      method: "POST",
+      path: "/v1/products",
+      summary: "Create a product",
+      tags: ["Products"],
+    })
+    .input(createProductPublicRequest)
+    .output(publicProductResource)
+    .errors(possibleErrorsOnCreatingResource)
+    .handler(
+      async ({ context, input }) =>
+        await productService.createFull({
+          workspaceId: context.workspace.id,
+          ...input,
+        }),
+    ),
+
+  update: workspaceTokenAuthAPI
+    .route({
+      method: "PATCH",
+      path: "/v1/products/{id}",
+      summary: "Replace a product",
+      description:
+        "Fully replaces the product, including its variant options, variants, and addons.",
+      tags: ["Products"],
+    })
+    .input(
+      updateProductPublicRequest.and(z.object({ id: zodBigintAsString() })),
+    )
+    .errors(possibleErrorsOnMutatingResource)
+    .handler(async ({ context, input }) => {
+      const { id, ...data } = input
+      await productService.updateFull({
+        workspaceId: context.workspace.id,
+        productId: id,
+        ...data,
+      })
+    }),
+
+  delete: workspaceTokenAuthAPI
+    .route({
+      method: "DELETE",
+      path: "/v1/products/{id}",
+      summary: "Delete a product",
+      successStatus: 204,
+      tags: ["Products"],
+    })
+    .input(z.object({ id: zodBigintAsString() }))
+    .errors(possibleErrorsOnDeletingResource)
+    .handler(async ({ context, input }) => {
+      // findById throws notFoundException (-> 404) for a missing id, so the
+      // delete call below never silently no-ops on a nonexistent product.
+      await productService.findById(input.id, context.workspace.id)
+      await productService.delete({
+        ids: [input.id],
+        workspaceId: context.workspace.id,
+      })
+    }),
+}

--- a/apps/builder/src/features/products/schema/public.ts
+++ b/apps/builder/src/features/products/schema/public.ts
@@ -1,0 +1,78 @@
+import { inventoryPolicyTypes } from "@chatbotx.io/database/partials"
+import { createSelectSchema, productModel } from "@chatbotx.io/database/schema"
+import { z } from "zod"
+import { productFormRequest } from "./action"
+
+// Explicit allow-list, not the whole row: every field picked here becomes a
+// stable contract MCP agents depend on (see products/schema/resource.ts for
+// the internal, unrestricted shape).
+export const publicProductResource = createSelectSchema(productModel, {
+  id: z.string(),
+  workspaceId: z.string(),
+  categoryId: z.string().nullable(),
+  subcategoryId: z.string().nullable(),
+  images: z.array(
+    z.object({ url: z.string(), type: z.enum(["link", "file"]) }),
+  ),
+  tags: z.array(z.string()),
+  inventoryPolicy: inventoryPolicyTypes,
+}).pick({
+  id: true,
+  workspaceId: true,
+  name: true,
+  shortDescription: true,
+  longDescription: true,
+  price: true,
+  taxes: true,
+  discount: true,
+  currency: true,
+  productUrl: true,
+  sku: true,
+  inventoryPolicy: true,
+  inventoryQuantity: true,
+  allowOutOfStockPurchase: true,
+  images: true,
+  tags: true,
+  vendor: true,
+  rank: true,
+  categoryId: true,
+  subcategoryId: true,
+  isActive: true,
+  isSearchable: true,
+  allowSpecialRequest: true,
+  isAddonOnly: true,
+  createdAt: true,
+  updatedAt: true,
+})
+
+const variantOption = z.object({
+  name: z.string(),
+  values: z.array(z.string()),
+  position: z.number(),
+})
+
+const variant = z.object({
+  combination: z.record(z.string(), z.string()),
+  price: z.number(),
+  isEnabled: z.boolean(),
+})
+
+const addon = z.object({
+  name: z.string(),
+  maxSelections: z.number(),
+  addonProductIds: z.array(z.string()),
+})
+
+export const publicProductDetailResource = publicProductResource.extend({
+  variantOptions: z.array(variantOption),
+  variants: z.array(variant),
+  addons: z.array(addon),
+})
+
+export const listProductsPublicResponse = z.object({
+  data: z.array(publicProductResource),
+  pageCount: z.number(),
+})
+
+export const createProductPublicRequest = productFormRequest
+export const updateProductPublicRequest = productFormRequest

--- a/apps/builder/src/routers/public.ts
+++ b/apps/builder/src/routers/public.ts
@@ -5,6 +5,7 @@ import { botFieldsPublicRouter } from "@/features/bot-fields/api/public"
 import { broadcastsPublicRouter } from "@/features/broadcasts/api/public"
 import { contactsPublicRouter } from "@/features/contacts/api/public"
 import { conversationsPublicRouter } from "@/features/conversations/api/public"
+import { couponsPublicRouter } from "@/features/coupons/api/public"
 import { customFieldsPublicRouter } from "@/features/custom-fields/api/public"
 import { errorLogsPublicRouter } from "@/features/error-logs/api/public"
 import { externalWebhooksPublicRouter } from "@/features/external-webhooks/api/public"
@@ -14,6 +15,8 @@ import { inboxesPublicRouter } from "@/features/inboxes/api/public"
 import { channelsPublicRouter } from "@/features/integration-api/api/public"
 import { templateMessagesPublicRouter } from "@/features/integration-whatsapp/message-templates/api/public"
 import { integrationsPublicRouter } from "@/features/integrations/api/public"
+import { productCategoriesPublicRouter } from "@/features/product-categories/api/public"
+import { productsPublicRouter } from "@/features/products/api/public"
 import { reflinksPublicRouter } from "@/features/reflinks/api/public"
 import { savedRepliesPublicRouter } from "@/features/saved-replies/api/public"
 import { sequencesPublicRouter } from "@/features/sequences/api/public"
@@ -29,6 +32,7 @@ export const publicRouter = {
   channels: channelsPublicRouter,
   contacts: contactsPublicRouter,
   conversations: conversationsPublicRouter,
+  coupons: couponsPublicRouter,
   customFields: customFieldsPublicRouter,
   errorLogs: errorLogsPublicRouter,
   externalWebhooks: externalWebhooksPublicRouter,
@@ -38,6 +42,8 @@ export const publicRouter = {
   inboxes: inboxesPublicRouter,
   integrations: integrationsPublicRouter,
   keywords: keywordsPublicRouter,
+  productCategories: productCategoriesPublicRouter,
+  products: productsPublicRouter,
   reflinks: reflinksPublicRouter,
   savedReplies: savedRepliesPublicRouter,
   sequences: sequencesPublicRouter,


### PR DESCRIPTION
…coupons

Fills the ecommerce workspace API token scope, which previously had zero endpoints despite being selectable in the token UI. Adds full CRUD for products and product categories, plus coupon topic management, issuing, and marking used — giving MCP agents catalog-management parity with the web app.