### PR TITLE
feat(messenger): let workspace admins clone templates to their pages

### DIFF
--- a/apps/builder/__tests__/messenger-clone-template-components.test.ts
+++ b/apps/builder/__tests__/messenger-clone-template-components.test.ts
@@ -2,33 +2,35 @@
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
 const resumableUploadImage = vi.fn(async () => "new-handle")
+const createPageMessageTemplate = vi.fn()
+const syncTemplates = vi.fn()
+const findByIdForWorkspace = vi.fn()
+const listCloneTargetsForUser = vi.fn()
+const findByIdForIntegration = vi.fn()
+
+// Captures the handler the safe-action chain wraps so the action's
+// authorization can be exercised directly.
+let cloneHandler: ((props: unknown) => Promise<unknown>) | null = null
 
 vi.mock("@chatbotx.io/integration-messenger/apis/upload", () => ({
   resumableUploadImage,
 }))
 
-vi.mock("@chatbotx.io/database/client", () => ({
-  db: {},
-  inArray: vi.fn(),
-}))
-
-vi.mock("@chatbotx.io/database/schema", () => ({
-  integrationMessengerModel: {},
-  messengerMessageTemplateModel: {},
-}))
-
 vi.mock("@chatbotx.io/business", () => ({
   messengerIntegrationService: {
-    findByIdForWorkspace: vi.fn(),
-    findByIds: vi.fn(),
+    findByIdForWorkspace: (...args: unknown[]) => findByIdForWorkspace(...args),
+    listCloneTargetsForUser: (...args: unknown[]) =>
+      listCloneTargetsForUser(...args),
   },
   messengerMessageTemplateService: {
-    findByIdForIntegration: vi.fn(),
+    findByIdForIntegration: (...args: unknown[]) =>
+      findByIdForIntegration(...args),
   },
 }))
 
 vi.mock("@chatbotx.io/integration-messenger/apis/message-templates", () => ({
-  createPageMessageTemplate: vi.fn(),
+  createPageMessageTemplate: (...args: unknown[]) =>
+    createPageMessageTemplate(...args),
 }))
 
 vi.mock("@chatbotx.io/redis", () => ({
@@ -38,21 +40,21 @@ vi.mock("@chatbotx.io/redis", () => ({
 vi.mock(
   "@/features/integration-messenger/message-templates/actions/sync-message-templates",
   () => ({
-    syncMessengerMessageTemplatesForIntegration: vi.fn(),
+    syncMessengerMessageTemplatesForIntegration: (...args: unknown[]) =>
+      syncTemplates(...args),
   }),
 )
 
-vi.mock("@/features/workspace-members/queries", () => ({
-  getAllWorkspaceMembers: vi.fn(),
-}))
-
 vi.mock("@/lib/safe-action", () => ({
   workspaceActionClient: {
-    bindArgsSchemas: vi.fn(() => ({
-      schema: vi.fn(() => ({
-        action: vi.fn(),
-      })),
-    })),
+    bindArgsSchemas: () => ({
+      schema: () => ({
+        action: (handler: (props: unknown) => Promise<unknown>) => {
+          cloneHandler = handler
+          return handler
+        },
+      }),
+    }),
   },
 }))
 
@@ -146,5 +148,107 @@ describe("prepareComponentsForClone", () => {
     expect(result[0].example).toEqual({
       header_handle: ["new-handle"],
     })
+  })
+})
+
+type CloneResult = {
+  succeeded: { channel: string }[]
+  failed: { channel: string; error: string }[]
+}
+
+const sourceTemplate = {
+  id: "tpl-src",
+  integrationMessengerId: "im-source",
+  name: "promo",
+  language: "vi",
+  category: "MARKETING",
+  parameterFormat: "POSITIONAL",
+  components: [{ type: "BODY", text: "Hi" }],
+}
+const target = (id: string, workspaceId = "ws-other") => ({
+  id,
+  name: `Page ${id}`,
+  workspaceId,
+  pageId: `page-${id}`,
+  auth: { accessToken: "token" },
+})
+
+const run = (targetIntegrationMessengerIds: string[]) => {
+  if (!cloneHandler) {
+    throw new Error("clone action handler was not captured")
+  }
+  return cloneHandler({
+    bindArgsParsedInputs: ["ws-source", "im-source", "tpl-src"],
+    parsedInput: { targetIntegrationMessengerIds },
+    ctx: { user: { id: "user-1" } },
+  }) as Promise<CloneResult>
+}
+
+describe("cloneMessengerMessageTemplateAction authorization", () => {
+  beforeEach(() => {
+    findByIdForIntegration.mockReset().mockResolvedValue(sourceTemplate)
+    findByIdForWorkspace
+      .mockReset()
+      .mockResolvedValue({ id: "im-source", pageId: "page-source" })
+    listCloneTargetsForUser.mockReset()
+    createPageMessageTemplate.mockReset().mockResolvedValue({
+      id: "meta-new",
+      status: "APPROVED",
+    })
+    syncTemplates.mockReset().mockResolvedValue(undefined)
+    resumableUploadImage.mockClear()
+  })
+
+  test("clones onto the requested pages the user administers, read uncached", async () => {
+    listCloneTargetsForUser.mockResolvedValue([
+      target("im-admin"),
+      target("im-owner", "ws-owner"),
+    ])
+
+    const result = await run(["im-admin", "im-owner"])
+
+    expect(listCloneTargetsForUser).toHaveBeenCalledWith({
+      userId: "user-1",
+      excludePageId: "page-source",
+      authoritative: true,
+    })
+    expect(createPageMessageTemplate).toHaveBeenCalledTimes(2)
+    expect(result.succeeded).toEqual([
+      { channel: "Page im-admin" },
+      { channel: "Page im-owner" },
+    ])
+    expect(result.failed).toEqual([])
+  })
+
+  test("drops requested pages outside the user's admin workspaces", async () => {
+    listCloneTargetsForUser.mockResolvedValue([target("im-admin")])
+
+    const result = await run(["im-admin", "im-foreign"])
+
+    expect(createPageMessageTemplate).toHaveBeenCalledTimes(1)
+    expect(result.succeeded).toEqual([{ channel: "Page im-admin" }])
+  })
+
+  test("fails when none of the requested pages is authorized", async () => {
+    listCloneTargetsForUser.mockResolvedValue([target("im-admin")])
+
+    await expect(run(["im-foreign"])).rejects.toThrow(
+      "No authorized target channels found",
+    )
+    expect(createPageMessageTemplate).not.toHaveBeenCalled()
+  })
+
+  test("reports a page whose Meta create fails without blocking the others", async () => {
+    listCloneTargetsForUser.mockResolvedValue([target("im-a"), target("im-b")])
+    createPageMessageTemplate
+      .mockRejectedValueOnce(new Error("rate limited"))
+      .mockResolvedValueOnce({ id: "meta-b", status: "APPROVED" })
+
+    const result = await run(["im-a", "im-b"])
+
+    expect(result.failed).toEqual([
+      { channel: "Page im-a", error: "rate limited" },
+    ])
+    expect(result.succeeded).toEqual([{ channel: "Page im-b" }])
   })
 })

--- a/apps/builder/src/app/space/[workspaceId]/messengers/[id]/message-templates/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/messengers/[id]/message-templates/page.tsx
@@ -1,12 +1,10 @@
-import { db, inArray } from "@chatbotx.io/database/client"
-import { integrationMessengerModel } from "@chatbotx.io/database/schema"
+import { messengerIntegrationService } from "@chatbotx.io/business"
 import { notFound } from "next/navigation"
 import { Suspense } from "react"
 import { MessengerMessageTemplatesTable } from "@/features/integration-messenger/message-templates/message-templates-table"
 import { messengerMessageTemplateService } from "@/features/integration-messenger/message-templates/queries"
 import { listMessengerMessageTemplatesSearchParamsCache } from "@/features/integration-messenger/message-templates/schema/query"
 import { findIntegrationMessenger } from "@/features/integration-messenger/queries"
-import { getAllWorkspaceMembers } from "@/features/workspace-members/queries"
 import { withWorkspaceIdAndIdSchema } from "@/features/workspaces/schema/resource"
 import { getCurrentUserId } from "@/lib/auth/utils"
 
@@ -32,36 +30,19 @@ export default async function MessengerMessageTemplatesPage(props: {
   }
 
   // Clone targets = every Messenger channel across all workspaces where the
-  // current user is an owner ("admin"), excluding the current channel.
+  // current user is an admin (owner or superAdmin), excluding the current
+  // Facebook Page. The clone action authorizes against the same list.
   const userId = await getCurrentUserId()
-  let channels: { id: string; name: string }[] = []
-  if (userId) {
-    const { workspaceMembers } = await getAllWorkspaceMembers(userId)
-    const ownerWorkspaceIds = Array.from(
-      new Set(
-        workspaceMembers
-          .filter((member) => member.role === "owner")
-          .map((member) => member.workspaceId),
-      ),
-    )
-    if (ownerWorkspaceIds.length > 0) {
-      const rows = await db
-        .select({
-          id: integrationMessengerModel.id,
-          name: integrationMessengerModel.name,
-          pageId: integrationMessengerModel.pageId,
-        })
-        .from(integrationMessengerModel)
-        .where(
-          inArray(integrationMessengerModel.workspaceId, ownerWorkspaceIds),
-        )
-      // Exclude the current Facebook Page (by pageId) — it may be connected in
-      // more than one workspace, so filtering by integration id alone is not enough.
-      channels = rows
-        .filter((channel) => channel.pageId !== integrationMessenger.pageId)
-        .map((channel) => ({ id: channel.id, name: channel.name }))
-    }
-  }
+  const cloneTargets = userId
+    ? await messengerIntegrationService.listCloneTargetsForUser({
+        userId,
+        excludePageId: integrationMessenger.pageId,
+      })
+    : []
+  const channels = cloneTargets.map((channel) => ({
+    id: channel.id,
+    name: channel.name,
+  }))
 
   const promises = messengerMessageTemplateService.listPaginated({
     where: {

--- a/apps/builder/src/features/broadcasts/components/broadcast-status-panel.tsx
+++ b/apps/builder/src/features/broadcasts/components/broadcast-status-panel.tsx
@@ -53,9 +53,9 @@ export function BroadcastStatusPanel({
   }
 
   return (
-    <aside className="flex w-[280px] shrink-0 flex-col border-e bg-sidebar">
-      <div className="flex h-16 items-center justify-between ps-6 pe-4">
-        <h2 className="font-bold text-xl">{t("broadcasts.title")}</h2>
+    <aside className="flex w-[220px] shrink-0 flex-col border-e bg-sidebar">
+      <div className="flex h-14 items-center justify-between ps-4 pe-2">
+        <h2 className="font-bold text-lg">{t("broadcasts.title")}</h2>
         <Button
           aria-label={t("broadcasts.panel.collapse")}
           onClick={() => onOpenChange(false)}
@@ -65,14 +65,14 @@ export function BroadcastStatusPanel({
           <PanelLeftCloseIcon aria-hidden="true" />
         </Button>
       </div>
-      <nav className="flex flex-col gap-1 px-4 py-2">
+      <nav className="flex flex-col gap-0.5 px-2 py-1">
         {PANEL_ITEMS.map((item) => {
           const isActive = status === item.value
           return (
             <button
               aria-pressed={isActive}
               className={cn(
-                "flex h-11 items-center gap-3.5 rounded-md px-4 text-[15px] transition-colors",
+                "flex h-9 items-center gap-2.5 rounded-md px-3 text-sm transition-colors",
                 isActive
                   ? "bg-primary/10 font-medium text-foreground"
                   : "text-muted-foreground hover:bg-accent hover:text-foreground",
@@ -88,7 +88,7 @@ export function BroadcastStatusPanel({
               <span
                 aria-hidden="true"
                 className={cn(
-                  "size-3 shrink-0 rounded-full",
+                  "size-2.5 shrink-0 rounded-full",
                   item.dotClassName,
                 )}
               />

--- a/apps/builder/src/features/integration-messenger/message-templates/actions/clone-message-templates.ts
+++ b/apps/builder/src/features/integration-messenger/message-templates/actions/clone-message-templates.ts
@@ -12,7 +12,6 @@ import { SdkException } from "@chatbotx.io/sdk"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { chunk } from "remeda"
 import { z } from "zod"
-import { getAllWorkspaceMembers } from "@/features/workspace-members/queries"
 import { workspaceActionClient } from "@/lib/safe-action"
 import { syncMessengerMessageTemplatesForIntegration } from "./sync-message-templates"
 
@@ -159,24 +158,18 @@ export const cloneMessengerMessageTemplateAction = workspaceActionClient
         workspaceId,
       })
 
-    // Resolve target rows by id (targets may live in OTHER workspaces).
-    const candidateTargets = await messengerIntegrationService.findByIds(
-      targetIntegrationMessengerIds,
-    )
-
-    // Authorize per target: the user must be an owner of the target's workspace,
-    // and the target must not be the source's own Facebook Page.
-    const { workspaceMembers } = await getAllWorkspaceMembers(user.id)
-    const ownerWorkspaceIds = new Set(
-      workspaceMembers
-        .filter((member) => member.role === "owner")
-        .map((member) => member.workspaceId),
-    )
-    const targets = candidateTargets.filter(
-      (target) =>
-        ownerWorkspaceIds.has(target.workspaceId) &&
-        target.pageId !== sourceIntegration?.pageId,
-    )
+    // Authorize per target: the user must be an admin (owner or superAdmin)
+    // of the target's workspace, and the target must not be the source's own
+    // Facebook Page. Memberships are read uncached so a just-revoked admin
+    // cannot clone across a workspace boundary.
+    const requested = new Set(targetIntegrationMessengerIds)
+    const cloneTargets =
+      await messengerIntegrationService.listCloneTargetsForUser({
+        userId: user.id,
+        excludePageId: sourceIntegration?.pageId,
+        authoritative: true,
+      })
+    const targets = cloneTargets.filter((target) => requested.has(target.id))
 
     if (targets.length === 0) {
       throw new Error("No authorized target channels found")

--- a/packages/business/__tests__/messenger-integration-clone-targets.test.ts
+++ b/packages/business/__tests__/messenger-integration-clone-targets.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  listByUserId: vi.fn(),
+  listByUserIdUncached: vi.fn(),
+  findMany: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: { query: { integrationMessengerModel: { findMany: mocks.findMany } } },
+  and: vi.fn(),
+  eq: vi.fn(),
+  findOrFail: vi.fn(),
+  inArray: vi.fn(),
+  sql: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/database/repositories", () => ({
+  integrationMessengerRepository: {},
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  integrationMessengerModel: {},
+  tagChannelModel: {},
+}))
+
+vi.mock("@chatbotx.io/database/partials", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@chatbotx.io/database/partials")>()),
+}))
+
+vi.mock("../src/inbox/connect-channel", () => ({
+  auditChannelConnected: vi.fn(),
+  connectChannelIntegration: vi.fn(),
+  runConnectTransaction: vi.fn(),
+}))
+
+vi.mock("../src/workspace-member/service", () => ({
+  workspaceMemberService: {
+    listByUserId: mocks.listByUserId,
+    listByUserIdUncached: mocks.listByUserIdUncached,
+  },
+}))
+
+const { messengerIntegrationService } = await import(
+  "../src/integration-messenger/service"
+)
+
+const member = (
+  workspaceId: string,
+  role: "owner" | "agent",
+  superAdmin = false,
+) => ({ workspaceId, role, permissions: { superAdmin } })
+
+beforeEach(() => {
+  mocks.listByUserId.mockReset()
+  mocks.listByUserIdUncached.mockReset()
+  mocks.findMany.mockReset().mockResolvedValue([])
+})
+
+describe("messengerIntegrationService.listCloneTargetsForUser", () => {
+  test("lists pages of every workspace where the user is owner or superAdmin, excluding the source page", async () => {
+    mocks.listByUserId.mockResolvedValue([
+      member("ws-owner", "owner"),
+      member("ws-admin", "agent", true),
+      member("ws-agent", "agent"),
+      member("ws-owner", "owner"),
+    ])
+    mocks.findMany.mockResolvedValue([{ id: "im-1", name: "Page 1" }])
+
+    const targets = await messengerIntegrationService.listCloneTargetsForUser({
+      userId: "user-1",
+      excludePageId: "page-source",
+    })
+
+    expect(targets).toEqual([{ id: "im-1", name: "Page 1" }])
+    expect(mocks.listByUserId).toHaveBeenCalledWith({ userId: "user-1" })
+    expect(mocks.findMany).toHaveBeenCalledWith({
+      where: {
+        workspaceId: { in: ["ws-owner", "ws-admin"] },
+        pageId: { ne: "page-source" },
+      },
+      orderBy: { name: "asc" },
+    })
+  })
+
+  test("does not narrow by page when there is no source page", async () => {
+    mocks.listByUserId.mockResolvedValue([member("ws-owner", "owner")])
+
+    await messengerIntegrationService.listCloneTargetsForUser({
+      userId: "user-1",
+    })
+
+    expect(mocks.findMany).toHaveBeenCalledWith({
+      where: { workspaceId: { in: ["ws-owner"] }, pageId: undefined },
+      orderBy: { name: "asc" },
+    })
+  })
+
+  test("reads memberships uncached when authorizing a write, so a revoked admin cannot clone", async () => {
+    // The cached list still says admin; the database no longer does.
+    mocks.listByUserId.mockResolvedValue([member("ws-admin", "agent", true)])
+    mocks.listByUserIdUncached.mockResolvedValue([member("ws-admin", "agent")])
+
+    const targets = await messengerIntegrationService.listCloneTargetsForUser({
+      userId: "user-1",
+      excludePageId: "page-source",
+      authoritative: true,
+    })
+
+    expect(targets).toEqual([])
+    expect(mocks.listByUserIdUncached).toHaveBeenCalledWith({
+      userId: "user-1",
+    })
+    expect(mocks.listByUserId).not.toHaveBeenCalled()
+    expect(mocks.findMany).not.toHaveBeenCalled()
+  })
+
+  test("returns nothing without querying when the user is an agent everywhere", async () => {
+    mocks.listByUserId.mockResolvedValue([member("ws-agent", "agent")])
+
+    const targets = await messengerIntegrationService.listCloneTargetsForUser({
+      userId: "user-1",
+      excludePageId: "page-source",
+    })
+
+    expect(targets).toEqual([])
+    expect(mocks.findMany).not.toHaveBeenCalled()
+  })
+})

--- a/packages/business/__tests__/messenger-integration.service.connect-page.test.ts
+++ b/packages/business/__tests__/messenger-integration.service.connect-page.test.ts
@@ -59,6 +59,12 @@ vi.mock("../src/inbox/connect-channel", () => ({
   runConnectTransaction: mocks.runConnectTransaction,
 }))
 
+// Only `listCloneTargetsForUser` reads memberships; keep the import chain
+// of this connect-page test as narrow as before.
+vi.mock("../src/workspace-member/service", () => ({
+  workspaceMemberService: {},
+}))
+
 const { messengerIntegrationService } = await import(
   "../src/integration-messenger/service"
 )

--- a/packages/business/__tests__/workspace-member-predicates.test.ts
+++ b/packages/business/__tests__/workspace-member-predicates.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest"
-import { isSupportAccessEnabled } from "../src/workspace-member/predicates"
+import {
+  isSupportAccessEnabled,
+  isWorkspaceAdminMember,
+} from "../src/workspace-member/predicates"
 
 describe("isSupportAccessEnabled", () => {
   test("returns false when supportAccessUntil is null", () => {
@@ -14,5 +17,46 @@ describe("isSupportAccessEnabled", () => {
   test("returns true when supportAccessUntil is in the future", () => {
     const future = new Date(Date.now() + 60_000)
     expect(isSupportAccessEnabled({ supportAccessUntil: future })).toBe(true)
+  })
+})
+
+describe("isWorkspaceAdminMember", () => {
+  test("an owner is an admin regardless of permissions", () => {
+    expect(
+      isWorkspaceAdminMember({
+        role: "owner",
+        permissions: { superAdmin: false },
+      }),
+    ).toBe(true)
+  })
+
+  test("an agent with the superAdmin permission is an admin", () => {
+    expect(
+      isWorkspaceAdminMember({
+        role: "agent",
+        permissions: { superAdmin: true },
+      }),
+    ).toBe(true)
+  })
+
+  test("a plain agent is not an admin", () => {
+    expect(
+      isWorkspaceAdminMember({
+        role: "agent",
+        permissions: { superAdmin: false, broadcast: true },
+      }),
+    ).toBe(false)
+  })
+
+  test("malformed permissions never grant admin", () => {
+    expect(isWorkspaceAdminMember({ role: "agent", permissions: null })).toBe(
+      false,
+    )
+    expect(
+      isWorkspaceAdminMember({
+        role: "agent",
+        permissions: { superAdmin: "yes" },
+      }),
+    ).toBe(false)
   })
 })

--- a/packages/business/src/integration-messenger/service.ts
+++ b/packages/business/src/integration-messenger/service.ts
@@ -25,6 +25,8 @@ import {
   connectChannelIntegration,
   runConnectTransaction,
 } from "../inbox/connect-channel"
+import { isWorkspaceAdminMember } from "../workspace-member/predicates"
+import { workspaceMemberService } from "../workspace-member/service"
 
 export type ConnectPageInput = {
   actorUserId: string
@@ -57,16 +59,6 @@ class MessengerIntegrationService extends BaseService {
   findByIdForWorkspace(props: { id: string; workspaceId: string }) {
     return db.query.integrationMessengerModel.findFirst({
       where: { id: props.id, workspaceId: props.workspaceId },
-    })
-  }
-
-  /** No workspace scope — targets in a clone-across-workspaces flow may live in other workspaces. */
-  findByIds(ids: string[]) {
-    if (ids.length === 0) {
-      return Promise.resolve([])
-    }
-    return db.query.integrationMessengerModel.findMany({
-      where: { id: { in: ids } },
     })
   }
 
@@ -312,6 +304,46 @@ class MessengerIntegrationService extends BaseService {
       .update(integrationMessengerModel)
       .set(data)
       .where(eq(integrationMessengerModel.id, props.id))
+  }
+
+  /**
+   * Every Messenger page the user may clone a template onto: the pages of
+   * all workspaces where the user is an admin (owner or `superAdmin`),
+   * minus the source Facebook Page itself — it may be connected in more than
+   * one workspace, so the exclusion is by `pageId`, not by integration id.
+   * The same list feeds the picker and authorizes the clone action; the
+   * action passes `authoritative` so a just-revoked membership can never be
+   * served from cache across a workspace boundary.
+   */
+  async listCloneTargetsForUser(input: {
+    userId: string
+    excludePageId?: string | null
+    /** Read memberships uncached — required whenever the list authorizes a write. */
+    authoritative?: boolean
+  }): Promise<IntegrationMessengerModel[]> {
+    const members = input.authoritative
+      ? await workspaceMemberService.listByUserIdUncached({
+          userId: input.userId,
+        })
+      : await workspaceMemberService.listByUserId({ userId: input.userId })
+    const adminWorkspaceIds = Array.from(
+      new Set(
+        members
+          .filter(isWorkspaceAdminMember)
+          .map((member) => member.workspaceId),
+      ),
+    )
+    if (adminWorkspaceIds.length === 0) {
+      return []
+    }
+
+    return await db.query.integrationMessengerModel.findMany({
+      where: {
+        workspaceId: { in: adminWorkspaceIds },
+        pageId: input.excludePageId ? { ne: input.excludePageId } : undefined,
+      },
+      orderBy: { name: "asc" },
+    })
   }
 
   /**

--- a/packages/business/src/workspace-member/predicates.ts
+++ b/packages/business/src/workspace-member/predicates.ts
@@ -1,4 +1,30 @@
-import type { WorkspaceModel } from "@chatbotx.io/database/types"
+import {
+  workspaceMemberPermissionsSchema,
+  workspaceMemberRoles,
+} from "@chatbotx.io/database/partials"
+import type {
+  WorkspaceMemberModel,
+  WorkspaceModel,
+} from "@chatbotx.io/database/types"
+
+/**
+ * "Admin" of a workspace: its owner, or any member granted the `superAdmin`
+ * permission. This is the bar for cross-workspace operations such as cloning
+ * a Messenger template onto another workspace's page — being a plain agent
+ * there is not enough. `permissions` is a jsonb column, so it is parsed
+ * rather than trusted.
+ */
+export function isWorkspaceAdminMember(
+  member: Pick<WorkspaceMemberModel, "role" | "permissions">,
+): boolean {
+  if (member.role === workspaceMemberRoles.enum.owner) {
+    return true
+  }
+  const permissions = workspaceMemberPermissionsSchema
+    .partial()
+    .safeParse(member.permissions)
+  return permissions.success && permissions.data.superAdmin === true
+}
 
 /**
  * Owner opt-in check. True while `Workspace.supportAccessUntil` is set and


### PR DESCRIPTION
## Summary

- Messenger template clone: target pages now include every workspace where the user is an admin (owner or `superAdmin`), not only workspaces they own. The clone action authorizes against the same list.
- Broadcast status sidebar is narrower.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm --filter @chatbotx.io/business check-types`, `pnpm --filter builder check-types`
- [x] `packages/business`: 2027 tests / 188 files
- [x] `apps/builder`: 3329 tests / 482 files
- [x] `next build --experimental-build-mode=compile` for the builder
- [ ] Manual: as a `superAdmin` member (not owner) of workspace B, clone a template from workspace A → B's pages are listed and the clone succeeds
- [ ] Manual: as a plain agent of workspace B, B's pages are not listed and a direct call is rejected
- [ ] Manual: broadcasts list — sidebar narrower, all statuses still selectable
