### PR TITLE
fix(builder): keep server-only startup in the nodejs runtime

### DIFF
--- a/apps/builder/src/instrumentation.ts
+++ b/apps/builder/src/instrumentation.ts
@@ -11,13 +11,20 @@ export async function register() {
   }
 
   // instrumentation also runs in the edge runtime, where process.exit doesn't
-  // exist — only gate on the license in the nodejs runtime.
-  if (process.env.NEXT_RUNTIME === "nodejs") {
-    const { assertLicenseAtStartup } = await import(
-      "@chatbotx.io/business/license-startup"
-    )
-    await assertLicenseAtStartup()
+  // exist and Node built-ins aren't bundleable. Everything below is nodejs-only:
+  // the license check calls process.exit, and the oRPC server router pulls in a
+  // Node-only tree (crypto, redis, bullmq, the DB client) that only ever backs
+  // SSR/RSC in the nodejs runtime. Importing it under edge drags `crypto` into
+  // the Edge Runtime and tries to compile worker-only packages there — so gate
+  // the whole block on the nodejs runtime.
+  if (process.env.NEXT_RUNTIME !== "nodejs") {
+    return
   }
+
+  const { assertLicenseAtStartup } = await import(
+    "@chatbotx.io/business/license-startup"
+  )
+  await assertLicenseAtStartup()
 
   await import("./lib/orpc/orpc.server")
 }


### PR DESCRIPTION
## Summary

- `instrumentation.ts`'s `register()` runs in every runtime Next boots, including the Edge Runtime. It imported the oRPC server router unconditionally, which pulls in a Node-only tree (`crypto`, redis, bullmq, the DB client) that cannot be bundled for edge — producing a `crypto`-in-Edge-Runtime warning and module-resolution errors during the build.
- The license check in the same file was already gated on `NEXT_RUNTIME === "nodejs"`; the router import was not. This consolidates both under a single early-return guard so all server-only startup runs only in the nodejs runtime.
- No behavior change in the nodejs runtime: SSR/RSC still initializes `globalThis.$client` before any render. The edge instance simply stops loading a module it never used — `proxy.ts` (middleware) authenticates via `better-auth` and does not touch oRPC, and no route opts into the edge runtime.

## Test plan

- [x] `pnpm lint` (i18n parity + schema drift included)
- [x] `pnpm --filter builder check-types`
- [x] `pnpm --filter worker check-types`
- [x] `pnpm --filter builder build` — compiled successfully, no edge-runtime warnings
