### PR TITLE
fix(sequence): compute dispatch bucket without node crypto

### DIFF
--- a/packages/sequence-scheduler/__tests__/dispatch-manager.test.ts
+++ b/packages/sequence-scheduler/__tests__/dispatch-manager.test.ts
@@ -88,6 +88,26 @@ describe("calculateBucket", () => {
     // so this test can assert the non-collision behavior for known inputs.
     expect(bucketA).not.toBe(bucketB)
   })
+
+  test("spreads sequential ids across all 256 buckets", async () => {
+    const { calculateBucket } = await import("../src/dispatch-manager")
+
+    // Sequential ids are the worst case for a weak hash (e.g. taking one byte
+    // of an FNV hash leaves half the buckets empty). Workers scan every bucket,
+    // so an uneven spread here means idle shards and hot shards. Guards the
+    // pure-JS bucketing against a distribution regression.
+    const buckets = new Set<number>()
+    const load = new Array<number>(256).fill(0)
+    for (let index = 0; index < 5000; index++) {
+      const bucket = calculateBucket(`workspace-${index}`, `contact-${index}`)
+      buckets.add(bucket)
+      load[bucket] += 1
+    }
+
+    expect(buckets.size).toBe(256)
+    // ~19.5 dispatches per bucket on average; assert nothing is wildly hot/cold.
+    expect(Math.max(...load)).toBeLessThan(50)
+  })
 })
 
 describe("generateIdempotencyKey", () => {

--- a/packages/sequence-scheduler/src/dispatch-cancel.ts
+++ b/packages/sequence-scheduler/src/dispatch-cancel.ts
@@ -11,13 +11,10 @@ import { sequenceConnections } from "@chatbotx.io/redis"
 import { SchedulerClient } from "@chatbotx.io/scheduler"
 
 /**
- * Cancellation lives apart from `dispatch-manager` on purpose. Creating a
- * dispatch needs `calculateBucket`, which hashes with Node's `crypto`; cancelling
- * one never does. Keeping them in one module meant every consumer of the cancel
- * path — including `@chatbotx.io/business`, which the builder loads into the Edge
- * Runtime — dragged `crypto` along and failed to compile. Import this module (or
- * the `@chatbotx.io/sequence-scheduler/dispatch-cancel` subpath) from anywhere
- * that must stay Edge-safe.
+ * Cancellation lives apart from `dispatch-manager` by responsibility: creating a
+ * dispatch assigns a bucket and inserts a row, cancelling one only reads rows
+ * back and clears their schedule entries. Both modules are Edge-safe now that
+ * `dispatch-manager` bucketing no longer imports Node's `crypto`.
  */
 
 type DrizzleClient = typeof db | Transaction

--- a/packages/sequence-scheduler/src/dispatch-manager.ts
+++ b/packages/sequence-scheduler/src/dispatch-manager.ts
@@ -1,24 +1,38 @@
 import { db, type Transaction } from "@chatbotx.io/database/client"
 import { sequenceDispatchModel } from "@chatbotx.io/database/schema"
 import { createId } from "@chatbotx.io/utils"
-import { createHash } from "crypto"
 
 /**
- * The dispatch *creation* path. It hashes with Node's `crypto` to pick a bucket,
- * so this module can only run in a Node process. Cancellation deliberately lives
- * in `./dispatch-cancel` — it needs no hashing, and Edge-Runtime consumers import
- * it directly instead of paying for `crypto` here.
+ * The dispatch *creation* path. Bucketing uses a small pure-JS string hash
+ * instead of Node's `crypto`, so nothing here imports a Node built-in: the
+ * builder pulls `@chatbotx.io/business` — and this module, transitively — into
+ * the Edge Runtime, where a `crypto` import fails to compile. Creation still
+ * lives apart from `./dispatch-cancel` by responsibility (creating vs.
+ * cancelling a dispatch), no longer because of `crypto`.
  */
 
 type DrizzleClient = typeof db | Transaction
 
+/**
+ * Maps a contact to one of 256 dispatch buckets for parallel worker scanning.
+ * The value is computed once at creation and persisted on the dispatch row;
+ * nothing ever recomputes it (cancel/scan read `bucket` back from the row), so
+ * the hash only needs to be deterministic and spread evenly across 0–255 — it
+ * is not security-sensitive.
+ */
 export function calculateBucket(
   workspaceId: string,
   contactId: string,
 ): number {
   const key = `${workspaceId}:${contactId}`
-  const hash = createHash("sha256").update(key).digest()
-  return hash[0] // First byte gives 0-255
+  // Polynomial string hash (base 31), reduced each step by a 31-bit Mersenne
+  // prime so it never leaves JS safe-integer range and needs no bitwise ops.
+  // `% 256` then spreads evenly across the 256 buckets.
+  let hash = 0
+  for (let index = 0; index < key.length; index++) {
+    hash = (hash * 31 + key.charCodeAt(index)) % 2_147_483_647
+  }
+  return hash % 256
 }
 
 export function generateIdempotencyKey(


### PR DESCRIPTION
## Problem
Since #1102, `sequence/service` imports `contact-schedule` → `dispatch-manager`, which picked a dispatch bucket with Node's `crypto.createHash`. That pulls `crypto` into the builder's Edge Runtime instrumentation (the `orpc.server` graph), so the Edge compile fails with `node-module-in-edge-runtime`.

## Fix
Replace `crypto` in `calculateBucket` with a pure-JS polynomial string hash (no Node built-in, no bitwise). The bucket is only a load-distribution key: computed once and persisted on the dispatch row, never recomputed (cancel/scan read it back). So the only requirement is an even 0–255 spread — verified full 256-bucket coverage.

## Test
- `pnpm --filter @chatbotx.io/sequence-scheduler test` — 104 passing
- typecheck: `sequence-scheduler` + `business`
- lint clean