### PR TITLE
feat(logging): add LOG_DEBUG flag for opt-in diagnostic logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -175,3 +175,8 @@ SCHEDULER_BUCKET_RANGE=0-255
 # ─────────────────────────────────────────────
 # Log verbosity: error | warn | info | debug
 LOG_LEVEL=debug
+# Promotes opt-in diagnostic lines (e.g. sanitized webhook request bodies) from
+# debug to info, so they survive LOG_LEVEL=info in production without turning
+# on every other debug line. Enable briefly; log content may include redacted
+# customer data.
+LOG_DEBUG=false

--- a/apps/builder/__tests__/webhook-log.test.ts
+++ b/apps/builder/__tests__/webhook-log.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment node
+
+import { afterAll, describe, expect, test, vi } from "vitest"
+
+const loggerInfo = vi.fn()
+const loggerDebug = vi.fn()
+
+vi.mock("@/lib/log", () => ({
+  logger: {
+    debug: loggerDebug,
+    error: vi.fn(),
+    info: loggerInfo,
+    // The real production logger is a pino child, so `isLevelEnabled` exists at
+    // runtime. Without it here the diagnostic path would throw and be swallowed
+    // by `logWebhookRequestBody`'s catch, hiding a broken call site.
+    isLevelEnabled: vi.fn(() => true),
+  },
+}))
+
+// Pin LOG_DEBUG before loading the module: `@chatbotx.io/logger` resolves its
+// diagnostic level once at import time, so a shell-exported LOG_DEBUG=true would
+// otherwise make `logDiagnostic` emit at info and flip this suite's assertions.
+vi.stubEnv("LOG_DEBUG", "")
+
+const { logWebhookRequestBody, sanitizeWebhookBody } = await import(
+  "../src/lib/webhook-log"
+)
+
+afterAll(() => {
+  vi.unstubAllEnvs()
+})
+
+// Redaction and capping themselves are covered generically in
+// `packages/logger/__tests__/redact.test.ts`. These tests cover only the
+// webhook-specific glue: parsing a raw body string and the fail-closed
+// omission of anything that cannot be safely redacted.
+describe("sanitizeWebhookBody", () => {
+  test("redacts secrets end-to-end for a parseable JSON body", () => {
+    const body = JSON.stringify({
+      access_token: "abc123",
+      user: { token: "nested-secret", name: "alice" },
+    })
+
+    const result = JSON.parse(sanitizeWebhookBody(body))
+
+    expect(result.access_token).toBe("[redacted]")
+    expect(result.user.token).toBe("[redacted]")
+    expect(result.user.name).toBe("alice")
+  })
+
+  test("omits a non-JSON body instead of logging it raw", () => {
+    const body = "access_token=super-secret&foo=bar"
+
+    const result = sanitizeWebhookBody(body)
+
+    expect(result).not.toContain("super-secret")
+    expect(result).toContain("[body omitted for safety")
+  })
+
+  test("omits an oversized body instead of parsing or logging it raw", () => {
+    const hugeValue = "a".repeat(70_000)
+    const body = JSON.stringify({ access_token: hugeValue })
+
+    const result = sanitizeWebhookBody(body)
+
+    // Parsing is skipped AND the raw body is not emitted — no secret leak.
+    expect(result).not.toContain(hugeValue)
+    expect(result).toContain("[body omitted for safety: too large to redact")
+  })
+
+  test("redacts a body exactly at the parse limit but omits one char over it", () => {
+    // For an all-"a" value the JSON is `{"v":"<value>"}` = value.length + 8.
+    const wrapperLength = `{"v":""}`.length
+
+    const atLimitBody = JSON.stringify({
+      v: "a".repeat(65_536 - wrapperLength),
+    })
+    expect(atLimitBody.length).toBe(65_536)
+    expect(sanitizeWebhookBody(atLimitBody)).not.toContain("[body omitted")
+
+    const overLimitBody = JSON.stringify({
+      v: "a".repeat(65_537 - wrapperLength),
+    })
+    expect(overLimitBody.length).toBe(65_537)
+    expect(sanitizeWebhookBody(overLimitBody)).toContain(
+      "[body omitted for safety: too large to redact",
+    )
+  })
+
+  test("leaves a small parseable body intact", () => {
+    const body = JSON.stringify({ ok: true })
+
+    expect(sanitizeWebhookBody(body)).toBe(JSON.stringify({ ok: true }))
+  })
+})
+
+describe("logWebhookRequestBody", () => {
+  test("never throws when reading the cloned request body rejects", async () => {
+    loggerInfo.mockClear()
+    const req = {
+      clone: () => ({
+        text: () => Promise.reject(new Error("stream errored")),
+      }),
+    } as unknown as Parameters<typeof logWebhookRequestBody>[1]
+
+    await expect(
+      logWebhookRequestBody("telegram", req),
+    ).resolves.toBeUndefined()
+
+    expect(loggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ integrationType: "telegram" }),
+      "Failed to read webhook request body for logging",
+    )
+  })
+
+  test("logs the metadata line and the sanitized diagnostic payload", async () => {
+    loggerInfo.mockClear()
+    loggerDebug.mockClear()
+    const rawBody = JSON.stringify({ ok: true, token: "secret" })
+    const req = {
+      clone: () => ({ text: () => Promise.resolve(rawBody) }),
+    } as unknown as Parameters<typeof logWebhookRequestBody>[1]
+
+    await logWebhookRequestBody("messenger", req)
+
+    // Metadata line only — original, uncapped content length; no failure line.
+    expect(loggerInfo).toHaveBeenCalledTimes(1)
+    expect(loggerInfo).toHaveBeenCalledWith(
+      { integrationType: "messenger", contentLength: rawBody.length },
+      "Webhook request body",
+    )
+    // Diagnostic payload actually emitted, with the body sanitized (redacted).
+    expect(loggerDebug).toHaveBeenCalledWith(
+      { integrationType: "messenger", body: sanitizeWebhookBody(rawBody) },
+      "Webhook request body payload",
+    )
+  })
+})

--- a/apps/builder/src/lib/webhook-log.ts
+++ b/apps/builder/src/lib/webhook-log.ts
@@ -1,13 +1,42 @@
+import { capText, logDiagnostic, redactSecrets } from "@chatbotx.io/logger"
 import type { NextRequest } from "next/server"
 import { logger } from "@/lib/log"
 
+const MAX_REDACT_PARSE_CHARS = 65_536 // above this, skip parse to bound CPU
+
+const omittedBody = (reason: string, length: number): string =>
+  `[body omitted for safety: ${reason}, ${length} chars]`
+
+/**
+ * Turn a raw webhook body (a JSON string) into a log-safe string, reusing the
+ * shared `redactSecrets` + `capText` helpers from `@chatbotx.io/logger`. Only
+ * JSON small enough to parse is shown; anything we cannot safely redact —
+ * non-JSON, oversized, or a redaction failure — is OMITTED (with its length as
+ * a hint) rather than logged raw, so a secret can never leak through a fallback
+ * path. This wrapper holds only the webhook-specific glue (a raw HTTP body is a
+ * string that must be parsed first); the redaction/capping logic itself is
+ * generic and shared for any other place that needs to debug-log safely.
+ */
+export const sanitizeWebhookBody = (body: string): string => {
+  if (body.length > MAX_REDACT_PARSE_CHARS) {
+    return omittedBody("too large to redact", body.length)
+  }
+  try {
+    return capText(JSON.stringify(redactSecrets(JSON.parse(body))))
+  } catch {
+    return omittedBody("not valid JSON", body.length)
+  }
+}
+
 /**
  * Logs an inbound channel webhook ("Webhook request body") so every channel's
- * traffic is observable the same way. The full raw body — which contains
- * customer message content — is only emitted at DEBUG level; the INFO line
- * carries metadata so production logs stay free of message PII. Reads a
- * CLONE of the request, so the caller's own body consumption is unaffected.
- * Never throws.
+ * traffic is observable the same way. The body — which contains customer
+ * message content — is redacted (secrets stripped by key name) and capped in
+ * size, then emitted at `debug` normally, or promoted to `info` when
+ * `LOG_DEBUG=true` (see `logDiagnostic`). The INFO line always carries
+ * metadata (including the ORIGINAL, uncapped content length) so production
+ * logs stay free of message PII by default. Reads a CLONE of the request, so
+ * the caller's own body consumption is unaffected. Never throws.
  */
 export const logWebhookRequestBody = async (
   integrationType: string,
@@ -19,7 +48,11 @@ export const logWebhookRequestBody = async (
       { integrationType, contentLength: body.length },
       "Webhook request body",
     )
-    logger.debug({ integrationType, body }, "Webhook request body payload")
+    logDiagnostic(
+      logger,
+      () => ({ integrationType, body: sanitizeWebhookBody(body) }),
+      "Webhook request body payload",
+    )
   } catch (e: unknown) {
     logger.info(
       { integrationType, err: e },

--- a/packages/logger/__tests__/diagnostic.test.ts
+++ b/packages/logger/__tests__/diagnostic.test.ts
@@ -1,0 +1,93 @@
+import pino from "pino"
+import { afterEach, describe, expect, test, vi } from "vitest"
+import { resolveDiagnosticLevel } from "../src/index"
+
+describe("resolveDiagnosticLevel", () => {
+  test("returns info when LOG_DEBUG is exactly 'true'", () => {
+    expect(resolveDiagnosticLevel({ LOG_DEBUG: "true" })).toBe("info")
+  })
+
+  test("returns debug when LOG_DEBUG is 'false'", () => {
+    expect(resolveDiagnosticLevel({ LOG_DEBUG: "false" })).toBe("debug")
+  })
+
+  test("returns debug when LOG_DEBUG is unset", () => {
+    expect(resolveDiagnosticLevel({})).toBe("debug")
+  })
+
+  test("returns debug when LOG_DEBUG is '1'", () => {
+    expect(resolveDiagnosticLevel({ LOG_DEBUG: "1" })).toBe("debug")
+  })
+
+  test("returns debug when LOG_DEBUG is 'TRUE' (strict match only)", () => {
+    expect(resolveDiagnosticLevel({ LOG_DEBUG: "TRUE" })).toBe("debug")
+  })
+})
+
+describe("logDiagnostic", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  // `diagnosticLevel` is fixed at module load, so each test imports a fresh
+  // module with LOG_DEBUG stubbed — making the branch deterministic regardless
+  // of the developer's shell environment.
+  const loadLogDiagnostic = async (logDebug: string) => {
+    vi.resetModules()
+    vi.stubEnv("LOG_DEBUG", logDebug)
+    const module = await import("../src/index")
+    return module.logDiagnostic
+  }
+
+  const createCaptureLogger = (level: "debug" | "info") => {
+    const lines: Record<string, unknown>[] = []
+    const logger = pino(
+      { level },
+      {
+        write: (line: string) => {
+          lines.push(JSON.parse(line))
+        },
+      },
+    )
+    return { lines, logger }
+  }
+
+  test("emits at debug by default (LOG_DEBUG unset)", async () => {
+    const logDiagnostic = await loadLogDiagnostic("")
+    const { lines, logger } = createCaptureLogger("debug")
+
+    logDiagnostic(logger, () => ({ foo: "bar" }), "diagnostic message")
+
+    expect(lines).toHaveLength(1)
+    // pino level 20 === debug: proves the default (unpromoted) path.
+    expect(lines[0]).toMatchObject({
+      level: 20,
+      foo: "bar",
+      msg: "diagnostic message",
+    })
+  })
+
+  test("promotes to info when LOG_DEBUG=true, surviving an info-level logger", async () => {
+    const logDiagnostic = await loadLogDiagnostic("true")
+    const { lines, logger } = createCaptureLogger("info")
+
+    logDiagnostic(logger, () => ({ foo: "bar" }), "diagnostic message")
+
+    expect(lines).toHaveLength(1)
+    // pino level 30 === info: proves the debug→info promotion path is live.
+    expect(lines[0]).toMatchObject({ level: 30, msg: "diagnostic message" })
+  })
+
+  test("does not invoke buildData when the resolved level is disabled", async () => {
+    // LOG_DEBUG unset ⇒ diagnostic level 'debug', which an 'info' logger drops.
+    const logDiagnostic = await loadLogDiagnostic("")
+    const { lines, logger } = createCaptureLogger("info")
+    const buildData = vi.fn(() => ({ foo: "bar" }))
+
+    logDiagnostic(logger, buildData, "diagnostic message")
+
+    expect(buildData).not.toHaveBeenCalled()
+    expect(lines).toHaveLength(0)
+  })
+})

--- a/packages/logger/__tests__/redact.test.ts
+++ b/packages/logger/__tests__/redact.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "vitest"
+import { capText, DEFAULT_MAX_LOG_CHARS, redactSecrets } from "../src/redact"
+
+describe("redactSecrets", () => {
+  test("redacts top-level sensitive keys and keeps ordinary ones", () => {
+    const result = redactSecrets({
+      access_token: "abc",
+      apiKey: "xyz",
+      api_key: "xyz",
+      verify_token: "vt",
+      password: "hunter2",
+      signature: "sig",
+      userId: "keep-me",
+    }) as Record<string, unknown>
+
+    expect(result.access_token).toBe("[redacted]")
+    expect(result.apiKey).toBe("[redacted]")
+    expect(result.api_key).toBe("[redacted]")
+    expect(result.verify_token).toBe("[redacted]")
+    expect(result.password).toBe("[redacted]")
+    expect(result.signature).toBe("[redacted]")
+    expect(result.userId).toBe("keep-me")
+  })
+
+  test("does not redact ordinary keys such as tokenCount (exact-match guard)", () => {
+    const result = redactSecrets({ tokenCount: 42 }) as Record<string, unknown>
+
+    expect(result.tokenCount).toBe(42)
+  })
+
+  test("redacts sensitive keys nested in objects and arrays", () => {
+    const result = redactSecrets({
+      user: { name: "alice", token: "secret-token" },
+      entries: [{ client_secret: "s1", value: 1 }],
+    }) as {
+      user: { name: string; token: string }
+      entries: Array<{ client_secret: string; value: number }>
+    }
+
+    expect(result.user.token).toBe("[redacted]")
+    expect(result.user.name).toBe("alice")
+    expect(result.entries[0].client_secret).toBe("[redacted]")
+    expect(result.entries[0].value).toBe(1)
+  })
+
+  test("passes primitives through untouched", () => {
+    expect(redactSecrets(42)).toBe(42)
+    expect(redactSecrets("hello")).toBe("hello")
+    expect(redactSecrets(null)).toBe(null)
+    expect(redactSecrets(true)).toBe(true)
+  })
+
+  test("does not mutate the input", () => {
+    const input = { token: "secret", nested: { password: "p" } }
+    redactSecrets(input)
+
+    expect(input.token).toBe("secret")
+    expect(input.nested.password).toBe("p")
+  })
+
+  test("drops subtrees deeper than the depth limit without throwing", () => {
+    let nested: unknown = { token: "deep-secret" }
+    for (let i = 0; i < 200; i++) {
+      nested = { child: nested }
+    }
+
+    let result: unknown
+    expect(() => {
+      result = redactSecrets(nested)
+    }).not.toThrow()
+
+    const serialized = JSON.stringify(result)
+    expect(serialized).not.toContain("deep-secret")
+    expect(serialized).toContain("[omitted: too deeply nested]")
+  })
+})
+
+describe("capText", () => {
+  test("leaves text at or under the limit untouched", () => {
+    expect(capText("hello", 10)).toBe("hello")
+    expect(capText("a".repeat(10), 10)).toBe("a".repeat(10))
+  })
+
+  test("truncates and appends a marker when over the limit", () => {
+    const result = capText("a".repeat(20), 10)
+
+    expect(result.startsWith("a".repeat(10))).toBe(true)
+    expect(result).toContain("…[truncated 10 chars]")
+  })
+
+  test("defaults to DEFAULT_MAX_LOG_CHARS", () => {
+    const result = capText("a".repeat(DEFAULT_MAX_LOG_CHARS + 100))
+
+    expect(result).toContain("…[truncated 100 chars]")
+  })
+
+  test("does not split a trailing surrogate pair", () => {
+    // "😀" is a surrogate pair; place its high half on the cap boundary.
+    const text = `${"a".repeat(9)}😀${"a".repeat(5)}`
+    const result = capText(text, 10)
+    const retained = result.slice(0, result.indexOf("…[truncated"))
+    const lastCode = retained.charCodeAt(retained.length - 1)
+
+    expect(lastCode >= 0xd8_00 && lastCode <= 0xdb_ff).toBe(false)
+  })
+})

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,4 +1,13 @@
-import pino from "pino"
+import pino, { type Logger } from "pino"
+
+// Re-export the reusable log-safety helpers so a single import from
+// `@chatbotx.io/logger` covers safe diagnostic logging end to end:
+// `logDiagnostic` (level promotion) + `redactSecrets` / `capText` (safe payload).
+export {
+  capText,
+  DEFAULT_MAX_LOG_CHARS,
+  redactSecrets,
+} from "./redact"
 
 const baseLogger = pino({
   level: process.env.LOG_LEVEL || "info",
@@ -14,3 +23,44 @@ export const getChildLogger = (name: string) =>
   baseLogger.child({ module: name })
 
 export default baseLogger
+
+export type DiagnosticLevel = "info" | "debug"
+
+/**
+ * Pure + env-injectable so both branches are unit-testable without module
+ * reloads. `LOG_DEBUG=true` promotes opt-in diagnostics to `info` (so they
+ * survive a production `LOG_LEVEL=info`) WITHOUT enabling every other
+ * `debug` line in the app.
+ */
+export const resolveDiagnosticLevel = (
+  env: NodeJS.ProcessEnv = process.env,
+): DiagnosticLevel => (env.LOG_DEBUG === "true" ? "info" : "debug")
+
+// Fixed for the process lifetime — re-evaluated per call would be wasted work
+// since env vars don't change at runtime.
+const diagnosticLevel = resolveDiagnosticLevel()
+
+/**
+ * Emit a heavy/sensitive diagnostic line at the resolved diagnostic level
+ * (`debug` normally, promoted to `info` when `LOG_DEBUG=true`).
+ *
+ * `buildData` is lazy: it is only invoked when the resolved level is
+ * enabled on `logger`, so callers pay zero cost on the hot path when the
+ * line would be dropped anyway.
+ *
+ * The CALLER is responsible for passing already-sanitized data — this
+ * helper only chooses the log level, it never sanitizes or redacts
+ * anything for you.
+ *
+ * Reusable anywhere a verbose/PII-adjacent line should be individually
+ * switchable in production without a channel- or feature-specific flag.
+ */
+export const logDiagnostic = (
+  logger: Logger,
+  buildData: () => Record<string, unknown>,
+  message: string,
+): void => {
+  if (logger.isLevelEnabled(diagnosticLevel)) {
+    logger[diagnosticLevel](buildData(), message)
+  }
+}

--- a/packages/logger/src/redact.ts
+++ b/packages/logger/src/redact.ts
@@ -1,0 +1,78 @@
+// Generic, reusable log-safety helpers: redact secrets by key name and cap
+// oversized text. Use these anywhere in the system that dumps data for
+// debugging (webhook bodies, AI payloads, integration responses, …) so a
+// diagnostic line can never leak a secret or flood the log with a giant line.
+// No domain- or channel-specific knowledge lives here — extend SENSITIVE_KEYS
+// once and every caller benefits.
+
+export const DEFAULT_MAX_LOG_CHARS = 16_000
+
+// Bounds recursion so a hostile or pathological deeply nested value cannot
+// overflow the call stack; the subtree beyond it is dropped, never leaked raw.
+const MAX_REDACT_DEPTH = 64
+
+// Redact by sensitive KEY NAME (exact, case-insensitive).
+const SENSITIVE_KEYS: ReadonlySet<string> = new Set([
+  "access_token",
+  "refresh_token",
+  "auth_token",
+  "id_token",
+  "verify_token",
+  "token",
+  "client_secret",
+  "app_secret",
+  "secret",
+  "secret_key",
+  "private_key",
+  "password",
+  "signature",
+  "api_key",
+  "apikey",
+  "authorization",
+])
+
+// Primitives never recurse, so the depth guard applies only to arrays/objects.
+const redactAtDepth = (value: unknown, depth: number): unknown => {
+  if (value === null || typeof value !== "object") {
+    return value
+  }
+  if (depth >= MAX_REDACT_DEPTH) {
+    return "[omitted: too deeply nested]"
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactAtDepth(item, depth + 1))
+  }
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, item]) =>
+      SENSITIVE_KEYS.has(key.toLowerCase())
+        ? [key, "[redacted]"]
+        : [key, redactAtDepth(item, depth + 1)],
+    ),
+  )
+}
+
+/**
+ * Recursively replace the value of any sensitive-named key with "[redacted]",
+ * returning a NEW structure (never mutates the input). Works on any JSON-like
+ * value; primitives pass through untouched; recursion is depth-bounded so a
+ * deeply nested value cannot overflow the stack.
+ */
+export const redactSecrets = (value: unknown): unknown =>
+  redactAtDepth(value, 0)
+
+/**
+ * Cap a string to `maxChars`, appending a truncation marker, without splitting
+ * a trailing UTF-16 surrogate pair (log payloads are often emoji-heavy).
+ */
+export const capText = (
+  text: string,
+  maxChars: number = DEFAULT_MAX_LOG_CHARS,
+): string => {
+  if (text.length <= maxChars) {
+    return text
+  }
+  const lastCharCode = text.charCodeAt(maxChars - 1)
+  const endsOnHighSurrogate = lastCharCode >= 0xd8_00 && lastCharCode <= 0xdb_ff
+  const end = endsOnHighSurrogate ? maxChars - 1 : maxChars
+  return `${text.slice(0, end)}…[truncated ${text.length - end} chars]`
+}


### PR DESCRIPTION
## Summary

- Adds `LOG_DEBUG`, a reusable flag that promotes opt-in diagnostic log lines from `debug` to `info` so they survive a production `LOG_LEVEL=info` — without turning on every other debug line.
- Uses it to surface the inbound webhook body for debugging: the body is redacted (secrets stripped by key name) and size-capped before logging, and is only shown when `LOG_DEBUG=true`. With the flag off, behavior is unchanged.
- The redaction and capping live in `@chatbotx.io/logger` as shared helpers, so any other part of the system can debug-log safely with a single import.

## Changes

- **`@chatbotx.io/logger`** — `logDiagnostic` (promotes a line to `info` when `LOG_DEBUG=true`, lazy so it costs nothing when the line would be dropped), plus reusable `redactSecrets` and `capText` helpers.
- **Webhook logging** (`apps/builder/src/lib/webhook-log.ts`) — reuses those helpers; a body that cannot be safely redacted (non-JSON or oversized) is omitted rather than logged raw, so a secret can never leak.
- **`.env.example`** — documents `LOG_DEBUG`.

## How to test

1. Set `LOG_DEBUG=true` on the builder and restart.
2. Send a webhook; confirm the `Webhook request body payload` line appears at info with the body redacted and size-capped.
3. Set `LOG_DEBUG=false`; confirm only the metadata line is logged.

## Test plan

- [x] `pnpm --filter @chatbotx.io/logger test` — 19 tests
- [x] `pnpm --filter builder test` (webhook-log) — green; full builder suite green
- [x] `check-types` — builder + logger
- [x] `pnpm lint` (ultracite + i18n + schema-drift) — green
- [ ] Manual: toggle `LOG_DEBUG` on the builder and confirm the sanitized body appears only when enabled

### Out of scope, deliberately

- The webhook logger reads the full request body before size limits apply. This is pre-existing and shared with the downstream handler; bounding it belongs at the route/proxy layer and is left to a separate PR.
