### PR TITLE
fix(contacts): show user_id and channel ids in contact detail panel

### DIFF
--- a/apps/builder/messages/ar.json
+++ b/apps/builder/messages/ar.json
@@ -2293,6 +2293,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "رمز المستخدم"
     }
   },
   "flows": {

--- a/apps/builder/messages/da.json
+++ b/apps/builder/messages/da.json
@@ -2156,6 +2156,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "Brugerkode"
     }
   },
   "flows": {

--- a/apps/builder/messages/de.json
+++ b/apps/builder/messages/de.json
@@ -2156,6 +2156,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "Benutzercode"
     }
   },
   "flows": {

--- a/apps/builder/messages/en.json
+++ b/apps/builder/messages/en.json
@@ -2293,6 +2293,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "User Code"
     }
   },
   "metaConversions": {

--- a/apps/builder/messages/es.json
+++ b/apps/builder/messages/es.json
@@ -2293,6 +2293,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "Código de usuario"
     }
   },
   "flows": {

--- a/apps/builder/messages/fi.json
+++ b/apps/builder/messages/fi.json
@@ -2156,6 +2156,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "Käyttäjäkoodi"
     }
   },
   "flows": {

--- a/apps/builder/messages/fr.json
+++ b/apps/builder/messages/fr.json
@@ -2156,6 +2156,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "Code utilisateur"
     }
   },
   "flows": {

--- a/apps/builder/messages/he.json
+++ b/apps/builder/messages/he.json
@@ -4843,6 +4843,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "קוד משתמש"
     }
   },
   "billing": {

--- a/apps/builder/messages/id.json
+++ b/apps/builder/messages/id.json
@@ -2156,6 +2156,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "Kode pengguna"
     }
   },
   "flows": {

--- a/apps/builder/messages/it.json
+++ b/apps/builder/messages/it.json
@@ -1458,6 +1458,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "Codice utente"
     }
   },
   "actions": {

--- a/apps/builder/messages/ja.json
+++ b/apps/builder/messages/ja.json
@@ -2156,6 +2156,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "ユーザーコード"
     }
   },
   "flows": {

--- a/apps/builder/messages/nl.json
+++ b/apps/builder/messages/nl.json
@@ -1969,6 +1969,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "Gebruikerscode"
     }
   },
   "condition": {

--- a/apps/builder/messages/pt-BR.json
+++ b/apps/builder/messages/pt-BR.json
@@ -2156,6 +2156,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "Código do usuário"
     }
   },
   "flows": {

--- a/apps/builder/messages/pt-PT.json
+++ b/apps/builder/messages/pt-PT.json
@@ -2156,6 +2156,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "Código do utilizador"
     }
   },
   "flows": {

--- a/apps/builder/messages/ro.json
+++ b/apps/builder/messages/ro.json
@@ -2940,6 +2940,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "Cod utilizator"
     }
   },
   "channels": {

--- a/apps/builder/messages/sv.json
+++ b/apps/builder/messages/sv.json
@@ -2991,6 +2991,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "Användarkod"
     }
   },
   "flowAnalytics": {

--- a/apps/builder/messages/tr.json
+++ b/apps/builder/messages/tr.json
@@ -2293,6 +2293,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "Kullanıcı kodu"
     }
   },
   "flows": {

--- a/apps/builder/messages/vi.json
+++ b/apps/builder/messages/vi.json
@@ -2293,6 +2293,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "Mã người dùng"
     }
   },
   "flows": {

--- a/apps/builder/messages/zh-CN.json
+++ b/apps/builder/messages/zh-CN.json
@@ -2994,6 +2994,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "用户代码"
     }
   },
   "flowAnalytics": {

--- a/apps/builder/messages/zh-TW.json
+++ b/apps/builder/messages/zh-TW.json
@@ -1458,6 +1458,9 @@
     },
     "adSource": {
       "label": "Ad source"
+    },
+    "userCode": {
+      "label": "使用者代碼"
     }
   },
   "messages": {

--- a/apps/builder/src/features/contacts/contact-detail.tsx
+++ b/apps/builder/src/features/contacts/contact-detail.tsx
@@ -163,6 +163,28 @@ const scopedIdentityRowsByChannel: Partial<
   ],
 }
 
+// Inicia funcion (buildUserCodeField)
+const buildUserCodeField = (
+  contactInbox: ContactInboxResource | undefined,
+  t: (key: string) => string,
+): ContactEditableField[] => {
+  const value = contactInbox?.sourceId
+  if (!value) {
+    return []
+  }
+  return [
+    {
+      key: "sourceId",
+      icon: PhoneIcon,
+      label: t("fields.userCode.label"),
+      value,
+      type: "shortText",
+      readOnly: true,
+    },
+  ]
+}
+// Finaliza funcion (buildUserCodeField)
+
 const buildScopedIdentityFields = (
   contactInbox: ContactInboxResource | undefined,
   t: (key: string) => string,
@@ -174,8 +196,7 @@ const buildScopedIdentityFields = (
   const rows = scopedIdentityRowsByChannel[parsedChannel.data] ?? []
   return rows.flatMap((row): ContactEditableField[] => {
     const value = contactInbox[row.key]
-    // Skip absent values, and a value that IS the Contact ID shown above
-    // (a scoped-id-keyed contact) — no duplicate row.
+    // Skip absent values, and scoped ids that duplicate {{user_code}} (sourceId).
     if (!value || value === contactInbox.sourceId) {
       return []
     }
@@ -318,9 +339,8 @@ export const ContactDetail = ({
 
       if (conversation?.contact) {
         const activeContactInbox = conversation.contactInboxes[0]
-        // Contact ID is the workspace contact record id — not the channel
-        // sourceId (e.g. WhatsApp wa_id), which has its own scoped rows below.
-        const contactId = conversation.contact.id
+        // {{user_id}} — workspace contact record id for API calls (GET /v1/contacts/id:{id}).
+        const userId = conversation.contact.id
         // The ad the contact clicked from (any ad-attributed inbox), shown as
         // a link right under Contact ID. Guarded to http(s) so a non-navigable
         // / `javascript:` referral value never becomes an anchor href.
@@ -333,13 +353,14 @@ export const ContactDetail = ({
             : null
         const tmpContactFields: ContactEditableField[] = [
           {
-            key: "contactId",
+            key: "userId",
             icon: IdCardIcon,
-            label: t("fields.contactId.label"),
-            value: contactId,
+            label: t("fields.userId.label"),
+            value: userId,
             type: "shortText",
             readOnly: true,
           },
+          ...buildUserCodeField(activeContactInbox, t),
           ...(adSourceUrl
             ? [
                 {

--- a/apps/builder/src/features/contacts/contact-detail.tsx
+++ b/apps/builder/src/features/contacts/contact-detail.tsx
@@ -163,7 +163,6 @@ const scopedIdentityRowsByChannel: Partial<
   ],
 }
 
-// Inicia funcion (buildUserCodeField)
 const buildUserCodeField = (
   contactInbox: ContactInboxResource | undefined,
   t: (key: string) => string,
@@ -183,7 +182,6 @@ const buildUserCodeField = (
     },
   ]
 }
-// Finaliza funcion (buildUserCodeField)
 
 const buildScopedIdentityFields = (
   contactInbox: ContactInboxResource | undefined,

--- a/apps/builder/src/features/contacts/contact-detail.tsx
+++ b/apps/builder/src/features/contacts/contact-detail.tsx
@@ -318,7 +318,9 @@ export const ContactDetail = ({
 
       if (conversation?.contact) {
         const activeContactInbox = conversation.contactInboxes[0]
-        const channelContactId = activeContactInbox?.sourceId
+        // Contact ID is the workspace contact record id — not the channel
+        // sourceId (e.g. WhatsApp wa_id), which has its own scoped rows below.
+        const contactId = conversation.contact.id
         // The ad the contact clicked from (any ad-attributed inbox), shown as
         // a link right under Contact ID. Guarded to http(s) so a non-navigable
         // / `javascript:` referral value never becomes an anchor href.
@@ -331,10 +333,10 @@ export const ContactDetail = ({
             : null
         const tmpContactFields: ContactEditableField[] = [
           {
-            key: "channelContactId",
+            key: "contactId",
             icon: IdCardIcon,
             label: t("fields.contactId.label"),
-            value: channelContactId,
+            value: contactId,
             type: "shortText",
             readOnly: true,
           },


### PR DESCRIPTION
## Summary

The contact detail sidebar showed `ContactInbox.sourceId` (e.g. WhatsApp wa_id) under **Contact ID** instead of the workspace contact record id.

This PR aligns the panel with ChatbotX system fields for faster API testing:
- **User ID** → `{{user_id}}` (`contact.id`, used in `GET /v1/contacts/id:{id}`)
- **User Code** → `{{user_code}}` (`ContactInbox.sourceId`, e.g. WhatsApp phone / wa_id)
- Existing WhatsApp scoped rows still show `{{wa_user_id}}` and `{{wa_user_name}}`

Tested in production on a WhatsApp Cloud API channel (IRIS).

## How to test

1. Open a WhatsApp conversation in the inbox.
2. Open the contact detail panel.
3. Confirm **User ID** matches `contact.id` from `GET /v1/contacts/id:{id}`.
4. Confirm **User Code** shows the channel `sourceId` (phone / wa_id).
5. Confirm **WhatsApp User ID** still shows `sourceUserId` when present.
6. On a non-WhatsApp channel, confirm **User Code** still shows `sourceId` when set.

## Screenshots

Contact detail panel after the change (User ID / User Code / WhatsApp User ID):

<img width="344" height="496" alt="image" src="https://github.com/user-attachments/assets/a4a19146-6f61-42c5-9f90-0c0d6f6edde7" />