### PR TITLE
fix(comment-automation): detect top-level comments on photo posts and resolve replies-by-date timezone

### DIFF
--- a/.agents/skills/fb-comment-automation/SKILL.md
+++ b/.agents/skills/fb-comment-automation/SKILL.md
@@ -42,10 +42,16 @@ Read it before non-trivial changes. This skill is the quick map + the traps.
 
 ## The traps (read before editing)
 
-1. **`parent_id` is ALWAYS present and equals `post_id` for top-level comments.** A truthy
-   `parentId` does NOT mean "reply." Use `isCommentReply(parentId, postId)`
-   (`parentId !== postId`). Breaking this + default `ignoreCommentReplies: true` silently
-   drops every top-level comment.
+1. **`parent_id` is ALWAYS present, but it does NOT always equal `post_id` on a top-level
+   comment.** A truthy `parentId` does not mean "reply", and neither does
+   `parentId !== postId` — Facebook varies the composite per post type. A reel sends
+   `parent_id` byte-identical to `post_id`; a **photo post sends `{albumId}_{storyId}`**,
+   where only the trailing story id agrees. Use
+   `isCommentReply(parentId, postId, commentId)`, which compares the **trailing** ids via
+   `normalizePostId`. Testing the raw strings + default `ignoreCommentReplies: true`
+   silently drops every top-level comment on a photo post. A reply is still safe to spot
+   because `comment_id` stays anchored to the story (`{storyId}_{replyId}`) even for a
+   reply, so it can never collide with its own `parent_id`'s trailing half.
 
 2. **Post ids are composite `{pageId}_{storyId}`**; the picker stores 3 different formats
    (published/ads composite, reels bare id, manual free-text). Always compare through

--- a/apps/worker/__tests__/comment-automation.test.ts
+++ b/apps/worker/__tests__/comment-automation.test.ts
@@ -354,7 +354,7 @@ beforeEach(() => {
 
 describe("isCommentReply", () => {
   test("top-level comment: parentId equals postId", () => {
-    expect(isCommentReply(POST_ID, POST_ID)).toBe(false)
+    expect(isCommentReply(POST_ID, POST_ID, COMMENT_ID)).toBe(false)
   })
 
   // Production payload: on a photo post the leading half of `parent_id` is the
@@ -403,12 +403,11 @@ describe("isCommentReply", () => {
   })
 
   test("reply: parentId is another comment id", () => {
-    expect(isCommentReply(OTHER_COMMENT_ID, POST_ID)).toBe(true)
     expect(isCommentReply(OTHER_COMMENT_ID, POST_ID, COMMENT_ID)).toBe(true)
   })
 
   test("no parentId", () => {
-    expect(isCommentReply(undefined, POST_ID)).toBe(false)
+    expect(isCommentReply(undefined, POST_ID, COMMENT_ID)).toBe(false)
   })
 })
 

--- a/apps/worker/__tests__/comment-automation.test.ts
+++ b/apps/worker/__tests__/comment-automation.test.ts
@@ -209,6 +209,20 @@ const POST_ID = `${PAGE_ID}_${STORY_ID}`
 const COMMENT_ID = `${STORY_ID}_1544045903933592`
 const OTHER_COMMENT_ID = `${STORY_ID}_9999999999999999`
 
+// Ids captured from production `feed` webhooks on one Page (2026-09-11). The
+// shape of `parent_id` differs per post type and is the whole reason
+// `isCommentReply` cannot compare it to `post_id` verbatim, so these are kept
+// verbatim rather than reduced to a synthetic pattern.
+const REAL_PAGE_ID = "698869923319232"
+const PHOTO_STORY_ID = "122101949313003083"
+const PHOTO_POST_ID = `${REAL_PAGE_ID}_${PHOTO_STORY_ID}`
+const PHOTO_ALBUM_PARENT_ID = `39455509950714790_${PHOTO_STORY_ID}`
+const PHOTO_COMMENT_ID = `${PHOTO_STORY_ID}_1777723936764611`
+const PHOTO_REPLY_COMMENT_ID = `${PHOTO_STORY_ID}_1828228944833185`
+const REEL_STORY_ID = "122151505431003083"
+const REEL_POST_ID = `${REAL_PAGE_ID}_${REEL_STORY_ID}`
+const REEL_COMMENT_ID = `${REEL_STORY_ID}_1779826613208365`
+
 type AutomationOverrides = {
   id?: string
   options?: Record<string, boolean>
@@ -343,8 +357,54 @@ describe("isCommentReply", () => {
     expect(isCommentReply(POST_ID, POST_ID)).toBe(false)
   })
 
+  // Production payload: on a photo post the leading half of `parent_id` is the
+  // ALBUM, not the Page, so `parentId !== postId` read every top-level comment
+  // as a reply and — with `ignoreCommentReplies` on by default — swallowed the
+  // whole automation. Only the trailing story id agrees between the two.
+  test("photo post, top-level comment: parentId is {albumId}_{storyId}", () => {
+    expect(
+      isCommentReply(PHOTO_ALBUM_PARENT_ID, PHOTO_POST_ID, PHOTO_COMMENT_ID),
+    ).toBe(false)
+  })
+
+  // Production payload: a reel sends `parent_id` byte-identical to `post_id`.
+  test("reel post, top-level comment: parentId equals postId", () => {
+    expect(isCommentReply(REEL_POST_ID, REEL_POST_ID, REEL_COMMENT_ID)).toBe(
+      false,
+    )
+  })
+
+  // Production payload: a reply's own `comment_id` stays anchored to the story,
+  // never to the comment it answers — which is what keeps the `objectIdOf`
+  // safety net from misreading a reply as top-level.
+  test("reply: comment_id stays anchored to the story, parentId is the parent comment", () => {
+    expect(
+      isCommentReply(PHOTO_COMMENT_ID, PHOTO_POST_ID, PHOTO_REPLY_COMMENT_ID),
+    ).toBe(true)
+  })
+
+  // Production payloads: Instagram ids are bare and a top-level comment carries
+  // no `parent_id` at all, on both the IG-Login and the Facebook-Login variant.
+  test.each([
+    ["instagramFacebook", "17981236959118569", "17967295770157071"],
+    ["instagram", "18055975949799859", "17876890326629016"],
+  ])("%s top-level comment: no parentId", (_variant, mediaId, commentId) => {
+    expect(isCommentReply(undefined, mediaId, commentId)).toBe(false)
+  })
+
+  test("instagram reply: bare parent comment id is still a reply", () => {
+    expect(
+      isCommentReply(
+        "17967295770157071",
+        "17981236959118569",
+        "17967295770157099",
+      ),
+    ).toBe(true)
+  })
+
   test("reply: parentId is another comment id", () => {
     expect(isCommentReply(OTHER_COMMENT_ID, POST_ID)).toBe(true)
+    expect(isCommentReply(OTHER_COMMENT_ID, POST_ID, COMMENT_ID)).toBe(true)
   })
 
   test("no parentId", () => {
@@ -364,6 +424,18 @@ describe("processCommentAutomation reply filtering", () => {
       postId: POST_ID,
       workspaceId: "workspace-1",
     })
+  })
+
+  test("runs the automation for a top-level comment whose parentId is the bare story id", async () => {
+    mockFindActiveAutomations.mockResolvedValue([buildAutomation()])
+
+    await processCommentAutomation(buildJobData({ parentId: STORY_ID }) as any)
+
+    expect(mockInsertDedup).toHaveBeenCalled()
+    expect(mockLoggerInfo).not.toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "comment is a reply" }),
+      "Comment automation skipped",
+    )
   })
 
   test("skips a real comment reply when ignoreCommentReplies is on", async () => {

--- a/apps/worker/src/integration/handlers/comment-automation/automation-matching.ts
+++ b/apps/worker/src/integration/handlers/comment-automation/automation-matching.ts
@@ -23,6 +23,16 @@ function normalizePostId(id: string): string {
   return idx === -1 ? id : id.slice(idx + 1)
 }
 
+// The leading half of a composite id — the object the comment hangs off
+// (`{objectId}_{commentId}`). A bare id (Instagram) has no leading half and so
+// answers itself, which reduces the comparison in `isCommentReply` to
+// `parentId === commentId` — something no comment can satisfy. Instagram
+// therefore never takes that branch.
+function objectIdOf(id: string): string {
+  const idx = id.indexOf("_")
+  return idx === -1 ? id : id.slice(0, idx)
+}
+
 export function matchPost(post: FBCommentPost, postId: string): boolean {
   if (post.type !== "postIds") {
     return true
@@ -56,13 +66,42 @@ export function matchKeywords(
 }
 
 // Facebook feed webhooks set parent_id on every comment: for a top-level
-// comment it equals the post id, and only a reply to another comment carries
+// comment it points at the post, and only a reply to another comment carries
 // that comment's id instead.
+//
+// "Points at the post" is NOT reliably the same string as `post_id` — the
+// composite Facebook puts in `parent_id` varies by post type. Two production
+// payloads from one Page (2026-09-11):
+//
+//   reel   post_id   698869923319232_122151505431003083
+//          parent_id 698869923319232_122151505431003083   identical
+//   photo  post_id   698869923319232_122101949313003083
+//          parent_id 39455509950714790_122101949313003083  leading half is the
+//                                                          ALBUM, not the Page
+//
+// So a raw `parentId !== postId` reads every top-level comment on a photo post
+// as a reply and, with the default `ignoreCommentReplies`, silently drops the
+// whole automation. Both halves agree on the trailing story id, so compare on
+// that like `matchPost` does.
+//
+// The `objectIdOf` comparison is a safety net for a bare `parent_id`, a shape
+// no observed payload sends. It cannot misfire on a reply: a reply's
+// `comment_id` stays anchored to the story (`{storyId}_{replyId}`) while its
+// `parent_id` carries the parent comment's id, whose trailing half is that
+// comment — never the story.
 export function isCommentReply(
   parentId: string | undefined,
   postId: string,
+  commentId?: string,
 ): boolean {
-  return Boolean(parentId) && parentId !== postId
+  if (!parentId) {
+    return false
+  }
+  const parent = normalizePostId(parentId)
+  if (parent === normalizePostId(postId)) {
+    return false
+  }
+  return !(commentId && parent === objectIdOf(commentId))
 }
 
 export function willSendReply(reply: FBCommentReply): boolean {

--- a/apps/worker/src/integration/handlers/comment-automation/automation-matching.ts
+++ b/apps/worker/src/integration/handlers/comment-automation/automation-matching.ts
@@ -92,7 +92,7 @@ export function matchKeywords(
 export function isCommentReply(
   parentId: string | undefined,
   postId: string,
-  commentId?: string,
+  commentId: string,
 ): boolean {
   if (!parentId) {
     return false
@@ -101,7 +101,7 @@ export function isCommentReply(
   if (parent === normalizePostId(postId)) {
     return false
   }
-  return !(commentId && parent === objectIdOf(commentId))
+  return parent !== objectIdOf(commentId)
 }
 
 export function willSendReply(reply: FBCommentReply): boolean {

--- a/apps/worker/src/integration/handlers/comment-automation/index.ts
+++ b/apps/worker/src/integration/handlers/comment-automation/index.ts
@@ -196,13 +196,18 @@ export async function processCommentAutomation(
       }
       if (
         automation.options.ignoreCommentReplies &&
-        isCommentReply(parentId, postId)
+        isCommentReply(parentId, postId, commentId)
       ) {
         logAutomationSkipped({
           automationId: automation.id,
           commentId,
           postId,
           workspaceId,
+          // The one skip whose cause is invisible without the raw id: Facebook
+          // varies the composite form of `parent_id` per post type, and a
+          // wrongly-classified top-level comment looks identical in the log to
+          // a genuine reply.
+          parentId,
           reason: "comment is a reply",
         })
         continue
@@ -822,16 +827,18 @@ const logAutomationSkipped = ({
   commentId,
   postId,
   workspaceId,
+  parentId,
   reason,
 }: {
   automationId: string
   commentId: string
   postId: string
   workspaceId: string
+  parentId?: string
   reason: string
 }) => {
   logger.info(
-    { automationId, commentId, postId, workspaceId, reason },
+    { automationId, commentId, postId, workspaceId, parentId, reason },
     "Comment automation skipped",
   )
 }

--- a/docs/fb-comment-automation.md
+++ b/docs/fb-comment-automation.md
@@ -102,7 +102,7 @@ Each filter that fails calls `logAutomationSkipped(..., reason)` (logged at `inf
 | `type` | `messenger` \| `instagram` \| `instagramFacebook` | `findActiveAutomations` filters `type === channelType`, which is the incoming `integrationType`. The builder writes it: `fb-comments` → `messenger`, `ig-comments` → the selected Instagram variant. |
 | `startTime`/`endTime` | Daily active window (workspace tz) | `isWithinSchedule` — lexicographic `"HH:mm"` compare, handles overnight windows; null → always within. |
 | `post` (`all` / `postIds`) | Which posts | `matchPost` — `all` always true; `postIds` matches via normalized trailing id. |
-| `options.ignoreCommentReplies` (default **true**) | Skip replies-to-comments | Skips only when `isCommentReply(parentId, postId)` is true. |
+| `options.ignoreCommentReplies` (default **true**) | Skip replies-to-comments | Skips only when `isCommentReply(parentId, postId, commentId)` is true. |
 | `includeKeywords` (`all`/`equal`/`contain`) | Text must match | `matchKeywords` — lowercased both sides. `equal` = whole comment equals a keyword; `contain` = substring. |
 | `excludeKeywords` | Text must not contain | `matchKeywords` — substring, lowercased. |
 | `options.replyToNewContactsOnly` | Only first-time contacts | `getPriorContactInboxCount(contactId) > 1` → skip. Counts `ContactInbox` rows. |

--- a/docs/fb-comment-automation.md
+++ b/docs/fb-comment-automation.md
@@ -59,12 +59,28 @@ silent failures:
 | Field | Format | Example |
 |---|---|---|
 | `post_id` | `{pageId}_{storyId}` | `2094067177305463_2357494887629356` |
-| `comment_id` | `{storyId}_{commentId}` | `2357494887629356_1544045903933592` |
-| `parent_id` | **Always present.** For a **top-level** comment it equals `post_id`; only a **reply to another comment** carries that comment's id. | top-level → `2094067177305463_2357494887629356` |
+| `comment_id` | `{storyId}_{commentId}` — anchored to the story **even for a reply** | `2357494887629356_1544045903933592` |
+| `parent_id` | **Always present.** For a **top-level** comment it points at the post, but **not always as the same string as `post_id`** (see below); only a **reply to another comment** carries that comment's id. | top-level on a reel → `2094067177305463_2357494887629356` |
+
+**`parent_id` on a top-level comment varies by post type.** Production payloads from one
+Page (2026-09-11):
+
+| Post type | `post_id` | `parent_id` |
+|---|---|---|
+| Reel / video | `698869923319232_122151505431003083` | `698869923319232_122151505431003083` — identical |
+| Photo | `698869923319232_122101949313003083` | `39455509950714790_122101949313003083` — leading half is the **album**, not the Page |
+
+Only the trailing story id agrees in both. A photo post therefore breaks any
+`parentId !== postId` test, which reads every top-level comment as a reply and — with
+`ignoreCommentReplies` on by default — swallows the whole automation.
 
 - `parent_id` presence does **not** mean "this is a reply." Use
-  `isCommentReply(parentId, postId)` (`index.ts`), which is true only when
-  `parentId !== postId`.
+  `isCommentReply(parentId, postId, commentId)` (`index.ts`), which compares the
+  **trailing** ids via `normalizePostId` — never the raw strings.
+- A reply is safe to tell apart because `comment_id` stays anchored to the story: a reply
+  to `{storyId}_{parentCommentId}` is itself `{storyId}_{replyId}`, so the trailing half
+  of `parent_id` (the parent comment) is never the leading half of `comment_id` (the
+  story).
 - The post picker stores different formats per tab: **published/ads** store the composite
   `{pageId}_{postId}`; **reels** store a bare video id; **manual entry** is whatever the
   user pastes. `matchPost` normalizes both sides on the trailing story id

--- a/packages/analytics/__tests__/comment-automation-stats.repository.test.ts
+++ b/packages/analytics/__tests__/comment-automation-stats.repository.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+// `sql` is faked as a recording template tag rather than kept real, so this
+// package needs no drizzle dependency of its own: the static text the
+// repository writes lands in `strings`, and every `${…}` lands in `values`,
+// which is all these assertions look at.
+//
+// What the rendered statement itself must look like — no timezone name in the
+// SQL text, both spellings offered as parameters, UTC fallback — is asserted
+// where `resolvedTimezone` lives and where drizzle is already a dependency:
+// `packages/database/__tests__/zoned-date-key.test.ts`. This file only pins the
+// half that belongs to the repository: that the caller's timezone reaches that
+// helper instead of being bound straight into the statement.
+type RecordedStatement = { strings: string[]; values: unknown[] }
+
+const execute = vi.fn().mockResolvedValue({ rows: [] })
+
+const sql = (
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+): RecordedStatement => ({ strings: [...strings], values })
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  db: { execute, query: {} },
+  sql,
+}))
+
+// Stand-in for the drizzle fragment the real helper returns. Identity matters,
+// not shape: an assertion only has to tell "went through the helper" apart from
+// "was bound as a bare string", which is exactly what the bug did.
+const resolvedTimezoneFragment = (timezone: string) => ({
+  resolvedTimezoneFor: timezone,
+})
+const resolvedTimezone = vi.fn(resolvedTimezoneFragment)
+
+vi.mock("@chatbotx.io/database/queries/date-bucket", () => ({
+  resolvedTimezone,
+}))
+
+const { commentAutomationStatsRepository } = await import(
+  "../src/repositories/postgres/comment-automation-stats.repository"
+)
+
+const lastStatement = (): RecordedStatement =>
+  execute.mock.calls.at(-1)?.[0] as RecordedStatement
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  execute.mockResolvedValue({ rows: [] })
+  resolvedTimezone.mockImplementation(resolvedTimezoneFragment)
+})
+
+describe("getRepliesByDate timezone handling", () => {
+  const range = {
+    workspaceId: "workspace-1",
+    automationId: "automation-1",
+    startDate: "2026-09-04T00:00:00.000Z",
+    endDate: "2026-09-11T23:59:59.999Z",
+  }
+
+  // Regression: the browser's own `Intl` timezone name was bound straight into
+  // `AT TIME ZONE`, and a PostgreSQL build packaged without the `backward`
+  // tzdata file aborted the statement with 22023 "time zone not recognized".
+  // Only this query takes a timezone, so the replies chart and the
+  // replies-by-date table came back empty while the three panels beside them
+  // kept working.
+  test("routes the caller's timezone through resolvedTimezone", async () => {
+    await commentAutomationStatsRepository.getRepliesByDate({
+      ...range,
+      timezone: "Asia/Saigon",
+    })
+
+    expect(resolvedTimezone).toHaveBeenCalledWith("Asia/Saigon")
+  })
+
+  test("binds the resolved fragment, never the timezone name itself", async () => {
+    await commentAutomationStatsRepository.getRepliesByDate({
+      ...range,
+      timezone: "Asia/Saigon",
+    })
+
+    const { values } = lastStatement()
+
+    expect(values).toContainEqual(resolvedTimezoneFragment("Asia/Saigon"))
+    // The bug: `${timezone}` bound the raw name as a parameter of its own.
+    expect(values).not.toContain("Asia/Saigon")
+  })
+
+  test("never writes the timezone name into the statement text", async () => {
+    await commentAutomationStatsRepository.getRepliesByDate({
+      ...range,
+      timezone: "Asia/Saigon",
+    })
+
+    expect(lastStatement().strings.join("")).not.toContain("Asia/Saigon")
+  })
+
+  test("passes a canonical timezone name through unchanged too", async () => {
+    await commentAutomationStatsRepository.getRepliesByDate({
+      ...range,
+      timezone: "Asia/Ho_Chi_Minh",
+    })
+
+    expect(resolvedTimezone).toHaveBeenCalledWith("Asia/Ho_Chi_Minh")
+    expect(lastStatement().values).toContainEqual(
+      resolvedTimezoneFragment("Asia/Ho_Chi_Minh"),
+    )
+  })
+})

--- a/packages/analytics/src/repositories/postgres/comment-automation-stats.repository.ts
+++ b/packages/analytics/src/repositories/postgres/comment-automation-stats.repository.ts
@@ -1,4 +1,5 @@
 import { db, sql } from "@chatbotx.io/database/client"
+import { resolvedTimezone } from "@chatbotx.io/database/queries/date-bucket"
 import { fbCommentAutomationEventModel } from "@chatbotx.io/database/schema"
 import type { FBCommentAutomationEventInsert } from "@chatbotx.io/database/types"
 import { BaseRepository } from "./base.repository"
@@ -121,9 +122,15 @@ export class CommentAutomationStatsRepository extends BaseRepository {
   ): Promise<{ dateReport: string; count: number }[]> {
     const { workspaceId, automationId, startDate, endDate, timezone } = input
 
+    // `resolvedTimezone`, never the caller's name verbatim: browsers still
+    // report legacy IANA names (`Asia/Saigon`, `Asia/Calcutta`, `Europe/Kiev`)
+    // and a PostgreSQL build packaged without the `backward` tzdata file
+    // aborts the whole statement on one — which took this chart (and the
+    // "replies by date" table that shares its data) down to an empty series
+    // while the three panels that never touch `timezone` kept working.
     const result = await db.execute(sql`
       SELECT
-        TO_CHAR(("occurredAt" AT TIME ZONE ${timezone})::date, 'YYYY-MM-DD') AS "dateReport",
+        TO_CHAR(("occurredAt" AT TIME ZONE ${resolvedTimezone(timezone)})::date, 'YYYY-MM-DD') AS "dateReport",
         COUNT(*)::int AS count
       FROM "FBCommentAutomationEvent"
       WHERE "workspaceId" = ${workspaceId}


### PR DESCRIPTION
## Summary

- **Photo posts silently disabled every comment automation.** Facebook varies the composite it puts in `parent_id` per post type: a reel sends it byte-identical to `post_id`, but a photo post sends `{albumId}_{storyId}` — only the trailing story id agrees. The raw `parentId !== postId` test read every top-level comment on a photo post as a reply and, with `ignoreCommentReplies` on by default, dropped the automation with no error surfaced anywhere.
- **The replies-by-date panel crashed on legacy timezone names.** `getRepliesByDate` bound the caller's timezone straight into `AT TIME ZONE`. Browsers still report `Asia/Saigon`, `Asia/Calcutta`, `Europe/Kiev`, and a PostgreSQL build without the `backward` tzdata file aborts with 22023 — so the chart and its table came back empty while the three panels that never touch `timezone` kept working.
- **The skill file prescribed the broken formula.** `fb-comment-automation` trap #1 told readers to use `parentId !== postId`, and `CLAUDE.md` routes agents to that file *before* they touch this feature — so the trap written to prevent this bug was the thing reintroducing it.
- Both code fixes are pinned by tests built from **verbatim production webhook payloads** rather than invented id shapes.

## Changes

**Reply detection** — `apps/worker/src/integration/handlers/comment-automation/`
- `automation-matching.ts`: compare the trailing id via `normalizePostId` (the way `matchPost` already does) instead of the raw strings; take `commentId` — now required — so a bare `parent_id` can still be told apart from a reply. Docblocks now record the two real payload shapes instead of the previous — incorrect — claim that Facebook "frequently sends the bare object id".
- `index.ts`: log `parentId` on the "comment is a reply" skip. A wrongly-classified top-level comment is otherwise indistinguishable from a genuine reply in production logs.

**Timezone** — `packages/analytics/`
- `comment-automation-stats.repository.ts`: route the timezone through `resolvedTimezone`. This was the last repository in the package still interpolating the raw name; the other five already use the helper.
- New `__tests__/comment-automation-stats.repository.test.ts` fakes `sql` as a recording template tag, so the package needs no drizzle dependency of its own. The rendered-statement guarantees are already asserted next to the helper in `packages/database/__tests__/zoned-date-key.test.ts`.

**Tests & docs**
- `apps/worker/__tests__/comment-automation.test.ts`: fixtures replaced with captured production ids — photo top-level, reel top-level, reply, and both Instagram variants. The two removed cases were built on a bare `parent_id` shape that does not occur in practice and were locking in the wrong behaviour.
- `docs/fb-comment-automation.md`: ID-format section now documents that `parent_id` on a top-level comment is **not** always the same string as `post_id`, with the real payloads side by side, and that `comment_id` stays anchored to the story even for a reply.
- `.agents/skills/fb-comment-automation/SKILL.md`: trap #1 rewritten around the real per-post-type shapes.

## Test plan

- [x] `pnpm --filter worker exec vitest run __tests__/comment-automation.test.ts` — 95 passed
- [x] `pnpm --filter @chatbotx.io/analytics test` — 170 passed (18 files)
- [x] `pnpm --filter worker check-types`
- [x] `pnpm --filter @chatbotx.io/analytics check-types`
- [x] `pnpm check:agent-instructions` — 17 skills valid
- [x] `ultracite check` on every touched file
- [x] Analytics test verified to fail (3/4) against the pre-fix repository, confirming it catches the regression
- [ ] Manual: open a photo post's comment automation and confirm a top-level comment triggers it
- [ ] Manual: open the comment-automation analytics dashboard with `tz=Asia/Saigon` and confirm the replies-by-date chart renders