### PR TITLE
fix(user-quota): skip deleted users when syncing quota

### DIFF
--- a/apps/worker/__tests__/sync-user-quota-reconcile.test.ts
+++ b/apps/worker/__tests__/sync-user-quota-reconcile.test.ts
@@ -24,15 +24,32 @@ const state = {
   hmgetResult: [null, null] as (string | null)[],
   // Owner MAC count returned by the (mocked) ContactActiveMonthly ledger.
   ledgerMac: 0,
+  // Existence filter: `null` means every id in the batch exists; a Set restricts
+  // which ids the User table "contains" (the rest are treated as deleted ghosts).
+  existingUserIds: null as Set<string> | null,
+  // When set, the UserQuota upsert rejects with this error, to exercise both the
+  // FK race (user deleted between filter and upsert) and unrelated failures.
+  insertRejectError: null as Error | null,
 }
 
 function makeSelectChain() {
   const chain: Record<string, unknown> = {}
   chain.from = vi.fn(() => chain)
   chain.innerJoin = vi.fn(() => chain)
-  chain.where = vi.fn(() =>
-    Promise.resolve([{ count: state.countResults.shift() ?? 0 }]),
-  )
+  chain.where = vi.fn((whereArg: { __in?: string[] }) => {
+    // The existence filter is the only query built with `inArray` (mocked to
+    // `{ __in }`); everything else is a scalar COUNT consumed from countResults.
+    if (whereArg && Array.isArray(whereArg.__in)) {
+      const rows = whereArg.__in
+        .filter(
+          (id) =>
+            state.existingUserIds === null || state.existingUserIds.has(id),
+        )
+        .map((id) => ({ id }))
+      return Promise.resolve(rows)
+    }
+    return Promise.resolve([{ count: state.countResults.shift() ?? 0 }])
+  })
   return chain
 }
 
@@ -40,6 +57,9 @@ function makeInsertChain() {
   const chain: Record<string, unknown> = {}
   chain.values = vi.fn(() => chain)
   chain.onConflictDoUpdate = vi.fn((arg: { set: Record<string, unknown> }) => {
+    if (state.insertRejectError) {
+      return Promise.reject(state.insertRejectError)
+    }
     state.capturedSets.push(arg.set)
     return Promise.resolve()
   })
@@ -58,6 +78,11 @@ vi.mock("@chatbotx.io/database/client", () => ({
   count: vi.fn(() => ({ count: true })),
   countDistinct: mockCountDistinct,
   eq: vi.fn((a: unknown, b: unknown) => ({ eq: [a, b] })),
+  inArray: vi.fn((_column: unknown, values: string[]) => ({ __in: values })),
+  isForeignKeyViolationError: vi.fn(
+    (error: unknown) =>
+      error instanceof Error && error.message.includes("FK violation"),
+  ),
   ne: vi.fn((a: unknown, b: unknown) => ({ ne: [a, b] })),
   sql: (strings: TemplateStringsArray, ...vals: unknown[]) => ({
     __sql: strings.join("?"),
@@ -83,6 +108,7 @@ vi.mock("@chatbotx.io/business", () => ({
     countDistinctTeamMembersForOwner: vi.fn(
       async () => state.countResults.shift() ?? 0,
     ),
+    clearLiveCounters: vi.fn(async () => undefined),
   },
   // Non-reseller users: `findByOwner` returns nothing, so reconcileUser keeps
   // the per-user self-count path these tests exercise.
@@ -116,6 +142,7 @@ vi.mock("@chatbotx.io/database/schema", () => ({
     role: "wm.role",
   },
   workspaceModel: { id: "ws.id", ownerId: "ws.ownerId" },
+  userModel: { id: "user.id" },
 }))
 
 const redisClient = {
@@ -157,7 +184,12 @@ const { tenantService, userQuotaService } = (await import(
   userQuotaService: {
     reconcileOwnerPoolUsage: ReturnType<typeof vi.fn>
     countDistinctTeamMembersForOwner: ReturnType<typeof vi.fn>
+    clearLiveCounters: ReturnType<typeof vi.fn>
   }
+}
+
+const { logger } = (await import("../src/lib/logger")) as unknown as {
+  logger: { info: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> }
 }
 
 describe("reconcileUser — contacts/teamMembers reflect the current count", () => {
@@ -417,5 +449,118 @@ describe("syncUserQuota — cold reseller owners are included via DB fallback", 
 
     expect(userQuotaService.reconcileOwnerPoolUsage).not.toHaveBeenCalled()
     expect(state.capturedSets).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Regression: a live-counter key can outlive the user it belonged to (User
+// delete cascades UserQuota but not the Redis key). The sync must skip such
+// ghost ids and clean their stale keys, and tolerate a user deleted mid-run,
+// instead of violating UserQuota → User on every cron.
+// ---------------------------------------------------------------------------
+describe("syncUserQuota — skips and cleans up deleted (ghost) users", () => {
+  beforeEach(() => {
+    state.countResults = [0, 0, 0, 0]
+    state.capturedSets = []
+    state.hsetCalls = []
+    state.stored = {
+      contactsUsed: 0,
+      teamMembersUsed: 0,
+      workspacesUsed: 0,
+      channelsUsed: 0,
+      macUsed: 0,
+      periodStart: null,
+    }
+    state.existingUserIds = null
+    redisClient.scan.mockReset()
+    redisClient.scan.mockResolvedValue(["0", []])
+    tenantService.findByOwner.mockReset()
+    tenantService.findByOwner.mockResolvedValue(undefined)
+    tenantService.listActiveOwnerIds.mockReset()
+    tenantService.listActiveOwnerIds.mockResolvedValue([])
+    userQuotaService.clearLiveCounters.mockClear()
+  })
+
+  test("a live key for a deleted user is cleaned up and never reconciled", async () => {
+    redisClient.scan.mockResolvedValue([
+      "0",
+      ["user-quota-live:ghost-1", "user-quota-live:real-1"],
+    ])
+    // The User table only still has `real-1`.
+    state.existingUserIds = new Set(["real-1"])
+
+    await syncUserQuota()
+
+    // The ghost's stale live key is cleared and it never reaches reconcile.
+    expect(userQuotaService.clearLiveCounters).toHaveBeenCalledWith("ghost-1")
+    expect(userQuotaService.clearLiveCounters).not.toHaveBeenCalledWith(
+      "real-1",
+    )
+    // The surviving user is still reconciled (its upsert ran once).
+    expect(state.capturedSets).toHaveLength(1)
+  })
+})
+
+describe("reconcileUser — a user deleted mid-run is skipped, not error-logged", () => {
+  beforeEach(() => {
+    state.countResults = [0, 0, 0, 0]
+    state.capturedSets = []
+    state.hsetCalls = []
+    state.stored = null
+    state.insertRejectError = null
+    tenantService.findByOwner.mockReset()
+    tenantService.findByOwner.mockResolvedValue(undefined)
+    userQuotaService.clearLiveCounters.mockClear()
+    userQuotaService.reconcileOwnerPoolUsage.mockClear()
+    userQuotaService.reconcileOwnerPoolUsage.mockResolvedValue(undefined)
+    logger.info.mockClear()
+    logger.error.mockClear()
+  })
+
+  test("a foreign-key violation on the per-user upsert clears the stale key without throwing", async () => {
+    // The user vanished before the upsert committed.
+    state.insertRejectError = new Error("FK violation (test)")
+
+    await expect(reconcileUser("ghost-2")).resolves.toBeUndefined()
+
+    expect(userQuotaService.clearLiveCounters).toHaveBeenCalledWith("ghost-2")
+    expect(logger.error).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith(
+      { userId: "ghost-2" },
+      "user-quota: skipped reconcile for a user that no longer exists",
+    )
+  })
+
+  test("a foreign-key violation on the owner-pool upsert is skipped the same way", async () => {
+    // The owner branch (reconcileOwnerPoolUsage) throws the same FK — the shared
+    // catch must clear and skip it too, not just the per-user path.
+    tenantService.findByOwner.mockResolvedValueOnce({
+      id: "tenant-x",
+      ownerId: "owner-ghost",
+      status: "active",
+    })
+    userQuotaService.reconcileOwnerPoolUsage.mockRejectedValueOnce(
+      new Error("FK violation (test)"),
+    )
+
+    await expect(reconcileUser("owner-ghost")).resolves.toBeUndefined()
+
+    expect(userQuotaService.clearLiveCounters).toHaveBeenCalledWith(
+      "owner-ghost",
+    )
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  test("an unrelated failure still logs an error and does not clear the key", async () => {
+    // A non-FK error (e.g. a connection drop) must keep the old behavior.
+    state.insertRejectError = new Error("connection reset")
+
+    await expect(reconcileUser("user-live")).resolves.toBeUndefined()
+
+    expect(userQuotaService.clearLiveCounters).not.toHaveBeenCalled()
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user-live" }),
+      "user-quota: failed to reconcile user quota",
+    )
   })
 })

--- a/apps/worker/src/schedule/handlers/sync-user-quota.ts
+++ b/apps/worker/src/schedule/handlers/sync-user-quota.ts
@@ -6,10 +6,18 @@ import {
   WORKSPACE_USAGE_LABEL,
   workspaceUsageService,
 } from "@chatbotx.io/business"
-import { count, db, eq, sql } from "@chatbotx.io/database/client"
+import {
+  count,
+  db,
+  eq,
+  inArray,
+  isForeignKeyViolationError,
+  sql,
+} from "@chatbotx.io/database/client"
 import {
   contactModel,
   inboxModel,
+  userModel,
   userQuotaModel,
   workspaceMemberModel,
   workspaceModel,
@@ -79,7 +87,27 @@ export const syncUserQuota = async (): Promise<void> => {
   const BATCH_SIZE = 50
   for (let i = 0; i < allUserIds.length; i += BATCH_SIZE) {
     const batch = allUserIds.slice(i, i + BATCH_SIZE)
-    await Promise.all(batch.map(reconcileUser))
+
+    // A live-counter key can outlive the user it belonged to: deleting a User
+    // cascades its `UserQuota` row but not the Redis key. Reconciling such a
+    // ghost id would violate the `UserQuota → User` foreign key on every run, so
+    // filter the batch against the User table (one indexed lookup per 50 ids)
+    // and drop the stale keys instead of walking them again.
+    const existingRows = await db
+      .select({ id: userModel.id })
+      .from(userModel)
+      .where(inArray(userModel.id, batch))
+    const existingIds = new Set(existingRows.map((row) => row.id))
+
+    await Promise.all(
+      batch
+        .filter((id) => !existingIds.has(id))
+        .map((id) => userQuotaService.clearLiveCounters(id)),
+    )
+
+    await Promise.all(
+      batch.filter((id) => existingIds.has(id)).map(reconcileUser),
+    )
   }
 }
 
@@ -298,6 +326,18 @@ export const reconcileUser = async (userId: string): Promise<void> => {
 
     await userQuotaService.invalidate(userId)
   } catch (err) {
+    // A user deleted between the existence filter and this upsert races the
+    // `UserQuota → User` foreign key (covers both the per-user insert and the
+    // owner-pool insert). Treat it as a benign skip: clear the stale live key so
+    // the next run doesn't walk the ghost again, and don't raise an error.
+    if (isForeignKeyViolationError(err, "UserQuota_userId_User_id_fkey")) {
+      await userQuotaService.clearLiveCounters(userId)
+      logger.info(
+        { userId },
+        "user-quota: skipped reconcile for a user that no longer exists",
+      )
+      return
+    }
     logger.error({ err, userId }, "user-quota: failed to reconcile user quota")
   }
 }

--- a/packages/business/__tests__/live-counter-store.test.ts
+++ b/packages/business/__tests__/live-counter-store.test.ts
@@ -32,6 +32,7 @@ const redisClient = {
   hsetnx: vi.fn(async () => 1),
   hget: vi.fn(async () => null),
   hincrby: vi.fn(async () => 1),
+  del: vi.fn(async () => 1),
 }
 const cacheConnections = {
   useExisting: vi.fn(async () => redisClient),
@@ -47,6 +48,12 @@ vi.mock("@chatbotx.io/redis", () => ({
 }))
 
 const { userQuotaService } = await import("../src/user-quota/service")
+
+const { distributedStore } = (await import(
+  "@chatbotx.io/redis"
+)) as unknown as {
+  distributedStore: { delete: ReturnType<typeof vi.fn> }
+}
 
 const USER = "user-1"
 
@@ -151,5 +158,24 @@ describe("LiveCounterStore.getLiveCounts (via getLiveUsage)", () => {
       monthlyBotMessages: 70,
     })
     expect(findFirstQuota).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("LiveCounterStore.clearLive (via clearLiveCounters)", () => {
+  test("deletes the live-counter hash and invalidates the cached row", async () => {
+    await userQuotaService.clearLiveCounters(USER)
+
+    expect(redisClient.del).toHaveBeenCalledWith(`user-quota-live:${USER}`)
+    expect(distributedStore.delete).toHaveBeenCalledTimes(1)
+  })
+
+  test("still invalidates the cache and never throws when the Redis delete fails", async () => {
+    redisClient.del.mockRejectedValueOnce(new Error("redis down"))
+
+    await expect(
+      userQuotaService.clearLiveCounters(USER),
+    ).resolves.toBeUndefined()
+    // invalidate still runs even after the live-key delete fails.
+    expect(distributedStore.delete).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/business/src/quota-shared/live-counter-store.ts
+++ b/packages/business/src/quota-shared/live-counter-store.ts
@@ -225,6 +225,25 @@ export class LiveCounterStore<TRow> {
     }
   }
 
+  /**
+   * Forget all volatile state for a scope: delete the live-counter hash and the
+   * cached row. Use when the underlying entity no longer exists (e.g. a deleted
+   * user), so a stale live key can't keep a reconcile job walking a ghost id.
+   * Never throws.
+   */
+  async clearLive(id: string): Promise<void> {
+    try {
+      const client = await cacheConnections.useExisting()
+      await client.del(this.liveKey(id))
+    } catch (err) {
+      logger.warn(
+        { err },
+        `${this.config.label}: clearLive failed to delete the live key`,
+      )
+    }
+    await this.invalidate(id)
+  }
+
   /** Increment the live counter (cold-seeding first so it starts from the DB base). */
   async incrementBy(
     id: string,

--- a/packages/business/src/user-quota/service.ts
+++ b/packages/business/src/user-quota/service.ts
@@ -159,6 +159,16 @@ class UserQuotaService extends BaseService {
     await this.store.invalidate(userId)
   }
 
+  /**
+   * Drop the live counters and cached row for a user that no longer exists, so
+   * the quota reconcile job stops walking a stale live key (its `UserQuota` row
+   * is already gone via `ON DELETE CASCADE`). Safe to call from a future user
+   * delete flow too.
+   */
+  async clearLiveCounters(userId: string): Promise<void> {
+    await this.store.clearLive(userId)
+  }
+
   async getForUser(userId: string): Promise<UserQuotaModel | null> {
     const cached = await this.store.getCachedRow(userId)
     if (cached) {


### PR DESCRIPTION
## Summary

The quota sync cron kept failing on a foreign-key error for users that no longer exist. A Redis live-counter key outlives the user it belonged to (deleting a user removes its `UserQuota` row but not the Redis key), so the deleted user's id kept being reconciled and violating the `UserQuota → User` foreign key on every run.

The sync now skips ids whose user no longer exists and removes their stale keys, so the error stops instead of repeating every cycle. Existing users are reconciled exactly as before.

## How to test

1. Leave a `user-quota-live:<id>` key in Redis for a user id that no longer exists in `User`.
2. Run the quota sync.
3. Confirm the id is skipped, its live key is removed, and no foreign-key error is logged for it.

## Test plan

- [x] `pnpm --filter worker test` (sync-user-quota-reconcile) — 14 tests
- [x] `pnpm --filter @chatbotx.io/business test` (live-counter-store) — 6 tests
- [x] `check-types` — worker + business
- [x] `pnpm lint` — green
- [ ] Manual: confirm the recurring `user-quota: failed to reconcile user quota` foreign-key error stops after deploy
