### PR TITLE
fix(webchat): clear typing indicator when the bot reply arrives

### DIFF
--- a/apps/builder/src/features/integration-webchat/webchat-realtime.tsx
+++ b/apps/builder/src/features/integration-webchat/webchat-realtime.tsx
@@ -37,9 +37,16 @@ export function WebchatRealtime({ guestConversationId }: WebchatRealtimeProps) {
       try {
         const { eventType, data } = JSON.parse(e.data) as RealtimeEventData
         switch (eventType) {
-          case RealtimeEventType.messageCreated:
-            handleNewMessage(data as MessageResource)
+          case RealtimeEventType.messageCreated: {
+            const message = data as MessageResource
+            handleNewMessage(message)
+            // The worker only ever sends `typing: true`; clear the indicator
+            // once the bot reply itself arrives so the dots don't stay forever.
+            if (message.messageType === "outgoing") {
+              setIsTyping(false)
+            }
             break
+          }
           case RealtimeEventType.typing:
             setIsTyping(data.typing)
             break


### PR DESCRIPTION
Fixes #1148

### Problem
The worker's automated-response path posts `{ typing: true }` while generating a reply (immediately and every 4 s) and never posts `{ typing: false }`. The webchat widget only clears `isTyping` on a `typing` event, so after the first bot reply the typing dots stay on screen until the iframe is reloaded.

### Change
In `webchat-realtime.tsx`, when a `messageCreated` event with `messageType === "outgoing"` arrives, call `setIsTyping(false)` after `handleNewMessage`. Incoming messages (echo of the guest's own message) do not touch the indicator.

### Verification
Self-hosted install, images from 2026-09-08, AI agent as default reply. Confirmed in the realtime log that only `typing: true` and `messageCreated` are ever posted for the guest room.

Behavioral test on the live widget (headless Chromium, fresh guest per run, the served widget chunk intercepted and the same one-line change applied to the compiled code):

| scenario | bot reply | dots when the reply renders | dots 6 s later |
|---|---|---|---|
| unmodified widget | 14.7 s | 3 (stuck) | 3 |
| with this change | 14.9 s | 0 | 0 |

Not built from source in this environment; the change is the compiled equivalent of the diff. Happy to move the fix to the worker side (`typing: false` after `clearInterval`) if you prefer.