### PR TITLE
feat(api): scope email topics public API to workspace tokens

### DIFF
--- a/apps/builder/__tests__/__snapshots__/public-spec-operations.test.ts.snap
+++ b/apps/builder/__tests__/__snapshots__/public-spec-operations.test.ts.snap
@@ -519,6 +519,11 @@ exports[`public API spec — operation naming guard > operation list (operationI
   },
   {
     "method": "POST",
+    "operationId": "broadcasts.clone",
+    "path": "/v1/broadcasts/{id}/clone",
+  },
+  {
+    "method": "POST",
     "operationId": "broadcasts.create",
     "path": "/v1/broadcasts",
   },
@@ -1034,6 +1039,11 @@ exports[`public API spec — operation naming guard > operation list (operationI
   },
   {
     "method": "GET",
+    "operationId": "emailTopics.get",
+    "path": "/v1/email-topics/{id}",
+  },
+  {
+    "method": "GET",
     "operationId": "emailTopics.list",
     "path": "/v1/email-topics",
   },
@@ -1506,6 +1516,11 @@ exports[`public API spec — operation naming guard > operation list (operationI
     "method": "GET",
     "operationId": "sequences.list",
     "path": "/v1/sequences",
+  },
+  {
+    "method": "GET",
+    "operationId": "sequences.listStepContacts",
+    "path": "/v1/sequences/{id}/steps/{stepId}/contacts",
   },
   {
     "method": "PATCH",

--- a/apps/builder/__tests__/__snapshots__/public-spec-operations.test.ts.snap
+++ b/apps/builder/__tests__/__snapshots__/public-spec-operations.test.ts.snap
@@ -1023,6 +1023,26 @@ exports[`public API spec — operation naming guard > operation list (operationI
     "path": "/v1/dynamic-images/{id}",
   },
   {
+    "method": "POST",
+    "operationId": "emailTopics.create",
+    "path": "/v1/email-topics",
+  },
+  {
+    "method": "DELETE",
+    "operationId": "emailTopics.delete",
+    "path": "/v1/email-topics/{id}",
+  },
+  {
+    "method": "GET",
+    "operationId": "emailTopics.list",
+    "path": "/v1/email-topics",
+  },
+  {
+    "method": "PUT",
+    "operationId": "emailTopics.update",
+    "path": "/v1/email-topics/{id}",
+  },
+  {
     "method": "GET",
     "operationId": "errorLogs.list",
     "path": "/v1/error-logs",

--- a/apps/builder/__tests__/broadcasts-public-scope.test.ts
+++ b/apps/builder/__tests__/broadcasts-public-scope.test.ts
@@ -35,6 +35,7 @@ vi.mock("@chatbotx.io/business", () => ({
     stopSending: vi.fn(),
     resumeSending: vi.fn(),
     resendWithPruning: vi.fn(),
+    cloneBroadcast: vi.fn(),
     softDeleteBroadcasts: vi.fn(),
   },
 }))

--- a/apps/builder/__tests__/email-topics-public-api.test.ts
+++ b/apps/builder/__tests__/email-topics-public-api.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+type RouteConfig = {
+  method: string
+  path: string
+  summary: string
+  tags: string[]
+  successStatus?: number
+}
+
+type ProcedureInvocation = {
+  context: { workspace: { id: string } }
+  input: Record<string, unknown>
+}
+
+type ProcedureHandler = (args: ProcedureInvocation) => unknown
+
+type CapturedProcedure = {
+  route: RouteConfig
+  handler?: ProcedureHandler
+}
+
+const { workspaceTokenAuthAPIForScope, capturedProcedures } = vi.hoisted(() => {
+  const capturedProcedures: CapturedProcedure[] = []
+
+  const makeProcedure = (route: RouteConfig) => {
+    const record: CapturedProcedure = { route }
+    capturedProcedures.push(record)
+
+    const chain = {
+      input: vi.fn(() => chain),
+      output: vi.fn(() => chain),
+      errors: vi.fn(() => chain),
+      handler: vi.fn((fn: ProcedureHandler) => {
+        record.handler = fn
+        return { handler: fn }
+      }),
+    }
+    return chain
+  }
+
+  const workspaceTokenAuthAPI = {
+    route: vi.fn((config: RouteConfig) => makeProcedure(config)),
+  }
+
+  return {
+    workspaceTokenAuthAPIForScope: vi.fn(
+      (_scope: string) => workspaceTokenAuthAPI,
+    ),
+    capturedProcedures,
+  }
+})
+
+vi.mock("@/orpc", () => ({ workspaceTokenAuthAPIForScope }))
+
+const emailTopicService = {
+  list: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+}
+vi.mock("@chatbotx.io/business", () => ({ emailTopicService }))
+
+vi.mock("@chatbotx.io/database/schema", () => {
+  const schema = {
+    pick: vi.fn(() => schema),
+    extend: vi.fn(() => schema),
+    omit: vi.fn(() => schema),
+  }
+  return {
+    createSelectSchema: vi.fn(() => schema),
+    emailTopicModel: {},
+  }
+})
+
+await import("@/features/email-topics/api/public")
+
+const findProcedure = (method: string, path: string) => {
+  const found = capturedProcedures.find(
+    (procedure) =>
+      procedure.route.method === method && procedure.route.path === path,
+  )
+  if (!found) {
+    throw new Error(`No procedure registered for ${method} ${path}`)
+  }
+  return found
+}
+
+const scopeArgAtImport = workspaceTokenAuthAPIForScope.mock.calls[0]?.[0]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+test("registers the email topics public router under the broadcasts scope", () => {
+  expect(scopeArgAtImport).toBe("broadcasts")
+})
+
+test("registers the expected public CRUD routes", () => {
+  expect(capturedProcedures.map((procedure) => procedure.route)).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ method: "GET", path: "/v1/email-topics" }),
+      expect.objectContaining({ method: "POST", path: "/v1/email-topics" }),
+      expect.objectContaining({
+        method: "PUT",
+        path: "/v1/email-topics/{id}",
+      }),
+      expect.objectContaining({
+        method: "DELETE",
+        path: "/v1/email-topics/{id}",
+      }),
+    ]),
+  )
+})
+
+describe("GET /v1/email-topics", () => {
+  const procedure = findProcedure("GET", "/v1/email-topics")
+
+  test("lists email topics in the token workspace", async () => {
+    const response = { data: [{ id: "topic-1", name: "News" }], pageCount: 1 }
+    emailTopicService.list.mockResolvedValueOnce(response)
+
+    await expect(
+      procedure.handler?.({
+        context: { workspace: { id: "workspace-1" } },
+        input: { page: 2, perPage: 10, name: "News", folderId: "folder-1" },
+      }),
+    ).resolves.toEqual(response)
+
+    expect(emailTopicService.list).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      page: 2,
+      perPage: 10,
+      name: "News",
+      folderId: "folder-1",
+    })
+  })
+})
+
+describe("POST /v1/email-topics", () => {
+  const procedure = findProcedure("POST", "/v1/email-topics")
+
+  test("creates an email topic in the token workspace", async () => {
+    emailTopicService.create.mockResolvedValueOnce({ id: "topic-1" })
+
+    await expect(
+      procedure.handler?.({
+        context: { workspace: { id: "workspace-1" } },
+        input: { name: "News", folderId: "folder-1" },
+      }),
+    ).resolves.toEqual({ id: "topic-1" })
+
+    expect(emailTopicService.create).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      data: { name: "News", folderId: "folder-1" },
+    })
+  })
+})
+
+describe("PUT /v1/email-topics/{id}", () => {
+  const procedure = findProcedure("PUT", "/v1/email-topics/{id}")
+
+  test("updates an email topic in the token workspace", async () => {
+    const updatedTopic = { id: "topic-1", name: "Updates" }
+    emailTopicService.update.mockResolvedValueOnce(updatedTopic)
+
+    await expect(
+      procedure.handler?.({
+        context: { workspace: { id: "workspace-1" } },
+        input: { id: "topic-1", name: "Updates" },
+      }),
+    ).resolves.toEqual(updatedTopic)
+
+    expect(emailTopicService.update).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      id: "topic-1",
+      data: { name: "Updates" },
+    })
+  })
+
+  test("propagates a not-found error from the service", async () => {
+    emailTopicService.update.mockRejectedValueOnce(new Error("Topic not found"))
+
+    await expect(
+      procedure.handler?.({
+        context: { workspace: { id: "workspace-1" } },
+        input: { id: "missing", name: "Updates" },
+      }),
+    ).rejects.toThrow("Topic not found")
+  })
+})
+
+describe("DELETE /v1/email-topics/{id}", () => {
+  const procedure = findProcedure("DELETE", "/v1/email-topics/{id}")
+
+  test("deletes an email topic in the token workspace", async () => {
+    emailTopicService.delete.mockResolvedValueOnce(undefined)
+
+    await expect(
+      procedure.handler?.({
+        context: { workspace: { id: "workspace-1" } },
+        input: { id: "topic-1" },
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(emailTopicService.delete).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      ids: ["topic-1"],
+    })
+  })
+})

--- a/apps/builder/__tests__/email-topics-public-api.test.ts
+++ b/apps/builder/__tests__/email-topics-public-api.test.ts
@@ -55,6 +55,7 @@ vi.mock("@/orpc", () => ({ workspaceTokenAuthAPIForScope }))
 
 const emailTopicService = {
   list: vi.fn(),
+  findOrFail: vi.fn(),
   create: vi.fn(),
   update: vi.fn(),
   delete: vi.fn(),
@@ -100,6 +101,10 @@ test("registers the expected public CRUD routes", () => {
   expect(capturedProcedures.map((procedure) => procedure.route)).toEqual(
     expect.arrayContaining([
       expect.objectContaining({ method: "GET", path: "/v1/email-topics" }),
+      expect.objectContaining({
+        method: "GET",
+        path: "/v1/email-topics/{id}",
+      }),
       expect.objectContaining({ method: "POST", path: "/v1/email-topics" }),
       expect.objectContaining({
         method: "PUT",
@@ -133,6 +138,27 @@ describe("GET /v1/email-topics", () => {
       perPage: 10,
       name: "News",
       folderId: "folder-1",
+    })
+  })
+})
+
+describe("GET /v1/email-topics/{id}", () => {
+  const procedure = findProcedure("GET", "/v1/email-topics/{id}")
+
+  test("gets an email topic in the token workspace", async () => {
+    const topic = { id: "topic-1", name: "News" }
+    emailTopicService.findOrFail.mockResolvedValueOnce(topic)
+
+    await expect(
+      procedure.handler?.({
+        context: { workspace: { id: "workspace-1" } },
+        input: { id: "topic-1" },
+      }),
+    ).resolves.toEqual(topic)
+
+    expect(emailTopicService.findOrFail).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      id: "topic-1",
     })
   })
 })
@@ -194,7 +220,7 @@ describe("DELETE /v1/email-topics/{id}", () => {
   const procedure = findProcedure("DELETE", "/v1/email-topics/{id}")
 
   test("deletes an email topic in the token workspace", async () => {
-    emailTopicService.delete.mockResolvedValueOnce(undefined)
+    emailTopicService.delete.mockResolvedValueOnce({ deletedCount: 1 })
 
     await expect(
       procedure.handler?.({
@@ -207,5 +233,16 @@ describe("DELETE /v1/email-topics/{id}", () => {
       workspaceId: "workspace-1",
       ids: ["topic-1"],
     })
+  })
+
+  test("rejects with not found when nothing was deleted", async () => {
+    emailTopicService.delete.mockResolvedValueOnce({ deletedCount: 0 })
+
+    await expect(
+      procedure.handler?.({
+        context: { workspace: { id: "workspace-1" } },
+        input: { id: "missing" },
+      }),
+    ).rejects.toThrow("Email topic not found")
   })
 })

--- a/apps/builder/__tests__/email-topics-public-scope.test.ts
+++ b/apps/builder/__tests__/email-topics-public-scope.test.ts
@@ -1,0 +1,236 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+  findWorkspaceByTokenHash,
+  isWorkspaceScheduledForDeletion,
+  getAccessState,
+  isAtLimit,
+  assertApiNotRateLimited,
+} = vi.hoisted(() => ({
+  findWorkspaceByTokenHash: vi.fn(),
+  isWorkspaceScheduledForDeletion: vi.fn().mockReturnValue(false),
+  getAccessState: vi.fn().mockResolvedValue({ blocked: false }),
+  isAtLimit: vi.fn().mockResolvedValue(false),
+  assertApiNotRateLimited: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  workspaceApiTokenService: { findWorkspaceByTokenHash },
+  isWorkspaceScheduledForDeletion,
+  userQuotaService: { getAccessState },
+  quotaEnforcementService: { isAtLimit },
+  emailTopicService: {
+    list: vi.fn(),
+    findOrFail: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+vi.mock("@/lib/log", () => ({
+  logger: { warn: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock("@/lib/rate-limit/api-rate-limit", () => ({
+  assertApiNotRateLimited,
+}))
+
+vi.mock("@/lib/rate-limit/guest-rate-limit", () => ({
+  getGuestClientIp: () => "203.0.113.9",
+}))
+
+vi.mock("@/env", () => ({ isCloud: () => true }))
+
+vi.mock("@/middlewares/auth", () => ({
+  authMiddleware: vi.fn(),
+}))
+
+// Dynamic import required: `vi.mock` above is hoisted, and only a dynamic
+// `import()` after registration resolves to the mocked module — a static
+// top-level import would race the mock and pull in the real module (in
+// particular the full better-auth stack behind `@/orpc`'s other exports).
+const { call } = await import("@orpc/server")
+const { emailTopicsPublicRouter } = await import(
+  "../src/features/email-topics/api/public"
+)
+
+const TOKEN = "cbx_ws_fixture"
+
+const authResult = (scopes: string[] | null) => ({
+  workspace: { id: "ws-1", ownerId: "owner-1" },
+  apiToken: { id: "token-1", permission: "full" as const, scopes },
+})
+
+// Exercises every procedure in the router, whose input/output shapes are
+// all different.
+const invoke = (procedure: unknown, input: unknown = {}) =>
+  call(procedure as Parameters<typeof call>[0], input, {
+    context: { headers: new Headers({ Authorization: `Bearer ${TOKEN}` }) },
+  })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  isWorkspaceScheduledForDeletion.mockReturnValue(false)
+  getAccessState.mockResolvedValue({ blocked: false })
+  isAtLimit.mockResolvedValue(false)
+  assertApiNotRateLimited.mockResolvedValue(undefined)
+})
+
+describe("real router: email topics public API scope wiring", () => {
+  test("a contacts-scoped token is denied the real GET /v1/email-topics route with FORBIDDEN", async () => {
+    findWorkspaceByTokenHash.mockResolvedValue(authResult(["contacts"]))
+
+    await expect(invoke(emailTopicsPublicRouter.list)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "Token is not authorized for the 'broadcasts' scope",
+    })
+  })
+
+  test("null scopes (unrestricted) passes the real GET /v1/email-topics route", async () => {
+    findWorkspaceByTokenHash.mockResolvedValue(authResult(null))
+    const { emailTopicService } = await import("@chatbotx.io/business")
+    vi.mocked(emailTopicService.list).mockResolvedValue({
+      data: [],
+      pageCount: 1,
+    } as never)
+
+    await expect(invoke(emailTopicsPublicRouter.list)).resolves.toMatchObject({
+      data: [],
+      pageCount: 1,
+    })
+  })
+
+  // Every procedure the router exports must be built from
+  // `workspaceTokenAuthAPIForScope("broadcasts")` — a route that forgot it
+  // would either compile-fail (wrong base client) or, if built from an
+  // unscoped client by mistake, silently accept a contacts-scoped token
+  // here. Iterating every key means a newly added procedure is covered
+  // automatically without a matching test being written by hand.
+  const routeKeys = Object.keys(emailTopicsPublicRouter) as Array<
+    keyof typeof emailTopicsPublicRouter
+  >
+
+  test.each(
+    routeKeys,
+  )("a contacts-scoped token is denied %s with FORBIDDEN", async (key) => {
+    findWorkspaceByTokenHash.mockResolvedValue(authResult(["contacts"]))
+
+    await expect(
+      invoke(emailTopicsPublicRouter[key], { id: "et-1", name: "x" }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "Token is not authorized for the 'broadcasts' scope",
+    })
+  })
+
+  test("a read_only token is denied POST /v1/email-topics before any service call", async () => {
+    findWorkspaceByTokenHash.mockResolvedValue({
+      workspace: { id: "ws-1", ownerId: "owner-1" },
+      apiToken: {
+        id: "token-1",
+        permission: "read_only" as const,
+        scopes: null,
+      },
+    })
+
+    await expect(
+      invoke(emailTopicsPublicRouter.create, { name: "My topic" }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" })
+
+    const { emailTopicService } = await import("@chatbotx.io/business")
+    expect(emailTopicService.create).not.toHaveBeenCalled()
+  })
+
+  describe("update", () => {
+    beforeEach(() => {
+      findWorkspaceByTokenHash.mockResolvedValue(
+        authResult(null) /* unrestricted scope, full permission */,
+      )
+    })
+
+    test("passes workspaceId from the token, not from input", async () => {
+      const { emailTopicService } = await import("@chatbotx.io/business")
+      vi.mocked(emailTopicService.update).mockResolvedValue({
+        id: "888888",
+        name: "x",
+        workspaceId: "ws-1",
+        folderId: null,
+        sendsTotal: 0,
+        deliveredsTotal: 0,
+        seensTotal: 0,
+        clicksTotal: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as never)
+
+      await invoke(emailTopicsPublicRouter.update, {
+        id: "888888",
+        name: "x",
+      })
+
+      expect(emailTopicService.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspaceId: "ws-1",
+          id: "888888",
+        }),
+      )
+    })
+
+    test("strips workspaceId from the response even though the service returns it", async () => {
+      const { emailTopicService } = await import("@chatbotx.io/business")
+      vi.mocked(emailTopicService.update).mockResolvedValue({
+        id: "888888",
+        name: "x",
+        workspaceId: "ws-1",
+        folderId: null,
+        sendsTotal: 0,
+        deliveredsTotal: 0,
+        seensTotal: 0,
+        clicksTotal: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as never)
+
+      const result = (await invoke(emailTopicsPublicRouter.update, {
+        id: "888888",
+        name: "x",
+      })) as Record<string, unknown>
+
+      expect(result).not.toHaveProperty("workspaceId")
+      expect(result).toMatchObject({ id: "888888", name: "x" })
+    })
+  })
+
+  describe("delete", () => {
+    beforeEach(() => {
+      findWorkspaceByTokenHash.mockResolvedValue(
+        authResult(null) /* unrestricted scope, full permission */,
+      )
+    })
+
+    test("rejects with a 404 when the service reports nothing was deleted", async () => {
+      const { emailTopicService } = await import("@chatbotx.io/business")
+      vi.mocked(emailTopicService.delete).mockResolvedValue({
+        deletedCount: 0,
+      })
+
+      await expect(
+        invoke(emailTopicsPublicRouter.delete, { id: "999999" }),
+      ).rejects.toMatchObject({ status: 404 })
+    })
+
+    test("resolves when the service reports a deletion", async () => {
+      const { emailTopicService } = await import("@chatbotx.io/business")
+      vi.mocked(emailTopicService.delete).mockResolvedValue({
+        deletedCount: 1,
+      })
+
+      await expect(
+        invoke(emailTopicsPublicRouter.delete, { id: "888888" }),
+      ).resolves.toBeUndefined()
+    })
+  })
+})

--- a/apps/builder/__tests__/sequences-list-step-contacts-api.test.ts
+++ b/apps/builder/__tests__/sequences-list-step-contacts-api.test.ts
@@ -78,8 +78,8 @@ describe("privateListSequenceStepContactsAPI", () => {
   // The existence check, analytics/contact-inbox joins, and row shaping now
   // live in `sequenceService.listStepContactsPage` (shared orchestration —
   // see `packages/business/__tests__` for coverage of contactId mapping and
-  // the conversationId fallback). This route's job is just to call it,
-  // forward `total` from input, and pass the result through.
+  // the conversationId fallback). This route's job is just to call it and
+  // pass the result through — it must NOT forward a caller-supplied `total`.
   test("calls the service with the request params and returns its result", async () => {
     mocks.listStepContactsPage.mockResolvedValue({
       data: [
@@ -108,7 +108,6 @@ describe("privateListSequenceStepContactsAPI", () => {
         sequenceId: "seq-1",
         stepId: "step-1",
         eventType: "message:sent",
-        total: 1,
         page: 1,
         perPage: 20,
       },
@@ -119,7 +118,6 @@ describe("privateListSequenceStepContactsAPI", () => {
       sequenceId: "seq-1",
       stepId: "step-1",
       eventType: "message:sent",
-      total: 1,
       page: 1,
       perPage: 20,
     })
@@ -145,26 +143,28 @@ describe("privateListSequenceStepContactsAPI", () => {
     })
   })
 
-  test("defaults a missing total to 0 before calling the service", async () => {
+  test("does not forward a caller-supplied total; reports the service's own", async () => {
     mocks.listStepContactsPage.mockResolvedValue({
       data: [],
-      total: 0,
-      pageCount: 0,
+      total: 7,
+      pageCount: 1,
     })
 
-    await mocks.state.handler?.({
+    const result = await mocks.state.handler?.({
       input: {
         workspaceId: "ws-1",
         sequenceId: "seq-1",
         stepId: "step-1",
         eventType: "message:sent",
+        total: 999,
         page: 1,
         perPage: 20,
       },
     })
 
     expect(mocks.listStepContactsPage).toHaveBeenCalledWith(
-      expect.objectContaining({ total: 0 }),
+      expect.not.objectContaining({ total: expect.anything() }),
     )
+    expect(result).toMatchObject({ total: 7, pageCount: 1 })
   })
 })

--- a/apps/builder/__tests__/sequences-public-scope.test.ts
+++ b/apps/builder/__tests__/sequences-public-scope.test.ts
@@ -33,6 +33,7 @@ vi.mock("@chatbotx.io/business/sequence", () => ({
     assertOwned: vi.fn(),
     upsertStep: vi.fn(),
     deleteStep: vi.fn(),
+    listStepContactsPage: vi.fn(),
   },
 }))
 
@@ -119,7 +120,11 @@ describe("real router: sequences public API scope wiring", () => {
     findWorkspaceByTokenHash.mockResolvedValue(authResult(["contacts"]))
 
     await expect(
-      invoke(sequencesPublicRouter[key], { id: "seq-1", stepId: "step-1" }),
+      invoke(sequencesPublicRouter[key], {
+        id: "seq-1",
+        stepId: "step-1",
+        eventType: "message:sent",
+      }),
     ).rejects.toMatchObject({
       code: "FORBIDDEN",
       message: "Token is not authorized for the 'broadcasts' scope",

--- a/apps/builder/src/app/space/[workspaceId]/(integrations)/whatsapps/[id]/message-templates/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/(integrations)/whatsapps/[id]/message-templates/page.tsx
@@ -1,7 +1,7 @@
+import { whatsappMessageTemplateService } from "@chatbotx.io/business"
 import { notFound } from "next/navigation"
 import { Suspense } from "react"
 import { WhatsappMessageTemplatesTable } from "@/features/integration-whatsapp/message-templates/message-templates-table"
-import { whatsappMessageTemplateService } from "@/features/integration-whatsapp/message-templates/queries"
 import {
   findIntegrationWhatsapp,
   toIntegrationWhatsappLinkable,

--- a/apps/builder/src/app/space/[workspaceId]/messengers/[id]/message-templates/page.tsx
+++ b/apps/builder/src/app/space/[workspaceId]/messengers/[id]/message-templates/page.tsx
@@ -1,8 +1,10 @@
-import { messengerIntegrationService } from "@chatbotx.io/business"
+import {
+  messengerIntegrationService,
+  messengerMessageTemplateService,
+} from "@chatbotx.io/business"
 import { notFound } from "next/navigation"
 import { Suspense } from "react"
 import { MessengerMessageTemplatesTable } from "@/features/integration-messenger/message-templates/message-templates-table"
-import { messengerMessageTemplateService } from "@/features/integration-messenger/message-templates/queries"
 import { listMessengerMessageTemplatesSearchParamsCache } from "@/features/integration-messenger/message-templates/schema/query"
 import { findIntegrationMessenger } from "@/features/integration-messenger/queries"
 import { withWorkspaceIdAndIdSchema } from "@/features/workspaces/schema/resource"

--- a/apps/builder/src/features/ads/queries/conversion-rules.ts
+++ b/apps/builder/src/features/ads/queries/conversion-rules.ts
@@ -5,11 +5,11 @@ import {
   instagramIntegrationService,
   integrationWhatsappService,
   messengerIntegrationService,
+  messengerMessageTemplateService,
   whatsappMessageTemplateService,
 } from "@chatbotx.io/business"
 import { listAutomatedResponses } from "@/features/automated-response/queries"
 import type { AutomatedResponseResource } from "@/features/automated-response/schema/resource"
-import { messengerMessageTemplateService } from "@/features/integration-messenger/message-templates/queries"
 import type { ListMessengerMessageTemplatesResponse } from "@/features/integration-messenger/message-templates/schema/query"
 import type { ListWhatsappMessageTemplatesResponse } from "@/features/integration-whatsapp/message-templates/schema/query"
 import { listTags } from "@/features/tags/queries"

--- a/apps/builder/src/features/ads/queries/conversion-rules.ts
+++ b/apps/builder/src/features/ads/queries/conversion-rules.ts
@@ -5,12 +5,12 @@ import {
   instagramIntegrationService,
   integrationWhatsappService,
   messengerIntegrationService,
+  whatsappMessageTemplateService,
 } from "@chatbotx.io/business"
 import { listAutomatedResponses } from "@/features/automated-response/queries"
 import type { AutomatedResponseResource } from "@/features/automated-response/schema/resource"
 import { messengerMessageTemplateService } from "@/features/integration-messenger/message-templates/queries"
 import type { ListMessengerMessageTemplatesResponse } from "@/features/integration-messenger/message-templates/schema/query"
-import { whatsappMessageTemplateService } from "@/features/integration-whatsapp/message-templates/queries"
 import type { ListWhatsappMessageTemplatesResponse } from "@/features/integration-whatsapp/message-templates/schema/query"
 import { listTags } from "@/features/tags/queries"
 import type { TagResource } from "@/features/tags/schema/resource"

--- a/apps/builder/src/features/broadcasts/api/public.ts
+++ b/apps/builder/src/features/broadcasts/api/public.ts
@@ -38,9 +38,10 @@ const workspaceTokenAuthAPI = workspaceTokenAuthAPIForScope("broadcasts")
 //
 // This flag governs *write-side filter-condition pruning only*
 // (`pruneEmailPhoneFilterConditions`, applied in `create`/`updateDraft`/
-// `resendWithPruning`). Reads are unaffected by it: `get`/`list`, and in
-// particular `getAudience` below, already return full contact PII (email,
-// phone, gender) for any `broadcasts`-scoped token — including a
+// `resendWithPruning`/`cloneBroadcast`). Reads are unaffected by it: `get`/
+// `list`, and in particular `getAudience` below, already return full
+// contact PII (email, phone, gender) for any `broadcasts`-scoped token —
+// including a
 // `read_only` one — because a superAdmin who can mint the token already has
 // that PII in the builder UI. There is no field-level read gate to apply
 // here without diverging from the private route this public route mirrors
@@ -306,6 +307,28 @@ export const broadcastsPublicRouter = {
         await broadcastService.resendWithPruning({
           workspaceId: context.workspace.id,
           id: input.id,
+          canViewEmailAndPhone: TOKEN_CALLER_CAN_VIEW_EMAIL_AND_PHONE,
+        }),
+    ),
+
+  clone: workspaceTokenAuthAPI
+    .route({
+      method: "POST",
+      path: "/v1/broadcasts/{id}/clone",
+      summary: "Clone a broadcast",
+      description:
+        "Copies the broadcast into a new draft with a deduplicated name, including its targets and audience filter.",
+      successStatus: 201,
+      tags: ["Broadcasts"],
+    })
+    .input(z.object({ id: zodBigintAsString() }))
+    .output(publicBroadcastResource)
+    .errors(possibleErrorsOnMutatingResource)
+    .handler(
+      async ({ context, input }) =>
+        await broadcastService.cloneBroadcast({
+          workspaceId: context.workspace.id,
+          broadcastId: input.id,
           canViewEmailAndPhone: TOKEN_CALLER_CAN_VIEW_EMAIL_AND_PHONE,
         }),
     ),

--- a/apps/builder/src/features/broadcasts/components/broadcast-flow-type-selector.tsx
+++ b/apps/builder/src/features/broadcasts/components/broadcast-flow-type-selector.tsx
@@ -1,11 +1,11 @@
 "use client"
 
+import type { BroadcastSubaction } from "@chatbotx.io/database/partials"
 import {
   type BroadcastFlowType,
-  type BroadcastSubaction,
   broadcastFlowTypes,
   isTemplateBroadcastSubaction,
-} from "@chatbotx.io/database/partials"
+} from "@chatbotx.io/utils/broadcast"
 import { useTranslations } from "next-intl"
 import { useCallback, useState } from "react"
 import { useFormContext } from "react-hook-form"

--- a/apps/builder/src/features/broadcasts/components/broadcast-inbox-multi-select.tsx
+++ b/apps/builder/src/features/broadcasts/components/broadcast-inbox-multi-select.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { type ChannelType, inboxStatuses } from "@chatbotx.io/database/partials"
+import type { ChannelType } from "@chatbotx.io/database/partials"
 import { MultiSelectField } from "@chatbotx.io/ui/components/form/multi-select-field"
+import { inboxStatuses } from "@chatbotx.io/utils/conversation"
 import { useTranslations } from "next-intl"
 import { useMemo } from "react"
 import { useInboxStore } from "@/features/inboxes/provider/inbox-store-context"

--- a/apps/builder/src/features/contact-filter/components/contact-filter-condition-dialog.tsx
+++ b/apps/builder/src/features/contact-filter/components/contact-filter-condition-dialog.tsx
@@ -1,13 +1,6 @@
 "use client"
 
-import {
-  type FormFieldType,
-  operatorTypes,
-} from "@chatbotx.io/database/partials"
-import {
-  isValidDateTimeFilterValue,
-  valueContainsVariablePlaceholder,
-} from "@chatbotx.io/database/queries/contact-filter/value-format"
+import type { FormFieldType } from "@chatbotx.io/database/partials"
 import { ComboboxField } from "@chatbotx.io/ui/components/form/combobox-field"
 import { InputField } from "@chatbotx.io/ui/components/form/input-field"
 import { MultiSelectField } from "@chatbotx.io/ui/components/form/multi-select-field"
@@ -24,7 +17,14 @@ import {
   DialogTitle,
 } from "@chatbotx.io/ui/components/ui/dialog"
 import { Form } from "@chatbotx.io/ui/components/ui/form"
-import { canonicalBooleanLiteral } from "@chatbotx.io/utils/custom-field"
+import {
+  isValidDateTimeFilterValue,
+  valueContainsVariablePlaceholder,
+} from "@chatbotx.io/utils/contact-filter-value-format"
+import {
+  canonicalBooleanLiteral,
+  operatorTypes,
+} from "@chatbotx.io/utils/custom-field"
 import { useTranslations } from "next-intl"
 import { type ReactNode, useCallback, useMemo } from "react"
 import { useForm, useWatch } from "react-hook-form"

--- a/apps/builder/src/features/email-topics/api/public.ts
+++ b/apps/builder/src/features/email-topics/api/public.ts
@@ -1,5 +1,6 @@
 import { emailTopicService } from "@chatbotx.io/business"
 import { notFoundException } from "@chatbotx.io/business/errors"
+import { rootFolderId } from "@chatbotx.io/database/partials"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { z } from "zod"
 import {
@@ -69,9 +70,13 @@ export const emailTopicsPublicRouter = {
     .output(z.object({ id: zodBigintAsString() }))
     .errors(possibleErrorsOnCreatingEmailTopic)
     .handler(async ({ context, input }) => {
+      const folderId =
+        input.folderId && input.folderId !== rootFolderId
+          ? input.folderId
+          : null
       const topic = await emailTopicService.create({
         workspaceId: context.workspace.id,
-        data: input,
+        data: { ...input, folderId },
       })
       return { id: topic.id }
     }),

--- a/apps/builder/src/features/email-topics/api/public.ts
+++ b/apps/builder/src/features/email-topics/api/public.ts
@@ -1,0 +1,92 @@
+import { emailTopicService } from "@chatbotx.io/business"
+import { zodBigintAsString } from "@chatbotx.io/utils"
+import { z } from "zod"
+import {
+  possibleErrorsOnCreatingResource,
+  possibleErrorsOnDeletingResource,
+  possibleErrorsOnListingResource,
+  possibleErrorsOnMutatingResource,
+} from "@/lib/orpc/orpc-error-helper"
+import { workspaceTokenAuthAPIForScope } from "@/orpc"
+import {
+  createEmailTopicPublicRequest,
+  listEmailTopicsPublicRequest,
+  listEmailTopicsPublicResponse,
+  updateEmailTopicPublicRequest,
+} from "../schema/public"
+
+const workspaceTokenAuthAPI = workspaceTokenAuthAPIForScope("broadcasts")
+
+export const emailTopicsPublicRouter = {
+  list: workspaceTokenAuthAPI
+    .route({
+      method: "GET",
+      path: "/v1/email-topics",
+      summary: "List email topics",
+      tags: ["EmailTopics"],
+    })
+    .input(listEmailTopicsPublicRequest)
+    .output(listEmailTopicsPublicResponse)
+    .errors(possibleErrorsOnListingResource)
+    .handler(
+      async ({ context, input }) =>
+        await emailTopicService.list({
+          ...input,
+          workspaceId: context.workspace.id,
+        }),
+    ),
+
+  create: workspaceTokenAuthAPI
+    .route({
+      method: "POST",
+      path: "/v1/email-topics",
+      summary: "Create an email topic",
+      successStatus: 201,
+      tags: ["EmailTopics"],
+    })
+    .input(createEmailTopicPublicRequest)
+    .output(z.object({ id: zodBigintAsString() }))
+    .errors(possibleErrorsOnCreatingResource)
+    .handler(async ({ context, input }) => {
+      const topic = await emailTopicService.create({
+        workspaceId: context.workspace.id,
+        data: input,
+      })
+      return { id: topic.id }
+    }),
+
+  update: workspaceTokenAuthAPI
+    .route({
+      method: "PUT",
+      path: "/v1/email-topics/{id}",
+      summary: "Update email topic",
+      tags: ["EmailTopics"],
+    })
+    .input(updateEmailTopicPublicRequest)
+    .errors(possibleErrorsOnMutatingResource)
+    .handler(async ({ context, input }) => {
+      const { id, ...data } = input
+      return await emailTopicService.update({
+        workspaceId: context.workspace.id,
+        id,
+        data,
+      })
+    }),
+
+  delete: workspaceTokenAuthAPI
+    .route({
+      method: "DELETE",
+      path: "/v1/email-topics/{id}",
+      summary: "Delete email topic",
+      successStatus: 204,
+      tags: ["EmailTopics"],
+    })
+    .input(z.object({ id: zodBigintAsString() }))
+    .errors(possibleErrorsOnDeletingResource)
+    .handler(async ({ context, input }) => {
+      await emailTopicService.delete({
+        workspaceId: context.workspace.id,
+        ids: [input.id],
+      })
+    }),
+}

--- a/apps/builder/src/features/email-topics/api/public.ts
+++ b/apps/builder/src/features/email-topics/api/public.ts
@@ -1,15 +1,18 @@
 import { emailTopicService } from "@chatbotx.io/business"
+import { notFoundException } from "@chatbotx.io/business/errors"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { z } from "zod"
 import {
-  possibleErrorsOnCreatingResource,
+  possibleErrorsOnCreatingEmailTopic,
   possibleErrorsOnDeletingResource,
+  possibleErrorsOnFindingResource,
   possibleErrorsOnListingResource,
-  possibleErrorsOnMutatingResource,
+  possibleErrorsOnMutatingEmailTopic,
 } from "@/lib/orpc/orpc-error-helper"
 import { workspaceTokenAuthAPIForScope } from "@/orpc"
 import {
   createEmailTopicPublicRequest,
+  emailTopicPublicResource,
   listEmailTopicsPublicRequest,
   listEmailTopicsPublicResponse,
   updateEmailTopicPublicRequest,
@@ -36,6 +39,24 @@ export const emailTopicsPublicRouter = {
         }),
     ),
 
+  get: workspaceTokenAuthAPI
+    .route({
+      method: "GET",
+      path: "/v1/email-topics/{id}",
+      summary: "Get email topic",
+      tags: ["EmailTopics"],
+    })
+    .input(z.object({ id: zodBigintAsString() }))
+    .output(emailTopicPublicResource)
+    .errors(possibleErrorsOnFindingResource)
+    .handler(
+      async ({ context, input }) =>
+        await emailTopicService.findOrFail({
+          workspaceId: context.workspace.id,
+          id: input.id,
+        }),
+    ),
+
   create: workspaceTokenAuthAPI
     .route({
       method: "POST",
@@ -46,7 +67,7 @@ export const emailTopicsPublicRouter = {
     })
     .input(createEmailTopicPublicRequest)
     .output(z.object({ id: zodBigintAsString() }))
-    .errors(possibleErrorsOnCreatingResource)
+    .errors(possibleErrorsOnCreatingEmailTopic)
     .handler(async ({ context, input }) => {
       const topic = await emailTopicService.create({
         workspaceId: context.workspace.id,
@@ -63,7 +84,8 @@ export const emailTopicsPublicRouter = {
       tags: ["EmailTopics"],
     })
     .input(updateEmailTopicPublicRequest)
-    .errors(possibleErrorsOnMutatingResource)
+    .output(emailTopicPublicResource)
+    .errors(possibleErrorsOnMutatingEmailTopic)
     .handler(async ({ context, input }) => {
       const { id, ...data } = input
       return await emailTopicService.update({
@@ -84,9 +106,16 @@ export const emailTopicsPublicRouter = {
     .input(z.object({ id: zodBigintAsString() }))
     .errors(possibleErrorsOnDeletingResource)
     .handler(async ({ context, input }) => {
-      await emailTopicService.delete({
+      // `delete` is a bulk method for the UI's multi-select, which treats a
+      // partially-applied delete as success. A single-id REST DELETE is a
+      // different contract: 204 for an id that was nonexistent or foreign
+      // would tell the caller a topic is gone that still exists.
+      const { deletedCount } = await emailTopicService.delete({
         workspaceId: context.workspace.id,
         ids: [input.id],
       })
+      if (deletedCount === 0) {
+        throw notFoundException("Email topic not found")
+      }
     }),
 }

--- a/apps/builder/src/features/email-topics/schema/public.ts
+++ b/apps/builder/src/features/email-topics/schema/public.ts
@@ -5,8 +5,12 @@ import { createEmailTopicRequest, updateEmailTopicRequest } from "./action"
 import { emailTopicResource } from "./resource"
 
 export const listEmailTopicsPublicRequest = publicListRequest.extend({
-  name: createEmailTopicRequest.shape.name.nullish(),
-  folderId: zodBigintAsString().nullish(),
+  name: createEmailTopicRequest.shape.name
+    .nullish()
+    .describe("Case-insensitive substring match on the topic name."),
+  folderId: zodBigintAsString()
+    .nullish()
+    .describe('Folder id to filter by. Pass "0" for topics in no folder.'),
 })
 
 export const emailTopicPublicResource = emailTopicResource.omit({

--- a/apps/builder/src/features/email-topics/schema/public.ts
+++ b/apps/builder/src/features/email-topics/schema/public.ts
@@ -1,5 +1,4 @@
 import { zodBigintAsString } from "@chatbotx.io/utils"
-import { z } from "zod"
 import { publicListRequest, publicListResponse } from "@/lib/public-api/list"
 import { createEmailTopicRequest, updateEmailTopicRequest } from "./action"
 import { emailTopicResource } from "./resource"
@@ -23,6 +22,6 @@ export const listEmailTopicsPublicResponse = publicListResponse(
 
 export const createEmailTopicPublicRequest = createEmailTopicRequest
 
-export const updateEmailTopicPublicRequest = updateEmailTopicRequest.and(
-  z.object({ id: zodBigintAsString() }),
-)
+export const updateEmailTopicPublicRequest = updateEmailTopicRequest.extend({
+  id: zodBigintAsString(),
+})

--- a/apps/builder/src/features/email-topics/schema/public.ts
+++ b/apps/builder/src/features/email-topics/schema/public.ts
@@ -1,0 +1,24 @@
+import { zodBigintAsString } from "@chatbotx.io/utils"
+import { z } from "zod"
+import { publicListRequest, publicListResponse } from "@/lib/public-api/list"
+import { createEmailTopicRequest, updateEmailTopicRequest } from "./action"
+import { emailTopicResource } from "./resource"
+
+export const listEmailTopicsPublicRequest = publicListRequest.extend({
+  name: createEmailTopicRequest.shape.name.nullish(),
+  folderId: zodBigintAsString().nullish(),
+})
+
+export const emailTopicPublicResource = emailTopicResource.omit({
+  workspaceId: true,
+})
+
+export const listEmailTopicsPublicResponse = publicListResponse(
+  emailTopicPublicResource,
+)
+
+export const createEmailTopicPublicRequest = createEmailTopicRequest
+
+export const updateEmailTopicPublicRequest = updateEmailTopicRequest.and(
+  z.object({ id: zodBigintAsString() }),
+)

--- a/apps/builder/src/features/integration-messenger/message-templates/api/private.ts
+++ b/apps/builder/src/features/integration-messenger/message-templates/api/private.ts
@@ -1,4 +1,4 @@
-import { messengerMessageTemplateService } from "@/features/integration-messenger/message-templates/queries"
+import { messengerMessageTemplateService } from "@chatbotx.io/business"
 import { workspaceAuthorizedMidddleware } from "@/middlewares/auth"
 import { authorizedAPI } from "@/orpc"
 import {

--- a/apps/builder/src/features/integration-messenger/message-templates/queries/index.ts
+++ b/apps/builder/src/features/integration-messenger/message-templates/queries/index.ts
@@ -1,1 +1,0 @@
-export { messengerMessageTemplateService } from "@chatbotx.io/business"

--- a/apps/builder/src/features/integration-whatsapp/message-templates/api/private.ts
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/api/private.ts
@@ -1,5 +1,7 @@
-import { integrationMetaCatalogService } from "@chatbotx.io/business"
-import { whatsappMessageTemplateService } from "@/features/integration-whatsapp/message-templates/queries"
+import {
+  integrationMetaCatalogService,
+  whatsappMessageTemplateService,
+} from "@chatbotx.io/business"
 import { workspaceAuthorizedMidddleware } from "@/middlewares/auth"
 import { authorizedAPI } from "@/orpc"
 import {

--- a/apps/builder/src/features/integration-whatsapp/message-templates/api/public.ts
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/api/public.ts
@@ -1,6 +1,6 @@
+import { whatsappMessageTemplateService } from "@chatbotx.io/business"
 import { possibleErrorsOnListingResource } from "@/lib/orpc/orpc-error-helper"
 import { workspaceTokenAuthAPIForScope } from "@/orpc"
-import { whatsappMessageTemplateService } from "../queries"
 import {
   listWhatsappMessageTemplatesRequest,
   listWhatsappMessageTemplatesResponse,

--- a/apps/builder/src/features/integration-whatsapp/message-templates/queries/index.ts
+++ b/apps/builder/src/features/integration-whatsapp/message-templates/queries/index.ts
@@ -1,1 +1,0 @@
-export { whatsappMessageTemplateService } from "@chatbotx.io/business"

--- a/apps/builder/src/features/sequences/api/private.ts
+++ b/apps/builder/src/features/sequences/api/private.ts
@@ -40,15 +40,8 @@ export const sequencesPrivateAPI = {
     .output(listSequenceStepContactsResponse)
     .use(workspaceAuthorizedMidddleware, (input) => input.workspaceId)
     .handler(async ({ input }) => {
-      const {
-        workspaceId,
-        sequenceId,
-        stepId,
-        eventType,
-        total,
-        page,
-        perPage,
-      } = input
+      const { workspaceId, sequenceId, stepId, eventType, page, perPage } =
+        input
 
       const {
         data,
@@ -59,7 +52,6 @@ export const sequencesPrivateAPI = {
         sequenceId,
         stepId,
         eventType,
-        total: total ?? undefined,
         page,
         perPage,
       })

--- a/apps/builder/src/features/sequences/api/private.ts
+++ b/apps/builder/src/features/sequences/api/private.ts
@@ -59,7 +59,7 @@ export const sequencesPrivateAPI = {
         sequenceId,
         stepId,
         eventType,
-        total: total || 0,
+        total: total ?? undefined,
         page,
         perPage,
       })

--- a/apps/builder/src/features/sequences/api/public.ts
+++ b/apps/builder/src/features/sequences/api/public.ts
@@ -16,6 +16,10 @@ import {
   publicUpsertSequenceStepRequest,
   updateSequenceSchema,
 } from "../schema/action"
+import {
+  publicListSequenceStepContactsRequest,
+  publicListSequenceStepContactsResponse,
+} from "../schema/public"
 import { sequenceResource } from "../schema/resource"
 
 const workspaceTokenAuthAPI = workspaceTokenAuthAPIForScope("broadcasts")
@@ -167,5 +171,35 @@ export const sequencesPublicRouter = {
         sequenceId: input.id,
         stepId: input.stepId,
       })
+    }),
+
+  listStepContacts: workspaceTokenAuthAPI
+    .route({
+      method: "GET",
+      path: "/v1/sequences/{id}/steps/{stepId}/contacts",
+      summary: "List sequence step recipients by event type",
+      tags: ["Sequences"],
+    })
+    .input(publicListSequenceStepContactsRequest)
+    .output(publicListSequenceStepContactsResponse)
+    .errors(possibleErrorsOnFindingResource)
+    .handler(async ({ context, input }) => {
+      // `{id}` is the ownership anchor: without `assertOwned`, a `stepId`
+      // belonging to another workspace's sequence would resolve through the
+      // analytics lookup instead of 404ing (same reason `deleteStep` asserts).
+      await sequenceService.assertOwned({
+        workspaceId: context.workspace.id,
+        sequenceId: input.id,
+      })
+      const { data, total, pageCount } =
+        await sequenceService.listStepContactsPage({
+          workspaceId: context.workspace.id,
+          sequenceId: input.id,
+          stepId: input.stepId,
+          eventType: input.eventType,
+          page: input.page,
+          perPage: input.perPage,
+        })
+      return { data, total, pageCount }
     }),
 }

--- a/apps/builder/src/features/sequences/components/sequence-step-contacts-dialog.tsx
+++ b/apps/builder/src/features/sequences/components/sequence-step-contacts-dialog.tsx
@@ -51,14 +51,13 @@ export const SequenceStepContactsDialog = memo(
             sequenceId,
             stepId,
             eventType,
-            total,
             page,
             perPage,
           })
 
         return result.data
       },
-      [eventType, sequenceId, stepId, total, workspaceId],
+      [eventType, sequenceId, stepId, workspaceId],
     )
 
     const onManualTag = useCallback(

--- a/apps/builder/src/features/sequences/schema/public.ts
+++ b/apps/builder/src/features/sequences/schema/public.ts
@@ -1,0 +1,27 @@
+import {
+  sequenceStepContactResource,
+  sequenceStepEventTypes,
+} from "@chatbotx.io/analytics/schemas"
+import { zodBigintAsString } from "@chatbotx.io/utils"
+import { z } from "zod"
+import { publicListRequest } from "@/lib/public-api/list"
+
+// `sequenceStepContactResource`/the analytics request schemas carry
+// `workspaceId` (injected from the token's resolved workspace, never
+// accepted from client input) and the response's `conversationId` (an
+// internal builder-navigation detail, not a public API concern) — narrow
+// variants declared here instead of reusing those directly, mirroring
+// `broadcasts/schema/public.ts`.
+export const publicListSequenceStepContactsRequest = z.object({
+  id: zodBigintAsString(),
+  stepId: zodBigintAsString(),
+  eventType: sequenceStepEventTypes,
+  page: publicListRequest.shape.page,
+  perPage: publicListRequest.shape.perPage,
+})
+
+export const publicListSequenceStepContactsResponse = z.object({
+  data: z.array(sequenceStepContactResource),
+  total: z.number().int(),
+  pageCount: z.number().int(),
+})

--- a/apps/builder/src/lib/orpc/orpc-error-helper.ts
+++ b/apps/builder/src/lib/orpc/orpc-error-helper.ts
@@ -260,3 +260,27 @@ export const possibleErrorsOnMutatingMinigame = {
   businessError,
   nameAlreadyExists: minigameNameAlreadyExists,
 } satisfies ErrorMap
+
+/**
+ * Email topic create/update reject a duplicate name with `nameTaken` at 400
+ * (`packages/business/src/email-topic/service.ts`), and create surfaces a
+ * 404 when `folderId` names a folder that does not exist in the workspace
+ * (`folderService.ensureExists`). Same declare-or-vanish rule as
+ * `possibleErrorsOnBookingAppointment` above.
+ */
+const nameTaken = {
+  message: "Name is already taken",
+  status: 400,
+}
+
+export const possibleErrorsOnCreatingEmailTopic = {
+  notFound,
+  businessError,
+  nameTaken,
+} satisfies ErrorMap
+
+export const possibleErrorsOnMutatingEmailTopic = {
+  notFound,
+  businessError,
+  nameTaken,
+} satisfies ErrorMap

--- a/apps/builder/src/routers/public.ts
+++ b/apps/builder/src/routers/public.ts
@@ -17,6 +17,7 @@ import { conversationsPublicRouter } from "@/features/conversations/api/public"
 import { couponsPublicRouter } from "@/features/coupons/api/public"
 import { customFieldsPublicRouter } from "@/features/custom-fields/api/public"
 import { dynamicImagesPublicRouter } from "@/features/dynamic-images/api/public"
+import { emailTopicsPublicRouter } from "@/features/email-topics/api/public"
 import { errorLogsPublicRouter } from "@/features/error-logs/api/public"
 import { appointmentExternalCalendarsPublicRouter } from "@/features/external-calendars/api/public"
 import { externalWebhooksPublicRouter } from "@/features/external-webhooks/api/public"
@@ -65,6 +66,7 @@ export const publicRouter = {
   coupons: couponsPublicRouter,
   customFields: customFieldsPublicRouter,
   dynamicImages: dynamicImagesPublicRouter,
+  emailTopics: emailTopicsPublicRouter,
   errorLogs: errorLogsPublicRouter,
   externalWebhooks: externalWebhooksPublicRouter,
   flows: flowsPublicRouter,

--- a/docs/developer/workspace-api-tokens.md
+++ b/docs/developer/workspace-api-tokens.md
@@ -237,15 +237,15 @@ an endpoint's scope.
     `userService.findByIdOrFail(context.user.id)` call on this path the way
     the private API needs one for `tenantId`.
 
-- **Broadcasts** — covers broadcasts, sequences, **and** WhatsApp message
-  templates — three features share it because sequences and message
-  templates are broadcast-adjacent operations, not because they were
-  designed together. The token picker only shows the bare label "Broadcasts"
-  (`fields.tokenScopes.broadcasts`), so a superAdmin minting a `broadcasts`
-  token should know it also grants full sequence CRUD (including deleting
-  sequences and steps) and WhatsApp template listing — there is no
-  finer-grained scope to withhold just one of the three. Two things worth
-  knowing:
+- **Broadcasts** — covers broadcasts, sequences, email topics, **and**
+  WhatsApp message templates — four features share it because sequences,
+  email topics, and message templates are broadcast-adjacent operations,
+  not because they were designed together. The token picker only shows the
+  bare label "Broadcasts" (`fields.tokenScopes.broadcasts`), so a
+  superAdmin minting a `broadcasts` token should know it also grants full
+  sequence CRUD (including deleting sequences and steps), full email topic
+  CRUD, and WhatsApp template listing — there is no finer-grained scope to
+  withhold just one of the four. Two things worth knowing:
   - *`GET /v1/broadcasts/{idOrName}/audience` returns full contact PII*
     (email, phone, gender) with no field-level gating, including for a
     `read_only` token — unlike the write paths (`create`/`updateDraft`/

--- a/packages/analytics/src/repositories/postgres/sequence-stats.repository.ts
+++ b/packages/analytics/src/repositories/postgres/sequence-stats.repository.ts
@@ -188,30 +188,33 @@ export class SequenceStatsRepository extends BaseRepository {
   }): Promise<{
     contactInboxIds: string[]
     contactEventMap: Map<string, ContactEventData>
+    total: number
   }> {
     const { workspaceId, sequenceId, stepId, eventType, page, perPage } = input
     const offset = (page - 1) * perPage
     const t = sequenceDispatchModel
 
     const { eventCondition, orderColumn } = this.buildEventFilter(eventType)
+    const whereCondition = sql`${t.workspaceId} = ${workspaceId} AND ${t.sequenceId} = ${sequenceId} AND ${t.stepId} = ${stepId} AND ${eventCondition}`
 
-    const rows = await db
-      .select({
-        contactInboxId: t.contactInboxId,
-        contactId: t.contactId,
-        deliveredAt: t.deliveredAt,
-        seenAt: t.seenAt,
-        failedAt: t.failedAt,
-        clickedAt: t.clickedAt,
-        errorContent: t.errorContent,
-      })
-      .from(t)
-      .where(
-        sql`${t.workspaceId} = ${workspaceId} AND ${t.sequenceId} = ${sequenceId} AND ${t.stepId} = ${stepId} AND ${eventCondition}`,
-      )
-      .orderBy(sql`${orderColumn} DESC NULLS LAST`)
-      .limit(perPage)
-      .offset(offset)
+    const [rows, [totalRow]] = await Promise.all([
+      db
+        .select({
+          contactInboxId: t.contactInboxId,
+          contactId: t.contactId,
+          deliveredAt: t.deliveredAt,
+          seenAt: t.seenAt,
+          failedAt: t.failedAt,
+          clickedAt: t.clickedAt,
+          errorContent: t.errorContent,
+        })
+        .from(t)
+        .where(whereCondition)
+        .orderBy(sql`${orderColumn} DESC NULLS LAST`)
+        .limit(perPage)
+        .offset(offset),
+      db.select({ total: count() }).from(t).where(whereCondition),
+    ])
 
     const contactInboxIds = rows.map((r) => r.contactInboxId)
     const contactEventMap = new Map<string, ContactEventData>()
@@ -225,7 +228,7 @@ export class SequenceStatsRepository extends BaseRepository {
       })
     }
 
-    return { contactInboxIds, contactEventMap }
+    return { contactInboxIds, contactEventMap, total: totalRow?.total ?? 0 }
   }
 
   async getContactIdsPage(input: {

--- a/packages/analytics/src/schemas/sequence-stats.ts
+++ b/packages/analytics/src/schemas/sequence-stats.ts
@@ -40,7 +40,6 @@ export const listSequenceStepContactsRequest = z.object({
   sequenceId: z.string(),
   stepId: z.string(),
   eventType: sequenceStepEventTypes,
-  total: z.number().optional(),
   page: z.number().default(1),
   perPage: z.number().default(20),
 })

--- a/packages/analytics/src/services/sequence-analytics.service.ts
+++ b/packages/analytics/src/services/sequence-analytics.service.ts
@@ -100,6 +100,7 @@ export class SequenceAnalyticsService {
   }): Promise<{
     contactInboxIds: string[]
     contactEventMap: Map<string, ContactEventData>
+    total: number
   }> {
     return sequenceStatsRepository.getContacts(input)
   }

--- a/packages/business/__tests__/sequence-service-list-step-contacts.test.ts
+++ b/packages/business/__tests__/sequence-service-list-step-contacts.test.ts
@@ -45,6 +45,7 @@ describe("sequenceService.listStepContactsPage", () => {
     mocks.getContacts.mockResolvedValueOnce({
       contactInboxIds: [],
       contactEventMap: new Map(),
+      total: 0,
     })
 
     const result = await sequenceService.listStepContactsPage({
@@ -52,19 +53,19 @@ describe("sequenceService.listStepContactsPage", () => {
       sequenceId: "seq-1",
       stepId: "step-1",
       eventType: "message:sent",
-      total: 5,
       page: 1,
       perPage: 20,
     })
 
-    expect(result).toEqual({ data: [], total: 5, pageCount: 1 })
+    expect(result).toEqual({ data: [], total: 0, pageCount: 0 })
     expect(mocks.findManyByIds).not.toHaveBeenCalled()
   })
 
-  test("defaults a falsy total to 0", async () => {
+  test("takes total from the repository, not a caller-supplied value", async () => {
     mocks.getContacts.mockResolvedValueOnce({
       contactInboxIds: [],
       contactEventMap: new Map(),
+      total: 5,
     })
 
     const result = await sequenceService.listStepContactsPage({
@@ -72,13 +73,63 @@ describe("sequenceService.listStepContactsPage", () => {
       sequenceId: "seq-1",
       stepId: "step-1",
       eventType: "message:sent",
-      total: 0,
       page: 1,
       perPage: 20,
     })
 
-    expect(result.total).toBe(0)
-    expect(result.pageCount).toBe(0)
+    expect(result.total).toBe(5)
+    expect(result.pageCount).toBe(1)
+    expect(mocks.getContacts).toHaveBeenCalledWith(
+      expect.not.objectContaining({ total: expect.anything() }),
+    )
+  })
+
+  test("tracks total for event types outside getStepStats's five keys (flow:ref, message:received)", async () => {
+    mocks.getContacts.mockResolvedValueOnce({
+      contactInboxIds: ["ci-1"],
+      contactEventMap: new Map([
+        [
+          "ci-1",
+          {
+            contactId: "contact-1",
+            occurredAt: "2026-01-01T00:00:00.000Z",
+            errorContent: null,
+          },
+        ],
+      ]),
+      total: 1,
+    })
+    mocks.findManyByIds.mockResolvedValueOnce([
+      {
+        id: "ci-1",
+        sourceId: "src-1",
+        channel: "whatsapp",
+        conversation: { id: "conv-1" },
+        contact: {
+          id: "contact-1",
+          firstName: "Ada",
+          lastName: null,
+          fullName: "Ada",
+          avatar: null,
+        },
+      },
+    ])
+
+    const result = await sequenceService.listStepContactsPage({
+      workspaceId: "ws-1",
+      sequenceId: "seq-1",
+      stepId: "step-1",
+      eventType: "flow:ref",
+      page: 1,
+      perPage: 20,
+    })
+
+    // Previously this event type fell outside getStepStats's five keys and
+    // reported total: 0 alongside a non-empty page. Now total is derived
+    // from the same filter as the page itself.
+    expect(result.total).toBe(1)
+    expect(result.pageCount).toBe(1)
+    expect(result.data).toHaveLength(1)
   })
 
   test("joins recipient events with contact-inbox details, defaulting a missing conversationId to an empty string", async () => {
@@ -102,6 +153,7 @@ describe("sequenceService.listStepContactsPage", () => {
           },
         ],
       ]),
+      total: 2,
     })
     mocks.findManyByIds.mockResolvedValueOnce([
       {
@@ -137,7 +189,6 @@ describe("sequenceService.listStepContactsPage", () => {
       sequenceId: "seq-1",
       stepId: "step-1",
       eventType: "message:sent",
-      total: 2,
       page: 1,
       perPage: 20,
     })
@@ -160,7 +211,7 @@ describe("sequenceService.listStepContactsPage", () => {
     })
   })
 
-  test("drops a recipient whose contact-inbox no longer resolves, leaving pageCount driven by the caller-supplied total", async () => {
+  test("drops a recipient whose contact-inbox no longer resolves, leaving pageCount driven by the repository total", async () => {
     mocks.getContacts.mockResolvedValueOnce({
       contactInboxIds: ["ci-1", "ci-gone"],
       contactEventMap: new Map([
@@ -181,6 +232,7 @@ describe("sequenceService.listStepContactsPage", () => {
           },
         ],
       ]),
+      total: 2,
     })
     // `getContacts` scopes by the sequence's workspace while `findManyByIds`
     // scopes by `Contact.workspaceId`, so a contact deleted or moved out of
@@ -207,13 +259,12 @@ describe("sequenceService.listStepContactsPage", () => {
       sequenceId: "seq-1",
       stepId: "step-1",
       eventType: "message:sent",
-      total: 2,
       page: 1,
       perPage: 20,
     })
 
     // Unresolvable rows are dropped rather than emitted as nulls, and
-    // `pageCount` stays anchored to the caller-supplied total — so
+    // `pageCount` stays anchored to the repository-computed total — so
     // `data.length` can be shorter than the total implies.
     expect(result.data).toHaveLength(1)
     expect(result.total).toBe(2)
@@ -238,6 +289,7 @@ describe("sequenceService.listStepContactsPage", () => {
           },
         ],
       ]),
+      total: 1,
     })
     mocks.findManyByIds.mockResolvedValueOnce([
       {
@@ -260,7 +312,6 @@ describe("sequenceService.listStepContactsPage", () => {
       sequenceId: "seq-1",
       stepId: "step-1",
       eventType: "message:sent",
-      total: 1,
       page: 1,
       perPage: 20,
     })

--- a/packages/business/src/broadcast/service.ts
+++ b/packages/business/src/broadcast/service.ts
@@ -1276,7 +1276,7 @@ class BroadcastService extends BaseService {
       },
     })
     if (!source) {
-      throw new ChatbotXException("Broadcast not found")
+      throw notFoundException("Broadcast not found")
     }
 
     const name = await this.resolveCloneBroadcastName({

--- a/packages/business/src/email-topic/service.ts
+++ b/packages/business/src/email-topic/service.ts
@@ -3,6 +3,7 @@ import {
   type DatabaseClient,
   db,
   eq,
+  findOrFail,
   inArray,
   relationsFilterToSQL,
 } from "@chatbotx.io/database/client"
@@ -15,7 +16,7 @@ import {
   parsePagination,
 } from "@chatbotx.io/database/utils"
 import { createId } from "@chatbotx.io/utils"
-import { ChatbotXException } from "../errors"
+import { ChatbotXException, notFoundException } from "../errors"
 import { folderService } from "../folder/service"
 import type { PaginatedResult } from "../types"
 
@@ -51,6 +52,20 @@ class EmailTopicService {
     return row?.workspaceId
   }
 
+  async findOrFail(props: {
+    workspaceId: string
+    id: string
+    tx?: DatabaseClient
+  }): Promise<EmailTopicModel> {
+    const { workspaceId, id, tx = db } = props
+    return await findOrFail({
+      client: tx,
+      table: emailTopicModel,
+      where: { id, workspaceId },
+      message: "Email topic not found",
+    })
+  }
+
   async list(
     input: ListEmailTopicsInput,
   ): Promise<PaginatedResult<EmailTopicModel>> {
@@ -65,7 +80,13 @@ class EmailTopicService {
       name: input.name ? { ilike: likeContains(input.name) } : undefined,
     }
 
-    const orderBy = parseOrderByAsObject(emailTopicModel, input)
+    const requestedOrderBy = parseOrderByAsObject(emailTopicModel, input)
+    // Falls back to a deterministic order when no sort was requested (the
+    // public `GET /v1/email-topics` sends none), so paging cannot go unstable.
+    const orderBy =
+      Object.keys(requestedOrderBy).length > 0
+        ? requestedOrderBy
+        : { createdAt: "desc" as const }
     const pagination = parsePagination(input)
 
     const [data, total] = await Promise.all([
@@ -143,6 +164,9 @@ class EmailTopicService {
       )
       .returning()
 
+    if (!updated) {
+      throw notFoundException("Email topic not found")
+    }
     return updated
   }
 
@@ -150,10 +174,10 @@ class EmailTopicService {
     workspaceId: string
     ids: string[]
     tx?: DatabaseClient
-  }): Promise<void> {
+  }): Promise<{ deletedCount: number }> {
     const { workspaceId, ids, tx = db } = props
 
-    await tx
+    const deleted = await tx
       .delete(emailTopicModel)
       .where(
         and(
@@ -161,6 +185,9 @@ class EmailTopicService {
           inArray(emailTopicModel.id, ids),
         ),
       )
+      .returning({ id: emailTopicModel.id })
+
+    return { deletedCount: deleted.length }
   }
 }
 

--- a/packages/business/src/email-topic/service.ts
+++ b/packages/business/src/email-topic/service.ts
@@ -145,6 +145,8 @@ class EmailTopicService {
   }): Promise<EmailTopicModel> {
     const { workspaceId, id, data, tx = db } = props
 
+    await this.findOrFail({ workspaceId, id, tx })
+
     const existing = await tx.query.emailTopicModel.findFirst({
       columns: { id: true },
       where: { name: data.name, workspaceId, id: { ne: id } },

--- a/packages/business/src/media-library-file/service.ts
+++ b/packages/business/src/media-library-file/service.ts
@@ -3,10 +3,6 @@ import { BaseService } from "../base.service"
 import { resolveTenantSettings } from "../platform/settings"
 import { getPublicFileUrl } from "../utils"
 
-// Mirrored in
-// apps/builder/src/features/media-library/constants.ts because
-// @chatbotx.io/business is backend-only and must not be imported from a
-// "use client" component. Keep both values in sync.
 export const MEDIA_LIBRARY_FILES_PAGE_SIZE = 60
 
 export type ListMediaLibraryFilesInput = {

--- a/packages/business/src/sequence/service.ts
+++ b/packages/business/src/sequence/service.ts
@@ -218,11 +218,10 @@ class SequenceService extends BaseService {
    * foreign or non-existent `sequenceId` therefore yields an empty page
    * rather than another workspace's rows — it just does not 404.
    *
-   * `total` is caller-supplied rather than repository-computed: unlike
-   * broadcasts, `sequenceStatsRepository.getContacts` has no count query
-   * today, so trusting the client-reported total here preserves existing
-   * behaviour. Adding a server-computed count is a real analytics change
-   * and belongs in its own PR — don't "fix" this without one.
+   * `total` is optional: the builder passes the total it already fetched
+   * with the step stats, but an API caller has none, so when omitted this
+   * derives it from the same stats source (`sequenceAnalyticsService
+   * .getStepStats`) rather than reporting `pageCount: 0`.
    *
    * @remarks Behavior change from the pre-refactor per-handler
    * implementation: a contact-inbox row with no conversation used to be
@@ -240,7 +239,7 @@ class SequenceService extends BaseService {
     sequenceId: string
     stepId: string
     eventType: SequenceStepEventType
-    total: number
+    total?: number
     page: number
     perPage: number
   }): Promise<{
@@ -249,7 +248,30 @@ class SequenceService extends BaseService {
     pageCount: number
   }> {
     const { workspaceId, sequenceId, stepId, eventType, page, perPage } = input
-    const total = input.total || 0
+    // The builder passes the total it already fetched with the step stats;
+    // an API caller has no such value, so derive it from the same stats
+    // source rather than reporting pageCount 0. `??` (not `||`): a step
+    // that legitimately has zero recipients for this event must keep its
+    // real `total: 0` rather than triggering an unnecessary re-fetch.
+    //
+    // `stats[eventType]` doesn't type-check directly: `SequenceStepEventType`
+    // is the union of `messageEventTypeSchema`/`flowEventTypeSchema` (7
+    // values, including `message:received`/`flow:ref`), a wider set than
+    // `getSequenceStepStatsResponse`'s five keys — so a plain index is an
+    // implicit-any error, and an event type outside those five keys is a
+    // real `undefined` at runtime, not just a type-checker gap. `?? 0`
+    // covers that case rather than propagating `NaN` into `pageCount` and
+    // failing this route's own `total: z.number().int()` output schema.
+    const total =
+      input.total ??
+      (
+        (await sequenceAnalyticsService.getStepStats({
+          workspaceId,
+          sequenceId,
+          stepId,
+        })) as Partial<Record<SequenceStepEventType, number>>
+      )[eventType] ??
+      0
     const pageCount = Math.ceil(total / perPage)
 
     const { contactInboxIds, contactEventMap } =

--- a/packages/business/src/sequence/service.ts
+++ b/packages/business/src/sequence/service.ts
@@ -218,10 +218,10 @@ class SequenceService extends BaseService {
    * foreign or non-existent `sequenceId` therefore yields an empty page
    * rather than another workspace's rows — it just does not 404.
    *
-   * `total` is optional: the builder passes the total it already fetched
-   * with the step stats, but an API caller has none, so when omitted this
-   * derives it from the same stats source (`sequenceAnalyticsService
-   * .getStepStats`) rather than reporting `pageCount: 0`.
+   * `total` is repository-computed over the same filter as the page
+   * (`sequenceStatsRepository.getContacts`), matching
+   * `broadcastService.listContactsPage` — no caller-supplied `total`, no
+   * fallback to a different aggregate.
    *
    * @remarks Behavior change from the pre-refactor per-handler
    * implementation: a contact-inbox row with no conversation used to be
@@ -239,7 +239,6 @@ class SequenceService extends BaseService {
     sequenceId: string
     stepId: string
     eventType: SequenceStepEventType
-    total?: number
     page: number
     perPage: number
   }): Promise<{
@@ -248,33 +247,8 @@ class SequenceService extends BaseService {
     pageCount: number
   }> {
     const { workspaceId, sequenceId, stepId, eventType, page, perPage } = input
-    // The builder passes the total it already fetched with the step stats;
-    // an API caller has no such value, so derive it from the same stats
-    // source rather than reporting pageCount 0. `??` (not `||`): a step
-    // that legitimately has zero recipients for this event must keep its
-    // real `total: 0` rather than triggering an unnecessary re-fetch.
-    //
-    // `stats[eventType]` doesn't type-check directly: `SequenceStepEventType`
-    // is the union of `messageEventTypeSchema`/`flowEventTypeSchema` (7
-    // values, including `message:received`/`flow:ref`), a wider set than
-    // `getSequenceStepStatsResponse`'s five keys — so a plain index is an
-    // implicit-any error, and an event type outside those five keys is a
-    // real `undefined` at runtime, not just a type-checker gap. `?? 0`
-    // covers that case rather than propagating `NaN` into `pageCount` and
-    // failing this route's own `total: z.number().int()` output schema.
-    const total =
-      input.total ??
-      (
-        (await sequenceAnalyticsService.getStepStats({
-          workspaceId,
-          sequenceId,
-          stepId,
-        })) as Partial<Record<SequenceStepEventType, number>>
-      )[eventType] ??
-      0
-    const pageCount = Math.ceil(total / perPage)
 
-    const { contactInboxIds, contactEventMap } =
+    const { contactInboxIds, contactEventMap, total } =
       await sequenceAnalyticsService.getContacts({
         workspaceId,
         sequenceId,
@@ -283,6 +257,7 @@ class SequenceService extends BaseService {
         page,
         perPage,
       })
+    const pageCount = Math.ceil(total / perPage)
 
     if (contactInboxIds.length === 0) {
       return { data: [], total, pageCount }

--- a/packages/database/src/partials/broadcast.ts
+++ b/packages/database/src/partials/broadcast.ts
@@ -1,5 +1,22 @@
+import type { BroadcastSubaction } from "@chatbotx.io/utils/broadcast"
 import { z } from "zod"
 import type { ChannelType } from "./channel"
+
+/**
+ * `broadcastFlowTypes`/`broadcastSubactions`/`isTemplateBroadcastSubaction` are
+ * defined in `@chatbotx.io/utils/broadcast` so a "use client" component can use
+ * them without depending on the database layer. Re-exported here because this
+ * has long been the import site for the rest of the repo; both paths resolve
+ * to the same values. Mirrors the `channelTypes` precedent.
+ */
+export {
+  type BroadcastFlowType,
+  type BroadcastSubaction,
+  broadcastFlowTypes,
+  broadcastSubactions,
+  isTemplateBroadcastSubaction,
+  templateBroadcastSubactions,
+} from "@chatbotx.io/utils/broadcast"
 
 export const broadcastScheduleTypes = z.enum(["now", "future"])
 export type BroadcastScheduleType = z.infer<typeof broadcastScheduleTypes>
@@ -41,18 +58,6 @@ export const isBroadcastOutcomeGraceElapsed = (input: {
   input.now.getTime() - input.handoffCompletedAt.getTime() >=
   BROADCAST_OUTCOME_GRACE_MS
 
-export const broadcastSubactions = z.enum([
-  "allContacts",
-  "messengerActiveContacts",
-  "messengerTemplateMessage",
-  "whatsappTemplateMessage",
-  "whatsappWithin24Hours",
-  "instagramActiveContacts",
-  "telegramAllContacts",
-  "tiktokActiveContacts",
-])
-export type BroadcastSubaction = z.infer<typeof broadcastSubactions>
-
 type BroadcastAudienceRule = {
   requiresRecentInteractionWindow: boolean
 }
@@ -77,17 +82,6 @@ export const requiresRecentInteractionWindow = (
   subaction
     ? broadcastSubactionAudienceRules[subaction].requiresRecentInteractionWindow
     : false
-
-/** The subactions that deliver a template (one template per page in a multi-page broadcast). */
-export const templateBroadcastSubactions: readonly BroadcastSubaction[] = [
-  "messengerTemplateMessage",
-  "whatsappTemplateMessage",
-]
-
-export const isTemplateBroadcastSubaction = (
-  subaction: BroadcastSubaction | null | undefined,
-): boolean =>
-  subaction ? templateBroadcastSubactions.includes(subaction) : false
 
 export type BroadcastChannelCapability = {
   channel: ChannelType
@@ -150,9 +144,6 @@ export const findBroadcastChannelCapability = (
   broadcastChannelCapabilities.find(
     (capability) => capability.channel === channel,
   )
-
-export const broadcastFlowTypes = z.enum(["flow", "template"])
-export type BroadcastFlowType = z.infer<typeof broadcastFlowTypes>
 
 /**
  * Relation shape shared by every reader that shows which pages a broadcast

--- a/packages/database/src/partials/conversation.ts
+++ b/packages/database/src/partials/conversation.ts
@@ -1,5 +1,17 @@
 import z from "zod"
 
+/**
+ * `inboxStatuses` is defined in `@chatbotx.io/utils/conversation` so a
+ * "use client" component (e.g. the broadcast inbox picker) can use it without
+ * depending on the database layer. Re-exported here because this has long
+ * been the import site for the rest of the repo; both paths resolve to the
+ * same enum. Mirrors the `channelTypes` precedent.
+ */
+export {
+  type InboxStatus,
+  inboxStatuses,
+} from "@chatbotx.io/utils/conversation"
+
 export const conversationBotCategories = z.enum(["bot", "human", "all"])
 export type ConversationBotCategory = z.infer<typeof conversationBotCategories>
 
@@ -15,9 +27,6 @@ export type ConversationStatus = z.infer<typeof conversationStatuses>
 export const assignerFilterTypes = z.enum(["all", "unassigned"])
 export type AssignerFilterType =
   (typeof assignerFilterTypes)[keyof typeof assignerFilterTypes]
-
-export const inboxStatuses = z.enum(["connected", "disconnected"])
-export type InboxStatus = z.infer<typeof inboxStatuses>
 
 export const inboxDisconnectReasons = z.enum([
   "manual",

--- a/packages/database/src/partials/custom-field.ts
+++ b/packages/database/src/partials/custom-field.ts
@@ -10,28 +10,9 @@ import z from "zod"
 export {
   type CustomFieldType,
   customFieldTypes,
+  type OperatorType,
+  operatorTypes,
 } from "@chatbotx.io/utils/custom-field"
-
-export const operatorTypes = z.enum([
-  "in",
-  "notIn",
-  "isEmpty",
-  "isNotEmpty",
-  "eq",
-  "ne",
-  "startsWith",
-  "endsWith",
-  "contains",
-  "notContains",
-  "lt",
-  "lte",
-  "gt",
-  "gte",
-  "isBetween",
-  "notBetween",
-  "used",
-])
-export type OperatorType = z.infer<typeof operatorTypes>
 
 export const formFieldTypes = z.enum([
   "multiSelect",

--- a/packages/database/src/queries/contact-filter/value-format.ts
+++ b/packages/database/src/queries/contact-filter/value-format.ts
@@ -1,29 +1,13 @@
-import { datePartOf, isRealCalendarDate } from "@chatbotx.io/utils/datetime"
-
-export const NUMERIC_VALUE_PATTERN = /^-?\d+(\.\d+)?$/
-
-export const DATETIME_VALUE_PATTERN =
-  "^\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])([T ]([01]\\d|2[0-3]):[0-5]\\d(:[0-5]\\d(\\.\\d{1,6})?)?(Z|[+-]([01]\\d|2[0-3]):?[0-5]\\d)?)?$"
-
-const DATETIME_VALUE_RE = new RegExp(DATETIME_VALUE_PATTERN)
-
-// The regex accepts day 01-31 for every month, so "2026-02-30" slips through and
-// Date.parse leniently rolls it to March — but the ::timestamptz cast this feeds
-// is strict and throws. Reject non-real calendar dates before they reach SQL.
-export const isValidDateTimeFilterValue = (value: string): boolean =>
-  DATETIME_VALUE_RE.test(value) &&
-  isRealCalendarDate(datePartOf(value)) &&
-  !Number.isNaN(Date.parse(value))
-
-export const valueContainsVariablePlaceholder = (value: unknown): boolean => {
-  if (value === null || value === undefined) {
-    return false
-  }
-  if (typeof value === "string") {
-    return value.includes("{{")
-  }
-  if (Array.isArray(value)) {
-    return value.some(valueContainsVariablePlaceholder)
-  }
-  return false
-}
+/**
+ * These are defined in `@chatbotx.io/utils/contact-filter-value-format` so a
+ * "use client" component (e.g. the contact-filter condition dialog) can use
+ * them without depending on the database package. Re-exported here because
+ * this has long been the import site for the rest of the repo; both paths
+ * resolve to the same values. Mirrors the `channelTypes` precedent.
+ */
+export {
+  DATETIME_VALUE_PATTERN,
+  isValidDateTimeFilterValue,
+  NUMERIC_VALUE_PATTERN,
+  valueContainsVariablePlaceholder,
+} from "@chatbotx.io/utils/contact-filter-value-format"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,7 +18,10 @@
   },
   "exports": {
     ".": "./src/index.ts",
+    "./broadcast": "./src/broadcast.ts",
     "./channel": "./src/channel.ts",
+    "./contact-filter-value-format": "./src/contact-filter-value-format.ts",
+    "./conversation": "./src/conversation.ts",
     "./crypto": "./src/crypto.ts",
     "./custom-field": "./src/custom-field.ts",
     "./datetime": "./src/datetime.ts",

--- a/packages/utils/src/broadcast.ts
+++ b/packages/utils/src/broadcast.ts
@@ -1,0 +1,34 @@
+import { z } from "zod"
+
+/**
+ * Lives here (not `@chatbotx.io/database`) so a "use client" component (e.g.
+ * the broadcast flow-type selector) can read the enum without pulling in the
+ * database package. `@chatbotx.io/database/partials` re-exports this for
+ * existing backend importers. Mirrors the `channelTypes` precedent in
+ * `./channel.ts`.
+ */
+export const broadcastFlowTypes = z.enum(["flow", "template"])
+export type BroadcastFlowType = z.infer<typeof broadcastFlowTypes>
+
+export const broadcastSubactions = z.enum([
+  "allContacts",
+  "messengerActiveContacts",
+  "messengerTemplateMessage",
+  "whatsappTemplateMessage",
+  "whatsappWithin24Hours",
+  "instagramActiveContacts",
+  "telegramAllContacts",
+  "tiktokActiveContacts",
+])
+export type BroadcastSubaction = z.infer<typeof broadcastSubactions>
+
+/** The subactions that deliver a template (one template per page in a multi-page broadcast). */
+export const templateBroadcastSubactions: readonly BroadcastSubaction[] = [
+  "messengerTemplateMessage",
+  "whatsappTemplateMessage",
+]
+
+export const isTemplateBroadcastSubaction = (
+  subaction: BroadcastSubaction | null | undefined,
+): boolean =>
+  subaction ? templateBroadcastSubactions.includes(subaction) : false

--- a/packages/utils/src/contact-filter-value-format.ts
+++ b/packages/utils/src/contact-filter-value-format.ts
@@ -1,0 +1,36 @@
+import { datePartOf, isRealCalendarDate } from "./datetime"
+
+/**
+ * Lives here (not `@chatbotx.io/database`) so a "use client" component (e.g.
+ * the contact-filter condition dialog) can validate a filter value without
+ * depending on the database's query layer. `@chatbotx.io/database`'s
+ * contact-filter query module re-exports this for existing backend
+ * importers. Mirrors the `channelTypes` precedent in `./channel.ts`.
+ */
+export const NUMERIC_VALUE_PATTERN = /^-?\d+(\.\d+)?$/
+
+export const DATETIME_VALUE_PATTERN =
+  "^\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])([T ]([01]\\d|2[0-3]):[0-5]\\d(:[0-5]\\d(\\.\\d{1,6})?)?(Z|[+-]([01]\\d|2[0-3]):?[0-5]\\d)?)?$"
+
+const DATETIME_VALUE_RE = new RegExp(DATETIME_VALUE_PATTERN)
+
+// The regex accepts day 01-31 for every month, so "2026-02-30" slips through and
+// Date.parse leniently rolls it to March — but the ::timestamptz cast this feeds
+// is strict and throws. Reject non-real calendar dates before they reach SQL.
+export const isValidDateTimeFilterValue = (value: string): boolean =>
+  DATETIME_VALUE_RE.test(value) &&
+  isRealCalendarDate(datePartOf(value)) &&
+  !Number.isNaN(Date.parse(value))
+
+export const valueContainsVariablePlaceholder = (value: unknown): boolean => {
+  if (value === null || value === undefined) {
+    return false
+  }
+  if (typeof value === "string") {
+    return value.includes("{{")
+  }
+  if (Array.isArray(value)) {
+    return value.some(valueContainsVariablePlaceholder)
+  }
+  return false
+}

--- a/packages/utils/src/conversation.ts
+++ b/packages/utils/src/conversation.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+/**
+ * Lives here (not `@chatbotx.io/database`) so a "use client" component (e.g.
+ * the broadcast inbox picker) can read the enum without pulling in the
+ * database package. `@chatbotx.io/database/partials` re-exports this for
+ * existing backend importers. Mirrors the `channelTypes` precedent in
+ * `./channel.ts`.
+ */
+export const inboxStatuses = z.enum(["connected", "disconnected"])
+export type InboxStatus = z.infer<typeof inboxStatuses>

--- a/packages/utils/src/custom-field.ts
+++ b/packages/utils/src/custom-field.ts
@@ -22,6 +22,34 @@ export const customFieldTypes = z.enum([
 export type CustomFieldType = z.infer<typeof customFieldTypes>
 
 /**
+ * Contact-filter comparison operators. Lives here (not `@chatbotx.io/database`)
+ * so a "use client" component (e.g. the filter condition dialog) can read the
+ * enum without pulling in the database package. `@chatbotx.io/database/partials`
+ * re-exports this for existing backend importers. Mirrors the `channelTypes`
+ * precedent in `./channel.ts`.
+ */
+export const operatorTypes = z.enum([
+  "in",
+  "notIn",
+  "isEmpty",
+  "isNotEmpty",
+  "eq",
+  "ne",
+  "startsWith",
+  "endsWith",
+  "contains",
+  "notContains",
+  "lt",
+  "lte",
+  "gt",
+  "gte",
+  "isBetween",
+  "notBetween",
+  "used",
+])
+export type OperatorType = z.infer<typeof operatorTypes>
+
+/**
  * Canonical `(type, name)` identity used to match a flow export's custom-field
  * manifest against the target workspace's existing fields.
  *


### PR DESCRIPTION
Adds workspace-token-scoped public CRUD endpoints (create/list/update/delete) for email topics under the existing `broadcasts` scope. Each handler delegates to the same `packages/business` service method the private UI action already calls; no business logic was duplicated to publish these.

One of six PRs splitting a larger workspace-api-token public-API changeset by `workspaceApiTokenScope` (contacts, media, channels, minigames, broadcasts, automation).