### PR TITLE
feat(api): activate the minigames public API scope

### DIFF
--- a/apps/builder/__tests__/__snapshots__/public-spec-operations.test.ts.snap
+++ b/apps/builder/__tests__/__snapshots__/public-spec-operations.test.ts.snap
@@ -1319,6 +1319,41 @@ exports[`public API spec — operation naming guard > operation list (operationI
   },
   {
     "method": "POST",
+    "operationId": "minigames.create",
+    "path": "/v1/minigames",
+  },
+  {
+    "method": "DELETE",
+    "operationId": "minigames.delete",
+    "path": "/v1/minigames/{id}",
+  },
+  {
+    "method": "GET",
+    "operationId": "minigames.get",
+    "path": "/v1/minigames/{id}",
+  },
+  {
+    "method": "GET",
+    "operationId": "minigames.list",
+    "path": "/v1/minigames",
+  },
+  {
+    "method": "GET",
+    "operationId": "minigames.listPlays",
+    "path": "/v1/minigames/{id}/plays",
+  },
+  {
+    "method": "PATCH",
+    "operationId": "minigames.setEnabled",
+    "path": "/v1/minigames/{id}/enabled",
+  },
+  {
+    "method": "PUT",
+    "operationId": "minigames.update",
+    "path": "/v1/minigames/{id}",
+  },
+  {
+    "method": "POST",
     "operationId": "productCategories.create",
     "path": "/v1/product-categories",
   },

--- a/apps/builder/__tests__/__snapshots__/public-spec-operations.test.ts.snap
+++ b/apps/builder/__tests__/__snapshots__/public-spec-operations.test.ts.snap
@@ -1339,6 +1339,11 @@ exports[`public API spec — operation naming guard > operation list (operationI
   },
   {
     "method": "GET",
+    "operationId": "minigames.listPlayers",
+    "path": "/v1/minigames/{id}/players",
+  },
+  {
+    "method": "GET",
     "operationId": "minigames.listPlays",
     "path": "/v1/minigames/{id}/plays",
   },

--- a/apps/builder/__tests__/__snapshots__/public-spec-operations.test.ts.snap
+++ b/apps/builder/__tests__/__snapshots__/public-spec-operations.test.ts.snap
@@ -1328,6 +1328,11 @@ exports[`public API spec — operation naming guard > operation list (operationI
     "path": "/v1/minigames/{id}",
   },
   {
+    "method": "POST",
+    "operationId": "minigames.deleteMany",
+    "path": "/v1/minigames/bulk-delete",
+  },
+  {
     "method": "GET",
     "operationId": "minigames.get",
     "path": "/v1/minigames/{id}",
@@ -1346,6 +1351,11 @@ exports[`public API spec — operation naming guard > operation list (operationI
     "method": "GET",
     "operationId": "minigames.listPlays",
     "path": "/v1/minigames/{id}/plays",
+  },
+  {
+    "method": "PATCH",
+    "operationId": "minigames.patch",
+    "path": "/v1/minigames/{id}",
   },
   {
     "method": "PATCH",

--- a/apps/builder/__tests__/minigame-name-conflict-action.test.ts
+++ b/apps/builder/__tests__/minigame-name-conflict-action.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment node
+import { ChatbotXException } from "@chatbotx.io/business/errors"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const mockCreate = vi.fn()
+const mockUpdate = vi.fn()
+const mockReturnValidationErrors = vi.fn(
+  (_schema: unknown, errors: unknown) => ({ validationErrors: errors }),
+)
+
+vi.mock("@chatbotx.io/business/minigame", () => ({
+  minigameService: {
+    create: (...args: unknown[]) => mockCreate(...args),
+    update: (...args: unknown[]) => mockUpdate(...args),
+  },
+}))
+
+vi.mock("@/features/common/schema", () => ({
+  workspaceIdrequestParams: [],
+}))
+
+vi.mock("@/lib/safe-action", () => ({
+  workspaceActionClient: {
+    bindArgsSchemas: () => ({
+      inputSchema: () => ({ action: (fn: unknown) => fn }),
+    }),
+  },
+}))
+
+vi.mock("next-safe-action", () => ({
+  returnValidationErrors: (schema: unknown, errors: unknown) =>
+    mockReturnValidationErrors(schema, errors),
+}))
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: vi.fn(async () => (key: string) => key),
+}))
+
+vi.mock("../src/features/minigames/schema/action", () => ({
+  createMinigameRequest: {},
+  updateMinigameRequest: {},
+}))
+
+const { createMinigameAction: createMinigameActionUntyped } = await import(
+  "../src/features/minigames/actions/create-minigame.action"
+)
+const { updateMinigameAction: updateMinigameActionUntyped } = await import(
+  "../src/features/minigames/actions/update-minigame.action"
+)
+const createMinigameAction = createMinigameActionUntyped as unknown as (
+  props: unknown,
+) => Promise<unknown>
+const updateMinigameAction = updateMinigameActionUntyped as unknown as (
+  props: unknown,
+) => Promise<unknown>
+
+const minigameInput = {
+  type: "jackpot",
+  generalSettings: { name: "Prize game" },
+  appearance: {},
+  playerSettings: {},
+  prizeSettings: { prizes: [] },
+  winningMessageSettings: {},
+  nonWinningMessageSettings: {},
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("createMinigameAction — name conflict mapping", () => {
+  test("maps a nameAlreadyExists ChatbotXException to an inline form validation error, not a thrown 500", async () => {
+    mockCreate.mockRejectedValueOnce(
+      new ChatbotXException(
+        "Minigame name already exists",
+        "nameAlreadyExists",
+        409,
+      ),
+    )
+
+    const result = await createMinigameAction({
+      bindArgsParsedInputs: ["ws-1"],
+      parsedInput: minigameInput,
+    })
+
+    expect(mockReturnValidationErrors).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        generalSettings: expect.objectContaining({
+          name: expect.objectContaining({
+            _errors: expect.any(Array),
+          }),
+        }),
+      }),
+    )
+    expect(result).toEqual({
+      validationErrors: expect.objectContaining({
+        generalSettings: expect.anything(),
+      }),
+    })
+  })
+
+  test("rethrows an unrelated error instead of swallowing it", async () => {
+    mockCreate.mockRejectedValueOnce(new Error("boom"))
+
+    await expect(
+      createMinigameAction({
+        bindArgsParsedInputs: ["ws-1"],
+        parsedInput: minigameInput,
+      }),
+    ).rejects.toThrow("boom")
+
+    expect(mockReturnValidationErrors).not.toHaveBeenCalled()
+  })
+})
+
+describe("updateMinigameAction — name conflict mapping", () => {
+  test("maps a nameAlreadyExists ChatbotXException to an inline form validation error, not a thrown 500", async () => {
+    mockUpdate.mockRejectedValueOnce(
+      new ChatbotXException(
+        "Minigame name already exists",
+        "nameAlreadyExists",
+        409,
+      ),
+    )
+
+    await updateMinigameAction({
+      bindArgsParsedInputs: ["ws-1", "minigame-1", {}],
+      parsedInput: minigameInput,
+    })
+
+    expect(mockReturnValidationErrors).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        generalSettings: expect.objectContaining({
+          name: expect.objectContaining({
+            _errors: expect.any(Array),
+          }),
+        }),
+      }),
+    )
+  })
+
+  test("rethrows an unrelated error instead of swallowing it", async () => {
+    mockUpdate.mockRejectedValueOnce(new Error("boom"))
+
+    await expect(
+      updateMinigameAction({
+        bindArgsParsedInputs: ["ws-1", "minigame-1", {}],
+        parsedInput: minigameInput,
+      }),
+    ).rejects.toThrow("boom")
+
+    expect(mockReturnValidationErrors).not.toHaveBeenCalled()
+  })
+})

--- a/apps/builder/__tests__/minigames-public-api.test.ts
+++ b/apps/builder/__tests__/minigames-public-api.test.ts
@@ -57,7 +57,9 @@ const minigameService = {
   find: vi.fn(),
   create: vi.fn(),
   update: vi.fn(),
+  updatePartial: vi.fn(),
   delete: vi.fn(),
+  deleteMany: vi.fn(),
   setEnabled: vi.fn(),
 }
 const minigameContactService = { listPlays: vi.fn(), list: vi.fn() }
@@ -80,8 +82,13 @@ vi.mock("@/features/minigames/schema/public", () => ({
   listMinigamesPublicRequest: z.object({}),
   listMinigamesPublicResponse: z.object({}),
   minigamePublicResource: z.object({}),
+  patchMinigamePublicRequest: z.object({}),
   setMinigameEnabledPublicRequest: z.object({}),
   updateMinigamePublicRequest: z.object({}),
+}))
+
+vi.mock("@/features/common/schema", () => ({
+  bulkUpdateIdsRequest: z.object({}),
 }))
 
 vi.mock("@/lib/orpc/orpc-error-helper", () => ({
@@ -217,6 +224,28 @@ describe("PUT /v1/minigames/{id}", () => {
   })
 })
 
+describe("PATCH /v1/minigames/{id}", () => {
+  const procedure = findProcedure("PATCH", "/v1/minigames/{id}")
+
+  test("partially updates a minigame, forwarding only the submitted fields", async () => {
+    const minigame = { id: "game-1" }
+    minigameService.updatePartial.mockResolvedValueOnce(minigame)
+
+    await expect(
+      procedure.handler?.({
+        context,
+        input: { id: "game-1", generalSettings: { name: "Renamed" } },
+      }),
+    ).resolves.toEqual(minigame)
+
+    expect(minigameService.updatePartial).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      id: "game-1",
+      generalSettings: { name: "Renamed" },
+    })
+  })
+})
+
 describe("DELETE /v1/minigames/{id}", () => {
   const procedure = findProcedure("DELETE", "/v1/minigames/{id}")
 
@@ -241,6 +270,26 @@ describe("DELETE /v1/minigames/{id}", () => {
     await expect(
       procedure.handler?.({ context, input: { id: "missing" } }),
     ).rejects.toThrow("Minigame not found")
+  })
+})
+
+describe("POST /v1/minigames/bulk-delete", () => {
+  const procedure = findProcedure("POST", "/v1/minigames/bulk-delete")
+
+  test("deletes multiple minigames in the authenticated workspace", async () => {
+    minigameService.deleteMany.mockResolvedValueOnce(undefined)
+
+    await expect(
+      procedure.handler?.({
+        context,
+        input: { ids: ["game-1", "game-2"] },
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(minigameService.deleteMany).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      ids: ["game-1", "game-2"],
+    })
   })
 })
 

--- a/apps/builder/__tests__/minigames-public-api.test.ts
+++ b/apps/builder/__tests__/minigames-public-api.test.ts
@@ -57,10 +57,10 @@ const minigameService = {
   find: vi.fn(),
   create: vi.fn(),
   update: vi.fn(),
-  deleteMany: vi.fn(),
+  delete: vi.fn(),
   setEnabled: vi.fn(),
 }
-const minigameContactService = { listPlays: vi.fn() }
+const minigameContactService = { listPlays: vi.fn(), list: vi.fn() }
 
 vi.mock("@chatbotx.io/business/minigame", () => ({
   minigameService,
@@ -73,6 +73,8 @@ vi.mock("@/features/minigames/schema/resource", () => ({
 
 vi.mock("@/features/minigames/schema/public", () => ({
   createMinigamePublicRequest: z.object({}),
+  listMinigamePlayersPublicRequest: z.object({}),
+  listMinigamePlayersPublicResponse: z.object({}),
   listMinigamePlaysPublicRequest: z.object({}),
   listMinigamePlaysPublicResponse: z.object({}),
   listMinigamesPublicRequest: z.object({}),
@@ -83,11 +85,11 @@ vi.mock("@/features/minigames/schema/public", () => ({
 }))
 
 vi.mock("@/lib/orpc/orpc-error-helper", () => ({
-  possibleErrorsOnCreatingResource: {},
+  possibleErrorsOnCreatingMinigame: {},
   possibleErrorsOnDeletingResource: {},
   possibleErrorsOnFindingResource: {},
   possibleErrorsOnListingResource: {},
-  possibleErrorsOnMutatingResource: {},
+  possibleErrorsOnMutatingMinigame: {},
 }))
 
 await import("@/features/minigames/api/public")
@@ -127,7 +129,7 @@ test("registers the minigames public router under the minigames scope", () => {
 describe("GET /v1/minigames", () => {
   const procedure = findProcedure("GET", "/v1/minigames")
 
-  test("lists minigames in the authenticated workspace", async () => {
+  test("lists minigames in the authenticated workspace, pinned to createdAt desc", async () => {
     const result = { data: [{ id: "game-1" }], pageCount: 2 }
     minigameService.list.mockResolvedValueOnce(result)
 
@@ -143,6 +145,7 @@ describe("GET /v1/minigames", () => {
       page: 1,
       perPage: 50,
       name: "Prize",
+      sort: [{ id: "createdAt", desc: true }],
     })
   })
 })
@@ -194,15 +197,14 @@ describe("POST /v1/minigames", () => {
 describe("PUT /v1/minigames/{id}", () => {
   const procedure = findProcedure("PUT", "/v1/minigames/{id}")
 
-  test("updates a minigame and preserves the submitted prize baseline", async () => {
+  test("updates a minigame, honoring submitted prize quantities verbatim", async () => {
     const minigame = { id: "game-1" }
-    const originalPrizeQuantities = { "prize-1": 4 }
     minigameService.update.mockResolvedValueOnce(minigame)
 
     await expect(
       procedure.handler?.({
         context,
-        input: { id: "game-1", ...minigameInput, originalPrizeQuantities },
+        input: { id: "game-1", ...minigameInput },
       }),
     ).resolves.toEqual(minigame)
 
@@ -210,7 +212,7 @@ describe("PUT /v1/minigames/{id}", () => {
       workspaceId: "workspace-1",
       id: "game-1",
       ...minigameInput,
-      originalPrizeQuantities,
+      originalPrizeQuantities: null,
     })
   })
 })
@@ -219,16 +221,26 @@ describe("DELETE /v1/minigames/{id}", () => {
   const procedure = findProcedure("DELETE", "/v1/minigames/{id}")
 
   test("deletes the selected minigame in the authenticated workspace", async () => {
-    minigameService.deleteMany.mockResolvedValueOnce(undefined)
+    minigameService.delete.mockResolvedValueOnce(undefined)
 
     await expect(
       procedure.handler?.({ context, input: { id: "game-1" } }),
     ).resolves.toBeUndefined()
 
-    expect(minigameService.deleteMany).toHaveBeenCalledWith({
+    expect(minigameService.delete).toHaveBeenCalledWith({
       workspaceId: "workspace-1",
-      ids: ["game-1"],
+      id: "game-1",
     })
+  })
+
+  test("rejects instead of silently succeeding when the minigame doesn't exist", async () => {
+    minigameService.delete.mockRejectedValueOnce(
+      new Error("Minigame not found"),
+    )
+
+    await expect(
+      procedure.handler?.({ context, input: { id: "missing" } }),
+    ).rejects.toThrow("Minigame not found")
   })
 })
 
@@ -271,6 +283,47 @@ describe("GET /v1/minigames/{id}/plays", () => {
       workspaceId: "workspace-1",
       minigameId: "game-1",
       contactId: "contact-1",
+    })
+  })
+})
+
+describe("GET /v1/minigames/{id}/players", () => {
+  const procedure = findProcedure("GET", "/v1/minigames/{id}/players")
+
+  test("lists players for the requested minigame", async () => {
+    const result = { data: [{ id: "player-1" }], pageCount: 3 }
+    minigameContactService.list.mockResolvedValueOnce(result)
+
+    await expect(
+      procedure.handler?.({
+        context,
+        input: { id: "game-1", page: 2, perPage: 10 },
+      }),
+    ).resolves.toEqual(result)
+
+    expect(minigameContactService.list).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      minigameId: "game-1",
+      page: 2,
+      perPage: 10,
+    })
+  })
+
+  test("forwards the optional name filter", async () => {
+    minigameContactService.list.mockResolvedValueOnce({
+      data: [],
+      pageCount: 0,
+    })
+
+    await procedure.handler?.({
+      context,
+      input: { id: "game-1", name: "Jane" },
+    })
+
+    expect(minigameContactService.list).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      minigameId: "game-1",
+      name: "Jane",
     })
   })
 })

--- a/apps/builder/__tests__/minigames-public-api.test.ts
+++ b/apps/builder/__tests__/minigames-public-api.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import { z } from "zod"
+
+type RouteConfig = {
+  method: string
+  path: string
+  summary: string
+  tags: string[]
+  successStatus?: number
+}
+
+type CapturedHandler = (args: {
+  context: { workspace: { id: string } }
+  input: unknown
+}) => Promise<unknown>
+
+type CapturedProcedure = {
+  route: RouteConfig
+  handler?: CapturedHandler
+}
+
+const { workspaceTokenAuthAPIForScope, capturedProcedures } = vi.hoisted(() => {
+  const capturedProcedures: CapturedProcedure[] = []
+
+  const makeProcedure = (route: RouteConfig) => {
+    const record: CapturedProcedure = { route }
+    capturedProcedures.push(record)
+
+    const chain = {
+      input: vi.fn(() => chain),
+      output: vi.fn(() => chain),
+      errors: vi.fn(() => chain),
+      handler: vi.fn((fn: CapturedHandler) => {
+        record.handler = fn
+        return { handler: fn }
+      }),
+    }
+    return chain
+  }
+
+  const workspaceTokenAuthAPI = {
+    route: vi.fn((config: RouteConfig) => makeProcedure(config)),
+  }
+
+  return {
+    workspaceTokenAuthAPIForScope: vi.fn(
+      (_scope: string) => workspaceTokenAuthAPI,
+    ),
+    capturedProcedures,
+  }
+})
+
+vi.mock("@/orpc", () => ({ workspaceTokenAuthAPIForScope }))
+
+const minigameService = {
+  list: vi.fn(),
+  find: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  deleteMany: vi.fn(),
+  setEnabled: vi.fn(),
+}
+const minigameContactService = { listPlays: vi.fn() }
+
+vi.mock("@chatbotx.io/business/minigame", () => ({
+  minigameService,
+  minigameContactService,
+}))
+
+vi.mock("@/features/minigames/schema/resource", () => ({
+  minigameResource: z.object({}),
+}))
+
+vi.mock("@/features/minigames/schema/public", () => ({
+  createMinigamePublicRequest: z.object({}),
+  listMinigamePlaysPublicRequest: z.object({}),
+  listMinigamePlaysPublicResponse: z.object({}),
+  listMinigamesPublicRequest: z.object({}),
+  listMinigamesPublicResponse: z.object({}),
+  minigamePublicResource: z.object({}),
+  setMinigameEnabledPublicRequest: z.object({}),
+  updateMinigamePublicRequest: z.object({}),
+}))
+
+vi.mock("@/lib/orpc/orpc-error-helper", () => ({
+  possibleErrorsOnCreatingResource: {},
+  possibleErrorsOnDeletingResource: {},
+  possibleErrorsOnFindingResource: {},
+  possibleErrorsOnListingResource: {},
+  possibleErrorsOnMutatingResource: {},
+}))
+
+await import("@/features/minigames/api/public")
+
+const findProcedure = (method: string, path: string) => {
+  const found = capturedProcedures.find(
+    (procedure) =>
+      procedure.route.method === method && procedure.route.path === path,
+  )
+  if (!found) {
+    throw new Error(`No procedure registered for ${method} ${path}`)
+  }
+  return found
+}
+
+const scopeArgAtImport = workspaceTokenAuthAPIForScope.mock.calls[0]?.[0]
+const context = { workspace: { id: "workspace-1" } }
+
+const minigameInput = {
+  type: "jackpot",
+  generalSettings: { name: "Prize game" },
+  appearance: {},
+  playerSettings: {},
+  prizeSettings: { prizes: [] },
+  winningMessageSettings: {},
+  nonWinningMessageSettings: {},
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+test("registers the minigames public router under the minigames scope", () => {
+  expect(scopeArgAtImport).toBe("minigames")
+})
+
+describe("GET /v1/minigames", () => {
+  const procedure = findProcedure("GET", "/v1/minigames")
+
+  test("lists minigames in the authenticated workspace", async () => {
+    const result = { data: [{ id: "game-1" }], pageCount: 2 }
+    minigameService.list.mockResolvedValueOnce(result)
+
+    await expect(
+      procedure.handler?.({
+        context,
+        input: { page: 1, perPage: 50, name: "Prize" },
+      }),
+    ).resolves.toEqual(result)
+
+    expect(minigameService.list).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      page: 1,
+      perPage: 50,
+      name: "Prize",
+    })
+  })
+})
+
+describe("GET /v1/minigames/{id}", () => {
+  const procedure = findProcedure("GET", "/v1/minigames/{id}")
+
+  test("gets a minigame scoped to the authenticated workspace", async () => {
+    const minigame = { id: "game-1" }
+    minigameService.find.mockResolvedValueOnce(minigame)
+
+    await expect(
+      procedure.handler?.({ context, input: { id: "game-1" } }),
+    ).resolves.toEqual(minigame)
+
+    expect(minigameService.find).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      id: "game-1",
+    })
+  })
+
+  test("propagates the service's declared not-found error", async () => {
+    minigameService.find.mockRejectedValueOnce(new Error("Minigame not found"))
+
+    await expect(
+      procedure.handler?.({ context, input: { id: "missing" } }),
+    ).rejects.toThrow("Minigame not found")
+  })
+})
+
+describe("POST /v1/minigames", () => {
+  const procedure = findProcedure("POST", "/v1/minigames")
+
+  test("creates a minigame in the authenticated workspace", async () => {
+    const minigame = { id: "game-1" }
+    minigameService.create.mockResolvedValueOnce(minigame)
+
+    await expect(
+      procedure.handler?.({ context, input: minigameInput }),
+    ).resolves.toEqual(minigame)
+
+    expect(minigameService.create).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      ...minigameInput,
+    })
+  })
+})
+
+describe("PUT /v1/minigames/{id}", () => {
+  const procedure = findProcedure("PUT", "/v1/minigames/{id}")
+
+  test("updates a minigame and preserves the submitted prize baseline", async () => {
+    const minigame = { id: "game-1" }
+    const originalPrizeQuantities = { "prize-1": 4 }
+    minigameService.update.mockResolvedValueOnce(minigame)
+
+    await expect(
+      procedure.handler?.({
+        context,
+        input: { id: "game-1", ...minigameInput, originalPrizeQuantities },
+      }),
+    ).resolves.toEqual(minigame)
+
+    expect(minigameService.update).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      id: "game-1",
+      ...minigameInput,
+      originalPrizeQuantities,
+    })
+  })
+})
+
+describe("DELETE /v1/minigames/{id}", () => {
+  const procedure = findProcedure("DELETE", "/v1/minigames/{id}")
+
+  test("deletes the selected minigame in the authenticated workspace", async () => {
+    minigameService.deleteMany.mockResolvedValueOnce(undefined)
+
+    await expect(
+      procedure.handler?.({ context, input: { id: "game-1" } }),
+    ).resolves.toBeUndefined()
+
+    expect(minigameService.deleteMany).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      ids: ["game-1"],
+    })
+  })
+})
+
+describe("PATCH /v1/minigames/{id}/enabled", () => {
+  const procedure = findProcedure("PATCH", "/v1/minigames/{id}/enabled")
+
+  test("sets the minigame enabled state in the authenticated workspace", async () => {
+    const minigame = { id: "game-1", enabled: false }
+    minigameService.setEnabled.mockResolvedValueOnce(minigame)
+
+    await expect(
+      procedure.handler?.({
+        context,
+        input: { id: "game-1", enabled: false },
+      }),
+    ).resolves.toEqual(minigame)
+
+    expect(minigameService.setEnabled).toHaveBeenCalledWith(
+      { workspaceId: "workspace-1", id: "game-1" },
+      false,
+    )
+  })
+})
+
+describe("GET /v1/minigames/{id}/plays", () => {
+  const procedure = findProcedure("GET", "/v1/minigames/{id}/plays")
+
+  test("lists play records for the requested contact", async () => {
+    const plays = [{ id: "play-1", isWinning: true }]
+    minigameContactService.listPlays.mockResolvedValueOnce(plays)
+
+    await expect(
+      procedure.handler?.({
+        context,
+        input: { id: "game-1", contactId: "contact-1" },
+      }),
+    ).resolves.toEqual({ data: plays })
+
+    expect(minigameContactService.listPlays).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      minigameId: "game-1",
+      contactId: "contact-1",
+    })
+  })
+})

--- a/apps/builder/__tests__/minigames-public-scope.test.ts
+++ b/apps/builder/__tests__/minigames-public-scope.test.ts
@@ -23,7 +23,16 @@ vi.mock("@chatbotx.io/business", () => ({
   quotaEnforcementService: { isAtLimit },
 }))
 
-const minigameService = { list: vi.fn() }
+const minigameService = {
+  list: vi.fn(),
+  find: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  updatePartial: vi.fn(),
+  delete: vi.fn(),
+  deleteMany: vi.fn(),
+  setEnabled: vi.fn(),
+}
 const minigameContactService = { listPlays: vi.fn(), list: vi.fn() }
 
 vi.mock("@chatbotx.io/business/minigame", () => ({
@@ -64,14 +73,10 @@ const authResult = (scopes: string[] | null) => ({
   apiToken: { id: "token-1", permission: "full" as const, scopes },
 })
 
-const invoke = (procedure: typeof minigamesPublicRouter.list) =>
-  call(
-    procedure,
-    {},
-    {
-      context: { headers: new Headers({ Authorization: `Bearer ${TOKEN}` }) },
-    },
-  )
+const invoke = (procedure: unknown, input: unknown = {}) =>
+  call(procedure as Parameters<typeof call>[0], input, {
+    context: { headers: new Headers({ Authorization: `Bearer ${TOKEN}` }) },
+  })
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -98,6 +103,161 @@ describe("real router: minigames public API scope wiring", () => {
     await expect(invoke(minigamesPublicRouter.list)).resolves.toMatchObject({
       data: [],
       pageCount: 1,
+    })
+  })
+
+  const minigameInput = {
+    type: "jackpot",
+    generalSettings: { name: "Prize game" },
+    appearance: {},
+    playerSettings: {},
+    prizeSettings: { prizes: [] },
+    winningMessageSettings: {},
+    nonWinningMessageSettings: {},
+  }
+
+  test.each([
+    [
+      "POST /v1/minigames",
+      () => invoke(minigamesPublicRouter.create, minigameInput),
+    ],
+    [
+      "PUT /v1/minigames/{id}",
+      () =>
+        invoke(minigamesPublicRouter.update, {
+          id: "game-1",
+          ...minigameInput,
+        }),
+    ],
+    [
+      "PATCH /v1/minigames/{id}",
+      () =>
+        invoke(minigamesPublicRouter.patch, {
+          id: "game-1",
+          generalSettings: { name: "Renamed" },
+        }),
+    ],
+    [
+      "DELETE /v1/minigames/{id}",
+      () => invoke(minigamesPublicRouter.delete, { id: "game-1" }),
+    ],
+    [
+      "POST /v1/minigames/bulk-delete",
+      () => invoke(minigamesPublicRouter.deleteMany, { ids: ["game-1"] }),
+    ],
+  ])("a read_only token is denied %s before any service call", async (_label, run) => {
+    findWorkspaceByTokenHash.mockResolvedValue({
+      workspace: { id: "ws-1", ownerId: "owner-1" },
+      apiToken: {
+        id: "token-1",
+        permission: "read_only" as const,
+        scopes: null,
+      },
+    })
+
+    await expect(run()).rejects.toMatchObject({ code: "FORBIDDEN" })
+
+    expect(minigameService.create).not.toHaveBeenCalled()
+    expect(minigameService.update).not.toHaveBeenCalled()
+    expect(minigameService.updatePartial).not.toHaveBeenCalled()
+    expect(minigameService.delete).not.toHaveBeenCalled()
+    expect(minigameService.deleteMany).not.toHaveBeenCalled()
+  })
+
+  // Cross-workspace isolation: `workspaceId` must always come from the
+  // authenticated token's `context.workspace.id`, never from client input —
+  // even when the client's `{id}` path param names a minigame in a
+  // different workspace.
+  describe("cross-workspace isolation: workspaceId always comes from the token", () => {
+    beforeEach(() => {
+      findWorkspaceByTokenHash.mockResolvedValue(
+        authResult(null) /* unrestricted scope, full permission */,
+      )
+    })
+
+    test("patch scopes updatePartial to the token's workspace, not any workspace implied by the id", async () => {
+      minigameService.updatePartial.mockResolvedValueOnce({
+        id: "999999",
+        name: "Renamed",
+        type: "jackpot",
+        enabled: true,
+        generalSettings: {
+          name: "Renamed",
+          showName: false,
+          playedAtFrom: "2026-01-01T00:00:00.000Z",
+          playedAtTo: "2026-12-31T00:00:00.000Z",
+          rulesDescription: "",
+          openerTagIds: [],
+          playerTagIds: [],
+          newFriendTagIds: [],
+        },
+        appearance: {
+          backgroundColor: "#F5A623",
+          machineColor: "#4A90D9",
+          decorativeColor: "#FFFFFF",
+          ruleTextColor: "#000000",
+          backgroundImage: { mode: "file", url: "" },
+          prizeDescriptionImage: { mode: "file", url: "" },
+          startButtonImage: { mode: "file", url: "" },
+        },
+        playerSettings: {
+          resetPolicy: "never",
+          drawsPerPerson: 1,
+          maxSharesPerPerson: 0,
+          sharingFlowId: null,
+          sharingNodeId: null,
+        },
+        prizeSettings: {
+          prizes: [],
+          nonWinning: {
+            title: "Try again",
+            loseRate: 100,
+            loseImage: { mode: "file", url: "" },
+          },
+          prizeNameCustomFieldId: null,
+        },
+        winningMessageSettings: { enabled: false, mode: "text", text: "" },
+        nonWinningMessageSettings: {
+          enabled: false,
+          mode: "text",
+          text: "",
+        },
+        playsCount: 0,
+        participantsCount: 0,
+        winnersCount: 0,
+        sharesCount: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+
+      await invoke(minigamesPublicRouter.patch, {
+        id: "999999",
+        generalSettings: {
+          name: "Renamed",
+          playedAtFrom: "2026-01-01T00:00:00.000Z",
+          playedAtTo: "2026-12-31T00:00:00.000Z",
+        },
+      })
+
+      expect(minigameService.updatePartial).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspaceId: "ws-1",
+          id: "999999",
+        }),
+      )
+    })
+
+    test("deleteMany scopes to the token's workspace, not any workspace implied by the ids", async () => {
+      minigameService.deleteMany.mockResolvedValueOnce(undefined)
+
+      await invoke(minigamesPublicRouter.deleteMany, { ids: ["999999"] })
+
+      expect(minigameService.deleteMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspaceId: "ws-1",
+          ids: ["999999"],
+        }),
+      )
     })
   })
 })

--- a/apps/builder/__tests__/minigames-public-scope.test.ts
+++ b/apps/builder/__tests__/minigames-public-scope.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const {
+  findWorkspaceByTokenHash,
+  isWorkspaceScheduledForDeletion,
+  getAccessState,
+  isAtLimit,
+  assertApiNotRateLimited,
+} = vi.hoisted(() => ({
+  findWorkspaceByTokenHash: vi.fn(),
+  isWorkspaceScheduledForDeletion: vi.fn().mockReturnValue(false),
+  getAccessState: vi.fn().mockResolvedValue({ blocked: false }),
+  isAtLimit: vi.fn().mockResolvedValue(false),
+  assertApiNotRateLimited: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock("@chatbotx.io/business", () => ({
+  workspaceApiTokenService: { findWorkspaceByTokenHash },
+  isWorkspaceScheduledForDeletion,
+  userQuotaService: { getAccessState },
+  quotaEnforcementService: { isAtLimit },
+}))
+
+const minigameService = { list: vi.fn() }
+const minigameContactService = { listPlays: vi.fn(), list: vi.fn() }
+
+vi.mock("@chatbotx.io/business/minigame", () => ({
+  minigameService,
+  minigameContactService,
+}))
+
+vi.mock("@/lib/log", () => ({
+  logger: { warn: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock("@/lib/rate-limit/api-rate-limit", () => ({
+  assertApiNotRateLimited,
+}))
+
+vi.mock("@/lib/rate-limit/guest-rate-limit", () => ({
+  getGuestClientIp: () => "203.0.113.9",
+}))
+
+vi.mock("@/env", () => ({ isCloud: () => true }))
+
+// `@/orpc` also exports `authorizedAPI`, which pulls in the full better-auth
+// stack via `authMiddleware` — irrelevant here and unsafe to initialize in a
+// unit test. Same stub as workspace-token-scope-enforcement.test.ts.
+vi.mock("@/middlewares/auth", () => ({
+  authMiddleware: vi.fn(),
+}))
+
+const { call } = await import("@orpc/server")
+const { minigamesPublicRouter } = await import(
+  "../src/features/minigames/api/public"
+)
+
+const TOKEN = "cbx_ws_fixture"
+
+const authResult = (scopes: string[] | null) => ({
+  workspace: { id: "ws-1", ownerId: "owner-1" },
+  apiToken: { id: "token-1", permission: "full" as const, scopes },
+})
+
+const invoke = (procedure: typeof minigamesPublicRouter.list) =>
+  call(
+    procedure,
+    {},
+    {
+      context: { headers: new Headers({ Authorization: `Bearer ${TOKEN}` }) },
+    },
+  )
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  isWorkspaceScheduledForDeletion.mockReturnValue(false)
+  getAccessState.mockResolvedValue({ blocked: false })
+  isAtLimit.mockResolvedValue(false)
+  assertApiNotRateLimited.mockResolvedValue(undefined)
+})
+
+describe("real router: minigames public API scope wiring", () => {
+  test("a contacts-scoped token is denied the real GET /v1/minigames route with FORBIDDEN", async () => {
+    findWorkspaceByTokenHash.mockResolvedValue(authResult(["contacts"]))
+
+    await expect(invoke(minigamesPublicRouter.list)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "Token is not authorized for the 'minigames' scope",
+    })
+  })
+
+  test("null scopes (unrestricted) passes the real GET /v1/minigames route", async () => {
+    findWorkspaceByTokenHash.mockResolvedValue(authResult(null))
+    minigameService.list.mockResolvedValue({ data: [], pageCount: 1 })
+
+    await expect(invoke(minigamesPublicRouter.list)).resolves.toMatchObject({
+      data: [],
+      pageCount: 1,
+    })
+  })
+})

--- a/apps/builder/src/features/minigames/actions/create-minigame.action.ts
+++ b/apps/builder/src/features/minigames/actions/create-minigame.action.ts
@@ -1,7 +1,7 @@
 "use server"
 
+import { ChatbotXException } from "@chatbotx.io/business/errors"
 import { minigameService } from "@chatbotx.io/business/minigame"
-import { isUniqueViolationError } from "@chatbotx.io/database/client"
 import { getTranslations } from "next-intl/server"
 import { returnValidationErrors } from "next-safe-action"
 import {
@@ -34,7 +34,10 @@ export const createMinigameAction = workspaceActionClient
         })
         return { id: minigame.id }
       } catch (error) {
-        if (isUniqueViolationError(error)) {
+        if (
+          error instanceof ChatbotXException &&
+          error.code === "nameAlreadyExists"
+        ) {
           return returnValidationErrors(createMinigameRequest, {
             generalSettings: {
               name: {

--- a/apps/builder/src/features/minigames/actions/update-minigame.action.ts
+++ b/apps/builder/src/features/minigames/actions/update-minigame.action.ts
@@ -1,7 +1,7 @@
 "use server"
 
+import { ChatbotXException } from "@chatbotx.io/business/errors"
 import { minigameService } from "@chatbotx.io/business/minigame"
-import { isUniqueViolationError } from "@chatbotx.io/database/client"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { getTranslations } from "next-intl/server"
 import { returnValidationErrors } from "next-safe-action"
@@ -46,7 +46,10 @@ export const updateMinigameAction = workspaceActionClient
           ...parsedInput,
         })
       } catch (error) {
-        if (isUniqueViolationError(error)) {
+        if (
+          error instanceof ChatbotXException &&
+          error.code === "nameAlreadyExists"
+        ) {
           return returnValidationErrors(updateMinigameRequest, {
             generalSettings: {
               name: {

--- a/apps/builder/src/features/minigames/api/public.ts
+++ b/apps/builder/src/features/minigames/api/public.ts
@@ -5,15 +5,17 @@ import {
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { z } from "zod"
 import {
-  possibleErrorsOnCreatingResource,
+  possibleErrorsOnCreatingMinigame,
   possibleErrorsOnDeletingResource,
   possibleErrorsOnFindingResource,
   possibleErrorsOnListingResource,
-  possibleErrorsOnMutatingResource,
+  possibleErrorsOnMutatingMinigame,
 } from "@/lib/orpc/orpc-error-helper"
 import { workspaceTokenAuthAPIForScope } from "@/orpc"
 import {
   createMinigamePublicRequest,
+  listMinigamePlayersPublicRequest,
+  listMinigamePlayersPublicResponse,
   listMinigamePlaysPublicRequest,
   listMinigamePlaysPublicResponse,
   listMinigamesPublicRequest,
@@ -42,7 +44,7 @@ export const minigamesPublicRouter = {
       const result = await minigameService.list({
         ...input,
         workspaceId: context.workspace.id,
-        name: input.name ?? undefined,
+        sort: [{ id: "createdAt", desc: true }],
       })
       return { data: result.data, pageCount: result.pageCount }
     }),
@@ -75,12 +77,12 @@ export const minigamesPublicRouter = {
     })
     .input(createMinigamePublicRequest)
     .output(minigamePublicResource)
-    .errors(possibleErrorsOnCreatingResource)
+    .errors(possibleErrorsOnCreatingMinigame)
     .handler(
       async ({ context, input }) =>
         await minigameService.create({
-          workspaceId: context.workspace.id,
           ...input,
+          workspaceId: context.workspace.id,
         }),
     ),
 
@@ -93,13 +95,14 @@ export const minigamesPublicRouter = {
     })
     .input(updateMinigamePublicRequest)
     .output(minigamePublicResource)
-    .errors(possibleErrorsOnMutatingResource)
+    .errors(possibleErrorsOnMutatingMinigame)
     .handler(async ({ context, input }) => {
       const { id, ...data } = input
       return await minigameService.update({
+        ...data,
         workspaceId: context.workspace.id,
         id,
-        ...data,
+        originalPrizeQuantities: null,
       })
     }),
 
@@ -114,9 +117,9 @@ export const minigamesPublicRouter = {
     .input(z.object({ id: zodBigintAsString() }))
     .errors(possibleErrorsOnDeletingResource)
     .handler(async ({ context, input }) => {
-      await minigameService.deleteMany({
+      await minigameService.delete({
         workspaceId: context.workspace.id,
-        ids: [input.id],
+        id: input.id,
       })
     }),
 
@@ -129,7 +132,7 @@ export const minigamesPublicRouter = {
     })
     .input(setMinigameEnabledPublicRequest)
     .output(minigamePublicResource)
-    .errors(possibleErrorsOnMutatingResource)
+    .errors(possibleErrorsOnMutatingMinigame)
     .handler(
       async ({ context, input }) =>
         await minigameService.setEnabled(
@@ -155,5 +158,27 @@ export const minigamesPublicRouter = {
         contactId: input.contactId,
       })
       return { data }
+    }),
+
+  listPlayers: workspaceTokenAuthAPI
+    .route({
+      method: "GET",
+      path: "/v1/minigames/{id}/players",
+      summary: "List a minigame's players",
+      tags,
+    })
+    .input(listMinigamePlayersPublicRequest)
+    .output(listMinigamePlayersPublicResponse)
+    // `minigameContactService.list` resolves the parent minigame through
+    // `minigameService.find` first (MinigameContact has no workspaceId), so a
+    // foreign or unknown id 404s.
+    .errors(possibleErrorsOnFindingResource)
+    .handler(async ({ context, input }) => {
+      const { id, ...pagination } = input
+      return await minigameContactService.list({
+        ...pagination,
+        workspaceId: context.workspace.id,
+        minigameId: id,
+      })
     }),
 }

--- a/apps/builder/src/features/minigames/api/public.ts
+++ b/apps/builder/src/features/minigames/api/public.ts
@@ -4,6 +4,7 @@ import {
 } from "@chatbotx.io/business/minigame"
 import { zodBigintAsString } from "@chatbotx.io/utils"
 import { z } from "zod"
+import { bulkUpdateIdsRequest } from "@/features/common/schema"
 import {
   possibleErrorsOnCreatingMinigame,
   possibleErrorsOnDeletingResource,
@@ -21,6 +22,7 @@ import {
   listMinigamesPublicRequest,
   listMinigamesPublicResponse,
   minigamePublicResource,
+  patchMinigamePublicRequest,
   setMinigameEnabledPublicRequest,
   updateMinigamePublicRequest,
 } from "../schema/public"
@@ -106,6 +108,25 @@ export const minigamesPublicRouter = {
       })
     }),
 
+  patch: workspaceTokenAuthAPI
+    .route({
+      method: "PATCH",
+      path: "/v1/minigames/{id}",
+      summary: "Partially update a minigame",
+      tags,
+    })
+    .input(patchMinigamePublicRequest)
+    .output(minigamePublicResource)
+    .errors(possibleErrorsOnMutatingMinigame)
+    .handler(async ({ context, input }) => {
+      const { id, ...data } = input
+      return await minigameService.updatePartial({
+        ...data,
+        workspaceId: context.workspace.id,
+        id,
+      })
+    }),
+
   delete: workspaceTokenAuthAPI
     .route({
       method: "DELETE",
@@ -120,6 +141,23 @@ export const minigamesPublicRouter = {
       await minigameService.delete({
         workspaceId: context.workspace.id,
         id: input.id,
+      })
+    }),
+
+  deleteMany: workspaceTokenAuthAPI
+    .route({
+      method: "POST",
+      path: "/v1/minigames/bulk-delete",
+      summary: "Delete multiple minigames",
+      successStatus: 204,
+      tags,
+    })
+    .input(bulkUpdateIdsRequest)
+    .errors(possibleErrorsOnDeletingResource)
+    .handler(async ({ context, input }) => {
+      await minigameService.deleteMany({
+        workspaceId: context.workspace.id,
+        ids: input.ids,
       })
     }),
 

--- a/apps/builder/src/features/minigames/api/public.ts
+++ b/apps/builder/src/features/minigames/api/public.ts
@@ -1,0 +1,159 @@
+import {
+  minigameContactService,
+  minigameService,
+} from "@chatbotx.io/business/minigame"
+import { zodBigintAsString } from "@chatbotx.io/utils"
+import { z } from "zod"
+import {
+  possibleErrorsOnCreatingResource,
+  possibleErrorsOnDeletingResource,
+  possibleErrorsOnFindingResource,
+  possibleErrorsOnListingResource,
+  possibleErrorsOnMutatingResource,
+} from "@/lib/orpc/orpc-error-helper"
+import { workspaceTokenAuthAPIForScope } from "@/orpc"
+import {
+  createMinigamePublicRequest,
+  listMinigamePlaysPublicRequest,
+  listMinigamePlaysPublicResponse,
+  listMinigamesPublicRequest,
+  listMinigamesPublicResponse,
+  minigamePublicResource,
+  setMinigameEnabledPublicRequest,
+  updateMinigamePublicRequest,
+} from "../schema/public"
+
+const workspaceTokenAuthAPI = workspaceTokenAuthAPIForScope("minigames")
+
+const tags = ["Minigames"]
+
+export const minigamesPublicRouter = {
+  list: workspaceTokenAuthAPI
+    .route({
+      method: "GET",
+      path: "/v1/minigames",
+      summary: "List minigames",
+      tags,
+    })
+    .input(listMinigamesPublicRequest)
+    .output(listMinigamesPublicResponse)
+    .errors(possibleErrorsOnListingResource)
+    .handler(async ({ context, input }) => {
+      const result = await minigameService.list({
+        ...input,
+        workspaceId: context.workspace.id,
+        name: input.name ?? undefined,
+      })
+      return { data: result.data, pageCount: result.pageCount }
+    }),
+
+  get: workspaceTokenAuthAPI
+    .route({
+      method: "GET",
+      path: "/v1/minigames/{id}",
+      summary: "Get a minigame",
+      tags,
+    })
+    .input(z.object({ id: zodBigintAsString() }))
+    .output(minigamePublicResource)
+    .errors(possibleErrorsOnFindingResource)
+    .handler(
+      async ({ context, input }) =>
+        await minigameService.find({
+          workspaceId: context.workspace.id,
+          id: input.id,
+        }),
+    ),
+
+  create: workspaceTokenAuthAPI
+    .route({
+      method: "POST",
+      path: "/v1/minigames",
+      summary: "Create a minigame",
+      successStatus: 201,
+      tags,
+    })
+    .input(createMinigamePublicRequest)
+    .output(minigamePublicResource)
+    .errors(possibleErrorsOnCreatingResource)
+    .handler(
+      async ({ context, input }) =>
+        await minigameService.create({
+          workspaceId: context.workspace.id,
+          ...input,
+        }),
+    ),
+
+  update: workspaceTokenAuthAPI
+    .route({
+      method: "PUT",
+      path: "/v1/minigames/{id}",
+      summary: "Update a minigame",
+      tags,
+    })
+    .input(updateMinigamePublicRequest)
+    .output(minigamePublicResource)
+    .errors(possibleErrorsOnMutatingResource)
+    .handler(async ({ context, input }) => {
+      const { id, ...data } = input
+      return await minigameService.update({
+        workspaceId: context.workspace.id,
+        id,
+        ...data,
+      })
+    }),
+
+  delete: workspaceTokenAuthAPI
+    .route({
+      method: "DELETE",
+      path: "/v1/minigames/{id}",
+      summary: "Delete a minigame",
+      successStatus: 204,
+      tags,
+    })
+    .input(z.object({ id: zodBigintAsString() }))
+    .errors(possibleErrorsOnDeletingResource)
+    .handler(async ({ context, input }) => {
+      await minigameService.deleteMany({
+        workspaceId: context.workspace.id,
+        ids: [input.id],
+      })
+    }),
+
+  setEnabled: workspaceTokenAuthAPI
+    .route({
+      method: "PATCH",
+      path: "/v1/minigames/{id}/enabled",
+      summary: "Enable or disable a minigame",
+      tags,
+    })
+    .input(setMinigameEnabledPublicRequest)
+    .output(minigamePublicResource)
+    .errors(possibleErrorsOnMutatingResource)
+    .handler(
+      async ({ context, input }) =>
+        await minigameService.setEnabled(
+          { workspaceId: context.workspace.id, id: input.id },
+          input.enabled,
+        ),
+    ),
+
+  listPlays: workspaceTokenAuthAPI
+    .route({
+      method: "GET",
+      path: "/v1/minigames/{id}/plays",
+      summary: "List a contact's minigame play records",
+      tags,
+    })
+    .input(listMinigamePlaysPublicRequest)
+    .output(listMinigamePlaysPublicResponse)
+    .errors(possibleErrorsOnFindingResource)
+    .handler(async ({ context, input }) => {
+      const data = await minigameContactService.listPlays({
+        workspaceId: context.workspace.id,
+        minigameId: input.id,
+        contactId: input.contactId,
+      })
+      return { data }
+    }),
+}

--- a/apps/builder/src/features/minigames/schema/public.ts
+++ b/apps/builder/src/features/minigames/schema/public.ts
@@ -1,0 +1,47 @@
+import { zodBigintAsString } from "@chatbotx.io/utils"
+import { z } from "zod"
+import { publicListRequest, publicListResponse } from "@/lib/public-api/list"
+import { createMinigameRequest, updateMinigameRequest } from "./action"
+import { minigameResource } from "./resource"
+
+export const listMinigamesPublicRequest = publicListRequest.extend({
+  name: z.string().trim().min(1).optional(),
+})
+
+export const minigamePublicResource = minigameResource.omit({
+  workspaceId: true,
+})
+
+export const listMinigamesPublicResponse = publicListResponse(
+  minigamePublicResource,
+)
+
+export const createMinigamePublicRequest = createMinigameRequest
+
+export const updateMinigamePublicRequest = updateMinigameRequest.extend({
+  id: zodBigintAsString(),
+  originalPrizeQuantities: z
+    .record(z.string(), z.number().int().min(0).optional())
+    .default({}),
+})
+
+export const setMinigameEnabledPublicRequest = z.object({
+  id: zodBigintAsString(),
+  enabled: z.boolean(),
+})
+
+export const listMinigamePlaysPublicRequest = z.object({
+  id: zodBigintAsString(),
+  contactId: zodBigintAsString(),
+})
+
+export const minigamePlayResource = z.object({
+  id: z.string(),
+  isWinning: z.boolean(),
+  prizeName: z.string().nullable(),
+  createdAt: z.date(),
+})
+
+export const listMinigamePlaysPublicResponse = z.object({
+  data: z.array(minigamePlayResource),
+})

--- a/apps/builder/src/features/minigames/schema/public.ts
+++ b/apps/builder/src/features/minigames/schema/public.ts
@@ -20,9 +20,6 @@ export const createMinigamePublicRequest = createMinigameRequest
 
 export const updateMinigamePublicRequest = updateMinigameRequest.extend({
   id: zodBigintAsString(),
-  originalPrizeQuantities: z
-    .record(z.string(), z.number().int().min(0).optional())
-    .default({}),
 })
 
 export const setMinigameEnabledPublicRequest = z.object({
@@ -35,6 +32,33 @@ export const listMinigamePlaysPublicRequest = z.object({
   contactId: zodBigintAsString(),
 })
 
+export const listMinigamePlayersPublicRequest = publicListRequest.extend({
+  id: zodBigintAsString(),
+  name: z.string().trim().min(1).optional(),
+})
+
+export const minigamePlayerResource = z.object({
+  id: z.string(),
+  contactId: z.string(),
+  contactInboxId: z.string().nullable(),
+  played: z.number().int(),
+  remaining: z.number().int(),
+  sharesCount: z.number().int(),
+  openedAt: z.date(),
+  lastPlayedAt: z.date(),
+  contact: z.object({
+    id: z.string(),
+    fullName: z.string().nullable(),
+    firstName: z.string().nullable(),
+    lastName: z.string().nullable(),
+    avatar: z.string().nullable(),
+  }),
+})
+
+export const listMinigamePlayersPublicResponse = publicListResponse(
+  minigamePlayerResource,
+)
+
 export const minigamePlayResource = z.object({
   id: z.string(),
   isWinning: z.boolean(),
@@ -43,5 +67,9 @@ export const minigamePlayResource = z.object({
 })
 
 export const listMinigamePlaysPublicResponse = z.object({
-  data: z.array(minigamePlayResource),
+  data: z
+    .array(minigamePlayResource)
+    .describe(
+      "A contact's most recent plays, newest first, capped at 200 records.",
+    ),
 })

--- a/apps/builder/src/features/minigames/schema/public.ts
+++ b/apps/builder/src/features/minigames/schema/public.ts
@@ -22,6 +22,17 @@ export const updateMinigamePublicRequest = updateMinigameRequest.extend({
   id: zodBigintAsString(),
 })
 
+export const patchMinigamePublicRequest = createMinigameRequest
+  .partial()
+  .extend({ id: zodBigintAsString() })
+  .refine(
+    (data) =>
+      Object.entries(data).some(
+        ([key, value]) => key !== "id" && value !== undefined,
+      ),
+    { message: "At least one field must be provided" },
+  )
+
 export const setMinigameEnabledPublicRequest = z.object({
   id: zodBigintAsString(),
   enabled: z.boolean(),

--- a/apps/builder/src/lib/orpc/orpc-error-helper.ts
+++ b/apps/builder/src/lib/orpc/orpc-error-helper.ts
@@ -239,3 +239,24 @@ export const possibleErrorsOnSchedulingContactScan = {
     status: 409,
   },
 } satisfies ErrorMap
+
+/**
+ * Minigame create/update enforce `Minigame_workspaceId_name_key`, surfaced by
+ * `minigameService.rethrowNameConflict` as `nameAlreadyExists`/409. Same
+ * declare-or-vanish rule as the appointment-calendar pair above.
+ */
+const minigameNameAlreadyExists = {
+  message: "Minigame name already exists",
+  status: 409,
+}
+
+export const possibleErrorsOnCreatingMinigame = {
+  businessError,
+  nameAlreadyExists: minigameNameAlreadyExists,
+} satisfies ErrorMap
+
+export const possibleErrorsOnMutatingMinigame = {
+  notFound,
+  businessError,
+  nameAlreadyExists: minigameNameAlreadyExists,
+} satisfies ErrorMap

--- a/apps/builder/src/routers/public.ts
+++ b/apps/builder/src/routers/public.ts
@@ -32,6 +32,7 @@ import { zaloChannelsPublicRouter } from "@/features/integration-zalo/api/public
 import { integrationsPublicRouter } from "@/features/integrations/api/public"
 import { mediaLibraryPublicRouter } from "@/features/media-library/api/public"
 import { messagesPublicRouter } from "@/features/messages/api/public"
+import { minigamesPublicRouter } from "@/features/minigames/api/public"
 import { messengerPersonasPublicRouter } from "@/features/personas/api/public"
 import { productCategoriesPublicRouter } from "@/features/product-categories/api/public"
 import { productsPublicRouter } from "@/features/products/api/public"
@@ -76,6 +77,7 @@ export const publicRouter = {
   messages: messagesPublicRouter,
   messengerChannels: messengerChannelsPublicRouter,
   messengerPersonas: messengerPersonasPublicRouter,
+  minigames: minigamesPublicRouter,
   productCategories: productCategoriesPublicRouter,
   products: productsPublicRouter,
   reflinks: reflinksPublicRouter,

--- a/docs/developer/workspace-api-tokens.md
+++ b/docs/developer/workspace-api-tokens.md
@@ -345,12 +345,26 @@ Two invariants specific to this scope:
   must not re-implement it upstream.
 
 - **Minigames** — this scope shipped in the enum/registry/i18n alongside
-  `ads` but, like `ads`, carried no endpoints for a while. It now
-  publishes minigame CRUD, enable/disable, and per-contact play-history
-  reads — also its first endpoints. As with every other scope, each
-  public handler calls the same `packages/business` service method the
-  private/action code calls; no business logic was duplicated to publish
-  these.
+  `ads` but, like `ads`, carried no endpoints for a while. It now publishes
+  minigame CRUD, enable/disable, per-contact play-history reads, and a
+  players (participants) list — its first endpoints. As with every other
+  scope, each public handler calls the same `packages/business` service
+  method the private/action code calls; no business logic was duplicated to
+  publish these.
+  - *`GET /v1/minigames/{id}/players` returns contact display PII*
+    (`fullName`, `firstName`, `lastName`, `avatar` — no email/phone) with no
+    field-level gating, same rationale as the broadcasts-audience note
+    above.
+  - *`GET /v1/minigames/{id}/plays` is not paged* and is hard-capped at 200
+    records by `MAX_PLAY_RECORDS`
+    (`packages/business/src/minigame/minigame-contact-service.ts`).
+  - *`PUT /v1/minigames/{id}` passes `originalPrizeQuantities: null`*, so a
+    token write honors submitted prize quantities verbatim; the builder form
+    passes its load-time snapshot instead and keeps play-decremented stock.
+    Never expose that field on the public request schema.
+  - *A duplicate name is a `nameAlreadyExists`/409* from `minigameService`,
+    declared on both write routes — not the 500 the raw Postgres unique
+    violation used to produce.
 
 ### Ads scope — endpoint-to-scope table
 

--- a/docs/developer/workspace-api-tokens.md
+++ b/docs/developer/workspace-api-tokens.md
@@ -358,13 +358,20 @@ Two invariants specific to this scope:
   - *`GET /v1/minigames/{id}/plays` is not paged* and is hard-capped at 200
     records by `MAX_PLAY_RECORDS`
     (`packages/business/src/minigame/minigame-contact-service.ts`).
-  - *`PUT /v1/minigames/{id}` passes `originalPrizeQuantities: null`*, so a
-    token write honors submitted prize quantities verbatim; the builder form
-    passes its load-time snapshot instead and keeps play-decremented stock.
-    Never expose that field on the public request schema.
+  - *`PUT /v1/minigames/{id}` is a full replace* and passes
+    `originalPrizeQuantities: null`, so a token write honors submitted prize
+    quantities verbatim — a GET → modify → PUT round-trip discards any prize
+    stock decremented by plays that happened in between. `PATCH
+    /v1/minigames/{id}` is the safe partial update: only the top-level
+    settings objects present in the request body are merged over the current
+    row, so omitting `prizeSettings` preserves live stock. Never expose
+    `originalPrizeQuantities` on the public request schema.
+  - *`POST /v1/minigames/bulk-delete`* deletes multiple minigames by id in
+    one call, mirroring `minigameService.deleteMany` (also used by the
+    private bulk-delete action).
   - *A duplicate name is a `nameAlreadyExists`/409* from `minigameService`,
-    declared on both write routes — not the 500 the raw Postgres unique
-    violation used to produce.
+    declared on all three write routes (`POST`, `PUT`, `PATCH`) — not the 500
+    the raw Postgres unique violation used to produce.
 
 ### Ads scope — endpoint-to-scope table
 

--- a/docs/developer/workspace-api-tokens.md
+++ b/docs/developer/workspace-api-tokens.md
@@ -344,6 +344,14 @@ Two invariants specific to this scope:
   of `integrationWebchatService.update`/`.create` gets this for free and
   must not re-implement it upstream.
 
+- **Minigames** — this scope shipped in the enum/registry/i18n alongside
+  `ads` but, like `ads`, carried no endpoints for a while. It now
+  publishes minigame CRUD, enable/disable, and per-contact play-history
+  reads — also its first endpoints. As with every other scope, each
+  public handler calls the same `packages/business` service method the
+  private/action code calls; no business logic was duplicated to publish
+  these.
+
 ### Ads scope — endpoint-to-scope table
 
 `ads` shipped in the enum/registry/i18n from day one (alongside `channels`,

--- a/packages/business/__tests__/minigame-contact-service-scoping.test.ts
+++ b/packages/business/__tests__/minigame-contact-service-scoping.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const { findMock } = vi.hoisted(() => ({
+  findMock: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/database/client", () => ({
+  and: vi.fn((...conditions: unknown[]) => ({ conditions })),
+  asc: vi.fn((field: unknown) => ({ field, dir: "asc" })),
+  count: vi.fn(() => "count"),
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        innerJoin: vi.fn(() => ({
+          where: vi.fn(async () => Promise.resolve([{ value: 0 }])),
+        })),
+      })),
+    })),
+  },
+  desc: vi.fn((field: unknown) => ({ field, dir: "desc" })),
+  eq: vi.fn((field: unknown, value: unknown) => ({ field, value })),
+  ilike: vi.fn(),
+  lt: vi.fn(),
+  sql: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/database/schema", () => ({
+  contactModel: { id: "id", fullName: "fullName" },
+  conversationModel: { id: "id" },
+  minigameContactModel: { id: "id", minigameId: "minigameId" },
+  minigameModel: { id: "id", workspaceId: "workspaceId" },
+  minigamePlayModel: { id: "id", createdAt: "createdAt" },
+}))
+
+vi.mock("@chatbotx.io/database/repositories", () => ({
+  createMessageRepository: vi.fn(),
+}))
+
+vi.mock("@chatbotx.io/worker-config", () => ({
+  ChatJobAction: {},
+  chatQueue: { add: vi.fn() },
+  IntegrationJobAction: {},
+  integrationQueue: { add: vi.fn() },
+}))
+
+vi.mock("../src/contact-custom-field/service", () => ({
+  contactCustomFieldService: {},
+}))
+
+vi.mock("../src/contact-inbox/service", () => ({
+  contactInboxService: {},
+}))
+
+vi.mock("../src/conversation/service", () => ({
+  conversationService: {},
+}))
+
+vi.mock("../src/tag/service", () => ({
+  tagService: {},
+}))
+
+vi.mock("../src/minigame/service", () => ({
+  minigameService: { find: findMock },
+}))
+
+describe("MinigameContactService — indirect tenancy guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("listPlays rejects a minigameId belonging to another workspace before reading any play rows", async () => {
+    findMock.mockRejectedValueOnce(new Error("Minigame not found"))
+
+    const { minigameContactService } = await import(
+      "../src/minigame/minigame-contact-service"
+    )
+
+    await expect(
+      minigameContactService.listPlays({
+        workspaceId: "ws-1",
+        minigameId: "foreign-minigame",
+        contactId: "contact-1",
+      }),
+    ).rejects.toThrow("Minigame not found")
+
+    expect(findMock).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      id: "foreign-minigame",
+    })
+  })
+
+  test("listPlayers (list) rejects a minigameId belonging to another workspace before reading any player rows", async () => {
+    findMock.mockRejectedValueOnce(new Error("Minigame not found"))
+
+    const { minigameContactService } = await import(
+      "../src/minigame/minigame-contact-service"
+    )
+
+    await expect(
+      minigameContactService.list({
+        workspaceId: "ws-1",
+        minigameId: "foreign-minigame",
+      }),
+    ).rejects.toThrow("Minigame not found")
+
+    expect(findMock).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      id: "foreign-minigame",
+    })
+  })
+})

--- a/packages/business/__tests__/minigame-service-update.test.ts
+++ b/packages/business/__tests__/minigame-service-update.test.ts
@@ -1,3 +1,4 @@
+import { isUniqueViolationError } from "@chatbotx.io/database/client"
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
 const { mockSelectFor, mockUpdateReturning, mockUpdateSet, dbTransactionSpy } =
@@ -36,6 +37,7 @@ vi.mock("@chatbotx.io/database/client", () => ({
   eq: vi.fn((field: unknown, value: unknown) => ({ field, value })),
   ilike: vi.fn(),
   inArray: vi.fn((field: unknown, values: unknown[]) => ({ field, values })),
+  isUniqueViolationError: vi.fn(() => false),
 }))
 
 vi.mock("@chatbotx.io/database/schema", () => ({
@@ -128,5 +130,59 @@ describe("MinigameService.update — prize quantity reconciliation", () => {
         prizeSettings: { prizes: [], nonWinning: { loseRate: 100 } },
       } as never),
     ).rejects.toThrow()
+  })
+
+  test("honors submitted quantities verbatim when originalPrizeQuantities is null (public-API write)", async () => {
+    mockSelectFor.mockResolvedValue([
+      {
+        prizeSettings: {
+          prizes: [{ id: "p1", quantity: 3 }],
+          nonWinning: { loseRate: 25 },
+        },
+      },
+    ])
+
+    const { minigameService } = await import("../src/minigame/service")
+
+    await minigameService.update({
+      ...baseInput,
+      prizeSettings: {
+        prizes: [{ id: "p1", quantity: undefined }],
+        nonWinning: { loseRate: 25 },
+      },
+      originalPrizeQuantities: null,
+    } as never)
+
+    const setArg = mockUpdateSet.mock.calls.at(-1)?.[0] as {
+      prizeSettings: { prizes: { id: string; quantity?: number }[] }
+    }
+    expect(setArg.prizeSettings.prizes[0].quantity).toBeUndefined()
+  })
+
+  test("maps a unique-name violation to a 409 ChatbotXException", async () => {
+    mockSelectFor.mockResolvedValue([
+      {
+        prizeSettings: {
+          prizes: [{ id: "p1", quantity: 3 }],
+          nonWinning: { loseRate: 25 },
+        },
+      },
+    ])
+    mockUpdateReturning.mockRejectedValueOnce(new Error("unique violation"))
+
+    vi.mocked(isUniqueViolationError).mockReturnValueOnce(true)
+
+    const { minigameService } = await import("../src/minigame/service")
+
+    await expect(
+      minigameService.update({
+        ...baseInput,
+        prizeSettings: { prizes: [], nonWinning: { loseRate: 100 } },
+        originalPrizeQuantities: {},
+      } as never),
+    ).rejects.toMatchObject({
+      code: "nameAlreadyExists",
+      httpStatusCode: 409,
+    })
   })
 })

--- a/packages/business/__tests__/minigame-service-update.test.ts
+++ b/packages/business/__tests__/minigame-service-update.test.ts
@@ -48,6 +48,19 @@ vi.mock("@chatbotx.io/database/schema", () => ({
   },
 }))
 
+const baseCurrentRow = {
+  type: "jackpot",
+  generalSettings: { name: "Current name" },
+  appearance: { theme: "light" },
+  playerSettings: { drawsPerPerson: 1 },
+  prizeSettings: {
+    prizes: [{ id: "p1", quantity: 3 }],
+    nonWinning: { loseRate: 25 },
+  },
+  winningMessageSettings: { enabled: false },
+  nonWinningMessageSettings: { enabled: false },
+}
+
 const baseInput = {
   workspaceId: "workspace-1",
   id: "minigame-1",
@@ -179,6 +192,88 @@ describe("MinigameService.update — prize quantity reconciliation", () => {
         ...baseInput,
         prizeSettings: { prizes: [], nonWinning: { loseRate: 100 } },
         originalPrizeQuantities: {},
+      } as never),
+    ).rejects.toMatchObject({
+      code: "nameAlreadyExists",
+      httpStatusCode: 409,
+    })
+  })
+})
+
+describe("MinigameService.updatePartial — partial merge over the current row", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUpdateReturning.mockResolvedValue([{ id: "minigame-1" }])
+  })
+
+  test("omitting prizeSettings preserves the DB's live, play-decremented quantity verbatim", async () => {
+    mockSelectFor.mockResolvedValue([baseCurrentRow])
+
+    const { minigameService } = await import("../src/minigame/service")
+
+    await minigameService.updatePartial({
+      workspaceId: "workspace-1",
+      id: "minigame-1",
+      generalSettings: { name: "Renamed" },
+    } as never)
+
+    const setArg = mockUpdateSet.mock.calls.at(-1)?.[0] as {
+      name: string
+      generalSettings: { name: string }
+      prizeSettings: typeof baseCurrentRow.prizeSettings
+    }
+    expect(setArg.generalSettings.name).toBe("Renamed")
+    expect(setArg.name).toBe("Renamed")
+    expect(setArg.prizeSettings).toEqual(baseCurrentRow.prizeSettings)
+  })
+
+  test("sending prizeSettings replaces it wholesale, not deep-merged", async () => {
+    mockSelectFor.mockResolvedValue([baseCurrentRow])
+
+    const { minigameService } = await import("../src/minigame/service")
+
+    await minigameService.updatePartial({
+      workspaceId: "workspace-1",
+      id: "minigame-1",
+      prizeSettings: {
+        prizes: [{ id: "p2", quantity: 5 }],
+        nonWinning: { loseRate: 50 },
+      },
+    } as never)
+
+    const setArg = mockUpdateSet.mock.calls.at(-1)?.[0] as {
+      prizeSettings: { prizes: { id: string; quantity?: number }[] }
+    }
+    expect(setArg.prizeSettings.prizes).toEqual([{ id: "p2", quantity: 5 }])
+  })
+
+  test("throws not-found when the row doesn't exist in this workspace", async () => {
+    mockSelectFor.mockResolvedValue([])
+
+    const { minigameService } = await import("../src/minigame/service")
+
+    await expect(
+      minigameService.updatePartial({
+        workspaceId: "workspace-1",
+        id: "missing",
+        generalSettings: { name: "Renamed" },
+      } as never),
+    ).rejects.toThrow()
+  })
+
+  test("maps a unique-name violation to a 409 ChatbotXException", async () => {
+    mockSelectFor.mockResolvedValue([baseCurrentRow])
+    mockUpdateReturning.mockRejectedValueOnce(new Error("unique violation"))
+
+    vi.mocked(isUniqueViolationError).mockReturnValueOnce(true)
+
+    const { minigameService } = await import("../src/minigame/service")
+
+    await expect(
+      minigameService.updatePartial({
+        workspaceId: "workspace-1",
+        id: "minigame-1",
+        generalSettings: { name: "Duplicate" },
       } as never),
     ).rejects.toMatchObject({
       code: "nameAlreadyExists",

--- a/packages/business/src/minigame/minigame-contact-service.ts
+++ b/packages/business/src/minigame/minigame-contact-service.ts
@@ -94,39 +94,63 @@ export function deriveRemaining(props: {
   return Math.max(0, playerSettings.drawsPerPerson + bonusDraws - played)
 }
 
+/**
+ * Every branch appends `minigameContactModel.id` as a deterministic
+ * tie-break — `desc(updatedAt)` alone can duplicate or skip rows across
+ * pages when two rows share a timestamp.
+ */
 export function getMinigameContactListOrder(sort?: MinigameContactListSort) {
   const activeSort = sort?.[0]
+  const tieBreak = asc(minigameContactModel.id)
   if (!activeSort) {
-    return desc(minigameContactModel.updatedAt)
+    return [desc(minigameContactModel.updatedAt), tieBreak]
   }
 
   switch (activeSort.id) {
     case "name":
-      return activeSort.desc
-        ? desc(contactModel.fullName)
-        : asc(contactModel.fullName)
+      return [
+        activeSort.desc
+          ? desc(contactModel.fullName)
+          : asc(contactModel.fullName),
+        tieBreak,
+      ]
     case "played":
-      return activeSort.desc
-        ? desc(minigameContactModel.played)
-        : asc(minigameContactModel.played)
+      return [
+        activeSort.desc
+          ? desc(minigameContactModel.played)
+          : asc(minigameContactModel.played),
+        tieBreak,
+      ]
     case "remaining":
-      return activeSort.desc
-        ? desc(minigameContactModel.remaining)
-        : asc(minigameContactModel.remaining)
+      return [
+        activeSort.desc
+          ? desc(minigameContactModel.remaining)
+          : asc(minigameContactModel.remaining),
+        tieBreak,
+      ]
     case "sharesCount":
-      return activeSort.desc
-        ? desc(minigameContactModel.sharesCount)
-        : asc(minigameContactModel.sharesCount)
+      return [
+        activeSort.desc
+          ? desc(minigameContactModel.sharesCount)
+          : asc(minigameContactModel.sharesCount),
+        tieBreak,
+      ]
     case "openedAt":
-      return activeSort.desc
-        ? desc(minigameContactModel.openedAt)
-        : asc(minigameContactModel.openedAt)
+      return [
+        activeSort.desc
+          ? desc(minigameContactModel.openedAt)
+          : asc(minigameContactModel.openedAt),
+        tieBreak,
+      ]
     case "lastPlayedAt":
-      return activeSort.desc
-        ? desc(minigameContactModel.updatedAt)
-        : asc(minigameContactModel.updatedAt)
+      return [
+        activeSort.desc
+          ? desc(minigameContactModel.updatedAt)
+          : asc(minigameContactModel.updatedAt),
+        tieBreak,
+      ]
     default:
-      return desc(minigameContactModel.updatedAt)
+      return [desc(minigameContactModel.updatedAt), tieBreak]
   }
 }
 
@@ -726,7 +750,7 @@ class MinigameContactService extends BaseService {
           eq(minigameContactModel.contactId, contactModel.id),
         )
         .where(whereSQL)
-        .orderBy(getMinigameContactListOrder(input.sort))
+        .orderBy(...getMinigameContactListOrder(input.sort))
         .limit(pagination.limit)
         .offset(pagination.offset),
       db

--- a/packages/business/src/minigame/service.ts
+++ b/packages/business/src/minigame/service.ts
@@ -44,6 +44,10 @@ type UpsertInput = {
   nonWinningMessageSettings: MinigameNonWinningMessageSettings
 }
 
+type PartialUpdateInput = { workspaceId: string; id: string } & Partial<
+  Omit<UpsertInput, "workspaceId">
+>
+
 /**
  * `quantity` is admin-editable config AND live inventory decremented by
  * `MinigameContactService.drawPrize` under a row lock. The builder form
@@ -220,6 +224,65 @@ class MinigameService extends BaseService {
               prizeSettings: reconciledPrizeSettings,
             }),
           )
+          .where(
+            and(
+              eq(minigameModel.id, input.id),
+              eq(minigameModel.workspaceId, input.workspaceId),
+            ),
+          )
+          .returning()
+
+        return updated
+      })
+    } catch (error) {
+      this.rethrowNameConflict(error)
+    }
+  }
+
+  /**
+   * Partial update for the public API's PATCH route: merges only the
+   * top-level settings objects the caller actually sent over the current
+   * row, so omitting `prizeSettings` preserves live, play-decremented stock
+   * instead of the full-replace `update()`'s "resubmit everything" contract.
+   * Never deep-merges into a jsonb settings object — a caller who sends
+   * `prizeSettings` sends the whole object, keeping
+   * `isMinigameProbabilityTotalValid`'s 100%-sum check meaningful.
+   */
+  async updatePartial(input: PartialUpdateInput): Promise<MinigameModel> {
+    try {
+      return await db.transaction(async (tx) => {
+        const [current] = await tx
+          .select()
+          .from(minigameModel)
+          .where(
+            and(
+              eq(minigameModel.id, input.id),
+              eq(minigameModel.workspaceId, input.workspaceId),
+            ),
+          )
+          .for("update")
+
+        if (!current) {
+          throw notFoundException("Minigame not found")
+        }
+
+        const merged: UpsertInput = {
+          workspaceId: input.workspaceId,
+          type: input.type ?? current.type,
+          generalSettings: input.generalSettings ?? current.generalSettings,
+          appearance: input.appearance ?? current.appearance,
+          playerSettings: input.playerSettings ?? current.playerSettings,
+          prizeSettings: input.prizeSettings ?? current.prizeSettings,
+          winningMessageSettings:
+            input.winningMessageSettings ?? current.winningMessageSettings,
+          nonWinningMessageSettings:
+            input.nonWinningMessageSettings ??
+            current.nonWinningMessageSettings,
+        }
+
+        const [updated] = await tx
+          .update(minigameModel)
+          .set(this.toColumns(merged))
           .where(
             and(
               eq(minigameModel.id, input.id),

--- a/packages/business/src/minigame/service.ts
+++ b/packages/business/src/minigame/service.ts
@@ -1,4 +1,11 @@
-import { and, db, eq, ilike, inArray } from "@chatbotx.io/database/client"
+import {
+  and,
+  db,
+  eq,
+  ilike,
+  inArray,
+  isUniqueViolationError,
+} from "@chatbotx.io/database/client"
 import type {
   MinigameAppearance,
   MinigameGeneralSettings,
@@ -16,7 +23,7 @@ import {
   parseOrderBy,
 } from "@chatbotx.io/database/utils"
 import { BaseService } from "../base.service"
-import { notFoundException } from "../errors"
+import { ChatbotXException, notFoundException } from "../errors"
 
 type ListInput = {
   workspaceId: string
@@ -134,60 +141,98 @@ class MinigameService extends BaseService {
     }
   }
 
-  async create(input: UpsertInput): Promise<MinigameModel> {
-    const [row] = await db
-      .insert(minigameModel)
-      .values({ workspaceId: input.workspaceId, ...this.toColumns(input) })
-      .returning()
+  /**
+   * `Minigame_workspaceId_name_key` is the only unique index on the table, so a
+   * unique violation from create/update is always a duplicate name. Mapped here
+   * (not in each caller) so the public API and the builder form get the same
+   * failure — see `possibleErrorsOnCreatingMinigame` in
+   * `apps/builder/src/lib/orpc/orpc-error-helper.ts`.
+   */
+  private rethrowNameConflict(error: unknown): never {
+    if (isUniqueViolationError(error)) {
+      throw new ChatbotXException(
+        "Minigame name already exists",
+        "nameAlreadyExists",
+        409,
+      )
+    }
+    throw error
+  }
 
-    return row
+  async create(input: UpsertInput): Promise<MinigameModel> {
+    try {
+      const [row] = await db
+        .insert(minigameModel)
+        .values({ workspaceId: input.workspaceId, ...this.toColumns(input) })
+        .returning()
+
+      return row
+    } catch (error) {
+      this.rethrowNameConflict(error)
+    }
   }
 
   async update(
     input: UpsertInput & {
       id: string
-      originalPrizeQuantities?: Record<string, number | undefined>
+      originalPrizeQuantities?: Record<string, number | undefined> | null
     },
   ): Promise<MinigameModel> {
     const { originalPrizeQuantities = {} } = input
 
-    return await db.transaction(async (tx) => {
-      const [current] = await tx
-        .select({ prizeSettings: minigameModel.prizeSettings })
-        .from(minigameModel)
-        .where(
-          and(
-            eq(minigameModel.id, input.id),
-            eq(minigameModel.workspaceId, input.workspaceId),
-          ),
-        )
-        .for("update")
+    try {
+      return await db.transaction(async (tx) => {
+        const [current] = await tx
+          .select({ prizeSettings: minigameModel.prizeSettings })
+          .from(minigameModel)
+          .where(
+            and(
+              eq(minigameModel.id, input.id),
+              eq(minigameModel.workspaceId, input.workspaceId),
+            ),
+          )
+          .for("update")
 
-      if (!current) {
-        throw notFoundException("Minigame not found")
-      }
+        if (!current) {
+          throw notFoundException("Minigame not found")
+        }
 
-      const reconciledPrizeSettings = reconcilePrizeQuantities(
-        input.prizeSettings,
-        current.prizeSettings,
-        originalPrizeQuantities,
-      )
+        // `null` = "no form-load baseline" (a public-API write, not the builder
+        // form): honor the submitted quantities verbatim, including clearing a
+        // tracked quantity back to `undefined`. `{}` (the builder default) means
+        // "baseline unknown for every prize", which `reconcilePrizeQuantities`
+        // reads as untouched and therefore keeps the DB's live, play-decremented
+        // value.
+        const reconciledPrizeSettings =
+          originalPrizeQuantities === null
+            ? input.prizeSettings
+            : reconcilePrizeQuantities(
+                input.prizeSettings,
+                current.prizeSettings,
+                originalPrizeQuantities,
+              )
 
-      const [updated] = await tx
-        .update(minigameModel)
-        .set(
-          this.toColumns({ ...input, prizeSettings: reconciledPrizeSettings }),
-        )
-        .where(
-          and(
-            eq(minigameModel.id, input.id),
-            eq(minigameModel.workspaceId, input.workspaceId),
-          ),
-        )
-        .returning()
+        const [updated] = await tx
+          .update(minigameModel)
+          .set(
+            this.toColumns({
+              ...input,
+              prizeSettings: reconciledPrizeSettings,
+            }),
+          )
+          .where(
+            and(
+              eq(minigameModel.id, input.id),
+              eq(minigameModel.workspaceId, input.workspaceId),
+            ),
+          )
+          .returning()
 
-      return updated
-    })
+        return updated
+      })
+    } catch (error) {
+      this.rethrowNameConflict(error)
+    }
   }
 
   async setEnabled(


### PR DESCRIPTION
Activates the previously-inert `minigames` workspace-token scope with its first endpoints: minigame CRUD, enable/disable, and per-contact play-history reads. Each handler delegates to the same `packages/business` service the private UI uses.

One of six PRs splitting a larger workspace-api-token public-API changeset by `workspaceApiTokenScope` (contacts, media, channels, minigames, broadcasts, automation).